### PR TITLE
Add NAT table insertion for OUTPUT chain

### DIFF
--- a/intdataplane/int_dataplane.go
+++ b/intdataplane/int_dataplane.go
@@ -356,6 +356,9 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 		t.SetRuleInsertions("POSTROUTING", []iptables.Rule{{
 			Action: iptables.JumpAction{Target: rules.ChainNATPostrouting},
 		}})
+		t.SetRuleInsertions("OUTPUT", []iptables.Rule{{
+			Action: iptables.JumpAction{Target: rules.ChainNATOutput},
+		}})
 	}
 
 	// Retry any failed operations every 10s.


### PR DESCRIPTION
(Copy of justification from d36d46c5ac52a:

    This is needed so that an endpoint can be pinged from its own host
    using its floating IP.  One reason for wanting that is that that
    is what OpenStack Tempest tests do.  More generally it adds
    utility without any downside.

    The PREROUTING chain is only traversed for packets that are
    received on the compute host from elsewhere; so our use of
    PREROUTING to implement floating IPs works for such packets, but
    not for packets that originate from the compute host.  To cover
    the latter, we can traverse the floating IP DNAT rules from the
    OUTPUT chain as well.

    Note that we also (already) do floating IP-related SNATs in the
    POSTROUTING chain.  For those to operate correctly, the DNATs have
    to happen first.  (And happily they do:
    https://upload.wikimedia.org/wikipedia/commons/3/37/Netfilter-packet-flow.svg)
)

In this all-golang version of Felix, we already had what we needed to
generate the NAT cali-OUTPUT chain; we were just missing the top level
insertion to link from NAT OUTPUT to NAT cali-OUTPUT.