### PR TITLE
Configure an option to append or insert the iptables rules generated

### DIFF
--- a/go/felix/config/config_params.go
+++ b/go/felix/config/config_params.go
@@ -115,7 +115,7 @@ type Config struct {
 
 	InterfacePrefix string `config:"iface-list;cali;non-zero,die-on-fail"`
 
-  ChainInsertMode             string `config:"oneof(insert,append);insert;non-zero;die-on-fail"`
+	ChainInsertMode             string `config:"oneof(insert,append);insert;non-zero;die-on-fail"`
 	DefaultEndpointToHostAction string `config:"oneof(DROP,RETURN,ACCEPT);DROP;non-zero,die-on-fail"`
 	DropActionOverride          string `config:"oneof(DROP,ACCEPT,LOG-and-DROP,LOG-and-ACCEPT);DROP;non-zero,die-on-fail"`
 

--- a/go/felix/config/config_params.go
+++ b/go/felix/config/config_params.go
@@ -115,7 +115,7 @@ type Config struct {
 
 	InterfacePrefix string `config:"iface-list;cali;non-zero,die-on-fail"`
 
-	ChainInsertMode             string `config:"oneof(insert,append);insert;non-zero;die-on-fail"`
+	ChainInsertMode             string `config:"oneof(insert,append);insert;non-zero,die-on-fail"`
 	DefaultEndpointToHostAction string `config:"oneof(DROP,RETURN,ACCEPT);DROP;non-zero,die-on-fail"`
 	DropActionOverride          string `config:"oneof(DROP,ACCEPT,LOG-and-DROP,LOG-and-ACCEPT);DROP;non-zero,die-on-fail"`
 

--- a/go/felix/config/config_params.go
+++ b/go/felix/config/config_params.go
@@ -115,6 +115,7 @@ type Config struct {
 
 	InterfacePrefix string `config:"iface-list;cali;non-zero,die-on-fail"`
 
+  ChainInsertMode             string `config:"oneof(insert,append);insert;non-zero;die-on-fail"`
 	DefaultEndpointToHostAction string `config:"oneof(DROP,RETURN,ACCEPT);DROP;non-zero,die-on-fail"`
 	DropActionOverride          string `config:"oneof(DROP,ACCEPT,LOG-and-DROP,LOG-and-ACCEPT);DROP;non-zero,die-on-fail"`
 

--- a/go/felix/config/config_params_test.go
+++ b/go/felix/config/config_params_test.go
@@ -62,7 +62,9 @@ var _ = DescribeTable("Config parsing",
 	Entry("InterfacePrefix list", "InterfacePrefix", "tap,cali", "tap,cali"),
 
 	Entry("ChainInsertMode", "ChainInsertMode", "insert", "insert"),
-	Entry("ChainInsertMode", "ChainInsertMode", "append", "append"),
+	Entry("ChainInsertMode insert", "ChainInsertMode", "insert", "insert"),
+	Entry("ChainInsertMode append", "ChainInsertMode", "append", "append"),
+
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",
 		"RETURN", "RETURN"),
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",

--- a/go/felix/config/config_params_test.go
+++ b/go/felix/config/config_params_test.go
@@ -61,8 +61,8 @@ var _ = DescribeTable("Config parsing",
 	Entry("InterfacePrefix", "InterfacePrefix", "tap", "tap"),
 	Entry("InterfacePrefix list", "InterfacePrefix", "tap,cali", "tap,cali"),
 
-  Entry("ChainInsertMode", "ChainInsertMode", "insert", "insert")
-  Entry("ChainInsertMode", "ChainInsertMode", "append", "append")
+	Entry("ChainInsertMode", "ChainInsertMode", "insert", "insert")
+	Entry("ChainInsertMode", "ChainInsertMode", "append", "append")
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",
 		"RETURN", "RETURN"),
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",

--- a/go/felix/config/config_params_test.go
+++ b/go/felix/config/config_params_test.go
@@ -61,8 +61,8 @@ var _ = DescribeTable("Config parsing",
 	Entry("InterfacePrefix", "InterfacePrefix", "tap", "tap"),
 	Entry("InterfacePrefix list", "InterfacePrefix", "tap,cali", "tap,cali"),
 
-	Entry("ChainInsertMode", "ChainInsertMode", "insert", "insert")
-	Entry("ChainInsertMode", "ChainInsertMode", "append", "append")
+	Entry("ChainInsertMode", "ChainInsertMode", "insert", "insert"),
+	Entry("ChainInsertMode", "ChainInsertMode", "append", "append"),
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",
 		"RETURN", "RETURN"),
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",

--- a/go/felix/config/config_params_test.go
+++ b/go/felix/config/config_params_test.go
@@ -61,8 +61,7 @@ var _ = DescribeTable("Config parsing",
 	Entry("InterfacePrefix", "InterfacePrefix", "tap", "tap"),
 	Entry("InterfacePrefix list", "InterfacePrefix", "tap,cali", "tap,cali"),
 
-	Entry("ChainInsertMode", "ChainInsertMode", "insert", "insert"),
-	Entry("ChainInsertMode insert", "ChainInsertMode", "insert", "insert"),
+	Entry("ChainInsertMode", "ChainInsertMode", "", "insert"),
 	Entry("ChainInsertMode append", "ChainInsertMode", "append", "append"),
 
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",

--- a/go/felix/config/config_params_test.go
+++ b/go/felix/config/config_params_test.go
@@ -61,6 +61,8 @@ var _ = DescribeTable("Config parsing",
 	Entry("InterfacePrefix", "InterfacePrefix", "tap", "tap"),
 	Entry("InterfacePrefix list", "InterfacePrefix", "tap,cali", "tap,cali"),
 
+  Entry("ChainInsertMode", "ChainInsertMode", "insert", "insert")
+  Entry("ChainInsertMode", "ChainInsertMode", "append", "append")
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",
 		"RETURN", "RETURN"),
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",

--- a/go/felix/config/config_params_test.go
+++ b/go/felix/config/config_params_test.go
@@ -61,7 +61,6 @@ var _ = DescribeTable("Config parsing",
 	Entry("InterfacePrefix", "InterfacePrefix", "tap", "tap"),
 	Entry("InterfacePrefix list", "InterfacePrefix", "tap,cali", "tap,cali"),
 
-	Entry("ChainInsertMode", "ChainInsertMode", "", "insert"),
 	Entry("ChainInsertMode append", "ChainInsertMode", "append", "append"),
 
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",

--- a/python/calico/felix/config.py
+++ b/python/calico/felix/config.py
@@ -273,6 +273,10 @@ class Config(object):
                            "attempt to detect whether the system supports "
                            "IPv6 and use it if it does.",
                            "auto")
+        self.add_parameter("ChainInsertMode",
+                           "Whether to insert the felix chains or append them."
+                           "one of: insert, append. Defaults to insert.",
+                           "insert")
 
         # The following setting determines which flavour of Iptables Generator
         # plugin is loaded.  Note: this plugin support is currently highly
@@ -344,6 +348,7 @@ class Config(object):
         self.ACTION_ON_DROP = self.parameters["DropActionOverride"].value
         self.IGNORE_LOOSE_RPF = self.parameters["IgnoreLooseRPF"].value
         self.IPV6_SUPPORT = self.parameters["Ipv6Support"].value.lower()
+        self.CHAIN_INSERT_MODE = self.parameters["ChainInsertMode"].value
 
         self._validate_cfg(final=final)
 
@@ -531,6 +536,12 @@ class Config(object):
             log.warning("Unrecognized value for Ipv6Support (%s), "
                         "defaulting to 'auto'", self.IPV6_SUPPORT)
             self.IPV6_SUPPORT = "auto"
+
+        if self.CHAIN_INSERT_MODE not in ("insert", "append"):
+            raise ConfigException(
+                "Invalid field value",
+                self.parameters["ChainInsertMode"]
+            )
 
         if not final:
             # Do not check that unset parameters are defaulted; we have more


### PR DESCRIPTION
Configure an option to append or insert the iptables rules generated
by calico-felix.

This helps to solve https://github.com/projectcalico/felix/issues/1118

Change-Id: I7986a8a2fce17771d4c515239eacbf930820fb51