### PR TITLE
Handle other errors that can be raise during route removal

### DIFF
--- a/python/calico/felix/endpoint.py
+++ b/python/calico/felix/endpoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
 # Copyright (c) 2015 Cisco Systems.  All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -1060,7 +1060,9 @@ class WorkloadEndpoint(LocalEndpoint):
         try:
             devices.set_routes(self.ip_type, set(), self._iface_name, None)
         except FailedSystemCall as e:
-            if "Cannot find device" in e.stderr:
+            if ("Cannot find device" in e.stderr or
+                    "No such device" in e.stderr or
+                    not devices.interface_exists(self._iface_name)):
                 # Deleted under our feet - so the rules are gone.
                 _log.info("Interface %s for %s already deleted",
                           self._iface_name, self.combined_id)

--- a/python/calico/felix/test/test_endpoint.py
+++ b/python/calico/felix/test/test_endpoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2014-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2014-2017 Tigera, Inc. All rights reserved.
 # Copyright (c) 2015 Cisco Systems.  All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -853,7 +853,7 @@ class TestWorkloadEndpoint(BaseTestCase):
                 stderr='Foo bar'
             ),
             False,
-            "exception",
+            "info",
         )
 
     def test_on_endpoint_update_delete_fail_deleted(self):
@@ -862,6 +862,17 @@ class TestWorkloadEndpoint(BaseTestCase):
                 "", [], 1,
                 stdout="",
                 stderr='Cannot find device "tapabcdef"'
+            ),
+            False,
+            "info",
+        )
+
+    def test_on_endpoint_update_delete_fail_arp_deleted(self):
+        self._test_on_endpoint_update_delete_fail(
+            FailedSystemCall(
+                "", [], 1,
+                stdout="",
+                stderr='No such device "tapabcdef"'
             ),
             False,
             "info",


### PR DESCRIPTION
Also, re-instate interface existence check.