### PR TITLE
Port NAT gateway support to 2.0

### DIFF
--- a/python/calico/felix/plugins/fiptgenerator.py
+++ b/python/calico/felix/plugins/fiptgenerator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -458,7 +458,18 @@ class FelixIptablesGenerator(FelixPlugin):
                 (CHAIN_FORWARD, iface_match),
             ])
 
-        return forward_chain, set([CHAIN_FROM_ENDPOINT, CHAIN_TO_ENDPOINT])
+        # If we get to this point in the chain, the packet is not from or to
+        # a workload endpoint.  Hence, it must be being forwarded through
+        # this host, potentially via host endpoints that we want to police.
+        # Send the traffic to the host endpoint chains for processing.
+        # If there are no host endpoints configured, these chains are no-ops.
+        forward_chain.append("--append {chain} --jump {jump}".format(
+                chain=CHAIN_FORWARD, jump=CHAIN_FROM_IFACE))
+        forward_chain.append("--append {chain} --jump {jump}".format(
+                chain=CHAIN_FORWARD, jump=CHAIN_TO_IFACE))
+
+        return forward_chain, set([CHAIN_FROM_ENDPOINT, CHAIN_TO_ENDPOINT,
+                                   CHAIN_FROM_IFACE, CHAIN_TO_IFACE])
 
     def endpoint_chain_names(self, endpoint_suffix):
         """

--- a/python/calico/felix/plugins/fiptgenerator.py
+++ b/python/calico/felix/plugins/fiptgenerator.py
@@ -409,26 +409,17 @@ class FelixIptablesGenerator(FelixPlugin):
         :returns Tuple: list of rules, set of deps.
         """
         forward_chain = []
-        for iface_match in self.IFACE_MATCH:
-            forward_chain.extend(self.drop_rules(
-                ip_version, CHAIN_FORWARD,
-                "--in-interface %s --match conntrack --ctstate "
-                "INVALID" % iface_match, None))
-            forward_chain.extend(
-                self.drop_rules(
-                    ip_version, CHAIN_FORWARD,
-                    "--out-interface %s --match conntrack --ctstate "
-                    "INVALID" % iface_match, None))
-            forward_chain.extend([
-                # First, a pair of conntrack rules, which accept established
-                # flows to/from workload interfaces.
-                "--append %s --in-interface %s --match conntrack "
-                "--ctstate RELATED,ESTABLISHED --jump ACCEPT" %
-                (CHAIN_FORWARD, iface_match),
-                "--append %s --out-interface %s --match conntrack "
-                "--ctstate RELATED,ESTABLISHED --jump ACCEPT" %
-                (CHAIN_FORWARD, iface_match),
-            ])
+
+        forward_chain.extend(self.drop_rules(
+            ip_version, CHAIN_FORWARD,
+            "--match conntrack --ctstate INVALID", None))
+        forward_chain.extend([
+            # First, a pair of conntrack rules, which accept established
+            # flows to/from workload interfaces.
+            "--append %s --match conntrack "
+            "--ctstate RELATED,ESTABLISHED --jump ACCEPT" %
+            (CHAIN_FORWARD,),
+        ])
 
         for iface_match in self.IFACE_MATCH:
             forward_chain.extend([

--- a/python/calico/felix/test/test_fiptgenerator.py
+++ b/python/calico/felix/test/test_fiptgenerator.py
@@ -711,6 +711,10 @@ TAP_FORWARD_CHAIN = [
     # Then accept the packet if both pass.
     '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
     '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
+
+    # For non-workload packets, sent to the host endpoint chains.
+    "--append felix-FORWARD --jump felix-FROM-HOST-IF",
+    "--append felix-FORWARD --jump felix-TO-HOST-IF",
 ]
 
 TAP_CALI_FORWARD_CHAIN = [
@@ -737,6 +741,10 @@ TAP_CALI_FORWARD_CHAIN = [
     '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
     '--append felix-FORWARD --jump ACCEPT --in-interface cali+',
     '--append felix-FORWARD --jump ACCEPT --out-interface cali+',
+
+    # For non-workload packets, sent to the host endpoint chains.
+    "--append felix-FORWARD --jump felix-FROM-HOST-IF",
+    "--append felix-FORWARD --jump felix-TO-HOST-IF",
 ]
 
 
@@ -790,7 +798,9 @@ class TestGlobalChains(BaseTestCase):
         self.maxDiff = None
         self.assertEqual(chain, TAP_FORWARD_CHAIN)
         self.assertEqual(deps, set(["felix-FROM-ENDPOINT",
-                                    "felix-TO-ENDPOINT"]))
+                                    "felix-TO-ENDPOINT",
+                                    "felix-TO-HOST-IF",
+                                    "felix-FROM-HOST-IF"]))
 
     def test_forward_chain_multiple_prefixes(self):
         host_dict = {
@@ -802,7 +812,9 @@ class TestGlobalChains(BaseTestCase):
         self.maxDiff = None
         self.assertEqual(chain, TAP_CALI_FORWARD_CHAIN)
         self.assertEqual(deps, set(["felix-FROM-ENDPOINT",
-                                    "felix-TO-ENDPOINT"]))
+                                    "felix-TO-ENDPOINT",
+                                    "felix-TO-HOST-IF",
+                                    "felix-FROM-HOST-IF"]))
 
 
 class TestRules(BaseTestCase):

