### PR TITLE
Fix executable paths inside Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ WORKDIR /code
 
 # Minimal dummy config
 RUN mkdir /etc/calico && echo -e "[global]\nMetadataAddr = None\nLogFilePath = None\nLogSeverityFile = None" >/etc/calico/felix.cfg
+RUN ln -s /code/calico-felix /usr/bin
+RUN ln -s /code/calico-iptables-plugin /usr/bin
 
 # Run felix by default
-CMD ["./calico-felix"]
+CMD ["calico-felix"]


### PR DESCRIPTION
The calico-felix binary wasn't able to find the calico-iptables-plugin binary because it wasn't on the path.