### PR TITLE
Improve stats: add route table stats, swap histograms for summaries.

### DIFF
--- a/calc/async_calc_graph.go
+++ b/calc/async_calc_graph.go
@@ -54,12 +54,9 @@ var (
 		Name: "felix_calc_graph_output_events",
 		Help: "Number of events emitted by the calculation graph.",
 	})
-	histUpdateTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+	summaryUpdateTime = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name: "felix_calc_graph_update_time_seconds",
 		Help: "Seconds to update calculation graph for each datastore OnUpdate call.",
-		Buckets: []float64{
-			0.001, 0.010, 0.100, 1.0,
-		},
 	})
 )
 
@@ -68,7 +65,7 @@ func init() {
 	prometheus.MustRegister(resyncsStarted)
 	prometheus.MustRegister(countUpdatesProcessed)
 	prometheus.MustRegister(countOutputEvents)
-	prometheus.MustRegister(histUpdateTime)
+	prometheus.MustRegister(summaryUpdateTime)
 }
 
 type AsyncCalcGraph struct {
@@ -125,7 +122,7 @@ func (acg *AsyncCalcGraph) loop() {
 				updEndTime := time.Now()
 				if updEndTime.After(updStartTime) {
 					// Avoid recording a negative delta in case the clock jumps.
-					histUpdateTime.Observe(updEndTime.Sub(updStartTime).Seconds())
+					summaryUpdateTime.Observe(updEndTime.Sub(updStartTime).Seconds())
 				}
 				// Record stats for the number of messages processed.
 				for _, upd := range update {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2a26cc5aa99bcb07893e216443e5b898e0082318adf3e2f87da736457904f13a
-updated: 2017-03-08T18:14:30.857330778Z
+hash: e88a4a3bf0c2bc21e5ad5a3d890c95f37999033ee120e044275b836f52cb9307
+updated: 2017-03-13T10:00:11.757463865Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -13,9 +13,10 @@ imports:
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/coreos/etcd
-  version: 7f43fdde7485de5be2922024bb0aed1b14803b20
+  version: d2716fc5ae7909a3b9651e31cfb0eba22b4920c3
   subpackages:
   - client
+  - pkg/fileutil
   - pkg/pathutil
   - pkg/tlsutil
   - pkg/transport
@@ -33,6 +34,12 @@ imports:
   version: 568e959cd89871e61434c1143528d9162da89ef2
   subpackages:
   - semver
+- name: github.com/coreos/go-systemd
+  version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
+  subpackages:
+  - daemon
+  - journal
+  - util
 - name: github.com/coreos/pkg
   version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
   subpackages:
@@ -56,10 +63,12 @@ imports:
   subpackages:
   - log
   - swagger
+- name: github.com/gavv/monotime
+  version: 47d58efa69556a936a3c15eb2ed42706d968ab01
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: 74bdc99692c3408cb103221e38675ce8fda0a718
+  version: 300e940a926eb277d3901b20bdfcc54928ad3642
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -76,7 +85,7 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: c9c7427a2a70d2eb3bafa0ab2dc163e45f143317
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
   - proto
 - name: github.com/google/gofuzz
@@ -90,9 +99,9 @@ imports:
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kardianos/osext
-  version: 9b883c5eb462dd5cb1b0a7a104fe86bc6b9bd391
+  version: 9d302b58e975387d0b4d9be876622c86cefe64be
 - name: github.com/kelseyhightower/envconfig
-  version: 8bf4bbfc795e2c7c8a5ea47b707453ed019e2ad4
+  version: f611eb38b3875cc3bd991ca91c51d06446afa14c
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -106,7 +115,7 @@ imports:
 - name: github.com/mipearson/rfw
   version: b66ec87bd85055de3f749a8640e9e4c8053052e4
 - name: github.com/onsi/ginkgo
-  version: ab07225d112dc7a93c289ac5b2e12735c2c46035
+  version: bb93381d543b0e5725244abe752214a110791d01
   subpackages:
   - config
   - extensions/table
@@ -188,7 +197,7 @@ imports:
 - name: github.com/satori/go.uuid
   version: b061729afc07e77a8aa4fad0a2fd840958f1942a
 - name: github.com/Sirupsen/logrus
-  version: 0208149b40d863d2c1a2f8fe5753096a9cf2cc8b
+  version: c078b1e43f58d563c74cebe63c85789e76ddb627
   subpackages:
   - hooks/syslog
 - name: github.com/spf13/pflag
@@ -198,11 +207,11 @@ imports:
   subpackages:
   - codec
 - name: github.com/vishvananda/netlink
-  version: fe3b5664d23a11b52ba59bece4ff29c52772a56b
+  version: c19091b1c6fb954a80f9f67abed2e2d780bb485b
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: 54f0e4339ce73702a0607f49922aaa1e749b418d
+  version: 2c9454e4fc6e2edc1a1c84e64ed3d6e662fb6991
 - name: golang.org/x/crypto
   version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:
@@ -226,7 +235,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 99f16d856c9836c42d24e7ab64ea72916925fa97
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -383,7 +392,7 @@ imports:
   - transport
 testImports:
 - name: github.com/onsi/gomega
-  version: 1de7ab2df9105aa5c15c4d7e14a8a514e3cb8d4b
+  version: e85f63af4302dc0e4277c6008ecf803f1d80e4f0
   subpackages:
   - format
   - internal/assertion

--- a/glide.yaml
+++ b/glide.yaml
@@ -32,3 +32,4 @@ import:
 - package: github.com/gogo/protobuf
   version: ^0.3.0
 - package: github.com/vishvananda/netlink
+- package: github.com/gavv/monotime

--- a/intdataplane/int_dataplane.go
+++ b/intdataplane/int_dataplane.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/gavv/monotime"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/projectcalico/felix/ifacemonitor"
@@ -73,7 +74,7 @@ var (
 			"values indicate we're doing more batching to try to keep up.",
 	})
 
-	processStartTime time.Time
+	processStartTime time.Duration
 )
 
 func init() {
@@ -83,7 +84,7 @@ func init() {
 	prometheus.MustRegister(summaryBatchSize)
 	prometheus.MustRegister(summaryIfaceBatchSize)
 	prometheus.MustRegister(summaryAddrBatchSize)
-	processStartTime = time.Now()
+	processStartTime = monotime.Now()
 }
 
 type Config struct {
@@ -479,7 +480,7 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 		}
 		switch msg.(type) {
 		case *proto.InSync:
-			log.WithField("timeSinceStart", time.Since(processStartTime)).Info(
+			log.WithField("timeSinceStart", monotime.Since(processStartTime)).Info(
 				"Datastore in sync, flushing the dataplane for the first time...")
 			datastoreInSync = true
 		}
@@ -579,17 +580,14 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 					beingThrottled = false
 				}
 				log.Info("Applying dataplane updates")
-				applyStart := time.Now()
+				applyStart := monotime.Now()
 
 				// Actually apply the changes to the dataplane.
 				d.apply()
 
 				// Record stats.
-				applyTime := time.Since(applyStart)
-				if applyTime > 0 {
-					// Avoid a negative interval in case the clock jumps.
-					summaryApplyTime.Observe(applyTime.Seconds())
-				}
+				applyTime := monotime.Since(applyStart)
+				summaryApplyTime.Observe(applyTime.Seconds())
 
 				if d.dataplaneNeedsSync {
 					// Dataplane is still dirty, record an error.
@@ -604,8 +602,9 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 				}
 			}
 			if !doneFirstApply {
-				log.WithField("secsSinceStart", time.Since(processStartTime).Seconds()).Info(
-					"Completed first update to dataplane.")
+				log.WithField(
+					"secsSinceStart", monotime.Since(processStartTime).Seconds(),
+				).Info("Completed first update to dataplane.")
 				doneFirstApply = true
 				if d.config.PostInSyncCallback != nil {
 					d.config.PostInSyncCallback()
@@ -808,15 +807,12 @@ func (d *InternalDataplane) loopReportingStatus() {
 		log.Info("Process status reports disabled")
 		return
 	}
-	start := time.Now()
 	// Wait before first report so that we don't check in if we're in a tight cyclic restart.
 	time.Sleep(10 * time.Second)
 	for {
-		now := time.Now()
-		uptimeNanos := float64(now.Sub(start))
-		uptimeSecs := uptimeNanos / 1000000000
+		uptimeSecs := monotime.Since(processStartTime).Seconds()
 		d.fromDataplane <- &proto.ProcessStatusUpdate{
-			IsoTimestamp: now.UTC().Format(time.RFC3339),
+			IsoTimestamp: time.Now().UTC().Format(time.RFC3339),
 			Uptime:       uptimeSecs,
 		}
 		time.Sleep(d.config.StatusReportingInterval)

--- a/ipsets/ipsets.go
+++ b/ipsets/ipsets.go
@@ -25,6 +25,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/gavv/monotime"
+
 	"github.com/projectcalico/felix/set"
 )
 
@@ -315,13 +317,13 @@ func (s *IPSets) tryResync() (numProblems int, err error) {
 	// Capture error output into a buffer.
 	var stderr bytes.Buffer
 	cmd.SetStderr(&stderr)
-	execStartTime := time.Now()
+	execStartTime := monotime.Now()
 	err = cmd.Start()
 	if err != nil {
 		s.logCxt.WithError(err).Error("Failed to start 'ipset list'")
 		return
 	}
-	summaryExecStart.Observe(float64(time.Since(execStartTime).Nanoseconds()) / 1000.0)
+	summaryExecStart.Observe(float64(monotime.Since(execStartTime).Nanoseconds()) / 1000.0)
 	// Clear the set of known IP sets names, we'll fill it back in as we scan.
 	s.existingIPSetNames.Clear()
 	// Use a scanner to chunk the input into lines.
@@ -549,13 +551,13 @@ func (s *IPSets) tryUpdates() error {
 	cmd.SetStdout(&stdout)
 
 	// Actually start the child process.
-	startTime := time.Now()
+	startTime := monotime.Now()
 	err = cmd.Start()
 	if err != nil {
 		s.logCxt.WithError(err).Error("Failed to start ipset restore.")
 		return err
 	}
-	summaryExecStart.Observe(float64(time.Since(startTime).Nanoseconds()) / 1000.0)
+	summaryExecStart.Observe(float64(monotime.Since(startTime).Nanoseconds()) / 1000.0)
 
 	// Ask each dirty IP set to write its updates to the stream.
 	var writeErr error

--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -24,12 +24,13 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
+	"github.com/gavv/monotime"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/projectcalico/felix/conntrack"
 	"github.com/projectcalico/felix/ifacemonitor"
 	"github.com/projectcalico/felix/ip"
 	"github.com/projectcalico/felix/set"
-	"github.com/prometheus/client_golang/prometheus"
-	"time"
 )
 
 var (
@@ -143,7 +144,7 @@ func (r *RouteTable) QueueResync() {
 
 func (r *RouteTable) Apply() error {
 	if !r.inSync {
-		listStartTime := time.Now()
+		listStartTime := monotime.Now()
 
 		links, err := r.dataplane.LinkList()
 		if err != nil {
@@ -166,7 +167,7 @@ func (r *RouteTable) Apply() error {
 		}
 		r.inSync = true
 
-		listIfaceTime.Observe(time.Since(listStartTime).Seconds())
+		listIfaceTime.Observe(monotime.Since(listStartTime).Seconds())
 	}
 
 	r.dirtyIfaces.Iter(func(item interface{}) error {
@@ -208,9 +209,9 @@ func (r *RouteTable) Apply() error {
 }
 
 func (r *RouteTable) syncRoutesForLink(ifaceName string) error {
-	startTime := time.Now()
+	startTime := monotime.Now()
 	defer func() {
-		perIfaceSyncTime.Observe(time.Since(startTime).Seconds())
+		perIfaceSyncTime.Observe(monotime.Since(startTime).Seconds())
 	}()
 	logCxt := r.logCxt.WithField("ifaceName", ifaceName)
 	logCxt.Debug("Syncing interface routes")


### PR DESCRIPTION
Switch to monotime for calculating time deltas.  Removes need to check for time discontinuities.  Nice thing about that switch is the type system ensures that you can't get confused between a monotime timestamp (which is a `time.Duration`) and a `time.Time`.