### PR TITLE
Fix IP address parsing to use net.IP.To4() instead of len().

### DIFF
--- a/calc/event_sequencer.go
+++ b/calc/event_sequencer.go
@@ -449,7 +449,7 @@ func (buf *EventSequencer) OnIPPoolUpdate(key model.IPPoolKey, pool *model.IPPoo
 		"pool": pool,
 	}).Debug("IPPool update")
 	buf.pendingIPPoolDeletes.Discard(key)
-	cidr := ip.CIDRFromIPNet(key.CIDR)
+	cidr := ip.CIDRFromCalicoNet(key.CIDR)
 	buf.pendingIPPoolUpdates[cidr] = pool
 }
 
@@ -469,7 +469,7 @@ func (buf *EventSequencer) flushIPPoolUpdates() {
 
 func (buf *EventSequencer) OnIPPoolRemove(key model.IPPoolKey) {
 	log.WithField("key", key).Debug("IPPool removed")
-	cidr := ip.CIDRFromIPNet(key.CIDR)
+	cidr := ip.CIDRFromCalicoNet(key.CIDR)
 	delete(buf.pendingIPPoolUpdates, cidr)
 	if buf.sentIPPools.Contains(cidr) {
 		buf.pendingIPPoolDeletes.Add(cidr)

--- a/ip/ip_addr_test.go
+++ b/ip/ip_addr_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip_test
+
+import (
+	. "github.com/projectcalico/felix/ip"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeTable("IpAddr",
+	func(version int, inputIP, canonical string, bytes []byte) {
+		ip := FromString(inputIP)
+		Expect([]byte(ip.AsNetIP())).To(Equal(bytes))
+		Expect(ip.String()).To(Equal(canonical))
+		Expect(int(ip.Version())).To(Equal(version))
+	},
+	Entry("IPv4", 4, "10.0.0.1", "10.0.0.1", []byte{0xa, 0, 0, 1}),
+	Entry("IPv6", 6, "dead::beef", "dead::beef", []byte{
+		0xde, 0xad, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0xbe, 0xef},
+	),
+	Entry("IPv6 non-canon", 6, "dead:0:0::beef", "dead::beef", []byte{
+		0xde, 0xad, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0xbe, 0xef},
+	),
+)
+
+var _ = DescribeTable("CIDR",
+	func(version int, inputCIDR, canonical string, bytes []byte, len int) {
+		cidr := MustParseCIDR(inputCIDR)
+		Expect([]byte(cidr.Addr().AsNetIP())).To(Equal(bytes))
+		Expect(int(cidr.Prefix())).To(Equal(len))
+		Expect(cidr.String()).To(Equal(canonical))
+		Expect(int(cidr.Version())).To(Equal(version))
+	},
+	Entry("IPv4", 4, "10.0.0.0/16", "10.0.0.0/16", []byte{0xa, 0, 0, 0}, 16),
+	Entry("IPv4 should be masked", 4, "10.0.0.1/16", "10.0.0.0/16", []byte{0xa, 0, 0, 0}, 16),
+	Entry("IPv6", 6, "dead::/16", "dead::/16", []byte{
+		0xde, 0xad, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0},
+		16,
+	),
+	Entry("IPv6 non-canon", 6, "dead:0:0::beef/16", "dead::/16", []byte{
+		0xde, 0xad, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 00},
+		16,
+	),
+)

--- a/ip/ip_suite_test.go
+++ b/ip/ip_suite_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+
+	"github.com/projectcalico/felix/logutils"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+func TestIp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ip Suite")
+}
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+	logrus.AddHook(&logutils.ContextHook{})
+	logrus.SetFormatter(&logutils.Formatter{})
+}

--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -28,7 +28,6 @@ import (
 	"github.com/projectcalico/felix/ifacemonitor"
 	"github.com/projectcalico/felix/ip"
 	"github.com/projectcalico/felix/set"
-	calinet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
 var (
@@ -268,7 +267,7 @@ func (r *RouteTable) syncRoutesForLink(ifaceName string) error {
 	for _, route := range oldRoutes {
 		var dest ip.CIDR
 		if route.Dst != nil {
-			dest = ip.CIDRFromIPNet(calinet.IPNet{*route.Dst})
+			dest = ip.CIDRFromIPNet(route.Dst)
 		}
 		if !expectedCIDRs.Contains(dest) {
 			logCxt := logCxt.WithField("dest", dest)


### PR DESCRIPTION
len(ip) can be 16, even for an IPv4 address due to Go's internal representation of IPs.

Fixed up some bad function naming while I was in there.

Fixes #1359 