### PR TITLE
Aggressively re-check iptables after an update.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -106,7 +106,7 @@ type Config struct {
 	Ipv6Support    bool `config:"bool;true"`
 	IgnoreLooseRPF bool `config:"bool;false"`
 
-	IptablesRefreshInterval int `config:"int;60"`
+	IptablesRefreshInterval int `config:"int;10"`
 
 	MetadataAddr string `config:"hostname;127.0.0.1;die-on-fail"`
 	MetadataPort int    `config:"int(0,65535);8775;die-on-fail"`

--- a/intdataplane/int_dataplane.go
+++ b/intdataplane/int_dataplane.go
@@ -607,10 +607,10 @@ func (d *InternalDataplane) apply() {
 		d.cleanupPending = false
 	}
 
-	// Set up any needed rescheduling kick.  Any pending kick will have been recalculated above
-	// so we always cancel and reschedule.
+	// Set up any needed rescheduling kick.
 	if d.reschedC != nil {
-		// We have an active rescheduling timer, stop it so we can reset it below if needed.
+		// We have an active rescheduling timer, stop it so we can restart it with a
+		// different timeout below if it is still needed.
 		// This snippet comes from the docs for Timer.Stop().
 		if !d.reschedTimer.Stop() {
 			// Timer had already popped, drain its channel.

--- a/intdataplane/int_dataplane.go
+++ b/intdataplane/int_dataplane.go
@@ -130,6 +130,9 @@ type InternalDataplane struct {
 	forceDataplaneRefresh bool
 	cleanupPending        bool
 
+	reschedTimer *time.Timer
+	reschedC     <-chan time.Time
+
 	config Config
 }
 
@@ -162,6 +165,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			HistoricChainPrefixes:    rules.AllHistoricChainNamePrefixes,
 			ExtraCleanupRegexPattern: rules.HistoricInsertedNATRuleRegex,
 			InsertMode:               config.IptablesInsertMode,
+			RefreshInterval:          config.IptablesRefreshInterval,
 		},
 	)
 	rawTableV4 := iptables.NewTable(
@@ -171,6 +175,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		iptables.TableOptions{
 			HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 			InsertMode:            config.IptablesInsertMode,
+			RefreshInterval:       config.IptablesRefreshInterval,
 		})
 	filterTableV4 := iptables.NewTable(
 		"filter",
@@ -179,6 +184,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		iptables.TableOptions{
 			HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 			InsertMode:            config.IptablesInsertMode,
+			RefreshInterval:       config.IptablesRefreshInterval,
 		})
 	ipSetsConfigV4 := config.RulesConfig.IPSetConfigV4
 	ipSetRegV4 := ipsets.NewRegistry(ipSetsConfigV4)
@@ -218,6 +224,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				HistoricChainPrefixes:    rules.AllHistoricChainNamePrefixes,
 				ExtraCleanupRegexPattern: rules.HistoricInsertedNATRuleRegex,
 				InsertMode:               config.IptablesInsertMode,
+				RefreshInterval:          config.IptablesRefreshInterval,
 			},
 		)
 		rawTableV6 := iptables.NewTable(
@@ -227,6 +234,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			iptables.TableOptions{
 				HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 				InsertMode:            config.IptablesInsertMode,
+				RefreshInterval:       config.IptablesRefreshInterval,
 			},
 		)
 		filterTableV6 := iptables.NewTable(
@@ -236,6 +244,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			iptables.TableOptions{
 				HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 				InsertMode:            config.IptablesInsertMode,
+				RefreshInterval:       config.IptablesRefreshInterval,
 			},
 		)
 
@@ -445,6 +454,11 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 			log.Debug("Refreshing dataplane state")
 			d.forceDataplaneRefresh = true
 			d.dataplaneNeedsSync = true
+		case <-d.reschedC:
+			log.Debug("Reschedule kick received")
+			d.dataplaneNeedsSync = true
+			// nil out the channel to record that the timer is now inactive.
+			d.reschedC = nil
 		case <-retryTicker.C:
 		}
 
@@ -558,14 +572,15 @@ func (d *InternalDataplane) apply() {
 			// Queue a resync on the next Apply().
 			r.QueueResync()
 		}
-		for _, t := range d.allIptablesTables {
-			t.InvalidateDataplaneCache()
-		}
 		d.forceDataplaneRefresh = false
 	}
 	// Update iptables, this should sever any references to now-unused IP sets.
+	var reschedDelay time.Duration
 	for _, t := range d.allIptablesTables {
-		t.Apply()
+		tableReschedAfter := t.Apply()
+		if tableReschedAfter != 0 && (reschedDelay == 0 || tableReschedAfter < reschedDelay) {
+			reschedDelay = tableReschedAfter
+		}
 	}
 
 	// Update the routing table.
@@ -590,6 +605,31 @@ func (d *InternalDataplane) apply() {
 			w.AttemptCleanup()
 		}
 		d.cleanupPending = false
