### PR TITLE
Do floating IP DNATs from POSTROUTING as well as from PREROUTING

### DIFF
--- a/python/calico/felix/plugins/fiptgenerator.py
+++ b/python/calico/felix/plugins/fiptgenerator.py
@@ -181,6 +181,26 @@ class FelixIptablesGenerator(FelixPlugin):
 
         return chain, deps
 
+    def nat_output_chain(self, ip_version):
+        """
+        Generate the NAT felix-OUTPUT chain.
+
+        Returns a list of iptables fragments with which to program the
+        felix-OUTPUT chain which is unconditionally invoked from the
+        NAT OUTPUT chain.
+
+        Note that the list returned here should be the complete set of rules
+        required as any existing chain will be overwritten.
+
+        :param ip_version.
+        :returns Tuple: list of rules, set of deps.
+        """
+
+        chain = ["--append %s --jump %s" % (CHAIN_OUTPUT, CHAIN_FIP_DNAT)]
+        deps = set([CHAIN_FIP_DNAT])
+
+        return chain, deps
+
     def filter_input_chain(self, ip_version, hosts_set_name=None):
         """
         Generate the IPv4/IPv6 FILTER felix-INPUT chains.

--- a/python/calico/felix/test/test_frules.py
+++ b/python/calico/felix/test/test_frules.py
@@ -84,7 +84,8 @@ class TestRules(BaseTestCase):
                                   "-j MASQUERADE",
                                   async=False),
                 call("PREROUTING --jump felix-PREROUTING", async=False),
-                call("POSTROUTING --jump felix-POSTROUTING", async=False)
+                call("POSTROUTING --jump felix-POSTROUTING", async=False),
+                call("OUTPUT --jump felix-OUTPUT", async=False)
             ]
         )
 
@@ -105,12 +106,16 @@ class TestRules(BaseTestCase):
             ],
             'felix-POSTROUTING': [
                 '--append felix-POSTROUTING --jump felix-FIP-SNAT'
+            ],
+            'felix-OUTPUT': [
+                '--append felix-OUTPUT --jump felix-FIP-DNAT'
             ]
         }
         m_v4_nat_upd.rewrite_chains.assert_called_once_with(
             expected_chains,
             {'felix-PREROUTING': set(['felix-FIP-DNAT']),
-             'felix-POSTROUTING': set(['felix-FIP-SNAT'])},
+             'felix-POSTROUTING': set(['felix-FIP-SNAT']),
+             'felix-OUTPUT': set(['felix-FIP-DNAT'])},
             async=False
         )
 
@@ -164,6 +169,7 @@ class TestRules(BaseTestCase):
             [
                 call("PREROUTING --jump felix-PREROUTING", async=False),
                 call("POSTROUTING --jump felix-POSTROUTING", async=False),
+                call("OUTPUT --jump felix-OUTPUT", async=False),
             ]
         )
 
@@ -182,12 +188,16 @@ class TestRules(BaseTestCase):
             ],
             'felix-POSTROUTING': [
                 '--append felix-POSTROUTING --jump felix-FIP-SNAT'
+            ],
+            'felix-OUTPUT': [
+                '--append felix-OUTPUT --jump felix-FIP-DNAT'
             ]
         }
         m_v6_nat_upd.rewrite_chains.assert_called_once_with(
             expected_chains, {
                 'felix-PREROUTING': set(['felix-FIP-DNAT']),
-                'felix-POSTROUTING': set(['felix-FIP-SNAT'])
+                'felix-POSTROUTING': set(['felix-FIP-SNAT']),
+                'felix-OUTPUT': set(['felix-FIP-DNAT'])
             }, async=False
         )
 
@@ -251,7 +261,8 @@ class TestRules(BaseTestCase):
         self.assertEqual(
             m_v4_nat_upd.ensure_rule_inserted.mock_calls,
             [call("PREROUTING --jump felix-PREROUTING", async=False),
-             call("POSTROUTING --jump felix-POSTROUTING", async=False)]
+             call("POSTROUTING --jump felix-POSTROUTING", async=False),
+             call("OUTPUT --jump felix-OUTPUT", async=False)]
         )
 
         m_v4_upd.ensure_rule_inserted.assert_has_calls([
@@ -300,12 +311,16 @@ class TestRules(BaseTestCase):
             ],
             'felix-POSTROUTING': [
                 '--append felix-POSTROUTING --jump felix-FIP-SNAT'
+            ],
+            'felix-OUTPUT': [
+                '--append felix-OUTPUT --jump felix-FIP-DNAT'
             ]
         }
         m_v4_nat_upd.rewrite_chains.assert_called_once_with(
             expected_chains,
             {'felix-PREROUTING': set(['felix-FIP-DNAT']),
-             'felix-POSTROUTING': set(['felix-FIP-SNAT'])},
+             'felix-POSTROUTING': set(['felix-FIP-SNAT']),
+             'felix-OUTPUT': set(['felix-FIP-DNAT'])},
             async=False
         )
 
@@ -384,7 +399,8 @@ class TestRules(BaseTestCase):
         self.assertEqual(
             m_v4_nat_upd.ensure_rule_inserted.mock_calls,
             [call("PREROUTING --jump felix-PREROUTING", async=False),
-             call("POSTROUTING --jump felix-POSTROUTING", async=False)]
+             call("POSTROUTING --jump felix-POSTROUTING", async=False),
+             call("OUTPUT --jump felix-OUTPUT", async=False)]
         )
 
         m_v4_upd.ensure_rule_inserted.assert_has_calls([
@@ -417,12 +433,16 @@ class TestRules(BaseTestCase):
             ],
             'felix-POSTROUTING': [
                 '--append felix-POSTROUTING --jump felix-FIP-SNAT'
+            ],
+            'felix-OUTPUT': [
+                '--append felix-OUTPUT --jump felix-FIP-DNAT'
             ]
         }
         m_v4_nat_upd.rewrite_chains.assert_called_once_with(
             expected_chains,
             {'felix-PREROUTING': set(['felix-FIP-DNAT']),
-             'felix-POSTROUTING': set(['felix-FIP-SNAT'])},
+             'felix-POSTROUTING': set(['felix-FIP-SNAT']),
+             'felix-OUTPUT': set(['felix-FIP-DNAT'])},
             async=False
         )
 


### PR DESCRIPTION
This is needed so that an endpoint can be pinged from its own host using
its floating IP.  One reason for wanting that is that that is what
OpenStack Tempest tests do.  More generally it adds utility without any
downside.

The PREROUTING chain is only traversed for packets that are received on
the compute host from elsewhere; so our use of PREROUTING to implement
floating IPs works for such packets, but not for packets that originate
from the compute host.  To cover the latter, we can traverse the
floating IP DNAT rules from the POSTROUTING chain as well.

Note that we also (already) do floating IP-related SNATs in the
POSTROUTING chain.  For those to operate correctly, the DNATs have to
happen first.
