### PR TITLE
Add config option to do memory profile

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -147,6 +147,8 @@ type Config struct {
 	ClusterGUID           string `config:"string;baddecaf"`
 	ClusterType           string `config:"string;"`
 
+	DebugMemoryProfilePath string `config:"file;;"`
+
 	// State tracking.
 
 	// nameToSource tracks where we loaded each config param from.

--- a/intdataplane/int_dataplane.go
+++ b/intdataplane/int_dataplane.go
@@ -93,6 +93,8 @@ type Config struct {
 	RulesConfig rules.Config
 
 	StatusReportingInterval time.Duration
+
+	PostInSyncCallback func()
 }
 
 // InternalDataplane implements an in-process Felix dataplane driver based on iptables
@@ -562,6 +564,9 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 				log.WithField("secsSinceStart", time.Since(processStartTime).Seconds()).Info(
 					"Completed first update to dataplane.")
 				doneFirstApply = true
+				if d.config.PostInSyncCallback != nil {
+					d.config.PostInSyncCallback()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The resulting memory profile can be cracked with `go tool pprof bin/calico-felix mem.pprof`.  I've found it very useful in my occupancy optimisation work.

The heap dump is less useful, in that there's no tool to crack it right now but there may be one in future.