### PR TITLE
Port ChainInsertMode to Go

### DIFF
--- a/go/felix/felix.go
+++ b/go/felix/felix.go
@@ -218,6 +218,7 @@ configRetry:
 			},
 			IPIPMTU:                 configParams.IpInIpMtu,
 			IptablesRefreshInterval: time.Duration(configParams.IptablesRefreshInterval) * time.Second,
+			IptablesInsertMode:      configParams.ChainInsertMode,
 			MaxIPSetSize:            configParams.MaxIpsetSize,
 		}
 		intDP := intdataplane.NewIntDataplaneDriver(dpConfig)

--- a/go/felix/intdataplane/int_dataplane.go
+++ b/go/felix/intdataplane/int_dataplane.go
@@ -35,6 +35,7 @@ type Config struct {
 	MaxIPSetSize int
 
 	IptablesRefreshInterval time.Duration
+	IptablesInsertMode      string
 
 	RulesConfig rules.Config
 }

--- a/go/felix/intdataplane/int_dataplane.go
+++ b/go/felix/intdataplane/int_dataplane.go
@@ -124,12 +124,26 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	natTableV4 := iptables.NewTable(
 		"nat",
 		4,
-		rules.AllHistoricChainNamePrefixes,
 		rules.RuleHashPrefix,
-		rules.HistoricInsertedNATRuleRegex,
+		iptables.TableOptions{
+			HistoricChainPrefixes:    rules.AllHistoricChainNamePrefixes,
+			ExtraCleanupRegexPattern: rules.HistoricInsertedNATRuleRegex,
+		},
 	)
-	rawTableV4 := iptables.NewTable("raw", 4, rules.AllHistoricChainNamePrefixes, rules.RuleHashPrefix, "")
-	filterTableV4 := iptables.NewTable("filter", 4, rules.AllHistoricChainNamePrefixes, rules.RuleHashPrefix, "")
+	rawTableV4 := iptables.NewTable(
+		"raw",
+		4,
+		rules.RuleHashPrefix,
+		iptables.TableOptions{
+			HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
+		})
+	filterTableV4 := iptables.NewTable(
+		"filter",
+		4,
+		rules.RuleHashPrefix,
+		iptables.TableOptions{
+			HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
+		})
 	ipSetsConfigV4 := config.RulesConfig.IPSetConfigV4
 	ipSetRegV4 := ipsets.NewRegistry(ipSetsConfigV4)
 	dp.iptablesNATTables = append(dp.iptablesNATTables, natTableV4)
@@ -161,12 +175,28 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		natTableV6 := iptables.NewTable(
 			"nat",
 			6,
-			rules.AllHistoricChainNamePrefixes,
 			rules.RuleHashPrefix,
-			rules.HistoricInsertedNATRuleRegex,
+			iptables.TableOptions{
+				HistoricChainPrefixes:    rules.AllHistoricChainNamePrefixes,
+				ExtraCleanupRegexPattern: rules.HistoricInsertedNATRuleRegex,
+			},
 		)
-		rawTableV6 := iptables.NewTable("raw", 6, rules.AllHistoricChainNamePrefixes, rules.RuleHashPrefix, "")
-		filterTableV6 := iptables.NewTable("filter", 6, rules.AllHistoricChainNamePrefixes, rules.RuleHashPrefix, "")
+		rawTableV6 := iptables.NewTable(
+			"raw",
+			6,
+			rules.RuleHashPrefix,
+			iptables.TableOptions{
+				HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
+			},
+		)
+		filterTableV6 := iptables.NewTable(
+			"filter",
+			6,
+			rules.RuleHashPrefix,
+			iptables.TableOptions{
+				HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
+			},
+		)
 
 		ipSetsConfigV6 := config.RulesConfig.IPSetConfigV6
 		ipSetRegV6 := ipsets.NewRegistry(ipSetsConfigV6)

--- a/go/felix/iptables/rules_test.go
+++ b/go/felix/iptables/rules_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,9 +68,11 @@ var _ = Describe("Hash extraction tests", func() {
 		table = NewTable(
 			"filter",
 			4,
-			[]string{"felix-", "cali"},
 			"cali:",
-			"an-old-rule",
+			TableOptions{
+				HistoricChainPrefixes:    []string{"felix-", "cali"},
+				ExtraCleanupRegexPattern: "an-old-rule",
+			},
 		)
 	})
 

