### PR TITLE
Propagate datastore type from Felix config to CalicoAPIConfig

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -317,6 +317,7 @@ func (config *Config) DatastoreConfig() api.CalicoAPIConfig {
 		if err != nil {
 			log.WithError(err).Panic("Failed to create empty config")
 		}
+		cfg.Spec.DatastoreType = api.Kubernetes
 		return *cfg
 	} else {
 		var etcdEndpoints string


### PR DESCRIPTION
This seems to be needed when starting calico/felix with
FELIX_DATASTORETYPE=kubernetes so as to select the k8s datastore
backend.  Without this, libcalico-go/lib/backend.NewClient() still
constructs and returns an etcd v2 client.