### PR TITLE
Improve early logging configuration.

### DIFF
--- a/go/felix/felix.go
+++ b/go/felix/felix.go
@@ -100,6 +100,12 @@ configRetry:
 		}
 		// Parse and merge the local config.
 		configParams.UpdateFrom(envConfig, config.EnvironmentVariable)
+		if configParams.Err != nil {
+			log.WithError(configParams.Err).WithField("configFile", configFile).Error(
+				"Failed to parse configuration environment variable")
+			time.Sleep(1 * time.Second)
+			continue configRetry
+		}
 		configParams.UpdateFrom(fileConfig, config.ConfigFile)
 		if configParams.Err != nil {
 			log.WithError(configParams.Err).WithField("configFile", configFile).Error(


### PR DESCRIPTION
- Default to logging errors.
- Provide an override environment variable that allows early logging to be
  turned off or increased. (FELIX_EARLYLOGSEVERITYSCREEN)

Fixes #1156
Fixes #804