### PR TITLE
Install generator script and template for BIRD6 config

### DIFF
--- a/debian/calico-compute.install
+++ b/debian/calico-compute.install
@@ -6,4 +6,5 @@ usr/bin/neutron-disable-local-routing usr/bin
 usr/etc/neutron/calico_agent.ini etc/neutron
 usr/etc/neutron/rootwrap.d/calico.filters etc/neutron/rootwrap.d
 usr/bin/calico-gen-bird-conf.sh usr/bin
+usr/bin/calico-gen-bird6-conf.sh usr/bin
 usr/share/calico/* usr/share/calico

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,10 @@ data_files =
 	etc/calico.filters
         share/calico/bird =
         etc/bird/calico-bird.conf.template
+        etc/bird/calico-bird6.conf.template
 scripts = 
 	etc/calico-gen-bird-conf.sh
+	etc/calico-gen-bird6-conf.sh
 
 [global]
 setup-hooks = 


### PR DESCRIPTION
This is a missing piece of installation, that I noticed while investigating https://github.com/Metaswitch/calico/issues/14
