### PR TITLE
Make rule generation tolerate missing IP version for ICMP.

### DIFF
--- a/python/calico/felix/plugins/fiptgenerator.py
+++ b/python/calico/felix/plugins/fiptgenerator.py
@@ -562,8 +562,8 @@ class FelixIptablesGenerator(FelixPlugin):
         return set([self._profile_to_chain_name("inbound", profile_id),
                     self._profile_to_chain_name("outbound", profile_id)])
 
-    def profile_updates(self, profile_id, profile, ip_version, tag_to_ipset,
-                        selector_to_ipset, comment_tag=None):
+    def profile_updates(self, profile_id, profile, ip_version, ipset_id_to_name,
+                        comment_tag=None):
         """
         Generate a set of iptables updates that will program all of the chains
         needed for a given profile.
@@ -589,14 +589,11 @@ class FelixIptablesGenerator(FelixPlugin):
 
             fragments = []
             for r in rules:
-                rule_version = r.get('ip_version')
-                if rule_version is None or rule_version == ip_version:
-                    fragments.extend(self._rule_to_iptables_fragments(
-                        chain_name,
-                        r,
-                        ip_version,
-                        tag_to_ipset,
-                        selector_to_ipset))
+                fragments.extend(self._rule_to_iptables_fragments(
+                    chain_name,
+                    r,
+                    ip_version,
+                    ipset_id_to_name))
             updates[chain_name] = fragments
 
         return updates, deps
@@ -842,7 +839,7 @@ class FelixIptablesGenerator(FelixPlugin):
                                                  inbound_or_outbound[:1])
 
     def _rule_to_iptables_fragments(self, chain_name, rule, ip_version,
-                                    tag_to_ipset, selector_to_ipset):
+                                    ipset_id_to_name):
         """
         Convert a rule dict to a list of iptables fragments suitable to use
         with iptables-restore.
@@ -853,8 +850,8 @@ class FelixIptablesGenerator(FelixPlugin):
                the --append)
         :param dict[str,str|list|int] rule: Rule dict.
         :param ip_version.  Whether these are for the IPv4 or IPv6 iptables.
-        :param dict[str] tag_to_ipset: dictionary mapping from tag key to ipset
-               name.
+        :param dict[str] ipset_id_to_name: dictionary mapping from IP set ID to
+               name of IP set in the dataplane.
         :param dict[SelectorExpression,str] selector_to_ipset: dict mapping
                from selector to the name of the ipset that represents it.
         :return list[str]: iptables --append fragments.
@@ -863,6 +860,23 @@ class FelixIptablesGenerator(FelixPlugin):
         # Check we've not got any unknown fields.
         unknown_keys = set(rule.keys()) - KNOWN_RULE_KEYS
         assert not unknown_keys, "Unknown keys: %s" % ", ".join(unknown_keys)
+
+        # Since the names of the ICMP and ICMPv6 protocols are different in our
+        # datamodel, default the IP version to the correct value for the
+        # version of ICMP so that we won't try to render an ICMPv6 rule on IPv4
+        # or vice-versa.
+        implicit_rule_version = ip_version
+        if rule.get("protocol") == "icmp":
+            _log.debug("Rule is an ICMP rule, forcing IP version to 4")
+            implicit_rule_version = 4
+        elif rule.get("protocol") == "icmpv6":
+            _log.debug("Rule is an ICMPv6 rule, forcing IP version to 6")
+            implicit_rule_version = 6
+        rule_version = rule.get("ip_version", implicit_rule_version)
+
+        if rule_version != ip_version:
+            _log.debug("Rule's IP version doesn't match this chain, skipping")
+            return []
 
         # Ports are special, we have a limit on the number of ports that can go
         # in one rule so we need to break up rules with a lot of ports into
@@ -886,8 +900,7 @@ class FelixIptablesGenerator(FelixPlugin):
                     chain_name,
                     rule_copy,
                     ip_version,
-                    tag_to_ipset,
-                    selector_to_ipset)
+                    ipset_id_to_name)
                 fragments.extend(frags)
 
             return fragments
