### PR TITLE
Rev calico/go-build to v0.4.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ help:
 all: deb rpm calico/felix
 test: ut
 
-GO_BUILD_CONTAINER?=calico/go-build:v0.2
+GO_BUILD_CONTAINER?=calico/go-build:v0.3
 
 # Figure out version information.  To support builds from release tarballs, we default to
 # <unknown> if this isn't a git checkout.

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ help:
 all: deb rpm calico/felix
 test: ut
 
-GO_BUILD_CONTAINER?=calico/go-build:v0.3
+GO_BUILD_CONTAINER?=calico/go-build:v0.4
 
 # Figure out version information.  To support builds from release tarballs, we default to
 # <unknown> if this isn't a git checkout.


### PR DESCRIPTION
Improves performance by pulling in vfork patch.