### PR TITLE
Add extra prometheus metrics

### DIFF
--- a/calc/async_calc_graph.go
+++ b/calc/async_calc_graph.go
@@ -21,6 +21,7 @@ import (
 	"github.com/projectcalico/felix/proto"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/prometheus/client_golang/prometheus"
+	"reflect"
 	"time"
 )
 
@@ -43,11 +44,26 @@ var (
 		api.ResyncInProgress: 2,
 		api.InSync:           3,
 	}
+	countUpdatesProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "felix_calc_graph_updates_processed",
+		Help: "Number of datastore updates processed by the calculation graph.",
+	}, []string{"type"})
+	countOutputEvents = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_calc_graph_output_events",
+		Help: "Number of events emitted by the calculation graph.",
+	})
+	histUpdateTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "felix_calc_graph_update_time_seconds",
+		Help: "Seconds to update calculation graph for each datastore OnUpdate call.",
+	})
 )
 
 func init() {
 	prometheus.MustRegister(dataplaneStatusGauge)
 	prometheus.MustRegister(resyncsStarted)
+	prometheus.MustRegister(countUpdatesProcessed)
+	prometheus.MustRegister(countOutputEvents)
+	prometheus.MustRegister(histUpdateTime)
 }
 
 type AsyncCalcGraph struct {
@@ -65,11 +81,11 @@ type AsyncCalcGraph struct {
 
 func NewAsyncCalcGraph(conf *config.Config, outputEvents chan<- interface{}) *AsyncCalcGraph {
 	eventBuffer := NewEventBuffer(conf)
-	dispatcher := NewCalculationGraph(eventBuffer, conf.FelixHostname)
+	disp := NewCalculationGraph(eventBuffer, conf.FelixHostname)
 	g := &AsyncCalcGraph{
 		inputEvents:  make(chan interface{}, 10),
 		outputEvents: outputEvents,
-		Dispatcher:   dispatcher,
+		Dispatcher:   disp,
 		eventBuffer:  eventBuffer,
 	}
 	eventBuffer.Callback = g.onEvent
@@ -99,7 +115,18 @@ func (acg *AsyncCalcGraph) loop() {
 			case []api.Update:
 				// Update; send it to the dispatcher.
 				log.Debug("Pulled []KVPair off channel")
+				updStartTime := time.Now()
 				acg.Dispatcher.OnUpdates(update)
+				updEndTime := time.Now()
+				if updEndTime.After(updStartTime) {
+					histUpdateTime.Observe(updEndTime.Sub(updStartTime).Seconds())
+				}
+				// Record stats for the number of messages processed.
+				for _, upd := range update {
+					typeName := reflect.TypeOf(upd.Key).Name()
+					count := countUpdatesProcessed.WithLabelValues(typeName)
+					count.Add(float64(len(update)))
+				}
 			case api.SyncStatus:
 				// Sync status changed, check if we're now in-sync.
 				log.WithField("status", update).Debug(
@@ -152,6 +179,7 @@ func (acg *AsyncCalcGraph) maybeFlush() {
 func (acg *AsyncCalcGraph) onEvent(event interface{}) {
 	log.Debug("Sending output event on channel")
 	acg.outputEvents <- event
+	countOutputEvents.Inc()
 	log.Debug("Sent output event on channel")
 }
 

--- a/calc/async_calc_graph.go
+++ b/calc/async_calc_graph.go
@@ -119,13 +119,14 @@ func (acg *AsyncCalcGraph) loop() {
 				acg.Dispatcher.OnUpdates(update)
 				updEndTime := time.Now()
 				if updEndTime.After(updStartTime) {
+					// Avoid recording a negative delta in case the clock jumps.
 					histUpdateTime.Observe(updEndTime.Sub(updStartTime).Seconds())
 				}
 				// Record stats for the number of messages processed.
 				for _, upd := range update {
 					typeName := reflect.TypeOf(upd.Key).Name()
 					count := countUpdatesProcessed.WithLabelValues(typeName)
-					count.Add(float64(len(update)))
+					count.Inc()
 				}
 			case api.SyncStatus:
 				// Sync status changed, check if we're now in-sync.

--- a/calc/calc_graph.go
+++ b/calc/calc_graph.go
@@ -25,7 +25,24 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/hash"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/selector"
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+var (
+	gaugeNumActiveSelectors = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "felix_active_local_selectors",
+		Help: "Number of active selectors on this host.",
+	})
+	gaugeNumActiveTags = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "felix_active_local_tags",
+		Help: "Number of active tags on this host.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(gaugeNumActiveTags)
+	prometheus.MustRegister(gaugeNumActiveSelectors)
+}
 
 type ipSetUpdateCallbacks interface {
 	OnIPSetAdded(setID string)
@@ -112,15 +129,18 @@ func NewCalculationGraph(callbacks PipelineCallbacks, hostname string) (allUpdDi
 			memberCalc.MatchStopped(labelId.(model.Key), selId.(string))
 		},
 	)
+
 	ruleScanner.OnSelectorActive = func(sel selector.Selector) {
 		log.Infof("Selector %v now active", sel)
 		callbacks.OnIPSetAdded(sel.UniqueId())
 		activeSelectorIndex.UpdateSelector(sel.UniqueId(), sel)
+		gaugeNumActiveSelectors.Inc()
 	}
 	ruleScanner.OnSelectorInactive = func(sel selector.Selector) {
 		log.Infof("Selector %v now inactive", sel)
 		activeSelectorIndex.DeleteSelector(sel.UniqueId())
 		callbacks.OnIPSetRemoved(sel.UniqueId())
+		gaugeNumActiveSelectors.Dec()
 	}
 	activeSelectorIndex.RegisterWith(allUpdDispatcher)
 
@@ -139,11 +159,13 @@ func NewCalculationGraph(callbacks PipelineCallbacks, hostname string) (allUpdDi
 		log.Infof("Tag %v now active", tag)
 		callbacks.OnIPSetAdded(hash.MakeUniqueID("t", tag))
 		tagIndex.SetTagActive(tag)
+		gaugeNumActiveTags.Inc()
 	}
 	ruleScanner.OnTagInactive = func(tag string) {
 		log.Infof("Tag %v now inactive", tag)
 		tagIndex.SetTagInactive(tag)
 		callbacks.OnIPSetRemoved(hash.MakeUniqueID("t", tag))
+		gaugeNumActiveTags.Dec()
 	}
 	tagIndex.RegisterWith(allUpdDispatcher)
 

--- a/intdataplane/int_dataplane.go
+++ b/intdataplane/int_dataplane.go
@@ -437,6 +437,7 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 			d.apply()
 			applyEnd := time.Now()
 			if applyEnd.After(applyStart) {
+				// Avoid a negative interval in case the clock jumps.
 				histApplyTime.Observe(applyEnd.Sub(applyStart).Seconds())
 			}
 			if d.dataplaneNeedsSync {

--- a/intdataplane/int_dataplane.go
+++ b/intdataplane/int_dataplane.go
@@ -24,8 +24,31 @@ import (
 	"github.com/projectcalico/felix/routetable"
 	"github.com/projectcalico/felix/rules"
 	"github.com/projectcalico/felix/set"
+	"github.com/prometheus/client_golang/prometheus"
+	"reflect"
 	"time"
 )
+
+var (
+	countDataplaneSyncErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_int_dataplane_failures",
+		Help: "Number of times dataplane updates failed and will be retried.",
+	})
+	countMessages = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "felix_int_dataplane_messages",
+		Help: "Number dataplane messages by type.",
+	}, []string{"type"})
+	histApplyTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "felix_int_dataplane_apply_time_seconds",
+		Help: "Time in seconds that it took to apply a dataplane update.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(countDataplaneSyncErrors)
+	prometheus.MustRegister(histApplyTime)
+	prometheus.MustRegister(countMessages)
+}
 
 type Config struct {
 	DisableIPv6          bool
@@ -377,6 +400,7 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 		select {
 		case msg := <-d.toDataplane:
 			log.WithField("msg", msg).Info("Received update from calculation graph")
+			d.recordMsgStat(msg)
 			for _, mgr := range d.allManagers {
 				mgr.OnUpdate(msg)
 			}
@@ -409,9 +433,22 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 		}
 
 		if datastoreInSync && d.dataplaneNeedsSync {
+			applyStart := time.Now()
 			d.apply()
+			applyEnd := time.Now()
+			if applyEnd.After(applyStart) {
+				histApplyTime.Observe(applyEnd.Sub(applyStart).Seconds())
+			}
+			if d.dataplaneNeedsSync {
+				countDataplaneSyncErrors.Inc()
+			}
 		}
 	}
+}
+
+func (d *InternalDataplane) recordMsgStat(msg interface{}) {
+	typeName := reflect.ValueOf(msg).Elem().Type().Name()
+	countMessages.WithLabelValues(typeName).Inc()
 }
 
 func (d *InternalDataplane) apply() {

--- a/ipsets/ipset.go
+++ b/ipsets/ipset.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/felix/set"
+	"github.com/prometheus/client_golang/prometheus"
 	"io"
 	"time"
 )
@@ -32,6 +33,27 @@ const (
 	IPSetTypeHashIP  IPSetType = "hash:ip"
 	IPSetTypeHashNet IPSetType = "hash:net"
 )
+
+var (
+	countNumIPSetCalls = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_ipset_calls",
+		Help: "Number of ipset commands executed.",
+	})
+	countNumIPSetErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_ipset_errors",
+		Help: "Number of ipset command failures.",
+	})
+	countNumIPSetLinesExecuted = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_ipset_lines_executed",
+		Help: "Number of ipset operations executed.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(countNumIPSetCalls)
+	prometheus.MustRegister(countNumIPSetErrors)
+	prometheus.MustRegister(countNumIPSetLinesExecuted)
+}
 
 func (t IPSetType) IsValid() bool {
 	switch t {
@@ -237,10 +259,12 @@ func (s *IPSet) rewriteIPSet() error {
 
 func (s *IPSet) execIpsetRestore(stdin io.Reader) error {
 	// Execute the commands via the bulk "restore" sub-command.
+	countNumIPSetCalls.Inc()
 	cmd := s.newCmd("ipset", "restore")
 	cmd.SetStdin(stdin)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		countNumIPSetErrors.Inc()
 		log.WithError(err).WithField("output", string(output)).Warn(
 			"Failed to execute 'ipset restore'.")
 		return err
@@ -267,6 +291,7 @@ func (s *IPSet) writeFullRewrite(buf stringWriter) {
 		log.WithField("setID", s.SetID).Debug("Pre-creating main IP set")
 		fmt.Fprintf(buf, "create %s %s family %s maxelem %d\n",
 			mainSetName, s.Type, s.IPVersionConfig.Family, s.MaxSize)
+		countNumIPSetLinesExecuted.Inc()
 	}
 	tempSetName := s.TempIPSetName()
 	if s.existenceCache.IPSetExists(tempSetName) {
@@ -274,6 +299,7 @@ func (s *IPSet) writeFullRewrite(buf stringWriter) {
 		// parameters.
 		log.WithField("setID", s.SetID).Debug("Temp IP set exists, deleting it before rewrite")
 		fmt.Fprintf(buf, "destroy %s\n", tempSetName)
+		countNumIPSetLinesExecuted.Inc()
 	}
 	// Create the temporary IP set with the current parameters.
 	fmt.Fprintf(buf, "create %s %s family %s maxelem %d\n",
@@ -282,12 +308,15 @@ func (s *IPSet) writeFullRewrite(buf stringWriter) {
 	s.desiredMembers.Iter(func(item interface{}) error {
 		member := item.(string)
 		fmt.Fprintf(buf, "add %s %s\n", tempSetName, member)
+		countNumIPSetLinesExecuted.Inc()
 		return nil
 	})
 	// Atomically swap the temporary set into place.
 	fmt.Fprintf(buf, "swap %s %s\n", mainSetName, tempSetName)
+	countNumIPSetLinesExecuted.Inc()
 	// Then remove the temporary set (which was the old main set).
 	fmt.Fprintf(buf, "destroy %s\n", tempSetName)
+	countNumIPSetLinesExecuted.Inc()
 	// ipset restore input ends with "COMMIT" (but only the swap instruction is guaranteed to be
 	// atomic).
 	buf.WriteString("COMMIT\n")
@@ -300,11 +329,13 @@ func (s *IPSet) writeDeltas(buf stringWriter) {
 	s.pendingDeletions.Iter(func(item interface{}) error {
 		member := item.(string)
 		fmt.Fprintf(buf, "del %s %s\n", mainSetName, member)
+		countNumIPSetLinesExecuted.Inc()
 		return nil
 	})
 	s.pendingAdds.Iter(func(item interface{}) error {
 		member := item.(string)
 		fmt.Fprintf(buf, "add %s %s\n", mainSetName, member)
+		countNumIPSetLinesExecuted.Inc()
 		return nil
 	})
 	buf.WriteString("COMMIT\n")

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -341,9 +341,8 @@ func (t *Table) UpdateChains(chains []*Chain) {
 
 func (t *Table) UpdateChain(chain *Chain) {
 	t.logCxt.WithField("chainName", chain.Name).Info("Queueing update of chain.")
-	oldChain := t.chainNameToChain[chain.Name]
 	oldNumRules := 0
-	if oldChain != nil {
+	if oldChain := t.chainNameToChain[chain.Name]; oldChain != nil {
 		oldNumRules = len(oldChain.Rules)
 	}
 	t.chainNameToChain[chain.Name] = chain

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/felix/set"
+	"github.com/prometheus/client_golang/prometheus"
 	"reflect"
 	"regexp"
 	"strings"
@@ -43,7 +44,47 @@ var (
 	chainCreateRegexp = regexp.MustCompile(`^:(\S+)`)
 	// appendRegexp matches an iptables-save output line for an append operation.
 	appendRegexp = regexp.MustCompile(`^-A (\S+)`)
+
+	// Prometheus metrics.
+	countNumRestoreCalls = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_iptables_restore_calls",
+		Help: "Number of iptables-restore calls.",
+	})
+	countNumRestoreErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_iptables_restore_errors",
+		Help: "Number of iptables-restore errors.",
+	})
+	countNumSaveCalls = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_iptables_save_calls",
+		Help: "Number of iptables-save calls.",
+	})
+	countNumSaveErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "felix_iptables_save_errors",
+		Help: "Number of iptables-save errors.",
+	})
+	gaugeNumChains = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "felix_iptables_chains",
+		Help: "Number of active iptables chains.",
+	}, []string{"ip_version", "table"})
+	gaugeNumRules = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "felix_iptables_rules",
+		Help: "Number of active iptables rules.",
+	}, []string{"ip_version", "table"})
+	countNumLinesExecuted = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "felix_iptables_lines_executed",
+		Help: "Number of iptables rule updates executed.",
+	}, []string{"ip_version", "table"})
 )
