### PR TITLE
Don't error when i/f deleted while we are deconfiguring it

### DIFF
--- a/python/calico/felix/endpoint.py
+++ b/python/calico/felix/endpoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
 # Copyright (c) 2015 Cisco Systems.  All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -1060,7 +1060,9 @@ class WorkloadEndpoint(LocalEndpoint):
         try:
             devices.set_routes(self.ip_type, set(), self._iface_name, None)
         except FailedSystemCall as e:
-            if "Cannot find device" in e.stderr:
+            if ("Cannot find device" in e.stderr or
+                "No such device" in e.stderr or
+                not devices.interface_exists(self._iface_name)):
                 # Deleted under our feet - so the rules are gone.
                 _log.info("Interface %s for %s already deleted",
                           self._iface_name, self.combined_id)

--- a/python/calico/felix/test/test_endpoint.py
+++ b/python/calico/felix/test/test_endpoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2014-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2014-2017 Tigera, Inc. All rights reserved.
 # Copyright (c) 2015 Cisco Systems.  All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -845,7 +845,7 @@ class TestWorkloadEndpoint(BaseTestCase):
             else:
                 self.assertFalse(m_exc_fn.called)
 
-    def test_on_endpoint_update_delete_fail_unknown(self):
+    def test_on_endpoint_update_delete_fail_dev_deleted(self):
         self._test_on_endpoint_update_delete_fail(
             FailedSystemCall(
                 "", [], 1,
@@ -853,7 +853,7 @@ class TestWorkloadEndpoint(BaseTestCase):
                 stderr='Foo bar'
             ),
             False,
-            "exception",
+            "info",
         )
 
     def test_on_endpoint_update_delete_fail_deleted(self):


### PR DESCRIPTION
Specifically suppresses logs like this one, when the 'arp -d'
invocation fails because of the interface no longer existing:

calico.felix.endpoint 1073: Failed to remove routes from interface tapd8c3e6b5-a8 for WloadEndpointId<d8c3e6b5-a8e4-4fcf-b064-8936f39e7c53>, but interface appears to still be present. Assuming the interface flapped.
Traceback (most recent call last):
File "site-packages/calico/felix/endpoint.py", line 1061, in _deconfigure_interface
File "site-packages/calico/felix/devices.py", line 333, in set_routes
File "site-packages/calico/felix/devices.py", line 310, in del_route
File "site-packages/calico/felix/futils.py", line 355, in check_call
FailedSystemCall: Failed system call (retcode : 255, args : ('arp', '-d', '10.29.0.2', '-i', u'tapd8c3e6b5-a8'))
stdout  :
stderr  : SIOCDARP(dontpub): No such device

input  : None