### PR TITLE
Remove ginkgo pin.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b09db45186e8eb5791c87b46fd9c6f3bf18519983221af3a506b4e54eb691c71
-updated: 2017-04-17T14:27:46.140817125-07:00
+hash: 36f183d17b38dd392ad2205bcd073738f372de9d111d034b0938583dfa03ea7f
+updated: 2017-04-18T11:01:38.364491723Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -13,12 +13,12 @@ imports:
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/containernetworking/cni
-  version: 137b4975ecab6e1f0c24c1e3c228a50a3cfba75e
+  version: 4a2f3ddd5d5626e883af9b3485be123f30beb5b2
   subpackages:
   - pkg/ns
   - pkg/types
 - name: github.com/coreos/etcd
-  version: 4582a7e90035d40d79975f5f018413230ed5d691
+  version: 4fcea334adfc4a0fc73682aae3e62feec5b653b9
   subpackages:
   - client
   - pkg/pathutil
@@ -82,7 +82,7 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
   subpackages:
   - proto
 - name: github.com/google/gofuzz
@@ -98,7 +98,7 @@ imports:
 - name: github.com/kardianos/osext
   version: 9d302b58e975387d0b4d9be876622c86cefe64be
 - name: github.com/kelseyhightower/envconfig
-  version: f611eb38b3875cc3bd991ca91c51d06446afa14c
+  version: 8bf4bbfc795e2c7c8a5ea47b707453ed019e2ad4
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -195,7 +195,7 @@ imports:
 - name: github.com/satori/go.uuid
   version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/Sirupsen/logrus
-  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+  version: 10f801ebc38b33738c9d17d50860f484a0988ff5
 - name: github.com/spf13/pflag
   version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/ugorji/go

--- a/glide.yaml
+++ b/glide.yaml
@@ -33,8 +33,7 @@ import:
   version: ^0.3.0
 - package: github.com/vishvananda/netlink
 - package: github.com/gavv/monotime
-- package: github.com/onsi/ginkgo
-  version: f40a49d81e5c12e90400620b6242fb29a8e7c9
 testImport:
 - package: github.com/onsi/gomega
   version: 9b8c753e8dfb382618ba8fa19b4197b5dcb0434c
+- package: github.com/onsi/ginkgo


### PR DESCRIPTION
@heschlie I removed the pin and did a `make update-vendor` and it picked the same revision that you'd pinned it to; did you have a stale glide cache or something?