### PR TITLE
Add support for policing forwarded traffic with host endpoint rules

### DIFF
--- a/calico/felix/plugins/fiptgenerator.py
+++ b/calico/felix/plugins/fiptgenerator.py
@@ -434,31 +434,22 @@ class FelixIptablesGenerator(FelixPlugin):
         # the raw table.
         forward_chain.append(
             "--append {chain} --jump ACCEPT --match mark "
-            "--mark {mark}/{mark}".format(
+            "--mark {mark}/{mark} "
+            "--match conntrack --ctstate UNTRACKED".format(
                 chain=CHAIN_FORWARD,
                 mark=self.IPTABLES_MARK_ACCEPT)
         )
 
-        for iface_match in self.IFACE_MATCH:
-            forward_chain.extend(self.drop_rules(
-                ip_version, CHAIN_FORWARD,
-                "--in-interface %s --match conntrack --ctstate "
-                "INVALID" % iface_match, None))
-            forward_chain.extend(
-                self.drop_rules(
-                    ip_version, CHAIN_FORWARD,
-                    "--out-interface %s --match conntrack --ctstate "
-                    "INVALID" % iface_match, None))
-            forward_chain.extend([
-                # First, a pair of conntrack rules, which accept established
-                # flows to/from workload interfaces.
-                "--append %s --in-interface %s --match conntrack "
-                "--ctstate RELATED,ESTABLISHED --jump ACCEPT" %
-                (CHAIN_FORWARD, iface_match),
-                "--append %s --out-interface %s --match conntrack "
-                "--ctstate RELATED,ESTABLISHED --jump ACCEPT" %
-                (CHAIN_FORWARD, iface_match),
-            ])
+        forward_chain.extend(self.drop_rules(
+            ip_version, CHAIN_FORWARD,
+            "--match conntrack --ctstate INVALID", None))
+        forward_chain.extend([
+            # First, a pair of conntrack rules, which accept established
+            # flows to/from workload interfaces.
+            "--append %s --match conntrack "
+            "--ctstate RELATED,ESTABLISHED --jump ACCEPT" %
+            (CHAIN_FORWARD,),
+        ])
 
         for iface_match in self.IFACE_MATCH:
             forward_chain.extend([

--- a/calico/felix/test/test_fiptgenerator.py
+++ b/calico/felix/test/test_fiptgenerator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -592,13 +592,12 @@ TO_HOST_ENDPOINT_CHAIN = [
 
 TAP_FORWARD_CHAIN = [
     # Accept packets that matched in the raw table already.
-    '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000',
+    '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000 '
+    '--match conntrack --ctstate UNTRACKED',
 
     # Conntrack rules.
-    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+    '--append felix-FORWARD --match conntrack --ctstate INVALID --jump DROP',
+    '--append felix-FORWARD --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
 
     # Jump to egress and ingress policies.
     '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
@@ -615,17 +614,12 @@ TAP_FORWARD_CHAIN = [
 
 TAP_CALI_FORWARD_CHAIN = [
     # Accept packets that matched in the raw table already.
-    '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000',
+    '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000 '
+    '--match conntrack --ctstate UNTRACKED',
 
     # Conntrack rules for all interfaces come first.
-    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-    '--append felix-FORWARD --in-interface cali+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --out-interface cali+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --in-interface cali+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-    '--append felix-FORWARD --out-interface cali+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+    '--append felix-FORWARD --match conntrack --ctstate INVALID --jump DROP',
+    '--append felix-FORWARD --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
 
     # Then, all policies.  It's important that these come as a block since a packet may be going
     # from one prefix to another so we need to make sure it hits the tap and cali policies

--- a/calico/felix/test/test_fiptgenerator.py
+++ b/calico/felix/test/test_fiptgenerator.py
@@ -607,6 +607,10 @@ TAP_FORWARD_CHAIN = [
     # Then accept the packet if both pass.
     '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
     '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
+
+    # For non-workload packets, sent to the host endpoint chains.
+    "--append felix-FORWARD --jump felix-FROM-HOST-IF",
+    "--append felix-FORWARD --jump felix-TO-HOST-IF",
 ]
 
 TAP_CALI_FORWARD_CHAIN = [
@@ -636,6 +640,10 @@ TAP_CALI_FORWARD_CHAIN = [
     '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
     '--append felix-FORWARD --jump ACCEPT --in-interface cali+',
     '--append felix-FORWARD --jump ACCEPT --out-interface cali+',
+
+    # For non-workload packets, sent to the host endpoint chains.
+    "--append felix-FORWARD --jump felix-FROM-HOST-IF",
+    "--append felix-FORWARD --jump felix-TO-HOST-IF",
 ]
 
 
@@ -689,7 +697,9 @@ class TestGlobalChains(BaseTestCase):
         self.maxDiff = None
         self.assertEqual(chain, TAP_FORWARD_CHAIN)
         self.assertEqual(deps, set(["felix-FROM-ENDPOINT",
-                                    "felix-TO-ENDPOINT"]))
+                                    "felix-TO-ENDPOINT",
+                                    "felix-TO-HOST-IF",
+                                    "felix-FROM-HOST-IF"]))
 
     def test_forward_chain_multiple_prefixes(self):
         host_dict = {
@@ -701,7 +711,9 @@ class TestGlobalChains(BaseTestCase):
         self.maxDiff = None
         self.assertEqual(chain, TAP_CALI_FORWARD_CHAIN)
         self.assertEqual(deps, set(["felix-FROM-ENDPOINT",
-                                    "felix-TO-ENDPOINT"]))
+                                    "felix-TO-ENDPOINT",
+                                    "felix-TO-HOST-IF",
+                                    "felix-FROM-HOST-IF"]))
 
 
 class TestRules(BaseTestCase):

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -34,7 +34,8 @@ _log = logging.getLogger(__name__)
 EXPECTED_TOP_LEVEL_DEPS = {
     'felix-INPUT': set(['felix-FROM-ENDPOINT', 'felix-FROM-HOST-IF']),
     'felix-OUTPUT': set(['felix-TO-HOST-IF']),
-    'felix-FORWARD': set(['felix-FROM-ENDPOINT', 'felix-TO-ENDPOINT']),
+    'felix-FORWARD': set(['felix-FROM-ENDPOINT', 'felix-TO-ENDPOINT',
+                          'felix-TO-HOST-IF', 'felix-FROM-HOST-IF']),
     'felix-FAILSAFE-IN': set(), 'felix-FAILSAFE-OUT': set()
 }
 
@@ -147,7 +148,9 @@ class TestRules(BaseTestCase):
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
-                '--append felix-FORWARD --jump ACCEPT --out-interface tap+'
+                '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
+                '--append felix-FORWARD --jump felix-FROM-HOST-IF',
+                '--append felix-FORWARD --jump felix-TO-HOST-IF',
             ],
             'felix-FAILSAFE-IN': [
                 '--append felix-FAILSAFE-IN --protocol tcp --dport 22 --jump ACCEPT'
@@ -412,7 +415,9 @@ class TestRules(BaseTestCase):
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
-                '--append felix-FORWARD --jump ACCEPT --out-interface tap+'
+                '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
+                '--append felix-FORWARD --jump felix-FROM-HOST-IF',
+                '--append felix-FORWARD --jump felix-TO-HOST-IF',
             ],
             'felix-FAILSAFE-IN': [
                 '--append felix-FAILSAFE-IN --protocol tcp --dport 22 --jump ACCEPT'
@@ -536,7 +541,9 @@ class TestRules(BaseTestCase):
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
-                '--append felix-FORWARD --jump ACCEPT --out-interface tap+'
+                '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
+                '--append felix-FORWARD --jump felix-FROM-HOST-IF',
+                '--append felix-FORWARD --jump felix-TO-HOST-IF',
             ],
             'felix-FAILSAFE-IN': [
                 '--append felix-FAILSAFE-IN --protocol tcp --dport 22 --jump ACCEPT'

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
 # Copyright 2015 Cisco Systems
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -140,11 +140,10 @@ class TestRules(BaseTestCase):
                 '--append felix-OUTPUT --goto felix-TO-HOST-IF --match mark --mark 0/0x4000000',
             ],
             'felix-FORWARD': [
-                '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000',
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+                '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000 '
+                '--match conntrack --ctstate UNTRACKED',
+                '--append felix-FORWARD --match conntrack --ctstate INVALID --jump DROP',
+                '--append felix-FORWARD --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
@@ -407,11 +406,10 @@ class TestRules(BaseTestCase):
                 '--append felix-OUTPUT --goto felix-TO-HOST-IF --match mark --mark 0/0x4000000',
             ],
             'felix-FORWARD': [
-                '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000',
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+                '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000 '
+                '--match conntrack --ctstate UNTRACKED',
+                '--append felix-FORWARD --match conntrack --ctstate INVALID --jump DROP',
+                '--append felix-FORWARD --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
@@ -533,11 +531,10 @@ class TestRules(BaseTestCase):
                 '--append felix-OUTPUT --goto felix-TO-HOST-IF --match mark --mark 0/0x4000000',
             ],
             'felix-FORWARD': [
-                '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000',
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+                '--append felix-FORWARD --jump ACCEPT --match mark --mark 0x1000000/0x1000000 '
+                '--match conntrack --ctstate UNTRACKED',
+                '--append felix-FORWARD --match conntrack --ctstate INVALID --jump DROP',
+                '--append felix-FORWARD --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',


### PR DESCRIPTION
Includes the fix from #1242, which was in the same function.  That PR should be reviewed/merged first.

- [x] Double check that host endpoint chains use RETURN in compatible way
- [x] Add automated ST to cover