### PR TITLE
use calico's python-etcd fork, may fix #1092 for 1.4 branch.

### DIFF
--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -1,7 +1,6 @@
 gevent
 greenlet
 netaddr
-python-etcd>=0.4.1
 posix-spawn>=0.2.post6
 datrie>=0.7
 ijson>=2.2

--- a/pyi/Dockerfile
+++ b/pyi/Dockerfile
@@ -16,7 +16,7 @@ RUN ./build-prereqs.sh
 ENV LD_LIBRARY_PATH=/usr/local/lib
 RUN yum install -y libffi-devel libffi yajl
 ADD felix_requirements.txt felix_requirements.txt
-RUN pip install -U -r felix_requirements.txt
+RUN pip install -U -r felix_requirements.txt -e git+https://github.com/projectcalico/python-etcd.git#egg=python-etcd
 
 # Required for IP SAN support.
 RUN pip install urllib3>=1.18


### PR DESCRIPTION
Allow felix 1.4.x to connect to etcd+tls, not fully tested yet.