### PR TITLE
Make repo branch for coverage diff configurable

### DIFF
--- a/run-unit-test.sh
+++ b/run-unit-test.sh
@@ -34,5 +34,5 @@ tox "$@"
 source .tox/py27/bin/activate
 coverage html
 coverage xml
-diff-cover coverage.xml --compare-branch=origin/master
+diff-cover coverage.xml --compare-branch="${COMPARE_BRANCH:-origin/master}"
 deactivate


### PR DESCRIPTION
We can use some custom branch during code checkout, so let's
provide an ability for CI to redefine the branch

Env variable `COMPARE_BRANCH` can be used to re-define comparable branch