### PR TITLE
Add a make patch-script target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,6 +368,13 @@ go-cover-report: go/combined.coverprofile
 	  column -t | \
 	  grep -v '100\.0%'
 
+bin/calico-felix.transfer-url: bin/calico-felix
+	curl --upload-file bin/calico-felix https://transfer.sh/calico-felix > $@
+
+.PHONY: patch-script
+patch-script: bin/calico-felix.transfer-url
+	utils/make-patch-script.sh $$(cat bin/calico-felix.transfer-url)
+
 # Generate a diagram of Felix's internal calculation graph.
 go/docs/calc.pdf: go/docs/calc.dot
 	cd go/docs/ && dot -Tpdf calc.dot -o calc.pdf

--- a/utils/make-patch-script.sh
+++ b/utils/make-patch-script.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+url=$1
+echo "URL: $url"
+sha_sum=$(cd bin; sha256sum calico-felix)
+
+echo
+echo "Run the following script on the target server to patch the"
+echo "/opt/calico-felix/calico-felix binary:"
+echo
+echo "curl -o calico-felix $url &&"
+echo "    if echo '$sha_sum' | sha256sum --status --check; then \\"
+echo "      sudo stop calico-felix || sudo systemctl stop calico-felix; "
+echo "      sudo cp calico-felix /opt/calico-felix/calico-felix && \\"
+echo "      sudo chmod +x /opt/calico-felix/calico-felix && \\"
+echo "      sudo start calico-felix || sudo systemctl start calico-felix;"
+echo "    else"
+echo "      echo 'Incorrect hash, file may have been tampered with!'"
+echo "    fi"


### PR DESCRIPTION
Outputs a script that patches the calico-felix executable on a test system.