### PR TITLE
Fix 'pycparser' module installation issue

### DIFF
--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -6,6 +6,7 @@ posix-spawn>=0.2.post6
 datrie>=0.7
 ijson>=2.2
 msgpack-python>=0.3
+pycparser!=2.14
 pyparsing>=2.0.0
 prometheus_client>=0.0.13
 urllib3>=1.7.1


### PR DESCRIPTION
The version '2.14' is broken, see [0] for details.

[0] https://github.com/eliben/pycparser/issues/147

Change-Id: I0fca7dcce7da20c0f312310406a8622272483b58