### PR TITLE
Move log writing to background threads.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -147,7 +147,8 @@ type Config struct {
 	ClusterGUID           string `config:"string;baddecaf"`
 	ClusterType           string `config:"string;"`
 
-	DebugMemoryProfilePath string `config:"file;;"`
+	DebugMemoryProfilePath  string `config:"file;;"`
+	DebugDisableLogDropping bool   `config:"bool;false"`
 
 	// State tracking.
 

--- a/felix.go
+++ b/felix.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"reflect"
+	"runtime"
 	"runtime/debug"
 	"runtime/pprof"
 	"strings"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: a2a606221911856b912ba0abbc55521382a4b1cad07942cb13946b4f16a9f1ad
-updated: 2017-04-10T15:56:26.784382675Z
+updated: 2017-04-11T16:58:30.823493262Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -18,7 +18,7 @@ imports:
   - pkg/ns
   - pkg/types
 - name: github.com/coreos/etcd
-  version: 25acdbf41bb918b5b40274d9c62b6d272cb77626
+  version: 216a6347b2839c4ccc6a12298286fadf4014ed2c
   subpackages:
   - client
   - pkg/pathutil
@@ -196,8 +196,6 @@ imports:
   version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/Sirupsen/logrus
   version: 10f801ebc38b33738c9d17d50860f484a0988ff5
-  subpackages:
-  - hooks/syslog
 - name: github.com/spf13/pflag
   version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/ugorji/go

--- a/k8sfv/leastsquares_test.go
+++ b/k8sfv/leastsquares_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/projectcalico/felix/k8sfv/leastsquares"
 )
 

--- a/k8sfv/scale_test.go
+++ b/k8sfv/scale_test.go
@@ -21,8 +21,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/projectcalico/felix/k8sfv/leastsquares"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/projectcalico/felix/k8sfv/leastsquares"
 )
 
 var _ = Describe("testing the test code", func() {


### PR DESCRIPTION
- Replace separate hooks with a single BackgroundHook that queues logs to different destinations.
- Drop logs if the queue channels are full (but record stats).
- Handle fatal/panic logs specially, blocking until the log is written.
- Adjust felix's shutdown logic to use log.Fatal instead of os.Exit() directly so that its logs get flushed on exit.
- While making the change, I spotted that Felix was logging to stderr during startup then switching to stdout, I've changed that to log to stderr only.