--- a/go/felix/iptables/table_test.go
+++ b/go/felix/iptables/table_test.go
@@ -374,10 +374,11 @@ func describeDirtyDataplaneTests(appendMode bool) {
 				// This rule will get rewritten because its hash is incorrect.
 				"-m comment --comment \"cali:1234567890ksamdl\" --jump DROP",
 			},
-			"non-calico-insert": {
-				// This rule will get cleaned up because we don't insert any rules
-				// into this chain.
+			"unexpected-insert": {
 				"--jump ACCEPT",
+				// This rule will get cleaned up because it looks like a Calico
+				// insert rule but it's in a chain that we don't insert anything
+				// into.
 				"-m comment --comment \"cali:hecdSCslEjdBPfds\" --jump DROP",
 				"--jump DROP",
 			},
@@ -439,7 +440,7 @@ func describeDirtyDataplaneTests(appendMode bool) {
 			"non-calico": {
 				"--jump ACCEPT",
 			},
-			"non-calico-insert": {
+			"unexpected-insert": {
 				"--jump ACCEPT",
 				"--jump DROP",
 			},
@@ -473,19 +474,12 @@ func describeDirtyDataplaneTests(appendMode bool) {
 		})
 		checkFinalState := func() {
 			expChains := map[string][]string{
-				"FORWARD": {
-					"--jump RETURN",
-					"--jump ACCEPT",
-					"--jump foo-bar",
-					"-m comment --comment \"cali:hecdSCslEjdBPBPo\" --jump DROP",
-					"-m comment --comment \"cali:plvr29-ZiKUwbzDV\" --jump ACCEPT",
-				},
 				"cali-foobar": {
 					"-m comment --comment \"cali:42h7Q64_2XDzpwKe\" --jump ACCEPT",
 					"-m comment --comment \"cali:0sUFHicPNNqNyNx8\" --jump DROP",
 					"-m comment --comment \"cali:yilSOZ62PxMhMnS9\" --jump RETURN",
 				},
-				"non-calico-insert": {
+				"unexpected-insert": {
 					"--jump ACCEPT",
 					"--jump DROP",
 				},
@@ -679,7 +673,7 @@ func describeDirtyDataplaneTests(appendMode bool) {
 						"-m comment --comment \"cali:42h7Q64_2XDzpwKe\" --jump ACCEPT",
 						"-m comment --comment \"cali:ilM9uz5oPwfm0FE-\" --jump RETURN",
 					},
-					"non-calico-insert": {
+					"unexpected-insert": {
 						"--jump ACCEPT",
 						"--jump DROP",
 					},

--- a/go/felix/iptables/table_test.go
+++ b/go/felix/iptables/table_test.go
@@ -40,10 +40,9 @@ var _ = Describe("Table with an empty dataplane", func() {
 			4,
 			rules.RuleHashPrefix,
 			TableOptions{
-				HistoricChainPrefixes:    rules.AllHistoricChainNamePrefixes,
-				ExtraCleanupRegexPattern: "",
-				NewCmdOverride:           dataplane.newCmd,
-				SleepOverride:            dataplane.sleep,
+				HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
+				NewCmdOverride:        dataplane.newCmd,
+				SleepOverride:         dataplane.sleep,
 			},
 		)
 	})
@@ -58,6 +57,22 @@ var _ = Describe("Table with an empty dataplane", func() {
 		Expect(len(dataplane.Cmds)).To(BeZero())
 		table.Apply()
 		Expect(len(dataplane.Cmds)).NotTo(BeZero())
+	})
+
+	It("should police the insert mode", func() {
+		Expect(func() {
+			NewTable(
+				"filter",
+				4,
+				rules.RuleHashPrefix,
+				TableOptions{
+					HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
+					NewCmdOverride:        dataplane.newCmd,
+					SleepOverride:         dataplane.sleep,
+					InsertMode:            "unknown",
+				},
+			)
+		}).To(Panic())
 	})
 
 	Describe("after inserting a rule", func() {
@@ -322,7 +337,7 @@ var _ = Describe("Table with an empty dataplane", func() {
 	})
 })
 
-var _ = Describe("Table with a dirty dataplane", func() {
+func describeDirtyDataplaneTests(appendMode bool) {
 	// These tests all start with some rules already in the dataplane.  We include a mix of
 	// Calico and non-Calico rules.  Within the Calico rules,we include:
 	// - rules that match what we're going to ask the Table to program
@@ -359,6 +374,13 @@ var _ = Describe("Table with a dirty dataplane", func() {
 				// This rule will get rewritten because its hash is incorrect.
 				"-m comment --comment \"cali:1234567890ksamdl\" --jump DROP",
 			},
+			"non-calico-insert": {
+				// This rule will get cleaned up because we don't insert any rules
+				// into this chain.
+				"--jump ACCEPT",
+				"-m comment --comment \"cali:hecdSCslEjdBPfds\" --jump DROP",
+				"--jump DROP",
+			},
 			// Calico chain from previous version.  Should be cleaned up.
 			"felix-FORWARD": {
 				"--jump ACCEPT",
@@ -380,8 +402,13 @@ var _ = Describe("Table with a dirty dataplane", func() {
 			},
 		}
 	}
+
 	BeforeEach(func() {
 		dataplane = newMockDataplane("filter", initialChains())
+		insertMode := ""
+		if appendMode {
+			insertMode = "append"
+		}
 		table = NewTable(
 			"filter",
 			4,
@@ -391,6 +418,7 @@ var _ = Describe("Table with a dirty dataplane", func() {
 				ExtraCleanupRegexPattern: "sneaky-rule",
 				NewCmdOverride:           dataplane.newCmd,
 				SleepOverride:            dataplane.sleep,
+				InsertMode:               insertMode,
 			},
 		)
 	})
@@ -410,6 +438,10 @@ var _ = Describe("Table with a dirty dataplane", func() {
 			"OUTPUT": {},
 			"non-calico": {
 				"--jump ACCEPT",
+			},
+			"non-calico-insert": {
+				"--jump ACCEPT",
+				"--jump DROP",
 			},
 		}))
 	})
@@ -440,18 +472,22 @@ var _ = Describe("Table with a dirty dataplane", func() {
 			})
 		})
 		checkFinalState := func() {
-			Expect(dataplane.Chains).To(Equal(map[string][]string{
+			expChains := map[string][]string{
 				"FORWARD": {
-					"-m comment --comment \"cali:hecdSCslEjdBPBPo\" --jump DROP",
-					"-m comment --comment \"cali:plvr29-ZiKUwbzDV\" --jump ACCEPT",
 					"--jump RETURN",
 					"--jump ACCEPT",
 					"--jump foo-bar",
+					"-m comment --comment \"cali:hecdSCslEjdBPBPo\" --jump DROP",
+					"-m comment --comment \"cali:plvr29-ZiKUwbzDV\" --jump ACCEPT",
 				},
 				"cali-foobar": {
 					"-m comment --comment \"cali:42h7Q64_2XDzpwKe\" --jump ACCEPT",
 					"-m comment --comment \"cali:0sUFHicPNNqNyNx8\" --jump DROP",
 					"-m comment --comment \"cali:yilSOZ62PxMhMnS9\" --jump RETURN",
+				},
+				"non-calico-insert": {
+					"--jump ACCEPT",
+					"--jump DROP",
 				},
 				"INPUT": {},
 				"OUTPUT": {
@@ -463,7 +499,27 @@ var _ = Describe("Table with a dirty dataplane", func() {
 				"cali-correct": {
 					"-m comment --comment \"cali:dCKeL4JtUEDC2GQu\" --jump ACCEPT",
 				},
-			}))
+			}
+
+			if appendMode {
+				expChains["FORWARD"] = []string{
+					"--jump RETURN",
+					"--jump ACCEPT",
+					"--jump foo-bar",
+					"-m comment --comment \"cali:hecdSCslEjdBPBPo\" --jump DROP",
+					"-m comment --comment \"cali:plvr29-ZiKUwbzDV\" --jump ACCEPT",
+				}
+			} else {
+				expChains["FORWARD"] = []string{
+					"-m comment --comment \"cali:hecdSCslEjdBPBPo\" --jump DROP",
+					"-m comment --comment \"cali:plvr29-ZiKUwbzDV\" --jump ACCEPT",
+					"--jump RETURN",
+					"--jump ACCEPT",
+					"--jump foo-bar",
+				}
+			}
+
+			Expect(dataplane.Chains).To(Equal(expChains))
 		}
 		It("with no errors, it should get to correct final state", func() {
 			table.Apply()
@@ -617,17 +673,15 @@ var _ = Describe("Table with a dirty dataplane", func() {
 				})
 				// Next Apply() should refresh then put everything in sync.
 				table.Apply()
-				Expect(dataplane.Chains).To(Equal(map[string][]string{
-					"FORWARD": {
-						"-m comment --comment \"cali:hecdSCslEjdBPBPo\" --jump DROP",
-						"-m comment --comment \"cali:plvr29-ZiKUwbzDV\" --jump ACCEPT",
-						"--jump RETURN",
-						"--jump ACCEPT",
-						"--jump foo-bar",
-					},
+
+				expChains := map[string][]string{
 					"cali-foobar": {
 						"-m comment --comment \"cali:42h7Q64_2XDzpwKe\" --jump ACCEPT",
 						"-m comment --comment \"cali:ilM9uz5oPwfm0FE-\" --jump RETURN",
+					},
+					"non-calico-insert": {
+						"--jump ACCEPT",
+						"--jump DROP",
 					},
 					"INPUT": {},
 					"OUTPUT": {
@@ -639,8 +693,31 @@ var _ = Describe("Table with a dirty dataplane", func() {
 					"cali-correct": {
 						"-m comment --comment \"cali:dCKeL4JtUEDC2GQu\" --jump ACCEPT",
 					},
-				}))
+				}
+
+				if appendMode {
+					expChains["FORWARD"] = []string{
+						"--jump RETURN",
+						"--jump ACCEPT",
+						"--jump foo-bar",
+						"-m comment --comment \"cali:hecdSCslEjdBPBPo\" --jump DROP",
+						"-m comment --comment \"cali:plvr29-ZiKUwbzDV\" --jump ACCEPT",
+					}
+				} else {
+					expChains["FORWARD"] = []string{
+						"-m comment --comment \"cali:hecdSCslEjdBPBPo\" --jump DROP",
+						"-m comment --comment \"cali:plvr29-ZiKUwbzDV\" --jump ACCEPT",
+						"--jump RETURN",
+						"--jump ACCEPT",
+						"--jump foo-bar",
+					}
+				}
+
+				Expect(dataplane.Chains).To(Equal(expChains))
 			})
 		})
 	})
-})
+}
+
+var _ = Describe("Table with a dirty datatplane in append mode", func() { describeDirtyDataplaneTests(true) })
+var _ = Describe("Table with a dirty datatplane in insert mode", func() { describeDirtyDataplaneTests(false) })

--- a/go/felix/iptables/table_test.go
+++ b/go/felix/iptables/table_test.go
@@ -35,14 +35,16 @@ var _ = Describe("Table with an empty dataplane", func() {
 			"INPUT":   {},
 			"OUTPUT":  {},
 		})
-		table = NewTableWithShims(
+		table = NewTable(
 			"filter",
 			4,
-			rules.AllHistoricChainNamePrefixes,
 			rules.RuleHashPrefix,
-			"",
-			dataplane.newCmd,
-			dataplane.sleep,
+			TableOptions{
+				HistoricChainPrefixes:    rules.AllHistoricChainNamePrefixes,
+				ExtraCleanupRegexPattern: "",
+				NewCmdOverride:           dataplane.newCmd,
+				SleepOverride:            dataplane.sleep,
+			},
 		)
 	})
 
@@ -380,14 +382,16 @@ var _ = Describe("Table with a dirty dataplane", func() {
 	}
 	BeforeEach(func() {
 		dataplane = newMockDataplane("filter", initialChains())
-		table = NewTableWithShims(
+		table = NewTable(
 			"filter",
 			4,
-			rules.AllHistoricChainNamePrefixes,
 			rules.RuleHashPrefix,
-			"sneaky-rule",
-			dataplane.newCmd,
-			dataplane.sleep,
+			TableOptions{
+				HistoricChainPrefixes:    rules.AllHistoricChainNamePrefixes,
+				ExtraCleanupRegexPattern: "sneaky-rule",
+				NewCmdOverride:           dataplane.newCmd,
+				SleepOverride:            dataplane.sleep,
+			},
 		)
 	})
 


### PR DESCRIPTION
- Introduce TableOptions struct for optional Table params. (First commit.)
- Plumb ChainInsertMode through and implement in Table:
  - Use same logic to calculate hashes of insert chains when doing the insert and comparing them in the dataplane.  Makes the comparison a lot simpler.
  - Implement the append itself.
  - Add UT.