### PR TITLE
Move conntrack rules to per-interface chains

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -137,6 +137,8 @@ type Config struct {
 
 	IptablesMarkMask uint32 `config:"mark-bitmask;0xff000000;non-zero,die-on-fail"`
 
+	DisableConntrackInvalidCheck bool `config:"bool;false"`
+
 	PrometheusMetricsEnabled bool `config:"bool;false"`
 	PrometheusMetricsPort    int  `config:"int(0,65535);9091"`
 

--- a/felix.go
+++ b/felix.go
@@ -223,6 +223,8 @@ configRetry:
 
 				FailsafeInboundHostPorts:  configParams.FailsafeInboundHostPorts,
 				FailsafeOutboundHostPorts: configParams.FailsafeOutboundHostPorts,
+
+				DisableConntrackInvalid: configParams.DisableConntrackInvalidCheck,
 			},
 			IPIPMTU:                 configParams.IpInIpMtu,
 			IptablesRefreshInterval: time.Duration(configParams.IptablesRefreshInterval) * time.Second,

--- a/intdataplane/endpoint_mgr_test.go
+++ b/intdataplane/endpoint_mgr_test.go
@@ -124,16 +124,16 @@ func chainsForIfaces(ifaceMetadata []string, host bool, raw bool) []*iptables.Ch
 		outRules := []iptables.Rule{}
 
 		if !raw {
-			outRules = append(outRules, iptables.Rule{
-				Match:  iptables.Match().ConntrackState("INVALID"),
-				Action: iptables.DropAction{},
-			})
 			outRules = append(outRules,
 				iptables.Rule{
 					Match:  iptables.Match().ConntrackState("RELATED,ESTABLISHED"),
 					Action: iptables.AcceptAction{},
 				},
 			)
+			outRules = append(outRules, iptables.Rule{
+				Match:  iptables.Match().ConntrackState("INVALID"),
+				Action: iptables.DropAction{},
+			})
 		}
 
 		if host {
@@ -190,16 +190,16 @@ func chainsForIfaces(ifaceMetadata []string, host bool, raw bool) []*iptables.Ch
 		inRules := []iptables.Rule{}
 
 		if !raw {
-			inRules = append(inRules, iptables.Rule{
-				Match:  iptables.Match().ConntrackState("INVALID"),
-				Action: iptables.DropAction{},
-			})
 			inRules = append(inRules,
 				iptables.Rule{
 					Match:  iptables.Match().ConntrackState("RELATED,ESTABLISHED"),
 					Action: iptables.AcceptAction{},
 				},
 			)
+			inRules = append(inRules, iptables.Rule{
+				Match:  iptables.Match().ConntrackState("INVALID"),
+				Action: iptables.DropAction{},
+			})
 		}
 
 		if host {

--- a/intdataplane/endpoint_mgr_test.go
+++ b/intdataplane/endpoint_mgr_test.go
@@ -122,6 +122,20 @@ func chainsForIfaces(ifaceMetadata []string, host bool, raw bool) []*iptables.Ch
 		}
 
 		outRules := []iptables.Rule{}
+
+		if !raw {
+			outRules = append(outRules, iptables.Rule{
+				Match:  iptables.Match().ConntrackState("INVALID"),
+				Action: iptables.DropAction{},
+			})
+			outRules = append(outRules,
+				iptables.Rule{
+					Match:  iptables.Match().ConntrackState("RELATED,ESTABLISHED"),
+					Action: iptables.AcceptAction{},
+				},
+			)
+		}
+
 		if host {
 			outRules = append(outRules, iptables.Rule{
 				Match:  iptables.Match(),
@@ -174,6 +188,20 @@ func chainsForIfaces(ifaceMetadata []string, host bool, raw bool) []*iptables.Ch
 		}
 
 		inRules := []iptables.Rule{}
+
+		if !raw {
+			inRules = append(inRules, iptables.Rule{
+				Match:  iptables.Match().ConntrackState("INVALID"),
+				Action: iptables.DropAction{},
+			})
+			inRules = append(inRules,
+				iptables.Rule{
+					Match:  iptables.Match().ConntrackState("RELATED,ESTABLISHED"),
+					Action: iptables.AcceptAction{},
+				},
+			)
+		}
+
 		if host {
 			inRules = append(inRules, iptables.Rule{
 				Match:  iptables.Match(),

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -316,6 +316,13 @@ func (r *DefaultRuleRenderer) endpointToIptablesChains(
 }
 
 func (r *DefaultRuleRenderer) appendConntrackRules(rules []Rule) []Rule {
+	// Allow return packets for established connections.
+	rules = append(rules,
+		Rule{
+			Match:  Match().ConntrackState("RELATED,ESTABLISHED"),
+			Action: AcceptAction{},
+		},
+	)
 	if !r.Config.DisableConntrackInvalid {
 		// Drop packets that aren't either a valid handshake or part of an established
 		// connection.
@@ -324,13 +331,6 @@ func (r *DefaultRuleRenderer) appendConntrackRules(rules []Rule) []Rule {
 			Action: DropAction{},
 		})
 	}
-	// Allow return packets for established connections.
-	rules = append(rules,
-		Rule{
-			Match:  Match().ConntrackState("RELATED,ESTABLISHED"),
-			Action: AcceptAction{},
-		},
-	)
 	return rules
 }
 

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -316,11 +316,15 @@ func (r *DefaultRuleRenderer) endpointToIptablesChains(
 }
 
 func (r *DefaultRuleRenderer) appendConntrackRules(rules []Rule) []Rule {
-	// Drop packets that aren't either a valid handshake or part of an established connection.
-	rules = append(rules, Rule{
-		Match:  Match().ConntrackState("INVALID"),
-		Action: DropAction{},
-	})
+	if !r.Config.DisableConntrackInvalid {
+		// Drop packets that aren't either a valid handshake or part of an established
+		// connection.
+		rules = append(rules, Rule{
+			Match:  Match().ConntrackState("INVALID"),
+			Action: DropAction{},
+		})
+	}
+	// Allow return packets for established connections.
 	rules = append(rules,
 		Rule{
 			Match:  Match().ConntrackState("RELATED,ESTABLISHED"),

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -140,6 +140,13 @@ func (r *DefaultRuleRenderer) endpointToIptablesChains(
 		return []*Chain{&toEndpointChain, &fromEndpointChain}
 	}
 
+	if chainType == chainTypeTracked {
+		// Tracked chain: install conntrack rules, which implement our stateful connections.
+		// This allows return traffic associated with a previously-permitted request.
+		toRules = r.appendConntrackRules(toRules)
+		fromRules = r.appendConntrackRules(fromRules)
+	}
+
 	// First set up failsafes.
 	if toFailsafeChain != "" {
 		toRules = append(toRules, Rule{
@@ -306,6 +313,21 @@ func (r *DefaultRuleRenderer) endpointToIptablesChains(
 		Rules: fromRules,
 	}
 	return []*Chain{&toEndpointChain, &fromEndpointChain}
+}
+
+func (r *DefaultRuleRenderer) appendConntrackRules(rules []Rule) []Rule {
+	// Drop packets that aren't either a valid handshake or part of an established connection.
+	rules = append(rules, Rule{
+		Match:  Match().ConntrackState("INVALID"),
+		Action: DropAction{},
+	})
+	rules = append(rules,
+		Rule{
+			Match:  Match().ConntrackState("RELATED,ESTABLISHED"),
+			Action: AcceptAction{},
+		},
+	)
+	return rules
 }
 
 func EndpointChainName(prefix string, ifaceName string) string {

--- a/rules/endpoints_test.go
+++ b/rules/endpoints_test.go
@@ -44,6 +44,12 @@ var _ = Describe("Endpoints", func() {
 			{
 				Name: "cali-tw-cali1234",
 				Rules: []Rule{
+					// conntrack rules.
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
+					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+						Action: AcceptAction{}},
+
 					{Action: ClearMarkAction{Mark: 0x8}},
 					{Action: DropAction{},
 						Comment: "Drop if no profiles matched"},
@@ -52,6 +58,12 @@ var _ = Describe("Endpoints", func() {
 			{
 				Name: "cali-fw-cali1234",
 				Rules: []Rule{
+					// conntrack rules.
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
+					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+						Action: AcceptAction{}},
+
 					{Action: ClearMarkAction{Mark: 0x8}},
 					{Action: DropAction{},
 						Comment: "Drop if no profiles matched"},
@@ -89,6 +101,12 @@ var _ = Describe("Endpoints", func() {
 			{
 				Name: "cali-tw-cali1234",
 				Rules: []Rule{
+					// conntrack rules.
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
+					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+						Action: AcceptAction{}},
+
 					{Action: ClearMarkAction{Mark: 0x8}},
 
 					{Comment: "Start of policies",
@@ -123,6 +141,12 @@ var _ = Describe("Endpoints", func() {
 			{
 				Name: "cali-fw-cali1234",
 				Rules: []Rule{
+					// conntrack rules.
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
+					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+						Action: AcceptAction{}},
+
 					{Action: ClearMarkAction{Mark: 0x8}},
 
 					{Comment: "Start of policies",
@@ -162,6 +186,12 @@ var _ = Describe("Endpoints", func() {
 			{
 				Name: "cali-th-eth0",
 				Rules: []Rule{
+					// conntrack rules.
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
+					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+						Action: AcceptAction{}},
+
 					// Host endpoints get extra failsafe rules.
 					{Action: JumpAction{Target: "cali-failsafe-out"}},
 
@@ -199,6 +229,12 @@ var _ = Describe("Endpoints", func() {
 			{
 				Name: "cali-fh-eth0",
 				Rules: []Rule{
+					// conntrack rules.
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
+					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+						Action: AcceptAction{}},
+
 					// Host endpoints get extra failsafe rules.
 					{Action: JumpAction{Target: "cali-failsafe-in"}},
 

--- a/rules/endpoints_test.go
+++ b/rules/endpoints_test.go
@@ -54,10 +54,10 @@ var _ = Describe("Endpoints", func() {
 				Name: "cali-tw-cali1234",
 				Rules: []Rule{
 					// conntrack rules.
-					{Match: Match().ConntrackState("INVALID"),
-						Action: DropAction{}},
 					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
 						Action: AcceptAction{}},
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
 
 					{Action: ClearMarkAction{Mark: 0x8}},
 					{Action: DropAction{},
@@ -68,10 +68,10 @@ var _ = Describe("Endpoints", func() {
 				Name: "cali-fw-cali1234",
 				Rules: []Rule{
 					// conntrack rules.
-					{Match: Match().ConntrackState("INVALID"),
-						Action: DropAction{}},
 					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
 						Action: AcceptAction{}},
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
 
 					{Action: ClearMarkAction{Mark: 0x8}},
 					{Action: DropAction{},
@@ -146,10 +146,10 @@ var _ = Describe("Endpoints", func() {
 				Name: "cali-tw-cali1234",
 				Rules: []Rule{
 					// conntrack rules.
-					{Match: Match().ConntrackState("INVALID"),
-						Action: DropAction{}},
 					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
 						Action: AcceptAction{}},
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
 
 					{Action: ClearMarkAction{Mark: 0x8}},
 
@@ -186,10 +186,10 @@ var _ = Describe("Endpoints", func() {
 				Name: "cali-fw-cali1234",
 				Rules: []Rule{
 					// conntrack rules.
-					{Match: Match().ConntrackState("INVALID"),
-						Action: DropAction{}},
 					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
 						Action: AcceptAction{}},
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
 
 					{Action: ClearMarkAction{Mark: 0x8}},
 
@@ -231,10 +231,10 @@ var _ = Describe("Endpoints", func() {
 				Name: "cali-th-eth0",
 				Rules: []Rule{
 					// conntrack rules.
-					{Match: Match().ConntrackState("INVALID"),
-						Action: DropAction{}},
 					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
 						Action: AcceptAction{}},
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
 
 					// Host endpoints get extra failsafe rules.
 					{Action: JumpAction{Target: "cali-failsafe-out"}},
@@ -274,10 +274,10 @@ var _ = Describe("Endpoints", func() {
 				Name: "cali-fh-eth0",
 				Rules: []Rule{
 					// conntrack rules.
-					{Match: Match().ConntrackState("INVALID"),
-						Action: DropAction{}},
 					{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
 						Action: AcceptAction{}},
+					{Match: Match().ConntrackState("INVALID"),
+						Action: DropAction{}},
 
 					// Host endpoints get extra failsafe rules.
 					{Action: JumpAction{Target: "cali-failsafe-in"}},

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -194,6 +194,8 @@ type Config struct {
 
 	FailsafeInboundHostPorts  []uint16
 	FailsafeOutboundHostPorts []uint16
+
+	DisableConntrackInvalid bool
 }
 
 func NewRenderer(config Config) RuleRenderer {

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -76,12 +76,6 @@ var _ = Describe("Static", func() {
 							{Match: Match().MarkSet(0x10).ConntrackState("UNTRACKED"),
 								Action: AcceptAction{}},
 
-							// conntrack rules.
-							{Match: Match().ConntrackState("INVALID"),
-								Action: DropAction{}},
-							{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
-								Action: AcceptAction{}},
-
 							// Per-prefix workload jump rules.
 							{Match: Match().InInterface("cali+"),
 								Action: JumpAction{Target: ChainFromWorkloadDispatch}},
@@ -114,12 +108,6 @@ var _ = Describe("Static", func() {
 							{Match: Match().MarkSet(0x10).ConntrackState("UNTRACKED"),
 								Action: AcceptAction{}},
 
-							// conntrack rules.
-							{Match: Match().ConntrackState("INVALID"),
-								Action: DropAction{}},
-							{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
-								Action: AcceptAction{}},
-
 							// Per-prefix workload jump rules.  Note use of goto so that we
 							// don't return here.
 							{Match: Match().InInterface("cali+"),
@@ -142,12 +130,6 @@ var _ = Describe("Static", func() {
 						Rules: []Rule{
 							// Untracked packets already matched in raw table.
 							{Match: Match().MarkSet(0x10).ConntrackState("UNTRACKED"),
-								Action: AcceptAction{}},
-
-							// conntrack rules.
-							{Match: Match().ConntrackState("INVALID"),
-								Action: DropAction{}},
-							{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
 								Action: AcceptAction{}},
 
 							// Return if to workload.
@@ -415,12 +397,6 @@ var _ = Describe("Static", func() {
 					Action:  DropAction{},
 					Comment: "Drop IPIP packets from non-Calico hosts"},
 
-				// conntrack rules.
-				{Match: Match().ConntrackState("INVALID"),
-					Action: DropAction{}},
-				{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
-					Action: AcceptAction{}},
-
 				// Per-prefix workload jump rules.  Note use of goto so that we
 				// don't return here.
 				{Match: Match().InInterface("cali+"),
@@ -443,12 +419,6 @@ var _ = Describe("Static", func() {
 			Rules: []Rule{
 				// Untracked packets already matched in raw table.
 				{Match: Match().MarkSet(0x10).ConntrackState("UNTRACKED"),
-					Action: AcceptAction{}},
-
-				// conntrack rules.
-				{Match: Match().ConntrackState("INVALID"),
-					Action: DropAction{}},
-				{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
 					Action: AcceptAction{}},
 
 				// Per-prefix workload jump rules.  Note use of goto so that we


### PR DESCRIPTION
Prevents us from accepting traffic that is coming from interfaces that we don't own.

I also added an option to turn off the INVALID check since it can cause problems for users who are trying something off the beaten path.

Fixes #1423 