+	}
+
+	// Set up any needed rescheduling kick.  Any pending kick will have been recalculated above
+	// so we always cancel and reschedule.
+	if d.reschedC != nil {
+		// We have an active rescheduling timer, stop it so we can reset it below if needed.
+		// This snippet comes from the docs for Timer.Stop().
+		if !d.reschedTimer.Stop() {
+			// Timer had already popped, drain its channel.
+			<-d.reschedC
+		}
+		// Nil out our copy of the channel to record that the timer is inactive.
+		d.reschedC = nil
+	}
+	if reschedDelay != 0 {
+		// We need to reschedule.
+		log.WithField("delay", reschedDelay).Debug("Asked to reschedule.")
+		if d.reschedTimer == nil {
+			// First time, create the timer.
+			d.reschedTimer = time.NewTimer(reschedDelay)
+		} else {
+			// Have an existing timer, reset it.
+			d.reschedTimer.Reset(reschedDelay)
+		}
+		d.reschedC = d.reschedTimer.C
 	}
 }
 

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -487,6 +487,21 @@ func describePostUpdateCheckTests(enableRefresh bool) {
 					// Now waiting for the next refresh interval.
 					It("should request correct delay", assertDelayMillis(30000))
 				})
+				Describe("after advancing time by an hour", func() {
+					BeforeEach(resetAndAdvance(time.Hour))
+					It("should recheck", assertRecheck)
+
+					// Now waiting for the next refresh interval.
+					It("should request correct delay", assertDelayMillis(30000))
+
+					Describe("after advancing time by an hour", func() {
+						BeforeEach(resetAndAdvance(time.Hour))
+						It("should recheck", assertRecheck)
+
+						// Now waiting for the next refresh interval.
+						It("should request correct delay", assertDelayMillis(30000))
+					})
+				})
 			} else {
 				Describe("after advancing time 60s", func() {
 					BeforeEach(resetAndAdvance(60 * time.Second))
@@ -494,6 +509,20 @@ func describePostUpdateCheckTests(enableRefresh bool) {
 
 					// Refresh disabled, it just keeps increasing
 					It("should request correct delay", assertDelayMillis(41401))
+				})
+				Describe("after advancing time by an hour", func() {
+					BeforeEach(resetAndAdvance(time.Hour))
+					// Last recheck due to the post-write check.
+					It("should recheck", assertRecheck)
+
+					// Then, it should give up.
+					It("should request correct delay", assertDelayMillis(0))
+
+					Describe("after advancing time by an hour", func() {
+						BeforeEach(resetAndAdvance(time.Hour))
+						It("should not recheck", assertNoCheck)
+						It("should request correct delay", assertDelayMillis(0))
+					})
 				})
 			}
 		})

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -58,6 +58,10 @@ var _ = Describe("Table with an empty dataplane", func() {
 		}))
 	})
 
+	It("should have a refresh scheduled at start-of-day", func() {
+		Expect(table.Apply()).To(Equal(50 * time.Millisecond))
+	})
+
 	It("Should defer updates until Apply is called", func() {
 		table.SetRuleInsertions("FORWARD", []Rule{
 			{Action: DropAction{}},

--- a/iptables/utils_for_test.go
+++ b/iptables/utils_for_test.go
@@ -55,12 +55,19 @@ type mockDataplane struct {
 	ChainMods       set.Set
 	DeletedChains   set.Set
 	Cmds            []CmdIface
+	CmdNames        []string
 	FailNextRestore bool
 	FailAllRestores bool
 	OnPreRestore    func()
 	FailNextSave    bool
 	FailAllSaves    bool
 	CumulativeSleep time.Duration
+	Time            time.Time
+}
+
+func (d *mockDataplane) ResetCmds() {
+	d.Cmds = nil
+	d.CmdNames = nil
 }
 
 func (d *mockDataplane) newCmd(name string, arg ...string) CmdIface {
@@ -74,6 +81,7 @@ func (d *mockDataplane) newCmd(name string, arg ...string) CmdIface {
 	}).Info("Simulating new command.")
 
 	var cmd CmdIface
+	d.CmdNames = append(d.CmdNames, name)
 
 	switch name {
 	case "iptables-restore", "ip6tables-restore":
@@ -97,6 +105,15 @@ func (d *mockDataplane) newCmd(name string, arg ...string) CmdIface {
 
 func (d *mockDataplane) sleep(duration time.Duration) {
 	d.CumulativeSleep += duration
+	d.Time = d.Time.Add(duration)
+}
+
+func (d *mockDataplane) now() time.Time {
+	return d.Time
+}
+
+func (d *mockDataplane) AdvanceTimeBy(amount time.Duration) {
+	d.Time = d.Time.Add(amount)
 }
 
 func (d *mockDataplane) ChainFlushed(chainName string) bool {


### PR DESCRIPTION
- Add ability for int_dataplane to reschedule on a timer if requested by `iptables.Table`.
- After an iptables update, reschedule at exponential intervals to check that the update is still present.
- Reload dataplane state before each update.  (This is what kube-proxy does too, it probably doesn't slow us down that much.)