### PR TITLE
Fix that packets not policed when there were multiple interface prefixes.

### DIFF
--- a/calico/felix/plugins/fiptgenerator.py
+++ b/calico/felix/plugins/fiptgenerator.py
@@ -458,7 +458,10 @@ class FelixIptablesGenerator(FelixPlugin):
                 "--append %s --out-interface %s --match conntrack "
                 "--ctstate RELATED,ESTABLISHED --jump ACCEPT" %
                 (CHAIN_FORWARD, iface_match),
+            ])
 
+        for iface_match in self.IFACE_MATCH:
+            forward_chain.extend([
                 # Then, for traffic from a workload interface, jump to the
                 # from endpoint chain.  It will either DROP the packet or,
                 # if policy allows, return it to this chain for further
@@ -472,7 +475,10 @@ class FelixIptablesGenerator(FelixPlugin):
                 # the "from" and "to" chains.
                 "--append %s --jump %s --out-interface %s" %
                 (CHAIN_FORWARD, CHAIN_TO_ENDPOINT, iface_match),
+            ])
 
+        for iface_match in self.IFACE_MATCH:
+            forward_chain.extend([
                 # Finally, if the packet is from/to a workload and it passes
                 # both the "from" and "to" chains without being dropped, it
                 # must be allowed by policy; ACCEPT it.
@@ -481,6 +487,7 @@ class FelixIptablesGenerator(FelixPlugin):
                 "--append %s --jump ACCEPT --out-interface %s" %
                 (CHAIN_FORWARD, iface_match),
             ])
+
         return forward_chain, set([CHAIN_FROM_ENDPOINT, CHAIN_TO_ENDPOINT])
 
     def raw_prerouting_chain(self, ip_version):

--- a/calico/felix/test/test_fiptgenerator.py
+++ b/calico/felix/test/test_fiptgenerator.py
@@ -590,6 +590,56 @@ TO_HOST_ENDPOINT_CHAIN = [
 ]
 
 
+TAP_FORWARD_CHAIN = [
+    # Accept packets that matched in the raw table already.
+    '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000',
+
+    # Conntrack rules.
+    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
+    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
+    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+
+    # Jump to egress and ingress policies.
+    '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
+    '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
+
+    # Then accept the packet if both pass.
+    '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
+    '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
+]
+
+TAP_CALI_FORWARD_CHAIN = [
+    # Accept packets that matched in the raw table already.
+    '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000',
+
+    # Conntrack rules for all interfaces come first.
+    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
+    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
+    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+    '--append felix-FORWARD --in-interface cali+ --match conntrack --ctstate INVALID --jump DROP',
+    '--append felix-FORWARD --out-interface cali+ --match conntrack --ctstate INVALID --jump DROP',
+    '--append felix-FORWARD --in-interface cali+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+    '--append felix-FORWARD --out-interface cali+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+
+    # Then, all policies.  It's important that these come as a block since a packet may be going
+    # from one prefix to another so we need to make sure it hits the tap and cali policies
+    # before we accept the packet.
+    '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
+    '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
+    '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface cali+',
+    '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface cali+',
+
+    # Accept traffic that passed all the policies.
+    '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
+    '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
+    '--append felix-FORWARD --jump ACCEPT --in-interface cali+',
+    '--append felix-FORWARD --jump ACCEPT --out-interface cali+',
+]
+
+
+
 class TestGlobalChains(BaseTestCase):
     def setUp(self):
         super(TestGlobalChains, self).setUp()
@@ -628,6 +678,30 @@ class TestGlobalChains(BaseTestCase):
         self.assertEqual(chain, INPUT_CHAINS["Return"])
         self.assertEqual(deps, set(["felix-FROM-ENDPOINT",
                                     "felix-FROM-HOST-IF"]))
+
+    def test_forward_chain_single_prefix(self):
+        host_dict = {
+            "InterfacePrefix": "tap",
+        }
+        config = load_config("felix_empty.cfg", host_dict=host_dict)
+        generator = config.plugins["iptables_generator"]
+        chain, deps = generator.filter_forward_chain(ip_version=4)
+        self.maxDiff = None
+        self.assertEqual(chain, TAP_FORWARD_CHAIN)
+        self.assertEqual(deps, set(["felix-FROM-ENDPOINT",
+                                    "felix-TO-ENDPOINT"]))
+
+    def test_forward_chain_multiple_prefixes(self):
+        host_dict = {
+            "InterfacePrefix": "tap,cali",
+        }
+        config = load_config("felix_empty.cfg", host_dict=host_dict)
+        generator = config.plugins["iptables_generator"]
+        chain, deps = generator.filter_forward_chain(ip_version=4)
+        self.maxDiff = None
+        self.assertEqual(chain, TAP_CALI_FORWARD_CHAIN)
+        self.assertEqual(deps, set(["felix-FROM-ENDPOINT",
+                                    "felix-TO-ENDPOINT"]))
 
 
 class TestRules(BaseTestCase):


### PR DESCRIPTION
Given a system with `tap` and `cali` interfaces, say, and some packets going from a `tap` to a `cali` interface.  Previously, if the tap rules happened to be rendered first, only the `tap` egress policy would be applied and the `cali` ingress policy would be ignored.