### PR TITLE
Allow to customize repo branch for coverage diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ help:
 all: pyinstaller deb rpm felix-docker-image
 test: ut
 
+# re-define default --compare-branch=origin/master to some custom name
+UT_COMPARE_BRANCH?=
+
 # Extract current version from the debian-style changelog and replace the
 # placeholders with the stream name.
 DEB_VERSION:=$(shell grep felix debian/changelog | \
@@ -344,7 +347,7 @@ python-ut: python/calico/felix/felixbackend_pb2.py
 	# Do the install as root.
 	docker exec felix-ut sh -c 'pip install -e .'
 	# Run the UTs as non-root.
-	docker exec --user $(MY_UID):$(MY_GID) felix-ut ./run-unit-test.sh
+	docker exec --user $(MY_UID):$(MY_GID) felix-ut sh -c 'COMPARE_BRANCH=$(UT_COMPARE_BRANCH) ./run-unit-test.sh'
 	# Tear down the container.
 	docker rm -f felix-ut
 

--- a/python/run-unit-test-tox.sh
+++ b/python/run-unit-test-tox.sh
@@ -41,5 +41,5 @@ tox "$@"
 source .tox/py27/bin/activate
 coverage html
 coverage xml
-diff-cover coverage.xml --compare-branch=origin/master
+diff-cover coverage.xml --compare-branch="${COMPARE_BRANCH:-origin/master}"
 deactivate

--- a/python/run-unit-test.sh
+++ b/python/run-unit-test.sh
@@ -26,4 +26,4 @@ coverage erase
 coverage report -m
 coverage html
 coverage xml
-diff-cover coverage.xml --compare-branch=origin/master
+diff-cover coverage.xml --compare-branch="${COMPARE_BRANCH:-origin/master}"


### PR DESCRIPTION
We can use some custom branch during code checkout, so let's
provide an ability for CI to redefine the branch, e.g.:

   make ut UT_COMPARE_BRANCH=gerrit/master

the default value is origin/master