### PR TITLE
Pin pycparser version.

### DIFF
--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -7,6 +7,7 @@ datrie>=0.7
 ijson>=2.2
 msgpack-python>=0.3
 pyparsing>=2.0.0
+pycparser==2.14
 prometheus_client>=0.0.13
 urllib3>=1.7.1
 setuptools


### PR DESCRIPTION
Pinned in the tox.ini file because it's not currently a direct dependency of felix.  Installing it before installing felix itself is enough.