### PR TITLE
Revert "Fix 'pycparser' module installation issue"

### DIFF
--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -6,7 +6,6 @@ posix-spawn>=0.2.post6
 datrie>=0.7
 ijson>=2.2
 msgpack-python>=0.3
-pycparser!=2.14
 pyparsing>=2.0.0
 prometheus_client>=0.0.13
 urllib3>=1.7.1


### PR DESCRIPTION
Reverts projectcalico/felix#1120

Now resolved upstream so pin should not be required: https://github.com/eliben/pycparser/issues/147