### PR TITLE
[DO NOT MERGE] Pin libcalico-go to v1.0.0-beta-rc1

### DIFF
--- a/go/glide.yaml
+++ b/go/glide.yaml
@@ -22,6 +22,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
+  version: v1.0.0-beta-rc1
   subpackages:
   - lib
 - package: github.com/Sirupsen/logrus


### PR DESCRIPTION
PR is only to trigger CI.