### PR TITLE
Drop the severity of function entry log to DEBUG.

### DIFF
--- a/calico/agent/calico_neutron_agent.py
+++ b/calico/agent/calico_neutron_agent.py
@@ -68,7 +68,7 @@ class CalicoManager(object):
         return tap_device_name
 
     def add_static_route(self, tap_device_name, fixed_ips, mac_address):
-        LOG.warning('CalicoManager::add_static_route')
+        LOG.debug('CalicoManager::add_static_route')
         result = True
         for ip_data in fixed_ips:
             ip_address = ip_data["ip_address"]


### PR DESCRIPTION
QA testing revealed that we were logging this function entry point at WARNING level.

This is a vestige of our early debugging code, and no longer needs to be logged at this high level.
