### PR TITLE
Packaging: remove Python code from 'calico-common' package

### DIFF
--- a/debian/calico-common.install
+++ b/debian/calico-common.install
@@ -1,4 +1,3 @@
-usr/lib/python2.7/dist-packages/calico*
 usr/bin/calico-diags usr/bin
 usr/bin/calico-gen-bird-conf.sh usr/bin
 usr/bin/calico-gen-bird6-conf.sh usr/bin

--- a/debian/control
+++ b/debian/control
@@ -10,17 +10,7 @@ Package: calico-common
 Architecture: all
 Depends:
  ${misc:Depends},
- ${python:Depends},
- ${shlibs:Depends},
- python-pyparsing,
- python-etcd (>= 0.4.1+calico.1),
- python-ijson (>= 2.2-1),
- python-datrie (>= 0.7-1),
- python-prometheus-client (>= 0.0.13-1~ubuntu14.04.1~ppa1),
- python-setuptools,
- libyajl2 (>= 2.0.4-4),
- libdatrie1 (>= 0.2.8-1),
- python-msgpack (>= 0.3.0-1ubuntu3)
+ ${shlibs:Depends}
 Description: Project Calico virtual networking for cloud data centers.
  Project Calico is an open source solution for virtual networking in
  cloud data centers. Its IP-centric architecture offers numerous

--- a/rpm/calico.spec
+++ b/rpm/calico.spec
@@ -13,6 +13,9 @@ Source45:       calico-felix.service
 BuildArch:      x86_64
 
 
+%define _unpackaged_files_terminate_build 0
+
+
 %description
 Project Calico is an open source solution for virtual networking in
 cloud data centers. Its IP-centric architecture offers numerous
@@ -26,7 +29,6 @@ Virtualization (NFV).
 %package common
 Group:          Applications/Engineering
 Summary:        Project Calico virtual networking for cloud data centers
-Requires:       python-etcd, posix-spawn, python-setuptools
 
 %description common
 This package provides common files.
@@ -135,7 +137,6 @@ rm -rf $RPM_BUILD_ROOT
 
 %files common
 %defattr(-,root,root,-)
-%{python_sitelib}/calico*
 /usr/bin/calico-diags
 /usr/bin/calico-cleanup
 /usr/bin/calico-gen-bird-conf.sh


### PR DESCRIPTION
Continuing to include that code, in a Debian package, causes dependency
issues that are entirely spurious because we actually now use
PyInstaller to pull in all of our Python dependencies, and then wrap the
PyInstaller build into the 'calico-felix' package.  Hence we totally
don't need the Debian machinery also generating dependencies on
corresponding Python debs.

(Specifically, the remaining Python code now depends on grpcio, and it
appears that there is no python-grpcio package available in Ubuntu
Trusty.)

Therefore, this change trims 'calico-common' so that it only now
provides:

- calico-diags

- our BIRD config templates and sample shell scripts.