@@ -933,7 +946,7 @@ class FelixIptablesGenerator(FelixPlugin):
         return chunks
 
     def _rule_to_iptables_fragments_inner(self, chain_name, rule, ip_version,
-                                          tag_to_ipset, selector_to_ipset):
+                                          ipset_id_to_name):
         """
         Convert a rule dict to iptables fragments suitable to use with
         iptables-restore.
@@ -942,10 +955,8 @@ class FelixIptablesGenerator(FelixPlugin):
                 the --append)
         :param dict rule: Rule dict.
         :param ip_version.  Whether these are for the IPv4 or IPv6 iptables.
-        :param dict[str] tag_to_ipset: dictionary mapping from tag key to ipset
-               name.
-        :param dict[SelectorExpression,str] selector_to_ipset: dict mapping
-               from selector to the name of the ipset that represents it.
+        :param dict[str] ipset_id_to_name: dictionary mapping from IP set ID
+               to name used in the dataplane.
         :returns list[str]: list of iptables --append fragments.
         """
 
@@ -979,7 +990,7 @@ class FelixIptablesGenerator(FelixPlugin):
                 # Pre-calculated ipsets.
                 ipsets_key = neg_pfx + dirn + "_ip_set_ids"
                 for ipset_id in rule.get(ipsets_key) or []:
-                    ipset_name = tag_to_ipset[ipset_id]
+                    ipset_name = ipset_id_to_name[ipset_id]
                     append("--match set",
                            neg_pfx, "--match-set", ipset_name, dirn)
 

--- a/python/calico/felix/profilerules.py
+++ b/python/calico/felix/profilerules.py
@@ -263,9 +263,9 @@ class ProfileRules(RefCountedActor):
         _log.info("%s Programming iptables with our chains.", self)
         assert self._pending_profile is not None, \
             "_update_chains called with no _pending_profile"
-        tag_or_sel_to_ip_set_name = {}
+        ipset_id_to_name = {}
         for tag_or_sel, ipset in self._ipset_refs.iteritems():
-            tag_or_sel_to_ip_set_name[tag_or_sel] = ipset.ipset_name
+            ipset_id_to_name[tag_or_sel] = ipset.ipset_name
 
         _log.info("Updating chains for profile %s", self.id)
         _log.debug("Profile %s: %s", self.id, self._profile)
@@ -274,8 +274,7 @@ class ProfileRules(RefCountedActor):
             self.id,
             self._pending_profile,
             self.ip_version,
-            tag_to_ipset=tag_or_sel_to_ip_set_name,
-            selector_to_ipset=tag_or_sel_to_ip_set_name,
+            ipset_id_to_name=ipset_id_to_name,
             comment_tag=self.id)
 
         _log.debug("Queueing programming for rules %s: %s", self.id,

--- a/python/calico/felix/test/test_fiptgenerator.py
+++ b/python/calico/felix/test/test_fiptgenerator.py
@@ -75,22 +75,21 @@ INPUT_CHAINS = {
     ]
 }
 
