### PR TITLE
Import routes from all ethernet interfaces.

### DIFF
--- a/etc/bird/calico-bird.conf.template
+++ b/etc/bird/calico-bird.conf.template
@@ -26,7 +26,7 @@ protocol device {
 
 protocol direct {
    debug all;
-   interface "-dummy0", "dummy1", "eth0";
+   interface "-dummy0", "dummy1", "eth*";
 }
 
 # Peer with route reflector.


### PR DESCRIPTION
This resolves a problem whereby bird determines that some routes
are unreachable when they can only be accessed over interfaces
that are not named eth0.
