### PR TITLE
Streamline docker images used for builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,8 @@ bin/calico-felix: $(GO_FILES) \
 	    -v $${PWD}:/go/src/github.com/projectcalico/felix:rw \
 	    calico/build-felix-golang \
 	    go build -o $@ $(LDFLAGS) "./go/felix/felix.go"
+	# Check that the executable is correctly statically linked.
+	ldd bin/calico-felix | grep -q "not a dynamic executable"
 
 # Build the pyinstaller bundle, which is an output artefact in its own right
 # as well as being the input to our Deb and RPM builds.
@@ -355,7 +357,6 @@ go-ut go/combined.coverprofile: go/vendor/.up-to-date $(GO_FILES)
 	$(DOCKER_RUN_RM) \
 	    --net=host \
 	    -v $${PWD}:/go/src/github.com/projectcalico/felix:rw \
-	    -v $$HOME/.glide:/.glide:rw \
 	    -w /go/src/github.com/projectcalico/felix/go \
 	    calico/build-felix-golang \
 	    ./run-coverage
@@ -397,6 +398,8 @@ clean:
 	       docker-build-images/passwd \
 	       docker-build-images/group \
 	       go/docs/calc.pdf \
+	       go/.glide \
+	       go/vendor \
 	       python/.tox \
 	       htmlcov \
 	       python/htmlcov

--- a/docker-build-images/golang-build.Dockerfile
+++ b/docker-build-images/golang-build.Dockerfile
@@ -1,38 +1,19 @@
-# SL6.5 has the oldest version of glibc that we support.  Build against
-# that.
-FROM ringo/scientific:6.5
+FROM golang:1.7
 
 MAINTAINER Shaun Crampton <shaun@tigera.io>
 
-# gcc for cgo
-RUN yum install -y \
-		g++ \
-		gcc \
-		libc6-dev \
-		make \
-		curl \
-		tar \
-		wget
+# Install build pre-reqs:
+# - bsdmainutils contains the "column" command, used to format the coverage
+#   data.
+RUN apt-get update && \
+    apt-get install -y bsdmainutils && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-# Install newer version of git, default version on Centos 6.6 hangs under
-# go get.
-RUN wget http://repository.it4i.cz/mirrors/repoforge/redhat/el6/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm && \
-    yum install -y rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm && \
-    yum install -y --enablerepo=rpmforge-extras git
-
-ENV GOLANG_VERSION 1.7.1
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182
-
-RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
-	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz
-
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN go get github.com/Masterminds/glide \
+           github.com/onsi/ginkgo/ginkgo \
+           github.com/onsi/gomega \
+           github.com/wadey/gocovmerge
 
 # glide requires the current user to exist inside the container, copy in
 # some user/group entries calculated by the makefile.
@@ -41,11 +22,11 @@ RUN cat /passwd >> /etc/passwd
 ADD group /group
 RUN cat /group >> /etc/group
 
-RUN go get github.com/Masterminds/glide
-RUN go get github.com/onsi/ginkgo/ginkgo
-RUN go get github.com/onsi/gomega
-RUN go get github.com/wadey/gocovmerge
+# Make sure the normal user has write access to the GOPATH.  Needs to be done
+# at the end because the above commands will write into this directory as root.
+RUN chmod -R a+wX $GOPATH /usr/local/go
 
-RUN chmod -R a+w /go
+# Disable cgo so that binaries we build will be fully static.
+ENV CGO_ENABLED=0
 
 WORKDIR /go/src/github.com/projectcalico/felix

--- a/docker-build-images/pyi/Dockerfile
+++ b/docker-build-images/pyi/Dockerfile
@@ -1,25 +1,6 @@
-# SL6.5 has the oldest version of glibc that we support.  Build against that.
-FROM ringo/scientific:6.5
+# Build against wheezy for broadest libc compatibility.
+FROM python:2.7-wheezy
 MAINTAINER Shaun Crampton shaun@tigera.io
-
-# Install build prereqs.
-RUN yum -y groupinstall "Development tools"; \
-    yum -y install zlib-devel bzip2-devel openssl-devel ncurses-devel \
-                   sqlite-devel iptables-ipv6 ipset iptables libffi-devel \
-                   libffi yajl
-
-# Build Python.
-ENV PY_VERSION=2.7.11
-ADD docker-build-images/pyi/get-prereqs.sh get-prereqs.sh
-ADD docker-build-images/pyi/build-prereqs.sh build-prereqs.sh
-RUN ./get-prereqs.sh && \
-    ./build-prereqs.sh
-ENV LD_LIBRARY_PATH=/usr/local/lib
-
-# Install newer version of git, needed for diff-cover.
-RUN wget http://repository.it4i.cz/mirrors/repoforge/redhat/el6/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm && \
-    yum install -y rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm && \
-    yum install -y --enablerepo=rpmforge-extras git
 
 # Install Calico pre-reqs.
 RUN pip install pyinstaller
@@ -29,7 +10,8 @@ RUN pip install pyinstaller
 ADD python/requirements_frozen.txt python/requirements_frozen.txt
 RUN pip install -U -r python/requirements_frozen.txt
 
-# tox needs the current user to exist in /etc/passwd for some reason.
+# To run some commands (git, tox) as non-root user, we need to have a valid
+# passwd/group file.
 ADD docker-build-images/passwd /passwd
 RUN cat /passwd >> /etc/passwd
 ADD docker-build-images/group /group

--- a/go/run-coverage
+++ b/go/run-coverage
@@ -8,7 +8,7 @@ find . -name "*.coverprofile" -type f -delete
 
 echo "Calculating packages to cover..."
 go_dirs=$(find -type f -name '*.go' | \
-	      grep -vE '/vendor/|felix/proto' | \
+	      grep -vE '/vendor/|felix/proto|.glide' | \
 	      xargs -n 1 dirname | \
 	      sort | uniq | \
 	      tr '\n' ',' | \


### PR DESCRIPTION
- Use `python:2.7-wheezy` for pyinstaller build.  
- Use `golang:1.7` (jessie-based) for go builds and disable cgo to get a fully static executable.