-SELECTOR_A_EQ_B = "a == 'b'"
+IPSET_ID = "s:abcdefg1234567890_-"
 
 RULES_TESTS = [
     {
         "ip_version": 4,
-        "tag_to_ipset": {},
-        "sel_to_ipset": {SELECTOR_A_EQ_B: "a-eq-b"},
+        "tag_to_ipset": {IPSET_ID: "felix-_123456"},
         "profile": {
             "id": "prof1",
             "inbound_rules": [
-                {"src_selector": SELECTOR_A_EQ_B,
+                {"src_ip_set_ids": [IPSET_ID],
                  "log_prefix": "foo",
                  "action": "next-tier"}
             ],
             "outbound_rules": [
-                {"dst_selector": SELECTOR_A_EQ_B,
+                {"dst_ip_set_ids": [IPSET_ID],
                  "action": "next-tier"}
             ]
         },
@@ -98,7 +97,7 @@ RULES_TESTS = [
             'felix-p-prof1-i':
                 [
                     '--append felix-p-prof1-i '
-                    '--match set --match-set a-eq-b src '
+                    '--match set --match-set felix-_123456 src '
                     '--jump MARK --set-mark 0x2000000/0x2000000',
                     '--append felix-p-prof1-i --match mark '
                     '--mark 0x2000000/0x2000000 --jump LOG '
@@ -109,7 +108,7 @@ RULES_TESTS = [
             'felix-p-prof1-o':
                 [
                     '--append felix-p-prof1-o '
-                    '--match set --match-set a-eq-b dst '
+                    '--match set --match-set felix-_123456 dst '
                     '--jump MARK --set-mark 0x2000000/0x2000000',
                     '--append felix-p-prof1-o --match mark '
                     '--mark 0x2000000/0x2000000 --jump RETURN',
@@ -144,19 +143,20 @@ RULES_TESTS = [
     },
     {
         "ip_version": 4,
-        "tag_to_ipset": {"tag1": "t1", "tag2": "t2"},
-        "sel_to_ipset": {SELECTOR_A_EQ_B: "a-eq-b"},
+        "tag_to_ipset": {
+            "tag1": "t1",
+            "tag2": "t2",
+            IPSET_ID: "felix-_123456",
+        },
         "profile": {
             "id": "prof1",
             "inbound_rules": [
                 {"protocol": "tcp",
                  "src_net": "10.0.0.0/8",
-                 "src_tag": "tag1",
-                 "src_selector": SELECTOR_A_EQ_B,
+                 "src_ip_set_ids": ["tag1", IPSET_ID],
                  "src_ports": [1, "2:3"],
                  "!src_net": "11.0.0.0/8",
-                 "!src_tag": "tag2",
-                 "!src_selector": SELECTOR_A_EQ_B,
+                 "!src_ip_set_ids": ["tag2", IPSET_ID],
                  "!src_ports": [1, "2:3", 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
                                 14, 15, 16, 17],
                  "action": "next-tier",}
@@ -164,12 +164,10 @@ RULES_TESTS = [
             "outbound_rules": [
                 {"protocol": "udp",
                  "dst_net": "10.0.0.0/8",
-                 "dst_tag": "tag1",
-                 "dst_selector": SELECTOR_A_EQ_B,
+                 "dst_ip_set_ids": ["tag1", IPSET_ID],
                  "dst_ports": [1, "2:3"],
                  "!dst_net": "11.0.0.0/8",
-                 "!dst_tag": "tag2",
-                 "!dst_selector": SELECTOR_A_EQ_B,
+                 "!dst_ip_set_ids": ["tag2", IPSET_ID],
                  "!dst_ports": [1, "2:3", 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
                                 14, 15, 16, 17],
                  "action": "next-tier",}
@@ -181,11 +179,11 @@ RULES_TESTS = [
                 ' --protocol tcp'
                 ' --source 10.0.0.0/8'
                 ' --match set --match-set t1 src'
-                ' --match set --match-set a-eq-b src'
+                ' --match set --match-set felix-_123456 src'
                 ' --match multiport --source-ports 1,2:3'
                 ' ! --source 11.0.0.0/8'
                 ' --match set ! --match-set t2 src'
-                ' --match set ! --match-set a-eq-b src'
+                ' --match set ! --match-set felix-_123456 src'
                 ' --match multiport ! --source-ports'
                 ' 1,2:3,4,5,6,7,8,9,10,11,12,13,14,15'
                 ' --match multiport ! --source-ports 16,17'
@@ -199,11 +197,11 @@ RULES_TESTS = [
                 ' --protocol udp'
                 ' --destination 10.0.0.0/8'
                 ' --match set --match-set t1 dst'
-                ' --match set --match-set a-eq-b dst'
+                ' --match set --match-set felix-_123456 dst'
                 ' --match multiport --destination-ports 1,2:3'
                 ' ! --destination 11.0.0.0/8'
                 ' --match set ! --match-set t2 dst'
-                ' --match set ! --match-set a-eq-b dst'
+                ' --match set ! --match-set felix-_123456 dst'
                 ' --match multiport ! --destination-ports'
                 ' 1,2:3,4,5,6,7,8,9,10,11,12,13,14,15'
                 ' --match multiport ! --destination-ports 16,17'
@@ -216,8 +214,7 @@ RULES_TESTS = [
     },
     {
         "ip_version": 4,
-        "tag_to_ipset": {"tag1": "t1", "tag2": "t2"},
-        "sel_to_ipset": {SELECTOR_A_EQ_B: "a-eq-b"},
+        "tag_to_ipset": {"tag1": "t1", "tag2": "t2", IPSET_ID: "felix-_123456"},
         "profile": {
             "id": "prof1",
             "inbound_rules": [
@@ -363,6 +360,69 @@ RULES_TESTS = [
                     "1234::beef --match icmp6 --icmpv6-type 7 "
                     "--jump DROP",
                 ]
+        },
+    },
+
+    # Test that ICMPv6 rules are ignored when rendering IPv4 rules.
+    {
+        "ip_version": 4,
+        "tag_to_ipset": {},
+        "profile": {
+            "id": "prof1",
+            "inbound_rules": [
+                {
+                    "protocol": "icmp",
+                    "icmp_type": 8,
+                }
+            ],
+            "outbound_rules": [
+                {
+                    "protocol": "icmpv6",
+                    "icmp_type": 8,
+                }
+            ]
+        },
+        "updates": {
+            'felix-p-prof1-i':
+                [
+                    "--append felix-p-prof1-i --protocol icmp "
+                    "--match icmp --icmp-type 8 --jump MARK "
+                    "--set-mark 0x1000000/0x1000000",
+                    '--append felix-p-prof1-i --match mark '
+                    '--mark 0x1000000/0x1000000 --jump RETURN',
+                ],
+            'felix-p-prof1-o': []
+        },
+    },
+
+    # Test that ICMPv4 rules are ignored when rendering IPv6 rules.
+    {
+        "ip_version": 6,
+        "tag_to_ipset": {},
+        "profile": {
+            "id": "prof1",
+            "inbound_rules": [
+                {
+                    "protocol": "icmp",
+                    "icmp_type": 8,
+                }
+            ],
+            "outbound_rules": [
+                {
+                    "protocol": "icmpv6",
+                    "icmp_type": 8,
+                }
+            ]
+        },
+        "updates": {
+            'felix-p-prof1-i': [],
+            'felix-p-prof1-o': [
+                "--append felix-p-prof1-o --protocol icmpv6 "
+                "--match icmp6 --icmpv6-type 8 --jump MARK "
+                "--set-mark 0x1000000/0x1000000",
+                '--append felix-p-prof1-o --match mark '
+                '--mark 0x1000000/0x1000000 --jump RETURN',
+            ]
         },
     },
 ]
@@ -674,7 +734,6 @@ class TestRules(BaseTestCase):
              ['16', '17']]
         )
 
-    @skip("golang rewrite")
     def test_rules_generation(self):
         for test in RULES_TESTS:
             _log.info("Running rules test\n%s", pformat(test))
@@ -683,7 +742,6 @@ class TestRules(BaseTestCase):
                 test["profile"],
                 test["ip_version"],
                 test["tag_to_ipset"],
-                selector_to_ipset=test.get("sel_to_ipset", {}),
             )
             _log.info("Updates:\n%s", pformat(updates))
             _log.info("Deps:\n%s", pformat(deps))
@@ -698,7 +756,6 @@ class TestRules(BaseTestCase):
             },
             4,
             {},
-            selector_to_ipset={},
         )
         self.maxDiff = None
         # Should get back a drop rule.
@@ -762,13 +819,13 @@ class TestRules(BaseTestCase):
     def test_bad_icmp_type(self):
         with self.assertRaises(UnsupportedICMPType):
             self.iptables_generator._rule_to_iptables_fragments_inner(
-                "foo", {"icmp_type": 255}, 4, {}, {}
+                "foo", {"icmp_type": 255}, 4, {},
             )
 
     def test_bad_protocol_with_ports(self):
         with self.assertRaises(AssertionError):
             self.iptables_generator._rule_to_iptables_fragments_inner(
-                "foo", {"protocol": "10", "src_ports": [1]}, 4, {}, {}
+                "foo", {"protocol": "10", "src_ports": [1]}, 4, {},
             )
 
 


### PR DESCRIPTION
Previously, ICMP rules without an IP version would cause an assert when being rendered on the "wrong" IP version.  Now they are ignored.

Also, reinstate the UTs for rule generation and fix up in light of golang port.

Fixes #1206 