--- a/python/calico/felix/test/test_fiptgenerator.py
+++ b/python/calico/felix/test/test_fiptgenerator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -699,10 +699,8 @@ TO_HOST_ENDPOINT_CHAIN = [
 
 TAP_FORWARD_CHAIN = [
     # Conntrack rules.
-    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+    '--append felix-FORWARD --match conntrack --ctstate INVALID --jump DROP',
+    '--append felix-FORWARD --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
 
     # Jump to egress and ingress policies.
     '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
@@ -719,14 +717,8 @@ TAP_FORWARD_CHAIN = [
 
 TAP_CALI_FORWARD_CHAIN = [
     # Conntrack rules for all interfaces come first.
-    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-    '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-    '--append felix-FORWARD --in-interface cali+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --out-interface cali+ --match conntrack --ctstate INVALID --jump DROP',
-    '--append felix-FORWARD --in-interface cali+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-    '--append felix-FORWARD --out-interface cali+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+    '--append felix-FORWARD --match conntrack --ctstate INVALID --jump DROP',
+    '--append felix-FORWARD --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
 
     # Then, all policies.  It's important that these come as a block since a packet may be going
     # from one prefix to another so we need to make sure it hits the tap and cali policies

--- a/python/calico/felix/test/test_frules.py
+++ b/python/calico/felix/test/test_frules.py
@@ -35,7 +35,8 @@ _log = logging.getLogger(__name__)
 EXPECTED_TOP_LEVEL_DEPS = {
     'felix-INPUT': set(['felix-FROM-ENDPOINT', 'felix-FROM-HOST-IF']),
     'felix-OUTPUT': set(['felix-TO-HOST-IF']),
-    'felix-FORWARD': set(['felix-FROM-ENDPOINT', 'felix-TO-ENDPOINT']),
+    'felix-FORWARD': set(['felix-FROM-ENDPOINT', 'felix-TO-ENDPOINT',
+                          'felix-TO-HOST-IF', 'felix-FROM-HOST-IF']),
     'felix-FAILSAFE-IN': set(), 'felix-FAILSAFE-OUT': set()
 }
 
@@ -146,7 +147,9 @@ class TestRules(BaseTestCase):
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
-                '--append felix-FORWARD --jump ACCEPT --out-interface tap+'
+                '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
+                '--append felix-FORWARD --jump felix-FROM-HOST-IF',
+                '--append felix-FORWARD --jump felix-TO-HOST-IF',
             ],
             'felix-FAILSAFE-IN': [
                 '--append felix-FAILSAFE-IN --protocol tcp --dport 22 --jump ACCEPT'
@@ -351,7 +354,9 @@ class TestRules(BaseTestCase):
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
-                '--append felix-FORWARD --jump ACCEPT --out-interface tap+'
+                '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
+                '--append felix-FORWARD --jump felix-FROM-HOST-IF',
+                '--append felix-FORWARD --jump felix-TO-HOST-IF',
             ],
             'felix-FAILSAFE-IN': [
                 '--append felix-FAILSAFE-IN --protocol tcp --dport 22 --jump ACCEPT'
@@ -473,7 +478,9 @@ class TestRules(BaseTestCase):
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
-                '--append felix-FORWARD --jump ACCEPT --out-interface tap+'
+                '--append felix-FORWARD --jump ACCEPT --out-interface tap+',
+                '--append felix-FORWARD --jump felix-FROM-HOST-IF',
+                '--append felix-FORWARD --jump felix-TO-HOST-IF',
             ],
             'felix-FAILSAFE-IN': [
                 '--append felix-FAILSAFE-IN --protocol tcp --dport 22 --jump ACCEPT'

--- a/python/calico/felix/test/test_frules.py
+++ b/python/calico/felix/test/test_frules.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
 # Copyright 2015 Cisco Systems
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -140,10 +140,8 @@ class TestRules(BaseTestCase):
                 '--append felix-OUTPUT --goto felix-TO-HOST-IF --match mark --mark 0/0x4000000',
             ],
             'felix-FORWARD': [
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+                '--append felix-FORWARD --match conntrack --ctstate INVALID --jump DROP',
+                '--append felix-FORWARD --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
@@ -347,10 +345,8 @@ class TestRules(BaseTestCase):
                 '--append felix-OUTPUT --goto felix-TO-HOST-IF --match mark --mark 0/0x4000000',
             ],
             'felix-FORWARD': [
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+                '--append felix-FORWARD --match conntrack --ctstate INVALID --jump DROP',
+                '--append felix-FORWARD --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',
@@ -471,10 +467,8 @@ class TestRules(BaseTestCase):
                 '--append felix-OUTPUT --goto felix-TO-HOST-IF --match mark --mark 0/0x4000000',
             ],
             'felix-FORWARD': [
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate INVALID --jump DROP',
-                '--append felix-FORWARD --in-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
-                '--append felix-FORWARD --out-interface tap+ --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+                '--append felix-FORWARD --match conntrack --ctstate INVALID --jump DROP',
+                '--append felix-FORWARD --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
                 '--append felix-FORWARD --jump felix-FROM-ENDPOINT --in-interface tap+',
                 '--append felix-FORWARD --jump felix-TO-ENDPOINT --out-interface tap+',
                 '--append felix-FORWARD --jump ACCEPT --in-interface tap+',


### PR DESCRIPTION
Port the 1.4 version of NAT gateway support to 2.0; mainly to unblock merging of the container-based ST for this function.