### PR TITLE
Merge '2.1.x-k8sfv' into 'master'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ calico/felix: bin/calico-felix
 GET_CONTAINER_IP := docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'
 K8S_VERSION=1.5.3
 .PHONY: k8s-fv-test run-k8s-apiserver stop-k8s-apiserver run-etcd stop-etcd
-k8s-fv-test: calico/felix run-k8s-apiserver k8sfv/k8sfv.test
+k8sfv-ci: calico/felix run-k8s-apiserver k8sfv/k8sfv.test
 	@-docker rm -f k8sfv-felix
 	sleep 1
 	K8S_IP=`$(GET_CONTAINER_IP) k8sfv-apiserver` && \
@@ -170,7 +170,7 @@ k8s-fv-test: calico/felix run-k8s-apiserver k8sfv/k8sfv.test
 	/bin/sh -c "for n in 1 2; do calico-felix; done"
 	sleep 1
 	K8S_IP=`$(GET_CONTAINER_IP) k8sfv-apiserver` && \
-	docker exec k8sfv-felix /testcode/k8sfv/k8sfv.test -ginkgo.v https://$${K8S_IP}:6443
+	docker exec k8sfv-felix /testcode/k8sfv/k8sfv.test -ginkgo.v -ginkgo.focus=\\[ci\\] https://$${K8S_IP}:6443
 
 run-k8s-apiserver: stop-k8s-apiserver run-etcd
 	ETCD_IP=`$(GET_CONTAINER_IP) k8sfv-etcd` && \

--- a/k8sfv/pod.go
+++ b/k8sfv/pod.go
@@ -52,7 +52,7 @@ type localNetworking struct {
 var localNetworkingMap = map[string]*localNetworking{}
 var localNetworkingMutex = sync.Mutex{}
 
-func createPod(clientset *kubernetes.Clientset, d deployment, nsName string, spec podSpec) {
+func createPod(clientset *kubernetes.Clientset, d deployment, nsName string, spec podSpec) *v1.Pod {
 	name := spec.name
 	if name == "" {
 		name = fmt.Sprintf("run%d", rand.Uint32())
@@ -144,7 +144,7 @@ func createPod(clientset *kubernetes.Clientset, d deployment, nsName string, spe
 			namespace: podNamespace,
 		}
 	}
-	return
+	return pod_out
 }
 
 func removeLocalPodNetworking(pod *v1.Pod) {

--- a/k8sfv/pod_test.go
+++ b/k8sfv/pod_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	//. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes"
+)
+
+var _ = Context("[ci] with a k8s clientset", func() {
+
+	var (
+		clientset *kubernetes.Clientset
+		nsPrefix  string
+		d         deployment
+	)
+
+	BeforeEach(func() {
+		clientset = initialize(flag.Arg(0))
+		nsPrefix = getNamespacePrefix()
+	})
+
+	AfterEach(func() {
+		time.Sleep(10 * time.Second)
+		cleanupAll(clientset, nsPrefix)
+	})
+
+	Context("with 1 remote node", func() {
+
+		BeforeEach(func() {
+			d = NewDeployment(1, false)
+		})
+
+		It("should handle creating and deleting a pod", func() {
+			nsName := nsPrefix + "1"
+			createNamespace(clientset, nsName, nil)
+			createPod(clientset, d, nsName, podSpec{})
+			time.Sleep(20 * time.Second)
+			cleanupAllPods(clientset, nsName)
+		})
+
+		It("should handle creating and deleting a pod", func() {
+			nsName := nsPrefix + "1"
+			createNamespace(clientset, nsName, nil)
+
+			// Create pod.
+			podOut := createPod(clientset, d, nsName, podSpec{})
+
+			// Wait, then clear pod's IP address.
+			time.Sleep(20 * time.Second)
+			podOut.Status.PodIP = ""
+			_, err := clientset.Pods(nsName).UpdateStatus(podOut)
+			panicIfError(err)
+
+			// Wait, then delete pod.
+			time.Sleep(20 * time.Second)
+			cleanupAllPods(clientset, nsName)
+		})
+	})
+})


### PR DESCRIPTION
Specifically this pulls in:
- the '[ci]' mechanism for identifying tests to run in CI (pull-request-build)
- the test for libcalico-go #375