+
+func init() {
+	prometheus.MustRegister(countNumRestoreCalls)
+	prometheus.MustRegister(countNumRestoreErrors)
+	prometheus.MustRegister(countNumSaveCalls)
+	prometheus.MustRegister(countNumSaveErrors)
+	prometheus.MustRegister(gaugeNumChains)
+	prometheus.MustRegister(gaugeNumRules)
+	prometheus.MustRegister(countNumLinesExecuted)
+}
 
 // Table represents a single one of the iptables tables i.e. "raw", "nat", "filter", etc.  It
 // caches the desired state of that table, then attempts to bring it into sync when Apply() is
@@ -173,6 +214,10 @@ type Table struct {
 
 	logCxt *log.Entry
 
+	gaugeNumChains        prometheus.Gauge
+	gaugeNumRules         prometheus.Gauge
+	countNumLinesExecuted prometheus.Counter
+
 	// Factory for making commands, used by UTs to shim exec.Command().
 	newCmd cmdFactory
 	// sleep is a shim for time.Sleep.
@@ -263,6 +308,10 @@ func NewTable(
 
 		newCmd: newCmd,
 		sleep:  sleep,
+
+		gaugeNumChains:        gaugeNumChains.WithLabelValues(fmt.Sprintf("%d", ipVersion), name),
+		gaugeNumRules:         gaugeNumRules.WithLabelValues(fmt.Sprintf("%d", ipVersion), name),
+		countNumLinesExecuted: countNumLinesExecuted.WithLabelValues(fmt.Sprintf("%d", ipVersion), name),
 	}
 
 	if ipVersion == 4 {
@@ -277,7 +326,10 @@ func NewTable(
 
 func (t *Table) SetRuleInsertions(chainName string, rules []Rule) {
 	t.logCxt.WithField("chainName", chainName).Debug("Updating rule insertions")
+	oldRules := t.chainToInsertedRules[chainName]
 	t.chainToInsertedRules[chainName] = rules
+	numRulesDelta := len(rules) - len(oldRules)
+	t.gaugeNumRules.Add(float64(numRulesDelta))
 	t.dirtyInserts.Add(chainName)
 }
 
@@ -289,7 +341,14 @@ func (t *Table) UpdateChains(chains []*Chain) {
 
 func (t *Table) UpdateChain(chain *Chain) {
 	t.logCxt.WithField("chainName", chain.Name).Info("Queueing update of chain.")
+	oldChain := t.chainNameToChain[chain.Name]
+	oldNumRules := 0
+	if oldChain != nil {
+		oldNumRules = len(oldChain.Rules)
+	}
 	t.chainNameToChain[chain.Name] = chain
+	numRulesDelta := len(chain.Rules) - oldNumRules
+	t.gaugeNumRules.Add(float64(numRulesDelta))
 	t.dirtyChains.Add(chain.Name)
 }
 
@@ -301,7 +360,8 @@ func (t *Table) RemoveChains(chains []*Chain) {
 
 func (t *Table) RemoveChainByName(name string) {
 	t.logCxt.WithField("chainName", name).Info("Queing deletion of chain.")
-	if _, known := t.chainNameToChain[name]; known {
+	if oldChain, known := t.chainNameToChain[name]; known {
+		t.gaugeNumRules.Sub(float64(len(oldChain.Rules)))
 		delete(t.chainNameToChain, name)
 		t.dirtyChains.Add(name)
 	}
@@ -420,8 +480,10 @@ func (t *Table) getHashesFromDataplane() map[string][]string {
 	// us from spamming a panic into the log when we're being gracefully shut down by a SIGTERM.
 	for {
 		cmd := t.newCmd(t.iptablesSaveCmd, "-t", t.Name)
+		countNumSaveCalls.Inc()
 		output, err := cmd.Output()
 		if err != nil {
+			countNumSaveErrors.Inc()
 			t.logCxt.WithError(err).Warnf("%s command failed", t.iptablesSaveCmd)
 			if retries > 0 {
 				retries--
@@ -549,6 +611,8 @@ func (t *Table) Apply() {
 		}
 		break
 	}
+
+	t.gaugeNumChains.Set(float64(len(t.chainNameToChain)))
 }
 
 func (t *Table) applyUpdates() error {
@@ -571,6 +635,7 @@ func (t *Table) applyUpdates() error {
 		}
 		if chainNeedsToBeFlushed {
 			inputBuf.WriteString(fmt.Sprintf(":%s - -\n", chainName))
+			t.countNumLinesExecuted.Inc()
 		}
 		return nil
 	})
@@ -606,6 +671,7 @@ func (t *Table) applyUpdates() error {
 				}
 				inputBuf.WriteString(line)
 				inputBuf.WriteString("\n")
+				t.countNumLinesExecuted.Inc()
 			}
 		}
 		return nil // Delay clearing the set until we've programmed iptables.
@@ -637,6 +703,7 @@ func (t *Table) applyUpdates() error {
 				line := deleteRule(chainName, ruleNum)
 				inputBuf.WriteString(line)
 				inputBuf.WriteString("\n")
+				t.countNumLinesExecuted.Inc()
 			}
 		}
 
@@ -651,6 +718,7 @@ func (t *Table) applyUpdates() error {
 				line := rules[i].RenderInsert(chainName, prefixFrag)
 				inputBuf.WriteString(line)
 				inputBuf.WriteString("\n")
+				t.countNumLinesExecuted.Inc()
 			}
 		} else {
 			log.Debug("Rendering append rules.")
@@ -659,6 +727,7 @@ func (t *Table) applyUpdates() error {
 				line := rules[i].RenderAppend(chainName, prefixFrag)
 				inputBuf.WriteString(line)
 				inputBuf.WriteString("\n")
+				t.countNumLinesExecuted.Inc()
 			}
 		}
 
@@ -677,6 +746,7 @@ func (t *Table) applyUpdates() error {
 		if _, ok := t.chainNameToChain[chainName]; !ok {
 			// Chain deletion
 			inputBuf.WriteString(fmt.Sprintf("--delete-chain %s\n", chainName))
+			t.countNumLinesExecuted.Inc()
 			newHashes[chainName] = nil
 		}
 		return nil // Delay clearing the set until we've programmed iptables.
@@ -698,6 +768,7 @@ func (t *Table) applyUpdates() error {
 		cmd.SetStdin(&inputBuf)
 		cmd.SetStdout(&outputBuf)
 		cmd.SetStderr(&errBuf)
+		countNumRestoreCalls.Inc()
 		err := cmd.Run()
 		if err != nil {
 			t.logCxt.WithFields(log.Fields{
@@ -707,6 +778,7 @@ func (t *Table) applyUpdates() error {
 				"input":       input,
 			}).Warn("Failed to execute ip(6)tables-restore command")
 			t.inSyncWithDataPlane = false
+			countNumRestoreErrors.Inc()
 			return err
 		}
 	}


### PR DESCRIPTION
- [x] Current number of endpoints/policies being tracked on eahc
- [x] Number of policies which apply to endpoints on this node.
- [x] Error counts
- [x] Number of dataplane programming errors
- [x] Number of retries in various places.
- [x] Number of active selectors
- [x] Number of active ipsets
- [x] Number of iptables rules in place.
- [x] Number of updates by type
- [x] Histograms for time taken to process updates in the graph and dataplane.

Fixes #1291 