### PR TITLE
Use local 'libcalico-go' for containerized build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ PY_FILES:=$(GENERATED_PYTHON_FILES) \
 MY_UID:=$(shell id -u)
 MY_GID:=$(shell id -g)
 
+# (optional) Local path to the repository with 'libcalico-go' code
+LIBCALICOGO_PATH?=none
+
 # Build a docker image used for building our go code into a binary.
 .PHONY: golang-build-image
 golang-build-image:
@@ -237,10 +240,13 @@ go/vendor go/vendor/.up-to-date: go/glide.lock
 	# freshness checking for us.
 	$(MAKE) golang-build-image
 	mkdir -p $$HOME/.glide
+	if [ "$(LIBCALICOGO_PATH)" != "none" ]; then \
+	  EXTRA_DOCKER_BIND="-v $(LIBCALICOGO_PATH):/go/src/github.com/projectcalico/libcalico-go:ro"; \
+	fi; \
 	$(DOCKER_RUN_RM) \
 	    --net=host \
 	    -v $${PWD}:/go/src/github.com/projectcalico/felix:rw \
-	    -v $$HOME/.glide:/.glide:rw \
+	    -v $$HOME/.glide:/.glide:rw $$EXTRA_DOCKER_BIND \
 	    -w /go/src/github.com/projectcalico/felix/go \
 	    calico/build-felix-golang \
 	    glide install --strip-vcs --strip-vendor


### PR DESCRIPTION
Add a possibility to use custom 'libcalico-go' repo
location while building binaries inside container:

 - bind additional directory with local copy of the
   repository to '/go/src/github.com/projectcalico/libcalico-go'
   folder inside Docker container;
 - modify 'glide.lock', so 'libcalico-go' module is
   taken from local path when binary is built within container
   'repo: file:///go/src/github.com/projectcalico/libcalico-go'.

With this change it's possible to build GO binaries and
test them in order to verify changes to the 'libcalico-go'.

Change-Id: I6b46e8f65c1734eea73bc12fa25ab635d940bf1d