### PR TITLE
Fix configure_ipip_device() to pass IPAddress to set_interface_ips().

### DIFF
--- a/python/calico/felix/devices.py
+++ b/python/calico/felix/devices.py
@@ -173,6 +173,7 @@ def set_interface_ips(ip_type, interface, ips):
     assert ip_type in (futils.IPV4, futils.IPV6), (
         "Expected an IP type, got %s" % ip_type
     )
+    assert all(isinstance(ip, IPAddress) for ip in ips)
     old_ips = list_interface_ips(ip_type, interface)
     ips_to_add = ips - old_ips
     ips_to_remove = old_ips - ips

--- a/python/calico/felix/frules.py
+++ b/python/calico/felix/frules.py
@@ -120,8 +120,9 @@ Accept MARK (a configured bit in the MARK space):
 
 """
 import logging
-
 import time
+
+import netaddr
 
 from calico.felix import devices
 from calico.felix import futils
@@ -403,7 +404,7 @@ def _configure_ipip_device(config):
     # allow the host to have an IP on a private IPIP network so that it can
     # originate traffic and have it routed correctly.
     _log.info("Setting IPIP device IP to %s", config.IP_IN_IP_ADDR)
-    tunnel_addrs = [config.IP_IN_IP_ADDR] if config.IP_IN_IP_ADDR else []
+    tunnel_addrs = [netaddr.IPAddress(config.IP_IN_IP_ADDR)] if config.IP_IN_IP_ADDR else []
     devices.set_interface_ips(futils.IPV4, IP_IN_IP_DEV_NAME,
                               set(tunnel_addrs))
     _log.info("Configured IPIP device.")


### PR DESCRIPTION
Previously, it passed a string, which threw off the set calculations.

Fixes https://github.com/projectcalico/calico-containers/issues/1419