### PR TITLE
Fix that an empty string for FailsafeIn/OutboundHostPorts was rejected.

### DIFF
--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -122,6 +122,10 @@ var _ = DescribeTable("Config parsing",
 
 	Entry("FailsafeInboundHostPorts", "FailsafeInboundHostPorts", "1,2,3,4", []uint16{1, 2, 3, 4}),
 	Entry("FailsafeOutboundHostPorts", "FailsafeOutboundHostPorts", "1,2,3,4", []uint16{1, 2, 3, 4}),
+	Entry("FailsafeInboundHostPorts empty", "FailsafeInboundHostPorts", "none", []uint16(nil)),
+	Entry("FailsafeOutboundHostPorts empty", "FailsafeOutboundHostPorts", "none", []uint16(nil)),
+	Entry("FailsafeInboundHostPorts empty", "FailsafeInboundHostPorts", "", []uint16(nil)),
+	Entry("FailsafeOutboundHostPorts empty", "FailsafeOutboundHostPorts", "", []uint16(nil)),
 )
 
 var _ = DescribeTable("Mark bit calculation tests",

--- a/config/param_types.go
+++ b/config/param_types.go
@@ -210,8 +210,12 @@ type PortListParam struct {
 }
 
 func (p *PortListParam) Parse(raw string) (interface{}, error) {
-	result := []uint16{}
+	var result []uint16
 	for _, portStr := range strings.Split(raw, ",") {
+		portStr = strings.Trim(portStr, " ")
+		if portStr == "" {
+			continue
+		}
 		port, err := strconv.Atoi(portStr)
 		if err != nil {
 			err = p.parseFailed(raw, "ports should be integers")


### PR DESCRIPTION
Fixes #1297 