### PR TITLE
Buffer the signal channel.

### DIFF
--- a/felix.go
+++ b/felix.go
@@ -425,7 +425,7 @@ func servePrometheusMetrics(port int) {
 
 func monitorAndManageShutdown(failureReportChan <-chan string, driverCmd *exec.Cmd, stopSignalChans []chan<- bool) {
 	// Ask the runtime to tell us if we get a term signal.
-	termSignalChan := make(chan os.Signal)
+	termSignalChan := make(chan os.Signal, 1)
 	signal.Notify(termSignalChan, syscall.SIGTERM)
 
 	// Start a background thread to tell us when the dataplane driver stops.


### PR DESCRIPTION
@neiljerram For context, I'm revving the go-build container, which pulls in a newer linter with more checks.

Fix that the signal channel wasn't buffered (which presumably can block a system goroutine).  Not really an issue in this code, I think, but easier to fix than to suppress the false positive in the linter.