### PR TITLE
Project Calico version 0.2

### DIFF
--- a/debian/calico-compute.postinst
+++ b/debian/calico-compute.postinst
@@ -11,6 +11,9 @@ then
     iptables -C POSTROUTING -t mangle -p udp --dport 68 -j CHECKSUM --checksum-fill ||
     iptables -A POSTROUTING -t mangle -p udp --dport 68 -j CHECKSUM --checksum-fill
 
+    # Save current iptables for subsequent reboots.
+    iptables-save > /etc/iptables/rules.v4
+
     # Enable IP forwarding.
     echo 1 > /proc/sys/net/ipv4/ip_forward
 fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+calico (0.2) trusty; urgency=medium
+
+  * Make iptables rule for DHCP checksum filling persist across compute
+	node reboots.
+  * Add firewall_driver config to calico_agent.ini.
+
+ -- Neil Jerram <nj@metaswitch.com>  Tue, 01 Jul 2014 15:17:52 +0100
+
 calico (0.1) trusty; urgency=medium
 
   * Initial release.

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Depends:
  bird,
  calico-common,
  neutron-dhcp-agent,
+ iptables-persistent,
  ${misc:Depends},
  ${python:Depends},
  ${shlibs:Depends}

--- a/etc/calico_agent.ini
+++ b/etc/calico_agent.ini
@@ -86,3 +86,6 @@
 # Timeout for ovs-vsctl commands.
 # If the timeout expires, ovs commands will fail with ALARMCLOCK error.
 # ovs_vsctl_timeout = 10
+
+[SECURITYGROUP]
+firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver


### PR DESCRIPTION
- Make iptables rule for DHCP checksum filling persist across
  compute node reboots.
- Add firewall_driver config to calico_agent.ini.
