### PR TITLE
Fix slow Felix builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ version.txt
 bin
 local-utils
 python/version.py
+.go-pkg-cache

--- a/Makefile
+++ b/Makefile
@@ -281,11 +281,9 @@ bin/calico-felix: $(GO_FILES) \
 	    -v $${PWD}:/go/src/github.com/projectcalico/felix:rw \
 	    -v $${PWD}/.go-pkg-cache:/go/pkg/:rw \
 	    calico-build/golang \
-	    go build -i -o $@ -v $(LDFLAGS) "github.com/projectcalico/felix/go/felix"
-
-	@# Check that the executable is correctly statically linked.
-	@ldd bin/calico-felix | grep -q "not a dynamic executable" || \
-	     echo "Error: bin/calico-felix wasn't statically linked"
+	    sh -c 'go build -i -o $@ -v $(LDFLAGS) "github.com/projectcalico/felix/go/felix" && \
+               ( ldd bin/calico-felix | grep -q "not a dynamic executable" || \
+	             ( echo "Error: bin/calico-felix was not statically linked"; false ) )'
 
 # Build the pyinstaller bundle, which is an output artefact in its own right
 # as well as being the input to our Deb and RPM builds.

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ help:
 	@echo "  make go-fmt        Format our go code."
 	@echo "  make clean         Remove binary files."
 
+# Disable make's implicit rules, which are not useful for golang, and slow down the build
+# considerably.
+.SUFFIXES:
+
 all: pyinstaller deb rpm calico/felix
 test: ut
 
@@ -126,6 +130,7 @@ LIBCALICOGO_PATH?=none
 # Build a docker image used for building our go code into a binary.
 .PHONY: calico-build/golang
 calico-build/golang:
+	@echo "Checking freshness of calico-build/golang container image."
 	cd docker-build-images && \
 	  docker build \
 	  --build-arg=UID=$(MY_UID) \

--- a/docker-build-images/golang-build.Dockerfile
+++ b/docker-build-images/golang-build.Dockerfile
@@ -28,5 +28,8 @@ RUN chmod -R a+wX $GOPATH /usr/local/go
 
 # Disable cgo so that binaries we build will be fully static.
 ENV CGO_ENABLED=0
+# Recompile the standard library with cgo disabled.  This prevents the standard library from being
+# marked stale, causing full rebuilds every time.
+RUN go install -v std
 
 WORKDIR /go/src/github.com/projectcalico/felix


### PR DESCRIPTION
- Add a cache directory for $GOPATH/pkg that is mounted as a volume into the build container.
- As part of building the build container image, rebuild the standard library. This ensures the standard library is built with CGO disabled so that it isn't considered stale by subsequent builds.