### PR TITLE
Pass through IP pools to the dataplane driver.

### DIFF
--- a/go/felix/calc/calc_graph.go
+++ b/go/felix/calc/calc_graph.go
@@ -168,7 +168,7 @@ func NewCalculationGraph(callbacks PipelineCallbacks, hostname string) (allUpdDi
 	polResolver.Callbacks = callbacks
 
 	// Register for host IP updates.
-	hostIPPassthru := NewHostIPPassthru(callbacks)
+	hostIPPassthru := NewDataplanePassthru(callbacks)
 	hostIPPassthru.RegisterWith(allUpdDispatcher)
 
 	// Register for config updates.
@@ -191,7 +191,7 @@ type DataplanePassthru struct {
 	callbacks passthruCallbacks
 }
 
-func NewHostIPPassthru(callbacks passthruCallbacks) *DataplanePassthru {
+func NewDataplanePassthru(callbacks passthruCallbacks) *DataplanePassthru {
 	return &DataplanePassthru{callbacks: callbacks}
 }
 
@@ -205,15 +205,19 @@ func (h *DataplanePassthru) OnUpdate(update api.Update) (filterOut bool) {
 	case model.HostIPKey:
 		hostname := key.Hostname
 		if update.Value == nil {
+			log.WithField("update", update).Debug("Passing-through HostIP deletion")
 			h.callbacks.OnHostIPRemove(hostname)
 		} else {
+			log.WithField("update", update).Debug("Passing-through HostIP update")
 			ip := update.Value.(*net.IP)
 			h.callbacks.OnHostIPUpdate(hostname, ip)
 		}
 	case model.IPPoolKey:
 		if update.Value == nil {
+			log.WithField("update", update).Debug("Passing-through IPPool deletion")
 			h.callbacks.OnIPPoolRemove(key)
 		} else {
+			log.WithField("update", update).Debug("Passing-through IPPool update")
 			pool := update.Value.(*model.IPPool)
 			h.callbacks.OnIPPoolUpdate(key, pool)
 		}

--- a/go/felix/calc/calc_graph_test.go
+++ b/go/felix/calc/calc_graph_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calc_test
+
+import (
+	. "github.com/projectcalico/felix/go/felix/calc"
+
+	"github.com/Sirupsen/logrus"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/felix/go/felix/proto"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"reflect"
+)
+
+var testIP = mustParseIP("10.0.0.1")
+
+var _ = DescribeTable("Calculation graph pass-through tests",
+	func(key model.Key, input interface{}, expUpdate interface{}, expRemove interface{}) {
+		// Create a calculation graph/event buffer combo.
+		eb := NewEventBuffer(nil)
+		var messageReceived interface{}
+		eb.Callback = func(message interface{}) {
+			logrus.WithField("message", message).Info("Received message")
+			messageReceived = message
+		}
+		cg := NewCalculationGraph(eb, "hostname")
+
+		// Send in the update and flush the buffer.  It should deposit the message
+		// via our callback.
+		By("Emitting correct update")
+		cg.OnUpdate(api.Update{
+			UpdateType: api.UpdateTypeKVNew,
+			KVPair: model.KVPair{
+				Key:   key,
+				Value: input,
+			},
+		})
+		eb.Flush()
+		Expect(reflect.ValueOf(messageReceived).Elem().Interface()).To(Equal(expUpdate))
+
+		// Send in the delete and flush the buffer.  It should deposit the message
+		// via our callback.
+		By("Emitting correct remove")
+		cg.OnUpdate(api.Update{
+			UpdateType: api.UpdateTypeKVDeleted,
+			KVPair: model.KVPair{
+				Key:   key,
+				Value: nil,
+			},
+		})
+		eb.Flush()
+		Expect(reflect.ValueOf(messageReceived).Elem().Interface()).To(Equal(expRemove))
+	},
+	Entry("IPPool",
+		model.IPPoolKey{CIDR: mustParseNet("10.0.0.0/16")},
+		&model.IPPool{
+			CIDR: mustParseNet("10.0.0.0/16"),
+		},
+		proto.IPAMPoolUpdate{
+			Id: "10.0.0.0-16",
+			Pool: &proto.IPAMPool{
+				Cidr:       "10.0.0.0/16",
+				Masquerade: false,
+			},
+		},
+		proto.IPAMPoolRemove{
+			Id: "10.0.0.0-16",
+		}),
+	Entry("IPPool masquerade",
+		model.IPPoolKey{CIDR: mustParseNet("10.0.0.0/16")},
+		&model.IPPool{
+			CIDR:       mustParseNet("10.0.0.0/16"),
+			Masquerade: true,
+		},
+		proto.IPAMPoolUpdate{
+			Id: "10.0.0.0-16",
+			Pool: &proto.IPAMPool{
+				Cidr:       "10.0.0.0/16",
+				Masquerade: true,
+			},
+		},
+		proto.IPAMPoolRemove{
+			Id: "10.0.0.0-16",
+		}),
+	Entry("HostIP",
+		model.HostIPKey{Hostname: "foo"},
+		&testIP,
+		proto.HostMetadataUpdate{
+			Hostname: "foo",
+			Ipv4Addr: "10.0.0.1",
+		},
+		proto.HostMetadataRemove{
+			Hostname: "foo",
+		}),
+)

--- a/go/felix/calc/event_buffer.go
+++ b/go/felix/calc/event_buffer.go
@@ -312,6 +312,10 @@ func (buf *EventBuffer) OnEndpointTierUpdate(endpointKey model.Key,
 }
 
 func (buf *EventBuffer) OnHostIPUpdate(hostname string, ip *net.IP) {
+	log.WithFields(log.Fields{
+		"hostname": hostname,
+		"ip":       ip,
+	}).Debug("HostIP update")
 	buf.pendingUpdates = append(buf.pendingUpdates,
 		&proto.HostMetadataUpdate{
 			Hostname: hostname,
@@ -320,6 +324,7 @@ func (buf *EventBuffer) OnHostIPUpdate(hostname string, ip *net.IP) {
 }
 
 func (buf *EventBuffer) OnHostIPRemove(hostname string) {
+	log.WithField("hostname", hostname).Debug("HostIP removed")
 	buf.pendingUpdates = append(buf.pendingUpdates,
 		&proto.HostMetadataRemove{
 			Hostname: hostname,
@@ -327,6 +332,10 @@ func (buf *EventBuffer) OnHostIPRemove(hostname string) {
 }
 
 func (buf *EventBuffer) OnIPPoolUpdate(key model.IPPoolKey, pool *model.IPPool) {
+	log.WithFields(log.Fields{
+		"key":  key,
+		"pool": pool,
+	}).Debug("IPPool update")
 	buf.pendingUpdates = append(buf.pendingUpdates,
 		&proto.IPAMPoolUpdate{
 			Id: cidrToIPPoolID(key),
@@ -338,6 +347,7 @@ func (buf *EventBuffer) OnIPPoolUpdate(key model.IPPoolKey, pool *model.IPPool) 
 }
 
 func (buf *EventBuffer) OnIPPoolRemove(key model.IPPoolKey) {
+	log.WithField("key", key).Debug("IPPool removed")
 	buf.pendingUpdates = append(buf.pendingUpdates,
 		&proto.IPAMPoolRemove{
 			Id: cidrToIPPoolID(key),

--- a/go/felix/felix.go
+++ b/go/felix/felix.go
@@ -626,6 +626,10 @@ func (fc *DataplaneConn) marshalToDataplane(msg interface{}) {
 		envelope.Payload = &proto.ToDataplane_HostMetadataUpdate{msg}
 	case *proto.HostMetadataRemove:
 		envelope.Payload = &proto.ToDataplane_HostMetadataRemove{msg}
+	case *proto.IPAMPoolUpdate:
+		envelope.Payload = &proto.ToDataplane_IpamPoolUpdate{msg}
+	case *proto.IPAMPoolRemove:
+		envelope.Payload = &proto.ToDataplane_IpamPoolRemove{msg}
 	default:
 		log.WithField("msg", msg).Panic("Unknown message type")
 	}

--- a/python/calico/felix/masq.py
+++ b/python/calico/felix/masq.py
@@ -63,6 +63,9 @@ class MasqueradeManager(Actor):
                 _log.info("IPAM pool deleted: %s", pool_id)
                 del self.pools_by_id[pool_id]
             else:
+                if ":" in pool["cidr"]:
+                    _log.debug("Ignoring IPv6 pool: %s", pool_id)
+                    return
                 _log.info("IPAM pool %s updated: %s", pool_id, pool)
                 self.pools_by_id[pool_id] = pool
             self._dirty = True


### PR DESCRIPTION
Tests completed:
- Ran against an old etcd that had a bunch of pools from some old testing.
- Checked ipsets correctly rendered.
- Toggled masquerade bit on a pool on and off and saw it added/removed from the pool.

Fixes https://github.com/projectcalico/calico-containers/issues/1249.