### PR TITLE
UTs for IPIP manager; IP sets manager; masquerade manager; policy manager

### DIFF
--- a/go/felix/felix.go
+++ b/go/felix/felix.go
@@ -218,6 +218,7 @@ configRetry:
 			},
 			IPIPMTU:                 configParams.IpInIpMtu,
 			IptablesRefreshInterval: time.Duration(configParams.IptablesRefreshInterval) * time.Second,
+			MaxIPSetSize:            configParams.MaxIpsetSize,
 		}
 		intDP := intdataplane.NewIntDataplaneDriver(dpConfig)
 		intDP.Start()

--- a/go/felix/intdataplane/endpoint_mgr.go
+++ b/go/felix/intdataplane/endpoint_mgr.go
@@ -32,11 +32,6 @@ import (
 	"strings"
 )
 
-type table interface {
-	UpdateChains([]*iptables.Chain)
-	RemoveChains([]*iptables.Chain)
-}
-
 // endpointManager manages the dataplane resources that belong to each endpoint as well as
 // the "dispatch chains" that fan out packets to the right per-endpoint chain.
 //
@@ -52,7 +47,7 @@ type endpointManager struct {
 	wlIfacesRegexp *regexp.Regexp
 
 	// Our dependencies.
-	filterTable  table
+	filterTable  iptablesTable
 	ruleRenderer rules.RuleRenderer
 	routeTable   *routetable.RouteTable
 
@@ -84,7 +79,7 @@ type endpointManager struct {
 type EndpointStatusUpdateCallback func(ipVersion uint8, id proto.WorkloadEndpointID, status string)
 
 func newEndpointManager(
-	filterTable table,
+	filterTable iptablesTable,
 	ruleRenderer rules.RuleRenderer,
 	routeTable *routetable.RouteTable,
 	ipVersion uint8,

--- a/go/felix/intdataplane/endpoint_mgr_test.go
+++ b/go/felix/intdataplane/endpoint_mgr_test.go
@@ -15,7 +15,6 @@
 package intdataplane
 
 import (
-	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/projectcalico/felix/go/felix/ipsets"
@@ -23,69 +22,11 @@ import (
 	"github.com/projectcalico/felix/go/felix/proto"
 	"github.com/projectcalico/felix/go/felix/rules"
 	"github.com/projectcalico/felix/go/felix/set"
-	"reflect"
 	"strings"
 )
 
-type mockTable struct {
-	currentChains  map[string]*iptables.Chain
-	expectedChains map[string]*iptables.Chain
-}
-
-func newMockTable() *mockTable {
-	return &mockTable{
-		currentChains:  map[string]*iptables.Chain{},
-		expectedChains: map[string]*iptables.Chain{},
-	}
-}
-
-func logChains(message string, chains []*iptables.Chain) {
-	if chains == nil {
-		log.Debug(message, " with nil chains")
-	} else {
-		log.WithField("chains", chains).Debug(message)
-		for _, chain := range chains {
-			log.WithField("chain", *chain).Debug("")
-		}
-	}
-}
-
-func (t *mockTable) UpdateChains(chains []*iptables.Chain) {
-	logChains("UpdateChains", chains)
-	for _, chain := range chains {
-		t.currentChains[chain.Name] = chain
-	}
-}
-
-func (t *mockTable) RemoveChains(chains []*iptables.Chain) {
-	logChains("RemoveChains", chains)
-	for _, chain := range chains {
-		_, prs := t.currentChains[chain.Name]
-		Expect(prs).To(BeTrue())
-		delete(t.currentChains, chain.Name)
-	}
-}
-
-func (t *mockTable) checkChains(expecteds [][]*iptables.Chain) {
-	t.expectedChains = map[string]*iptables.Chain{}
-	for _, expected := range expecteds {
-		for _, chain := range expected {
-			t.expectedChains[chain.Name] = chain
-		}
-	}
-	t.checkChainsSameAsBefore()
-}
-
-func (t *mockTable) checkChainsSameAsBefore() {
-	log.Debug("Expected chains")
-	for _, chain := range t.expectedChains {
-		log.WithField("chain", *chain).Debug("")
-	}
-	Expect(reflect.DeepEqual(t.currentChains, t.expectedChains)).To(BeTrue())
-}
-
 var wlDispatchEmpty = []*iptables.Chain{
-	&iptables.Chain{
+	{
 		Name: "cali-to-wl-dispatch",
 		Rules: []iptables.Rule{
 			{
@@ -95,7 +36,7 @@ var wlDispatchEmpty = []*iptables.Chain{
 			},
 		},
 	},
-	&iptables.Chain{
+	{
 		Name: "cali-from-wl-dispatch",
 		Rules: []iptables.Rule{
 			{
@@ -108,11 +49,11 @@ var wlDispatchEmpty = []*iptables.Chain{
 }
 
 var hostDispatchEmpty = []*iptables.Chain{
-	&iptables.Chain{
+	{
 		Name:  "cali-to-host-endpoint",
 		Rules: []iptables.Rule{},
 	},
-	&iptables.Chain{
+	{
 		Name:  "cali-from-host-endpoint",
 		Rules: []iptables.Rule{},
 	},

--- a/go/felix/intdataplane/int_dataplane.go
+++ b/go/felix/intdataplane/int_dataplane.go
@@ -437,3 +437,10 @@ func (d *InternalDataplane) loopReportingStatus() {
 		}
 	}
 }
+
+// iptablesTable is a shim interface for iptables.Table.
+type iptablesTable interface {
+	UpdateChain(chain *iptables.Chain)
+	UpdateChains([]*iptables.Chain)
+	RemoveChains([]*iptables.Chain)
+}

--- a/go/felix/intdataplane/int_dataplane.go
+++ b/go/felix/intdataplane/int_dataplane.go
@@ -32,6 +32,8 @@ type Config struct {
 	RuleRendererOverride rules.RuleRenderer
 	IPIPMTU              int
 
+	MaxIPSetSize int
+
 	IptablesRefreshInterval time.Duration
 
 	RulesConfig rules.Config
@@ -140,7 +142,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 
 	dp.endpointStatusCombiner = newEndpointStatusCombiner(dp.fromDataplane, !config.DisableIPv6)
 
-	dp.RegisterManager(newIPSetsManager(ipSetRegV4))
+	dp.RegisterManager(newIPSetsManager(ipSetRegV4, config.MaxIPSetSize))
 	dp.RegisterManager(newPolicyManager(filterTableV4, ruleRenderer, 4))
 	dp.RegisterManager(newEndpointManager(
 		filterTableV4,
@@ -176,7 +178,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		routeTableV6 := routetable.New(config.RulesConfig.WorkloadIfacePrefixes, 6)
 		dp.routeTables = append(dp.routeTables, routeTableV6)
 
-		dp.RegisterManager(newIPSetsManager(ipSetRegV6))
+		dp.RegisterManager(newIPSetsManager(ipSetRegV6, config.MaxIPSetSize))
 		dp.RegisterManager(newPolicyManager(filterTableV6, ruleRenderer, 6))
 		dp.RegisterManager(newEndpointManager(
 			filterTableV6,

--- a/go/felix/intdataplane/int_dataplane.go
+++ b/go/felix/intdataplane/int_dataplane.go
@@ -443,4 +443,5 @@ type iptablesTable interface {
 	UpdateChain(chain *iptables.Chain)
 	UpdateChains([]*iptables.Chain)
 	RemoveChains([]*iptables.Chain)
+	RemoveChainByName(name string)
 }

--- a/go/felix/intdataplane/int_dataplane.go
+++ b/go/felix/intdataplane/int_dataplane.go
@@ -151,10 +151,10 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		4,
 		config.RulesConfig.WorkloadIfacePrefixes,
 		dp.endpointStatusCombiner.OnWorkloadEndpointStatusUpdate))
-	dp.RegisterManager(newMasqManager(ipSetRegV4, natTableV4, ruleRenderer, 1000000, 4))
+	dp.RegisterManager(newMasqManager(ipSetRegV4, natTableV4, ruleRenderer, config.MaxIPSetSize, 4))
 	if config.RulesConfig.IPIPEnabled {
 		// Add a manger to keep the all-hosts IP set up to date.
-		dp.ipipManager = newIPIPManager(ipSetRegV4, 1000000)
+		dp.ipipManager = newIPIPManager(ipSetRegV4, config.MaxIPSetSize)
 		dp.RegisterManager(dp.ipipManager) // IPv4-only
 	}
 	if !config.DisableIPv6 {
@@ -187,7 +187,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			6,
 			config.RulesConfig.WorkloadIfacePrefixes,
 			dp.endpointStatusCombiner.OnWorkloadEndpointStatusUpdate))
-		dp.RegisterManager(newMasqManager(ipSetRegV6, natTableV6, ruleRenderer, 1000000, 6))
+		dp.RegisterManager(newMasqManager(ipSetRegV6, natTableV6, ruleRenderer, config.MaxIPSetSize, 6))
 	}
 
 	for _, t := range dp.iptablesNATTables {

--- a/go/felix/intdataplane/ipip_mgr.go
+++ b/go/felix/intdataplane/ipip_mgr.go
@@ -225,4 +225,5 @@ type ipsetsRegistry interface {
 	AddOrReplaceIPSet(setMetadata ipsets.IPSetMetadata, members []string)
 	AddMembers(setID string, newMembers []string)
 	RemoveMembers(setID string, removedMembers []string)
+	RemoveIPSet(setID string)
 }

--- a/go/felix/intdataplane/ipip_mgr_netlink.go
+++ b/go/felix/intdataplane/ipip_mgr_netlink.go
@@ -15,44 +15,44 @@
 package intdataplane
 
 import (
-	. "github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink"
 	"os/exec"
 )
 
 // ipipDataplane is a shim interface for mocking netlink and os/exec in the IPIP manager.
 type ipipDataplane interface {
-	LinkByName(name string) (Link, error)
-	LinkSetMTU(link Link, mtu int) error
-	LinkSetUp(link Link) error
-	AddrList(link Link, family int) ([]Addr, error)
-	AddrAdd(link Link, addr *Addr) error
-	AddrDel(link Link, addr *Addr) error
+	LinkByName(name string) (netlink.Link, error)
+	LinkSetMTU(link netlink.Link, mtu int) error
+	LinkSetUp(link netlink.Link) error
+	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
+	AddrAdd(link netlink.Link, addr *netlink.Addr) error
+	AddrDel(link netlink.Link, addr *netlink.Addr) error
 	RunCmd(name string, args ...string) error
 }
 
 type realIPIPNetlink struct{}
 
-func (r realIPIPNetlink) LinkByName(name string) (Link, error) {
-	return LinkByName(name)
+func (r realIPIPNetlink) LinkByName(name string) (netlink.Link, error) {
+	return netlink.LinkByName(name)
 }
-func (r realIPIPNetlink) LinkSetMTU(link Link, mtu int) error {
-	return LinkSetMTU(link, mtu)
-}
-
-func (r realIPIPNetlink) LinkSetUp(link Link) error {
-	return LinkSetUp(link)
+func (r realIPIPNetlink) LinkSetMTU(link netlink.Link, mtu int) error {
+	return netlink.LinkSetMTU(link, mtu)
 }
 
-func (r realIPIPNetlink) AddrList(link Link, family int) ([]Addr, error) {
-	return AddrList(link, family)
+func (r realIPIPNetlink) LinkSetUp(link netlink.Link) error {
+	return netlink.LinkSetUp(link)
 }
 
-func (r realIPIPNetlink) AddrAdd(link Link, addr *Addr) error {
-	return AddrAdd(link, addr)
+func (r realIPIPNetlink) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
+	return netlink.AddrList(link, family)
 }
 
-func (r realIPIPNetlink) AddrDel(link Link, addr *Addr) error {
-	return AddrDel(link, addr)
+func (r realIPIPNetlink) AddrAdd(link netlink.Link, addr *netlink.Addr) error {
+	return netlink.AddrAdd(link, addr)
+}
+
+func (r realIPIPNetlink) AddrDel(link netlink.Link, addr *netlink.Addr) error {
+	return netlink.AddrDel(link, addr)
 }
 
 func (r realIPIPNetlink) RunCmd(name string, args ...string) error {

--- a/go/felix/intdataplane/ipip_mgr_netlink.go
+++ b/go/felix/intdataplane/ipip_mgr_netlink.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	. "github.com/vishvananda/netlink"
+	"os/exec"
+)
+
+// ipipDataplane is a shim interface for mocking netlink and os/exec in the IPIP manager.
+type ipipDataplane interface {
+	LinkByName(name string) (Link, error)
+	LinkSetMTU(link Link, mtu int) error
+	LinkSetUp(link Link) error
+	AddrList(link Link, family int) ([]Addr, error)
+	AddrAdd(link Link, addr *Addr) error
+	AddrDel(link Link, addr *Addr) error
+	RunCmd(name string, args ...string) error
+}
+
+type realIPIPNetlink struct{}
+
+func (r realIPIPNetlink) LinkByName(name string) (Link, error) {
+	return LinkByName(name)
+}
+func (r realIPIPNetlink) LinkSetMTU(link Link, mtu int) error {
+	return LinkSetMTU(link, mtu)
+}
+
+func (r realIPIPNetlink) LinkSetUp(link Link) error {
+	return LinkSetUp(link)
+}
+
+func (r realIPIPNetlink) AddrList(link Link, family int) ([]Addr, error) {
+	return AddrList(link, family)
+}
+
+func (r realIPIPNetlink) AddrAdd(link Link, addr *Addr) error {
+	return AddrAdd(link, addr)
+}
+
+func (r realIPIPNetlink) AddrDel(link Link, addr *Addr) error {
+	return AddrDel(link, addr)
+}
+
+func (r realIPIPNetlink) RunCmd(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	return cmd.Run()
+}

--- a/go/felix/intdataplane/ipip_mgr_test.go
+++ b/go/felix/intdataplane/ipip_mgr_test.go
@@ -225,8 +225,7 @@ var _ = Describe("ipipManager IP set updates", func() {
 		})
 
 		It("should add host1's IP to the IP set", func() {
-			Expect(allHostsSet().Len()).To(Equal(1))
-			Expect(allHostsSet().Contains("10.0.0.1")).To(BeTrue())
+			Expect(allHostsSet()).To(Equal(set.From("10.0.0.1")))
 		})
 
 		Describe("after adding an IP for host2", func() {
@@ -238,9 +237,7 @@ var _ = Describe("ipipManager IP set updates", func() {
 				ipipMgr.CompleteDeferredWork()
 			})
 			It("should add the IP to the IP set", func() {
-				Expect(allHostsSet().Len()).To(Equal(2))
-				Expect(allHostsSet().Contains("10.0.0.1")).To(BeTrue())
-				Expect(allHostsSet().Contains("10.0.0.2")).To(BeTrue())
+				Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", "10.0.0.2")))
 			})
 		})
 
@@ -253,8 +250,7 @@ var _ = Describe("ipipManager IP set updates", func() {
 				ipipMgr.CompleteDeferredWork()
 			})
 			It("should tolerate the duplicate", func() {
-				Expect(allHostsSet().Len()).To(Equal(1))
-				Expect(allHostsSet().Contains("10.0.0.1")).To(BeTrue())
+				Expect(allHostsSet()).To(Equal(set.From("10.0.0.1")))
 			})
 
 			Describe("after removing a duplicate IP", func() {
@@ -265,8 +261,7 @@ var _ = Describe("ipipManager IP set updates", func() {
 					ipipMgr.CompleteDeferredWork()
 				})
 				It("should keep the IP in the IP set", func() {
-					Expect(allHostsSet().Len()).To(Equal(1))
-					Expect(allHostsSet().Contains("10.0.0.1")).To(BeTrue())
+					Expect(allHostsSet()).To(Equal(set.From("10.0.0.1")))
 				})
 
 				Describe("after removing iniital copy of IP", func() {
@@ -295,8 +290,7 @@ var _ = Describe("ipipManager IP set updates", func() {
 				ipipMgr.CompleteDeferredWork()
 			})
 			It("should keep the IP in the IP set", func() {
-				Expect(allHostsSet().Len()).To(Equal(1))
-				Expect(allHostsSet().Contains("10.0.0.1")).To(BeTrue())
+				Expect(allHostsSet()).To(Equal(set.From("10.0.0.1")))
 			})
 		})
 
@@ -309,8 +303,7 @@ var _ = Describe("ipipManager IP set updates", func() {
 				ipipMgr.CompleteDeferredWork()
 			})
 			It("should update the IP set", func() {
-				Expect(allHostsSet().Len()).To(Equal(1))
-				Expect(allHostsSet().Contains("10.0.0.2")).To(BeTrue())
+				Expect(allHostsSet()).To(Equal(set.From("10.0.0.2")))
 			})
 		})
 

--- a/go/felix/intdataplane/ipip_mgr_test.go
+++ b/go/felix/intdataplane/ipip_mgr_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"errors"
+	log "github.com/Sirupsen/logrus"
+	"github.com/projectcalico/felix/go/felix/ipsets"
+	. "github.com/vishvananda/netlink"
+	"net"
+)
+
+var (
+	notImplemented = errors.New("Not implemented")
+	notFound       = errors.New("not found")
+)
+
+var _ = Describe("IpipMgr", func() {
+	var (
+		ipipMgr   *ipipManager
+		ipSets    *mockIPSets
+		dataplane *mockIPIPDataplane
+	)
+	BeforeEach(func() {
+		dataplane = &mockIPIPDataplane{}
+		ipSets = &mockIPSets{}
+		ipipMgr = newIPIPManagerWithShim(ipSets, 1024, dataplane)
+	})
+
+	Describe("after calling configureIPIPDevice", func() {
+		ip, _, err := net.ParseCIDR("10.0.0.1/32")
+		if err != nil {
+			panic("Failed to parse test IP")
+		}
+		ip2, _, err := net.ParseCIDR("10.0.0.2/32")
+		if err != nil {
+			panic("Failed to parse test IP")
+		}
+
+		BeforeEach(func() {
+			ipipMgr.configureIPIPDevice(1400, ip)
+		})
+
+		It("should create the interface", func() {
+			Expect(dataplane.tunnelLink).ToNot(BeNil())
+		})
+		It("should set the MTU", func() {
+			Expect(dataplane.tunnelLinkAttrs.MTU).To(Equal(1400))
+		})
+		It("should set the interface UP", func() {
+			Expect(dataplane.tunnelLinkAttrs.Flags).To(Equal(net.FlagUp))
+		})
+		It("should configure the address", func() {
+			Expect(dataplane.addrs).To(HaveLen(1))
+			Expect(dataplane.addrs[0].IP.String()).To(Equal("10.0.0.1"))
+		})
+
+		Describe("after second call with same params", func() {
+			BeforeEach(func() {
+				dataplane.ResetCalls()
+				ipipMgr.configureIPIPDevice(1400, ip)
+			})
+			It("should avoid creating the interface", func() {
+				Expect(dataplane.RunCmdCalled).To(BeFalse())
+			})
+			It("should avoid setting the interface UP again", func() {
+				Expect(dataplane.LinkSetUpCalled).To(BeFalse())
+			})
+			It("should avoid setting the MTU again", func() {
+				Expect(dataplane.LinkSetMTUCalled).To(BeFalse())
+			})
+			It("should avoid setting the address again", func() {
+				Expect(dataplane.AddrUpdated).To(BeFalse())
+			})
+		})
+
+		Describe("after second call with different params", func() {
+			BeforeEach(func() {
+				dataplane.ResetCalls()
+				ipipMgr.configureIPIPDevice(1500, ip2)
+			})
+			It("should avoid creating the interface", func() {
+				Expect(dataplane.RunCmdCalled).To(BeFalse())
+			})
+			It("should avoid setting the interface UP again", func() {
+				Expect(dataplane.LinkSetUpCalled).To(BeFalse())
+			})
+			It("should set the MTU", func() {
+				Expect(dataplane.tunnelLinkAttrs.MTU).To(Equal(1500))
+			})
+			It("should reconfigure the address", func() {
+				Expect(dataplane.addrs).To(HaveLen(1))
+				Expect(dataplane.addrs[0].IP.String()).To(Equal("10.0.0.2"))
+			})
+		})
+
+		Describe("after second call with nil IP", func() {
+			BeforeEach(func() {
+				dataplane.ResetCalls()
+				ipipMgr.configureIPIPDevice(1500, nil)
+			})
+			It("should avoid creating the interface", func() {
+				Expect(dataplane.RunCmdCalled).To(BeFalse())
+			})
+			It("should avoid setting the interface UP again", func() {
+				Expect(dataplane.LinkSetUpCalled).To(BeFalse())
+			})
+			It("should set the MTU", func() {
+				Expect(dataplane.tunnelLinkAttrs.MTU).To(Equal(1500))
+			})
+			It("should remove the address", func() {
+				Expect(dataplane.addrs).To(HaveLen(0))
+			})
+		})
+	})
+
+	Describe("after calling configureIPIPDevice with no IP", func() {
+		BeforeEach(func() {
+			ipipMgr.configureIPIPDevice(1400, nil)
+		})
+
+		It("should create the interface", func() {
+			Expect(dataplane.tunnelLink).ToNot(BeNil())
+		})
+		It("should set the MTU", func() {
+			Expect(dataplane.tunnelLinkAttrs.MTU).To(Equal(1400))
+		})
+		It("should set the interface UP", func() {
+			Expect(dataplane.tunnelLinkAttrs.Flags).To(Equal(net.FlagUp))
+		})
+		It("should configure the address", func() {
+			Expect(dataplane.addrs).To(HaveLen(0))
+		})
+	})
+})
+
+type mockIPSets struct{}
+
+func (s *mockIPSets) AddOrReplaceIPSet(setMetadata ipsets.IPSetMetadata, members []string) {
+
+}
+func (s *mockIPSets) AddMembers(setID string, newMembers []string) {
+
+}
+func (s *mockIPSets) RemoveMembers(setID string, removedMembers []string) {
+
+}
+
+type mockIPIPDataplane struct {
+	tunnelLink      *mockLink
+	tunnelLinkAttrs *LinkAttrs
+	addrs           []Addr
+
+	RunCmdCalled     bool
+	LinkSetMTUCalled bool
+	LinkSetUpCalled  bool
+	AddrUpdated      bool
+}
+
+func (d *mockIPIPDataplane) ResetCalls() {
+	d.RunCmdCalled = false
+	d.LinkSetMTUCalled = false
+	d.LinkSetUpCalled = false
+	d.AddrUpdated = false
+}
+
+func (d *mockIPIPDataplane) LinkByName(name string) (Link, error) {
+	log.WithField("name", name).Info("LinkByName called")
+	Expect(name).To(Equal("tunl0"))
+	if d.tunnelLink == nil {
+		return nil, notFound
+	}
+	return d.tunnelLink, nil
+}
+
+func (d *mockIPIPDataplane) LinkSetMTU(link Link, mtu int) error {
+	d.LinkSetMTUCalled = true
+	Expect(link.Attrs().Name).To(Equal("tunl0"))
+	d.tunnelLinkAttrs.MTU = mtu
+	return nil
+}
+
+func (d *mockIPIPDataplane) LinkSetUp(link Link) error {
+	d.LinkSetUpCalled = true
+	Expect(link.Attrs().Name).To(Equal("tunl0"))
+	d.tunnelLinkAttrs.Flags |= net.FlagUp
+	return nil
+}
+
+func (d *mockIPIPDataplane) AddrList(link Link, family int) ([]Addr, error) {
+	Expect(link.Attrs().Name).To(Equal("tunl0"))
+	return d.addrs, nil
+}
+
+func (d *mockIPIPDataplane) AddrAdd(link Link, addr *Addr) error {
+	d.AddrUpdated = true
+	Expect(d.addrs).NotTo(ContainElement(*addr))
+	d.addrs = append(d.addrs, *addr)
+	return nil
+}
+
+func (d *mockIPIPDataplane) AddrDel(link Link, addr *Addr) error {
+	d.AddrUpdated = true
+	Expect(d.addrs).To(HaveLen(1))
+	Expect(d.addrs[0].IP.String()).To(Equal(addr.IP.String()))
+	d.addrs = nil
+	return nil
+}
+
+func (d *mockIPIPDataplane) RunCmd(name string, args ...string) error {
+	d.RunCmdCalled = true
+	log.WithFields(log.Fields{"name": name, "args": args}).Info("RunCmd called")
+	Expect(name).To(Equal("ip"))
+	Expect(args).To(Equal([]string{"tunnel", "add", "tunl0", "mode", "ipip"}))
+
+	if d.tunnelLink == nil {
+		log.Info("Creating tunnel link")
+		link := &mockLink{}
+		link.attrs.Name = "tunl0"
+		d.tunnelLinkAttrs = &link.attrs
+		d.tunnelLink = link
+	}
+	return nil
+}
+
+type mockLink struct {
+	attrs LinkAttrs
+}
+
+func (l *mockLink) Attrs() *LinkAttrs {
+	return &l.attrs
+}
+
+func (l *mockLink) Type() string {
+	return "not implemented"
+}

--- a/go/felix/intdataplane/ipip_mgr_test.go
+++ b/go/felix/intdataplane/ipip_mgr_test.go
@@ -158,11 +158,13 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 
 	// Cover the error cases.  We pass the error back up the stack, check that that happens
 	// for all calls.
-	expNumCalls := 9
+	const expNumCalls = 8
 	It("a successful call should only call into dataplane expected number of times", func() {
-		Expect(dataplane.NumCalls).To(BeNumerically("<=", expNumCalls))
+		// This spec is a sanity-check that we've got the expNumCalls constant correct.
+		ipipMgr.configureIPIPDevice(1400, ip)
+		Expect(dataplane.NumCalls).To(BeNumerically("==", expNumCalls))
 	})
-	for i := 1; i < expNumCalls; i++ {
+	for i := 1; i <= expNumCalls; i++ {
 		if i == 1 {
 			continue // First LinkByName failure is handled.
 		}
@@ -264,7 +266,7 @@ var _ = Describe("ipipManager IP set updates", func() {
 					Expect(allHostsSet()).To(Equal(set.From("10.0.0.1")))
 				})
 
-				Describe("after removing iniital copy of IP", func() {
+				Describe("after removing initial copy of IP", func() {
 					BeforeEach(func() {
 						ipipMgr.OnUpdate(&proto.HostMetadataRemove{
 							Hostname: "host1",

--- a/go/felix/intdataplane/ipsets_mgr.go
+++ b/go/felix/intdataplane/ipsets_mgr.go
@@ -22,7 +22,7 @@ import (
 // ipSetsManager simply passes through IP set updates from the datastore to the ipsets.IPSets
 // dataplane layer.
 type ipSetsManager struct {
-	ipsetReg *ipsets.Registry
+	ipsetReg ipsetsRegistry
 	maxSize  int
 }
 

--- a/go/felix/intdataplane/ipsets_mgr_test.go
+++ b/go/felix/intdataplane/ipsets_mgr_test.go
@@ -46,7 +46,7 @@ var _ = Describe("IP Sets manager", func() {
 		})
 		It("should add the right members", func() {
 			Expect(ipSets.Members).To(HaveLen(1))
-			expIPs := set.FromArray([]string{"10.0.0.1", "10.0.0.2"})
+			expIPs := set.From("10.0.0.1", "10.0.0.2")
 			Expect(ipSets.Members["id1"]).To(Equal(expIPs))
 		})
 
@@ -64,7 +64,7 @@ var _ = Describe("IP Sets manager", func() {
 				Expect(ipSets.AddOrReplaceCalled).To(BeFalse())
 			})
 			It("should contain the right IPs", func() {
-				expIPs := set.FromArray([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"})
+				expIPs := set.From("10.0.0.2", "10.0.0.3", "10.0.0.4")
 				Expect(ipSets.Members["id1"]).To(Equal(expIPs))
 			})
 
@@ -95,7 +95,7 @@ var _ = Describe("IP Sets manager", func() {
 			})
 			It("should add the right members", func() {
 				Expect(ipSets.Members).To(HaveLen(1))
-				expIPs := set.FromArray([]string{"10.0.0.2", "10.0.0.3"})
+				expIPs := set.From("10.0.0.2", "10.0.0.3")
 				Expect(ipSets.Members["id1"]).To(Equal(expIPs))
 			})
 		})

--- a/go/felix/intdataplane/ipsets_mgr_test.go
+++ b/go/felix/intdataplane/ipsets_mgr_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/go/felix/proto"
+	"github.com/projectcalico/felix/go/felix/set"
+)
+
+var _ = Describe("IP Sets manager", func() {
+	var (
+		ipsetsMgr *ipSetsManager
+		ipSets    *mockIPSets
+	)
+
+	BeforeEach(func() {
+		ipSets = newMockIPSets()
+		ipsetsMgr = newIPSetsManager(ipSets, 1024)
+	})
+
+	Describe("after sending a replace", func() {
+		BeforeEach(func() {
+			ipsetsMgr.OnUpdate(&proto.IPSetUpdate{
+				Id:      "id1",
+				Members: []string{"10.0.0.1", "10.0.0.2"},
+			})
+			ipsetsMgr.CompleteDeferredWork()
+		})
+		It("should create the IP set", func() {
+			Expect(ipSets.AddOrReplaceCalled).To(BeTrue())
+		})
+		It("should add the right members", func() {
+			Expect(ipSets.Members).To(HaveLen(1))
+			expIPs := set.FromArray([]string{"10.0.0.1", "10.0.0.2"})
+			Expect(ipSets.Members["id1"]).To(Equal(expIPs))
+		})
+
+		Describe("after sending a delta update", func() {
+			BeforeEach(func() {
+				ipSets.AddOrReplaceCalled = false
+				ipsetsMgr.OnUpdate(&proto.IPSetDeltaUpdate{
+					Id:             "id1",
+					AddedMembers:   []string{"10.0.0.3", "10.0.0.4"},
+					RemovedMembers: []string{"10.0.0.1"},
+				})
+				ipsetsMgr.CompleteDeferredWork()
+			})
+			It("should not replace the IP set", func() {
+				Expect(ipSets.AddOrReplaceCalled).To(BeFalse())
+			})
+			It("should contain the right IPs", func() {
+				expIPs := set.FromArray([]string{"10.0.0.2", "10.0.0.3", "10.0.0.4"})
+				Expect(ipSets.Members["id1"]).To(Equal(expIPs))
+			})
+
+			Describe("after sending a delete", func() {
+				BeforeEach(func() {
+					ipsetsMgr.OnUpdate(&proto.IPSetRemove{
+						Id: "id1",
+					})
+					ipsetsMgr.CompleteDeferredWork()
+				})
+				It("should remove the IP set", func() {
+					Expect(ipSets.Members["id1"]).To(BeNil())
+				})
+			})
+		})
+
+		Describe("after sending another replace", func() {
+			BeforeEach(func() {
+				ipSets.AddOrReplaceCalled = false
+				ipsetsMgr.OnUpdate(&proto.IPSetUpdate{
+					Id:      "id1",
+					Members: []string{"10.0.0.2", "10.0.0.3"},
+				})
+				ipsetsMgr.CompleteDeferredWork()
+			})
+			It("should replace the IP set", func() {
+				Expect(ipSets.AddOrReplaceCalled).To(BeTrue())
+			})
+			It("should add the right members", func() {
+				Expect(ipSets.Members).To(HaveLen(1))
+				expIPs := set.FromArray([]string{"10.0.0.2", "10.0.0.3"})
+				Expect(ipSets.Members["id1"]).To(Equal(expIPs))
+			})
+		})
+	})
+})

--- a/go/felix/intdataplane/masq_mgr.go
+++ b/go/felix/intdataplane/masq_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package intdataplane
 import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/felix/go/felix/ipsets"
-	"github.com/projectcalico/felix/go/felix/iptables"
 	"github.com/projectcalico/felix/go/felix/proto"
 	"github.com/projectcalico/felix/go/felix/rules"
 	"github.com/projectcalico/felix/go/felix/set"
@@ -37,8 +36,8 @@ import (
 // pool is excluded.
 type masqManager struct {
 	ipVersion    uint8
-	ipsetReg     *ipsets.Registry
-	natTable     *iptables.Table
+	ipsetReg     ipsetsRegistry
+	natTable     iptablesTable
 	activePools  map[string]*proto.IPAMPool
 	masqPools    set.Set
 	dirty        bool
@@ -48,8 +47,8 @@ type masqManager struct {
 }
 
 func newMasqManager(
-	ipSetReg *ipsets.Registry,
-	natTable *iptables.Table,
+	ipSetReg ipsetsRegistry,
+	natTable iptablesTable,
 	ruleRenderer rules.RuleRenderer,
 	maxIPSetSize int,
 	ipVersion uint8,

--- a/go/felix/intdataplane/masq_mgr_test.go
+++ b/go/felix/intdataplane/masq_mgr_test.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/go/felix/ipsets"
+	"github.com/projectcalico/felix/go/felix/iptables"
+	"github.com/projectcalico/felix/go/felix/proto"
+	"github.com/projectcalico/felix/go/felix/rules"
+	"github.com/projectcalico/felix/go/felix/set"
+)
+
+var _ = Describe("Masquerade manager", func() {
+	var (
+		masqMgr      *masqManager
+		natTable     *mockTable
+		ipSets       *mockIPSets
+		ruleRenderer rules.RuleRenderer
+	)
+
+	BeforeEach(func() {
+		ipSets = newMockIPSets()
+		natTable = newMockTable()
+		ruleRenderer = rules.NewRenderer(rules.Config{
+			IPSetConfigV4: ipsets.NewIPVersionConfig(
+				ipsets.IPFamilyV4,
+				"cali",
+				nil,
+				nil,
+			),
+		})
+		masqMgr = newMasqManager(ipSets, natTable, ruleRenderer, 1024, 4)
+	})
+
+	It("should create its IP sets on startup", func() {
+		Expect(ipSets.Members).To(Equal(map[string]set.Set{
+			"all-ipam-pools":  set.New(),
+			"masq-ipam-pools": set.New(),
+		}))
+	})
+
+	Describe("after adding a masq pool", func() {
+		BeforeEach(func() {
+			masqMgr.OnUpdate(&proto.IPAMPoolUpdate{
+				Id: "pool-1",
+				Pool: &proto.IPAMPool{
+					Cidr:       "10.0.0.0/16",
+					Masquerade: true,
+				},
+			})
+			// This one should be ignored due to wrong IP version.
+			masqMgr.OnUpdate(&proto.IPAMPoolUpdate{
+				Id: "pool-1v6",
+				Pool: &proto.IPAMPool{
+					Cidr:       "feed:beef::/96",
+					Masquerade: true,
+				},
+			})
+			masqMgr.CompleteDeferredWork()
+		})
+
+		It("should add the pool to the masq IP set", func() {
+			Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.From("10.0.0.0/16")))
+		})
+		It("should add the pool to the all IP set", func() {
+			Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From("10.0.0.0/16")))
+		})
+		It("should program the chain", func() {
+			natTable.checkChains([][]*iptables.Chain{{{
+				Name: "cali-nat-outgoing",
+				Rules: []iptables.Rule{
+					{
+						Action: iptables.MasqAction{},
+						Match: iptables.Match().
+							SourceIPSet("cali4-masq-ipam-pools").
+							NotDestIPSet("cali4-all-ipam-pools"),
+					},
+				},
+			}}})
+		})
+
+		Describe("after adding a non-masq pool", func() {
+			BeforeEach(func() {
+				masqMgr.OnUpdate(&proto.IPAMPoolUpdate{
+					Id: "pool-2",
+					Pool: &proto.IPAMPool{
+						Cidr:       "10.2.0.0/16",
+						Masquerade: false,
+					},
+				})
+				masqMgr.CompleteDeferredWork()
+			})
+
+			It("should not add the pool to the masq IP set", func() {
+				Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.From("10.0.0.0/16")))
+			})
+			It("should add the pool to the all IP set", func() {
+				Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From(
+					"10.0.0.0/16", "10.2.0.0/16")))
+			})
+			It("should program the chain", func() {
+				natTable.checkChains([][]*iptables.Chain{{{
+					Name: "cali-nat-outgoing",
+					Rules: []iptables.Rule{
+						{
+							Action: iptables.MasqAction{},
+							Match: iptables.Match().
+								SourceIPSet("cali4-masq-ipam-pools").
+								NotDestIPSet("cali4-all-ipam-pools"),
+						},
+					},
+				}}})
+			})
+
+			Describe("after removing masq pool", func() {
+				BeforeEach(func() {
+					masqMgr.OnUpdate(&proto.IPAMPoolRemove{
+						Id: "pool-1",
+					})
+					masqMgr.CompleteDeferredWork()
+				})
+				It("should remove from the masq IP set", func() {
+					Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.New()))
+				})
+				It("should remove from the all IP set", func() {
+					Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From(
+						"10.2.0.0/16")))
+				})
+				It("should program empty chain", func() {
+					natTable.checkChains([][]*iptables.Chain{{{
+						Name:  "cali-nat-outgoing",
+						Rules: nil,
+					}}})
+				})
+
+				Describe("after removing the non-masq pool", func() {
+					BeforeEach(func() {
+						masqMgr.OnUpdate(&proto.IPAMPoolRemove{
+							Id: "pool-2",
+						})
+						masqMgr.CompleteDeferredWork()
+					})
+					It("masq set should be empty", func() {
+						Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.New()))
+					})
+					It("all set should be empty", func() {
+						Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.New()))
+					})
+					It("should program empty chain", func() {
+						natTable.checkChains([][]*iptables.Chain{{{
+							Name:  "cali-nat-outgoing",
+							Rules: nil,
+						}}})
+					})
+				})
+			})
+		})
+	})
+
+	Describe("after adding a non-masq pool", func() {
+		BeforeEach(func() {
+			masqMgr.OnUpdate(&proto.IPAMPoolUpdate{
+				Id: "pool-1",
+				Pool: &proto.IPAMPool{
+					Cidr:       "10.0.0.0/16",
+					Masquerade: false,
+				},
+			})
+			masqMgr.CompleteDeferredWork()
+		})
+
+		It("should not add the pool to the masq IP set", func() {
+			Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.New()))
+		})
+		It("should add the pool to the all IP set", func() {
+			Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From("10.0.0.0/16")))
+		})
+		It("should program empty chain", func() {
+			natTable.checkChains([][]*iptables.Chain{{{
+				Name:  "cali-nat-outgoing",
+				Rules: nil,
+			}}})
+		})
+	})
+})

--- a/go/felix/intdataplane/mock_ipsets_for_test.go
+++ b/go/felix/intdataplane/mock_ipsets_for_test.go
@@ -38,7 +38,9 @@ func (s *mockIPSets) AddOrReplaceIPSet(setMetadata ipsets.IPSetMetadata, newMemb
 	s.Metadata[setMetadata.SetID] = setMetadata
 	members := set.New()
 	for _, member := range newMembers {
-		Expect(net.ParseIP(member)).ToNot(BeNil())
+		if setMetadata.Type == ipsets.IPSetTypeHashIP {
+			Expect(net.ParseIP(member)).ToNot(BeNil())
+		}
 		members.Add(member)
 	}
 	s.Members[setMetadata.SetID] = members
@@ -47,7 +49,9 @@ func (s *mockIPSets) AddOrReplaceIPSet(setMetadata ipsets.IPSetMetadata, newMemb
 func (s *mockIPSets) AddMembers(setID string, newMembers []string) {
 	members := s.Members[setID]
 	for _, member := range newMembers {
-		Expect(net.ParseIP(member)).ToNot(BeNil())
+		if s.Metadata[setID].Type == ipsets.IPSetTypeHashIP {
+			Expect(net.ParseIP(member)).ToNot(BeNil())
+		}
 		Expect(members.Contains(member)).To(BeFalse())
 		members.Add(member)
 	}
@@ -56,7 +60,9 @@ func (s *mockIPSets) AddMembers(setID string, newMembers []string) {
 func (s *mockIPSets) RemoveMembers(setID string, removedMembers []string) {
 	members := s.Members[setID]
 	for _, member := range removedMembers {
-		Expect(net.ParseIP(member)).ToNot(BeNil())
+		if s.Metadata[setID].Type == ipsets.IPSetTypeHashIP {
+			Expect(net.ParseIP(member)).ToNot(BeNil())
+		}
 		Expect(members.Contains(member)).To(BeTrue())
 		members.Discard(member)
 	}

--- a/go/felix/intdataplane/mock_ipsets_for_test.go
+++ b/go/felix/intdataplane/mock_ipsets_for_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/felix/go/felix/ipsets"
+	"github.com/projectcalico/felix/go/felix/set"
+	"net"
+)
+
+type mockIPSets struct {
+	Members            map[string]set.Set
+	Metadata           map[string]ipsets.IPSetMetadata
+	AddOrReplaceCalled bool
+}
+
+func newMockIPSets() *mockIPSets {
+	return &mockIPSets{
+		Members:  map[string]set.Set{},
+		Metadata: map[string]ipsets.IPSetMetadata{},
+	}
+}
+
+func (s *mockIPSets) AddOrReplaceIPSet(setMetadata ipsets.IPSetMetadata, newMembers []string) {
+	s.Metadata[setMetadata.SetID] = setMetadata
+	members := set.New()
+	for _, member := range newMembers {
+		Expect(net.ParseIP(member)).ToNot(BeNil())
+		members.Add(member)
+	}
+	s.Members[setMetadata.SetID] = members
+	s.AddOrReplaceCalled = true
+}
+func (s *mockIPSets) AddMembers(setID string, newMembers []string) {
+	members := s.Members[setID]
+	for _, member := range newMembers {
+		Expect(net.ParseIP(member)).ToNot(BeNil())
+		Expect(members.Contains(member)).To(BeFalse())
+		members.Add(member)
+	}
+}
+
+func (s *mockIPSets) RemoveMembers(setID string, removedMembers []string) {
+	members := s.Members[setID]
+	for _, member := range removedMembers {
+		Expect(net.ParseIP(member)).ToNot(BeNil())
+		Expect(members.Contains(member)).To(BeTrue())
+		members.Discard(member)
+	}
+}
+
+func (s *mockIPSets) RemoveIPSet(setID string) {
+	delete(s.Members, setID)
+	delete(s.Metadata, setID)
+}

--- a/go/felix/intdataplane/mock_iptables_for_test.go
+++ b/go/felix/intdataplane/mock_iptables_for_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	log "github.com/Sirupsen/logrus"
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/felix/go/felix/iptables"
+)
+
+type mockTable struct {
+	currentChains  map[string]*iptables.Chain
+	expectedChains map[string]*iptables.Chain
+}
+
+func newMockTable() *mockTable {
+	return &mockTable{
+		currentChains:  map[string]*iptables.Chain{},
+		expectedChains: map[string]*iptables.Chain{},
+	}
+}
+
+func logChains(message string, chains []*iptables.Chain) {
+	if chains == nil {
+		log.Debug(message, " with nil chains")
+	} else {
+		log.WithField("chains", chains).Debug(message)
+		for _, chain := range chains {
+			log.WithField("chain", *chain).Debug("")
+		}
+	}
+}
+
+func (t *mockTable) UpdateChain(chain *iptables.Chain) {
+	t.UpdateChains([]*iptables.Chain{chain})
+}
+
+func (t *mockTable) UpdateChains(chains []*iptables.Chain) {
+	logChains("UpdateChains", chains)
+	for _, chain := range chains {
+		t.currentChains[chain.Name] = chain
+	}
+}
+
+func (t *mockTable) RemoveChains(chains []*iptables.Chain) {
+	logChains("RemoveChains", chains)
+	for _, chain := range chains {
+		_, prs := t.currentChains[chain.Name]
+		Expect(prs).To(BeTrue())
+		delete(t.currentChains, chain.Name)
+	}
+}
+
+func (t *mockTable) checkChains(expecteds [][]*iptables.Chain) {
+	t.expectedChains = map[string]*iptables.Chain{}
+	for _, expected := range expecteds {
+		for _, chain := range expected {
+			t.expectedChains[chain.Name] = chain
+		}
+	}
+	t.checkChainsSameAsBefore()
+}
+
+func (t *mockTable) checkChainsSameAsBefore() {
+	log.Debug("Expected chains")
+	for _, chain := range t.expectedChains {
+		log.WithField("chain", *chain).Debug("")
+	}
+	Expect(t.currentChains).To(Equal(t.expectedChains))
+}

--- a/go/felix/intdataplane/mock_iptables_for_test.go
+++ b/go/felix/intdataplane/mock_iptables_for_test.go
@@ -23,6 +23,7 @@ import (
 type mockTable struct {
 	currentChains  map[string]*iptables.Chain
 	expectedChains map[string]*iptables.Chain
+	UpdateCalled   bool
 }
 
 func newMockTable() *mockTable {
@@ -48,6 +49,7 @@ func (t *mockTable) UpdateChain(chain *iptables.Chain) {
 }
 
 func (t *mockTable) UpdateChains(chains []*iptables.Chain) {
+	t.UpdateCalled = true
 	logChains("UpdateChains", chains)
 	for _, chain := range chains {
 		t.currentChains[chain.Name] = chain

--- a/go/felix/intdataplane/mock_iptables_for_test.go
+++ b/go/felix/intdataplane/mock_iptables_for_test.go
@@ -59,10 +59,14 @@ func (t *mockTable) UpdateChains(chains []*iptables.Chain) {
 func (t *mockTable) RemoveChains(chains []*iptables.Chain) {
 	logChains("RemoveChains", chains)
 	for _, chain := range chains {
-		_, prs := t.currentChains[chain.Name]
-		Expect(prs).To(BeTrue())
+		Expect(t.currentChains).To(HaveKey(chain.Name))
 		delete(t.currentChains, chain.Name)
 	}
+}
+
+func (t *mockTable) RemoveChainByName(name string) {
+	Expect(t.currentChains).To(HaveKey(name))
+	delete(t.currentChains, name)
 }
 
 func (t *mockTable) checkChains(expecteds [][]*iptables.Chain) {

--- a/go/felix/intdataplane/policy_mgr.go
+++ b/go/felix/intdataplane/policy_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,12 +24,17 @@ import (
 // policyManager simply renders policy/profile updates into iptables.Chain objects and sends
 // them to the dataplane layer.
 type policyManager struct {
-	filterTable  *iptables.Table
-	ruleRenderer rules.RuleRenderer
+	filterTable  iptablesTable
+	ruleRenderer policyRenderer
 	ipVersion    uint8
 }
 
-func newPolicyManager(filterTable *iptables.Table, ruleRenderer rules.RuleRenderer, ipVersion uint8) *policyManager {
+type policyRenderer interface {
+	PolicyToIptablesChains(policyID *proto.PolicyID, policy *proto.Policy, ipVersion uint8) []*iptables.Chain
+	ProfileToIptablesChains(profileID *proto.ProfileID, policy *proto.Profile, ipVersion uint8) []*iptables.Chain
+}
+
+func newPolicyManager(filterTable iptablesTable, ruleRenderer policyRenderer, ipVersion uint8) *policyManager {
 	return &policyManager{
 		filterTable:  filterTable,
 		ruleRenderer: ruleRenderer,

--- a/go/felix/intdataplane/policy_mgr_test.go
+++ b/go/felix/intdataplane/policy_mgr_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/felix/go/felix/iptables"
+	"github.com/projectcalico/felix/go/felix/proto"
+	"github.com/projectcalico/felix/go/felix/rules"
+)
+
+var _ = Describe("Policy manager", func() {
+	var (
+		policyMgr    *policyManager
+		filterTable  *mockTable
+		ruleRenderer *mockPolRenderer
+	)
+
+	BeforeEach(func() {
+		filterTable = newMockTable()
+		ruleRenderer = newMockPolRenderer()
+		policyMgr = newPolicyManager(filterTable, ruleRenderer, 4)
+	})
+
+	It("shouldn't touch iptables", func() {
+		Expect(filterTable.UpdateCalled).To(BeFalse())
+	})
+
+	Describe("after a policy update", func() {
+		BeforeEach(func() {
+			policyMgr.OnUpdate(&proto.ActivePolicyUpdate{
+				Id: &proto.PolicyID{Name: "pol1", Tier: "tier1"},
+				Policy: &proto.Policy{
+					InboundRules: []*proto.Rule{
+						{Action: "deny"},
+					},
+					OutboundRules: []*proto.Rule{
+						{Action: "allow"},
+					},
+				},
+			})
+			policyMgr.CompleteDeferredWork()
+		})
+
+		It("should install the in and out chain", func() {
+			filterTable.checkChains([][]*iptables.Chain{{
+				{Name: "calipi-tier1/pol1"},
+				{Name: "calipo-tier1/pol1"},
+			}})
+		})
+
+		Describe("after a policy remove", func() {
+			BeforeEach(func() {
+				policyMgr.OnUpdate(&proto.ActivePolicyRemove{
+					Id: &proto.PolicyID{Name: "pol1", Tier: "tier1"},
+				})
+			})
+
+			It("should remove the in and out chain", func() {
+				filterTable.checkChains([][]*iptables.Chain{})
+			})
+		})
+	})
+
+	Describe("after a profile update", func() {
+		BeforeEach(func() {
+			policyMgr.OnUpdate(&proto.ActiveProfileUpdate{
+				Id: &proto.ProfileID{Name: "prof1"},
+				Profile: &proto.Profile{
+					InboundRules: []*proto.Rule{
+						{Action: "deny"},
+					},
+					OutboundRules: []*proto.Rule{
+						{Action: "allow"},
+					},
+				},
+			})
+			policyMgr.CompleteDeferredWork()
+		})
+
+		It("should install the in and out chain", func() {
+			filterTable.checkChains([][]*iptables.Chain{{
+				{Name: "calipi-prof1"},
+				{Name: "calipo-prof1"},
+			}})
+		})
+
+		Describe("after a policy remove", func() {
+			BeforeEach(func() {
+				policyMgr.OnUpdate(&proto.ActiveProfileRemove{
+					Id: &proto.ProfileID{Name: "prof1"},
+				})
+			})
+
+			It("should remove the in and out chain", func() {
+				filterTable.checkChains([][]*iptables.Chain{})
+			})
+		})
+	})
+})
+
+type mockPolRenderer struct {
+}
+
+func (r *mockPolRenderer) PolicyToIptablesChains(policyID *proto.PolicyID, policy *proto.Policy, ipVersion uint8) []*iptables.Chain {
+	inName := rules.PolicyChainName(rules.PolicyInboundPfx, policyID)
+	outName := rules.PolicyChainName(rules.PolicyOutboundPfx, policyID)
+	return []*iptables.Chain{
+		{Name: inName},
+		{Name: outName},
+	}
+}
+func (r *mockPolRenderer) ProfileToIptablesChains(profID *proto.ProfileID, policy *proto.Profile, ipVersion uint8) []*iptables.Chain {
+	inName := rules.ProfileChainName(rules.PolicyInboundPfx, profID)
+	outName := rules.ProfileChainName(rules.PolicyOutboundPfx, profID)
+	return []*iptables.Chain{
+		{Name: inName},
+		{Name: outName},
+	}
+}
+
+func newMockPolRenderer() *mockPolRenderer {
+	return &mockPolRenderer{}
+}

--- a/go/felix/rules/rule_defs.go
+++ b/go/felix/rules/rule_defs.go
@@ -97,7 +97,7 @@ type RuleRenderer interface {
 	HostEndpointToIptablesChains(ifaceName string, endpoint *proto.HostEndpoint) []*iptables.Chain
 
 	PolicyToIptablesChains(policyID *proto.PolicyID, policy *proto.Policy, ipVersion uint8) []*iptables.Chain
-	ProfileToIptablesChains(policyID *proto.ProfileID, policy *proto.Profile, ipVersion uint8) []*iptables.Chain
+	ProfileToIptablesChains(profileID *proto.ProfileID, policy *proto.Profile, ipVersion uint8) []*iptables.Chain
 	ProtoRuleToIptablesRules(pRule *proto.Rule, ipVersion uint8) []iptables.Rule
 
 	NATOutgoingChain(active bool, ipVersion uint8) *iptables.Chain

--- a/go/felix/set/set.go
+++ b/go/felix/set/set.go
@@ -45,6 +45,12 @@ func New() Set {
 	return make(mapSet)
 }
 
+func From(members ...interface{}) Set {
+	s := New()
+	s.AddAll(members)
+	return s
+}
+
 func FromArray(membersArray interface{}) Set {
 	s := New()
 	s.AddAll(membersArray)

--- a/go/felix/set/set.go
+++ b/go/felix/set/set.go
@@ -17,11 +17,13 @@ package set
 import (
 	"errors"
 	log "github.com/Sirupsen/logrus"
+	"reflect"
 )
 
 type Set interface {
 	Len() int
 	Add(interface{})
+	AddAll(itemArray interface{})
 	Discard(interface{})
 	Clear()
 	Contains(interface{}) bool
@@ -43,6 +45,12 @@ func New() Set {
 	return make(mapSet)
 }
 
+func FromArray(membersArray interface{}) Set {
+	s := New()
+	s.AddAll(membersArray)
+	return s
+}
+
 func Empty() Set {
 	return mapSet(nil)
 }
@@ -55,6 +63,14 @@ func (set mapSet) Len() int {
 
 func (set mapSet) Add(item interface{}) {
 	set[item] = emptyValue
+}
+
+func (set mapSet) AddAll(itemArray interface{}) {
+
+	arrVal := reflect.ValueOf(itemArray)
+	for i := 0; i < arrVal.Len(); i++ {
+		set.Add(arrVal.Index(i).Interface())
+	}
 }
 
 func (set mapSet) Discard(item interface{}) {

--- a/go/felix/set/set_test.go
+++ b/go/felix/set/set_test.go
@@ -27,6 +27,7 @@ var _ = Describe("Set", func() {
 		s = set.New()
 	})
 
+<<<<<<< 369494803c8730eca18e569b1b3edfdcf440f4eb
 	It("should be empty", func() {
 		Expect(s.Len()).To(BeZero())
 	})
@@ -41,6 +42,21 @@ var _ = Describe("Set", func() {
 	It("should do nothing on clear", func() {
 		s.Clear()
 		Expect(s.Len()).To(BeZero())
+=======
+	Describe("Set created by FromArray", func() {
+		BeforeEach(func() {
+			s = set.FromArray([]int{1, 2})
+		})
+		It("should contain 1", func() {
+			Expect(s.Contains(1)).To(BeTrue())
+		})
+		It("should contain 2", func() {
+			Expect(s.Contains(2)).To(BeTrue())
+		})
+		It("should not contain 3", func() {
+			Expect(s.Contains(3)).To(BeFalse())
+		})
+>>>>>>> Add set.FromArray() and Set.AddAll() functions.
 	})
 
 	Describe("after adding 1 and 2", func() {
@@ -134,6 +150,7 @@ var _ = Describe("Set", func() {
 				Expect(s.Contains(3)).To(BeFalse())
 			})
 		})
+<<<<<<< 369494803c8730eca18e569b1b3edfdcf440f4eb
 
 		Describe("after Clear()", func() {
 			BeforeEach(func() {
@@ -141,6 +158,23 @@ var _ = Describe("Set", func() {
 			})
 			It("should be empty", func() {
 				Expect(s.Len()).To(BeZero())
+=======
+		Describe("after using AddAll to add 2, 3, 4", func() {
+			BeforeEach(func() {
+				s.AddAll([]int{2, 3, 4})
+			})
+			It("should contain 1", func() {
+				Expect(s.Contains(1)).To(BeTrue())
+			})
+			It("should contain 2", func() {
+				Expect(s.Contains(2)).To(BeTrue())
+			})
+			It("should contain 3", func() {
+				Expect(s.Contains(3)).To(BeTrue())
+			})
+			It("should contain 4", func() {
+				Expect(s.Contains(4)).To(BeTrue())
+>>>>>>> Add set.FromArray() and Set.AddAll() functions.
 			})
 		})
 	})

--- a/go/felix/set/set_test.go
+++ b/go/felix/set/set_test.go
@@ -27,7 +27,6 @@ var _ = Describe("Set", func() {
 		s = set.New()
 	})
 
-<<<<<<< 369494803c8730eca18e569b1b3edfdcf440f4eb
 	It("should be empty", func() {
 		Expect(s.Len()).To(BeZero())
 	})
@@ -42,7 +41,8 @@ var _ = Describe("Set", func() {
 	It("should do nothing on clear", func() {
 		s.Clear()
 		Expect(s.Len()).To(BeZero())
-=======
+	})
+
 	Describe("Set created by FromArray", func() {
 		BeforeEach(func() {
 			s = set.FromArray([]int{1, 2})
@@ -56,7 +56,21 @@ var _ = Describe("Set", func() {
 		It("should not contain 3", func() {
 			Expect(s.Contains(3)).To(BeFalse())
 		})
->>>>>>> Add set.FromArray() and Set.AddAll() functions.
+	})
+
+	Describe("Set created by From", func() {
+		BeforeEach(func() {
+			s = set.From(1, 2)
+		})
+		It("should contain 1", func() {
+			Expect(s.Contains(1)).To(BeTrue())
+		})
+		It("should contain 2", func() {
+			Expect(s.Contains(2)).To(BeTrue())
+		})
+		It("should not contain 3", func() {
+			Expect(s.Contains(3)).To(BeFalse())
+		})
 	})
 
 	Describe("after adding 1 and 2", func() {
@@ -150,15 +164,6 @@ var _ = Describe("Set", func() {
 				Expect(s.Contains(3)).To(BeFalse())
 			})
 		})
-<<<<<<< 369494803c8730eca18e569b1b3edfdcf440f4eb
-
-		Describe("after Clear()", func() {
-			BeforeEach(func() {
-				s.Clear()
-			})
-			It("should be empty", func() {
-				Expect(s.Len()).To(BeZero())
-=======
 		Describe("after using AddAll to add 2, 3, 4", func() {
 			BeforeEach(func() {
 				s.AddAll([]int{2, 3, 4})
@@ -174,7 +179,15 @@ var _ = Describe("Set", func() {
 			})
 			It("should contain 4", func() {
 				Expect(s.Contains(4)).To(BeTrue())
->>>>>>> Add set.FromArray() and Set.AddAll() functions.
+			})
+		})
+
+		Describe("after Clear()", func() {
+			BeforeEach(func() {
+				s.Clear()
+			})
+			It("should be empty", func() {
+				Expect(s.Len()).To(BeZero())
 			})
 		})
 	})


### PR DESCRIPTION
Included in this change: 

- I spotted that the ipipManager didn't correctly handle transient duplicate IPs so I simplified the logic to have it always rewrite the IP set.  I think that'll be OK since host churn is fairly rare and we're talking about a few thousand IPs at most.
- I spotted that we weren't honouring the config for max IP set size so I plumbed that in.

I kicked the tyres on the tunnel config updates.  Seems to work as expected without flapping the IP if it's already present.