### PR TITLE
k8sfv test improvements for ongoing CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,4 @@ htmlcov/
 
 /k8sfv/prometheus/data
 /k8sfv/prometheus/prometheus.yml
-/k8sfv/k8sfv.test
-/k8sfv/junit.xml
+/k8sfv/output/

--- a/Makefile
+++ b/Makefile
@@ -153,51 +153,10 @@ calico/felix: bin/calico-felix
 # Targets for Felix testing with the k8s backend and a k8s API server,
 # with k8s model resources being injected by a separate test client.
 GET_CONTAINER_IP := docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'
-K8S_VERSION=1.5.3
 GRAFANA_VERSION=4.1.2
-.PHONY: k8sfv-test run-k8s-apiserver stop-k8s-apiserver run-etcd stop-etcd
-k8sfv-test: calico/felix run-k8s-apiserver k8sfv/k8sfv.test
-	@-docker rm -f k8sfv-felix
-	sleep 1
-	K8S_IP=`$(GET_CONTAINER_IP) k8sfv-apiserver` && \
-	docker run --detach --privileged --name=k8sfv-felix \
-	-e FELIX_LOGSEVERITYSCREEN=info \
-	-e FELIX_DATASTORETYPE=kubernetes \
-	-e FELIX_PROMETHEUSMETRICSENABLED=true \
-	-e FELIX_USAGEREPORTINGENABLED=false \
-	-e FELIX_DEBUGMEMORYPROFILEPATH="heap-<timestamp>" \
-	-e K8S_API_ENDPOINT=https://$${K8S_IP}:6443 \
-	-e K8S_INSECURE_SKIP_TLS_VERIFY=true \
-	-v $${PWD}:/testcode \
-	-w /testcode/k8sfv \
-	calico/felix \
-	/bin/sh -c "for n in 1 2; do calico-felix; done"
-	sleep 1
-	FELIX_IP=`$(GET_CONTAINER_IP) k8sfv-felix` && \
-	K8S_IP=`$(GET_CONTAINER_IP) k8sfv-apiserver` && \
-	docker exec k8sfv-felix /bin/sh -c "cd /testcode/k8sfv && /testcode/k8sfv/k8sfv.test -ginkgo.v https://$${K8S_IP}:6443 $${FELIX_IP}"
-
-run-k8s-apiserver: stop-k8s-apiserver run-etcd
-	ETCD_IP=`$(GET_CONTAINER_IP) k8sfv-etcd` && \
-	docker run --detach \
-	  --name k8sfv-apiserver \
-	gcr.io/google_containers/hyperkube-amd64:v$(K8S_VERSION) \
-		  /hyperkube apiserver --etcd-servers=http://$${ETCD_IP}:2379 \
-		  --service-cluster-ip-range=10.101.0.0/16 -v=10
-
-stop-k8s-apiserver: stop-etcd
-	@-docker rm -f k8sfv-apiserver
-	sleep 2
-
-run-etcd: stop-etcd
-	docker run --detach \
-	--name k8sfv-etcd quay.io/coreos/etcd \
-	etcd \
-	--advertise-client-urls "http://127.0.0.1:2379,http://127.0.0.1:4001" \
-	--listen-client-urls "http://0.0.0.0:2379,http://0.0.0.0:4001"
-
-stop-etcd:
-	@-docker rm -f k8sfv-etcd
+.PHONY: k8sfv-test
+k8sfv-test: calico/felix bin/k8sfv.test
+	k8sfv/run-test
 
 PROMETHEUS_DATA_DIR := $$HOME/prometheus-data
 K8SFV_PROMETHEUS_DATA_DIR := $(PROMETHEUS_DATA_DIR)/k8sfv
@@ -328,10 +287,10 @@ bin/calico-felix: $(FELIX_GO_FILES) vendor/.up-to-date
                ( ldd bin/calico-felix 2>&1 | grep -q "Not a valid dynamic program" || \
 	             ( echo "Error: bin/calico-felix was not statically linked"; false ) )'
 
-k8sfv/k8sfv.test: $(K8SFV_GO_FILES)
+bin/k8sfv.test: $(K8SFV_GO_FILES)
 	@echo Building $@...
 	$(DOCKER_GO_BUILD) \
-	    sh -c 'ginkgo build k8sfv && \
+	    sh -c 'go test -c -o $@ ./k8sfv && \
                ( ldd $@ 2>&1 | grep -q "Not a valid dynamic program" || \
 	             ( echo "Error: $@ was not statically linked"; false ) )'
 

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ calico/felix: bin/calico-felix
 GET_CONTAINER_IP := docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'
 GRAFANA_VERSION=4.1.2
 .PHONY: k8sfv-test
-k8sfv-test: calico/felix bin/k8sfv.test
+k8sfv-test: calico/felix
 	k8sfv/run-test
 
 PROMETHEUS_DATA_DIR := $$HOME/prometheus-data
@@ -286,13 +286,6 @@ bin/calico-felix: $(FELIX_GO_FILES) vendor/.up-to-date
 	    sh -c 'go build -v -i -o $@ -v $(LDFLAGS) "github.com/projectcalico/felix" && \
                ( ldd bin/calico-felix 2>&1 | grep -q "Not a valid dynamic program" || \
 	             ( echo "Error: bin/calico-felix was not statically linked"; false ) )'
-
-bin/k8sfv.test: $(K8SFV_GO_FILES)
-	@echo Building $@...
-	$(DOCKER_GO_BUILD) \
-	    sh -c 'go test -c -o $@ ./k8sfv && \
-               ( ldd $@ 2>&1 | grep -q "Not a valid dynamic program" || \
-	             ( echo "Error: $@ was not statically linked"; false ) )'
 
 dist/calico-felix/calico-felix: bin/calico-felix
 	mkdir -p dist/calico-felix/

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ calico/felix: bin/calico-felix
 GET_CONTAINER_IP := docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'
 GRAFANA_VERSION=4.1.2
 .PHONY: k8sfv-test
-k8sfv-test: calico/felix
+k8sfv-test: calico/felix bin/k8sfv.test
 	k8sfv/run-test
 
 PROMETHEUS_DATA_DIR := $$HOME/prometheus-data
@@ -286,6 +286,13 @@ bin/calico-felix: $(FELIX_GO_FILES) vendor/.up-to-date
 	    sh -c 'go build -v -i -o $@ -v $(LDFLAGS) "github.com/projectcalico/felix" && \
                ( ldd bin/calico-felix 2>&1 | grep -q "Not a valid dynamic program" || \
 	             ( echo "Error: bin/calico-felix was not statically linked"; false ) )'
+
+bin/k8sfv.test: $(K8SFV_GO_FILES)
+	@echo Building $@...
+	$(DOCKER_GO_BUILD) \
+	    sh -c 'go test -c -o $@ ./k8sfv && \
+               ( ldd $@ 2>&1 | grep -q "Not a valid dynamic program" || \
+	             ( echo "Error: $@ was not statically linked"; false ) )'
 
 dist/calico-felix/calico-felix: bin/calico-felix
 	mkdir -p dist/calico-felix/

--- a/k8sfv/README.md
+++ b/k8sfv/README.md
@@ -177,3 +177,32 @@ So, some possible tests:
 	 selector = random set of labels to work on, random ops and values
 	 between 1 and 10 rules, each with random source selector (as above) and ports
 	Create say 10 of those, then churn by deleting the oldest, making a new one, etc.
+
+## Test design notes
+
+The test architecture involves:
+
+- an etcd container, as backing store for the k8s API server
+
+- a k8s API server container (hyperkube, 1.5.3)
+
+- a full Felix executable:
+  - running in a container, so as to have its own network namespace
+  - configured to use KDD
+  - other miscellaneous config for logging, prometheus, no usage reporting,
+    memory dumps etc.
+
+Each of those containers has its own IP address, and they are all bridged
+together on the default 'docker0' bridge.
+
+Then there is a separate test program executable, `k8sfv.test`.  This:
+
+- is run (with docker-exec) in the Felix container, so that it can create
+  workload interfaces in Felix's network namespace
+
+- has various test cases, organized in the Ginkgo way
+
+- acts as a k8s client, creating, updating and deleting k8s API resources
+  (Node, Namespace, Pod etc.)
+
+- thereby drives Felix, via the KDD backend.

--- a/k8sfv/calc_graph.go
+++ b/k8sfv/calc_graph.go
@@ -42,7 +42,7 @@ func rotateLabels(clientset *kubernetes.Clientset, nsPrefix string) error {
 		}
 	}
 
-	d := NewDeployment(49, true)
+	d := NewDeployment(clientset, 49, true)
 
 	// Create pods.
 	waiter := sync.WaitGroup{}

--- a/k8sfv/calc_graph_test.go
+++ b/k8sfv/calc_graph_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
@@ -30,6 +31,7 @@ var _ = Describe("calculation graph scale test", func() {
 	)
 
 	BeforeEach(func() {
+		log.Info(">>> BeforeEach <<<")
 		clientset = initialize(k8sServerEndpoint)
 		nsPrefix = getNamespacePrefix()
 	})
@@ -43,6 +45,7 @@ var _ = Describe("calculation graph scale test", func() {
 	})
 
 	AfterEach(func() {
+		log.Info(">>> AfterEach <<<")
 		time.Sleep(10 * time.Second)
 		cleanupAll(clientset, nsPrefix)
 	})

--- a/k8sfv/deployment.go
+++ b/k8sfv/deployment.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
@@ -43,7 +42,11 @@ type localPlusRemotes struct {
 	mutex         sync.Mutex
 }
 
-func NewDeployment(numRemotes int, includeLocal bool) deployment {
+func NewDeployment(
+	clientset *kubernetes.Clientset,
+	numRemotes int,
+	includeLocal bool,
+) deployment {
 	numLocal := 0
 	if includeLocal {
 		numLocal = 1
@@ -55,9 +58,33 @@ func NewDeployment(numRemotes int, includeLocal bool) deployment {
 		k8sCreated:   map[string]bool{},
 	}
 	if includeLocal {
-		d.localHostname, _ = os.Hostname()
+		d.localHostname = felixHostname
 	}
+	// Regardless of whether we're going to place _pods_ on the local host, we need to define a
+	// Node resource for the local host, so that Felix can get going.
+	d.ensureNodeDefined(clientset, felixHostname)
 	return d
+}
+
+func (d *localPlusRemotes) ensureNodeDefined(
+	clientset *kubernetes.Clientset,
+	hostName string,
+) {
+	d.mutex.Lock()
+	if !d.k8sCreated[hostName] {
+		node_in := &v1.Node{
+			ObjectMeta: v1.ObjectMeta{Name: hostName},
+			Spec:       v1.NodeSpec{},
+		}
+		log.WithField("node_in", node_in).Debug("Node defined")
+		node_out, err := clientset.Nodes().Create(node_in)
+		log.WithField("node_out", node_out).Debug("Created node")
+		if err != nil {
+			panic(err)
+		}
+		d.k8sCreated[hostName] = true
+	}
+	d.mutex.Unlock()
 }
 
 func (d *localPlusRemotes) ChooseHost(clientset *kubernetes.Clientset) (h host) {
@@ -67,21 +94,7 @@ func (d *localPlusRemotes) ChooseHost(clientset *kubernetes.Clientset) (h host) 
 	} else {
 		h = host{name: fmt.Sprintf("%s%d", d.remotePrefix, r), isLocal: false}
 	}
-	d.mutex.Lock()
-	if !d.k8sCreated[h.name] {
-		node_in := &v1.Node{
-			ObjectMeta: v1.ObjectMeta{Name: h.name},
-			Spec:       v1.NodeSpec{},
-		}
-		log.WithField("node_in", node_in).Debug("Node defined")
-		node_out, err := clientset.Nodes().Create(node_in)
-		log.WithField("node_out", node_out).Debug("Created node")
-		if err != nil {
-			panic(err)
-		}
-		d.k8sCreated[h.name] = true
-	}
-	d.mutex.Unlock()
+	d.ensureNodeDefined(clientset, h.name)
 	return
 }
 

--- a/k8sfv/ipam.go
+++ b/k8sfv/ipam.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+func ipAddrAllocator(pattern string) func() (addr string) {
+	ipNum := 1
+	return func() (addr string) {
+		addr = fmt.Sprintf(pattern, ipNum/255, ipNum%255)
+		ipNum++
+		return
+	}
+}

--- a/k8sfv/k8sfv.go
+++ b/k8sfv/k8sfv.go
@@ -63,6 +63,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
+	log.Info(">>> BeforeSuite <<<")
 	// Get and log command line args.
 	k8sServerEndpoint = flag.Arg(0)
 	felixIP = flag.Arg(1)
@@ -87,10 +88,12 @@ var _ = BeforeSuite(func() {
 var testName string
 
 var _ = JustBeforeEach(func() {
+	log.Info(">>> JustBeforeEach <<<")
 	testName = CurrentGinkgoTestDescription().FullTestText
 })
 
 var _ = AfterEach(func() {
+	log.Info(">>> AfterEach <<<")
 	result := float64(1)
 	if CurrentGinkgoTestDescription().Failed {
 		result = 0
@@ -99,6 +102,7 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	log.Info(">>> AfterSuite <<<")
 	if prometheusPushURL != "" {
 		// Push metrics to Prometheus push gateway.
 		err := push.FromGatherer(

--- a/k8sfv/k8sfv.go
+++ b/k8sfv/k8sfv.go
@@ -108,6 +108,7 @@ var _ = AfterSuite(func() {
 
 	metricFamilies, err := prometheus.DefaultGatherer.Gather()
 	panicIfError(err)
+	fmt.Println("")
 	for _, family := range metricFamilies {
 		if strings.HasPrefix(*family.Name, "k8sfv") {
 			fmt.Println(proto.MarshalTextString(family))

--- a/k8sfv/k8sfv.go
+++ b/k8sfv/k8sfv.go
@@ -37,6 +37,7 @@ import (
 var (
 	k8sServerEndpoint string // e.g. "http://172.17.0.2:6443"
 	felixIP           string // e.g. "172.17.0.3"
+	felixHostname     string // e.g. "b6fc45dcc1cb"
 	prometheusPushURL string // e.g. "http://172.17.0.3:9091"
 	codeLevel         string // e.g. "master"
 )
@@ -65,11 +66,13 @@ var _ = BeforeSuite(func() {
 	// Get and log command line args.
 	k8sServerEndpoint = flag.Arg(0)
 	felixIP = flag.Arg(1)
-	prometheusPushURL = flag.Arg(2)
-	codeLevel = flag.Arg(3)
+	felixHostname = flag.Arg(2)
+	prometheusPushURL = flag.Arg(3)
+	codeLevel = flag.Arg(4)
 	log.WithFields(log.Fields{
 		"k8sServerEndpoint": k8sServerEndpoint,
 		"felixIP":           felixIP,
+		"felixHostname":     felixHostname,
 		"prometheusPushURL": prometheusPushURL,
 		"codeLevel":         codeLevel,
 	}).Info("Args")
@@ -167,7 +170,7 @@ func initializeCalicoDeployment(k8sServerEndpoint string) {
 
 func create1000Pods(clientset *kubernetes.Clientset, nsPrefix string) error {
 
-	d := NewDeployment(49, true)
+	d := NewDeployment(clientset, 49, true)
 	nsName := nsPrefix + "test"
 
 	// Create 1000 pods.

--- a/k8sfv/k8sfv_suite_test.go
+++ b/k8sfv/k8sfv_suite_test.go
@@ -17,7 +17,7 @@ package main
 import (
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
@@ -29,7 +29,7 @@ import (
 func init() {
 	testutils.HookLogrusForGinkgo()
 	logutils.ConfigureEarlyLogging()
-	logrus.SetLevel(logrus.InfoLevel)
+	log.SetLevel(log.InfoLevel)
 }
 
 func TestMain(t *testing.T) {

--- a/k8sfv/k8sfv_suite_test.go
+++ b/k8sfv/k8sfv_suite_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
@@ -29,7 +30,9 @@ import (
 func init() {
 	testutils.HookLogrusForGinkgo()
 	logutils.ConfigureEarlyLogging()
-	log.SetLevel(log.InfoLevel)
+	logLevel, err := log.ParseLevel(os.Getenv("K8SFV_LOG_LEVEL"))
+	panicIfError(err)
+	log.SetLevel(logLevel)
 }
 
 func TestMain(t *testing.T) {

--- a/k8sfv/pod.go
+++ b/k8sfv/pod.go
@@ -61,7 +61,7 @@ func createPod(clientset *kubernetes.Clientset, d deployment, nsName string, spe
 	host := d.ChooseHost(clientset)
 	ip := spec.ipv4Addr
 	if ip == "" {
-		ip = GetNextAddr()
+		ip = GetNextPodAddr()
 	}
 	pod_in := &v1.Pod{
 		ObjectMeta: v1.ObjectMeta{Name: name},
@@ -183,13 +183,7 @@ func removeLocalPodNetworking(pod *v1.Pod) {
 	return
 }
 
-var ipNum = 0
-
-func GetNextAddr() (addr string) {
-	addr = fmt.Sprintf("10.28.%d.%d", ipNum/255, ipNum%255)
-	ipNum++
-	return
-}
+var GetNextPodAddr = ipAddrAllocator("10.28.%d.%d")
 
 func cleanupAllPods(clientset *kubernetes.Clientset, nsPrefix string) {
 	log.WithField("nsPrefix", nsPrefix).Info("Cleaning up all pods...")

--- a/k8sfv/pod_test.go
+++ b/k8sfv/pod_test.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
@@ -32,11 +33,13 @@ var _ = Context("with a k8s clientset", func() {
 	)
 
 	BeforeEach(func() {
+		log.Info(">>> BeforeEach <<<")
 		clientset = initialize(flag.Arg(0))
 		nsPrefix = getNamespacePrefix()
 	})
 
 	AfterEach(func() {
+		log.Info(">>> AfterEach <<<")
 		time.Sleep(10 * time.Second)
 		cleanupAll(clientset, nsPrefix)
 	})
@@ -44,6 +47,7 @@ var _ = Context("with a k8s clientset", func() {
 	Context("with 1 remote node", func() {
 
 		BeforeEach(func() {
+			log.Info(">>> BeforeEach <<<")
 			d = NewDeployment(clientset, 1, false)
 		})
 

--- a/k8sfv/pod_test.go
+++ b/k8sfv/pod_test.go
@@ -44,7 +44,7 @@ var _ = Context("with a k8s clientset", func() {
 	Context("with 1 remote node", func() {
 
 		BeforeEach(func() {
-			d = NewDeployment(1, false)
+			d = NewDeployment(clientset, 1, false)
 		})
 
 		// Test for https://github.com/projectcalico/libcalico-go/pull/375.

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -23,9 +23,16 @@
 # should set this to the name of that branch, e.g. 'master'.
 : ${CODE_LEVEL:=dev}
 #
-# Tell this script to wait before cleaning up the test containers -
-# e.g. to allow investigation of Felix logs.
-: ${SLEEP_BEFORE_CLEANUP:=0}
+# Whether to clean up the etcd, API server and Felix containers that
+# this test creates.  The default 'false' is intended to be what
+# development work typically needs: containers are not cleaned up,
+# because (1) that allows the developer to look at them when a test
+# has completed, and (2) the containers from a previous run will
+# always be cleaned up when this script is run again - so we are never
+# going to leak an increasing number of containers.  CI should set
+# CLEANUP to 'true', so that the containers are cleaned up regardless
+# of test outcome.
+: ${CLEANUP:=false}
 #
 # Felix logging level.
 : ${FELIX_LOG_LEVEL:=info}
@@ -41,7 +48,8 @@
 # will create.
 prefix=k8sfv${UNIQUE}
 
-# Arrange to always clean up the containers that we create.
+# If CLEANUP says so, arrange to always clean up the containers that
+# we create.
 function cleanup {
     # Clean up the containers that this script generates.
     docker rm -f ${prefix}-felix || true
@@ -50,7 +58,9 @@ function cleanup {
     # List all remaining containers.
     docker ps -a
 }
-trap cleanup EXIT SIGINT SIGQUIT
+if ${CLEANUP}; then
+    trap cleanup EXIT SIGINT SIGQUIT
+fi
 
 # Utilities - get a container's IP address and hostname.
 function get_container_ip {
@@ -110,14 +120,5 @@ args=-ginkgo.v
 if test -n "${GINKGO_FOCUS}"; then
     args="${args} -ginkgo.focus"
 fi
-set +e
 docker exec ${prefix}-felix /bin/sh -c \
        "cd /testcode/k8sfv/output && /testcode/bin/k8sfv.test ${args} \"${GINKGO_FOCUS}\" ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} \"${PROMPG_URL}\" \"${CODE_LEVEL}\""
-test_result=$?
-set -e
-
-# Sleep before cleanup.
-sleep ${SLEEP_BEFORE_CLEANUP}
-
-# Report the test result.
-exit ${test_result}

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -33,6 +33,9 @@
 # Ginkgo focus term (regexp); this can be set to focus on particular
 # tests.
 : ${GINKGO_FOCUS:=}
+#
+# k8sfv logging level.
+: ${K8SFV_LOG_LEVEL:=info}
 
 # Generate a unique prefix for the names of the containers that we
 # will create.
@@ -94,6 +97,7 @@ docker run --detach --privileged --name ${prefix}-felix \
        -e FELIX_DEBUGMEMORYPROFILEPATH="heap-<timestamp>" \
        -e K8S_API_ENDPOINT=${k8s_api_endpoint} \
        -e K8S_INSECURE_SKIP_TLS_VERIFY=true \
+       -e K8SFV_LOG_LEVEL=${K8SFV_LOG_LEVEL} \
        -v ${PWD}:/testcode \
        -w /testcode/k8sfv/output \
        calico/felix \

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -22,6 +22,10 @@
 # A CI job that regularly tests a particular (checked in) code branch
 # should set this to the name of that branch, e.g. 'master'.
 : ${CODE_LEVEL:=dev}
+#
+# Tell this script to wait before cleaning up the test containers -
+# e.g. to allow investigation of Felix logs.
+: ${SLEEP_BEFORE_CLEANUP:=0}
 
 # Generate a unique prefix for the names of the containers that we
 # will create.
@@ -87,5 +91,13 @@ docker run --detach --privileged --name ${prefix}-felix \
 felix_ip=$(get_container_ip ${prefix}-felix)
 
 # Run the test suite.
+set +e
 docker exec ${prefix}-felix /bin/sh -c \
        "cd /testcode/k8sfv/output && /testcode/bin/k8sfv.test -ginkgo.v ${k8s_api_endpoint} ${felix_ip} \"${PROMPG_URL}\" \"${CODE_LEVEL}\""
+test_result=$?
+
+# Sleep before cleanup.
+sleep ${SLEEP_BEFORE_CLEANUP}
+
+# Report the test result.
+exit ${test_result}

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -42,9 +42,12 @@ function cleanup {
 }
 trap cleanup EXIT SIGINT SIGQUIT
 
-# Utility - get a container's IP address.
+# Utilities - get a container's IP address and hostname.
 function get_container_ip {
     docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $1
+}
+function get_container_hostname {
+    docker inspect --format='{{.Config.Hostname}}' $1
 }
 
 # Just in case containers already exist with the same names, clean
@@ -89,12 +92,14 @@ docker run --detach --privileged --name ${prefix}-felix \
        calico/felix \
        /bin/sh -c "for n in 1 2; do calico-felix; done"
 felix_ip=$(get_container_ip ${prefix}-felix)
+felix_hostname=$(get_container_hostname ${prefix}-felix)
 
 # Run the test suite.
 set +e
-docker exec ${prefix}-felix /bin/sh -c \
-       "cd /testcode/k8sfv/output && /testcode/bin/k8sfv.test -ginkgo.v ${k8s_api_endpoint} ${felix_ip} \"${PROMPG_URL}\" \"${CODE_LEVEL}\""
+ginkgo -v k8sfv -- ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} "${PROMPG_URL}" "${CODE_LEVEL}"
 test_result=$?
+set -e
+mv k8sfv/junit.xml k8sfv/output/
 
 # Sleep before cleanup.
 sleep ${SLEEP_BEFORE_CLEANUP}

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -29,6 +29,10 @@
 #
 # Felix logging level.
 : ${FELIX_LOG_LEVEL:=info}
+#
+# Ginkgo focus term (regexp); this can be set to focus on particular
+# tests.
+: ${GINKGO_FOCUS:=}
 
 # Generate a unique prefix for the names of the containers that we
 # will create.
@@ -98,8 +102,12 @@ felix_ip=$(get_container_ip ${prefix}-felix)
 felix_hostname=$(get_container_hostname ${prefix}-felix)
 
 # Run the test suite.
+args=-v
+if test -n "${GINKGO_FOCUS}"; then
+    args="${args} -focus"
+fi
 set +e
-ginkgo -v k8sfv -- ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} "${PROMPG_URL}" "${CODE_LEVEL}"
+ginkgo ${args} "${GINKGO_FOCUS[@]}" k8sfv -- ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} "${PROMPG_URL}" "${CODE_LEVEL}"
 test_result=$?
 set -e
 mv k8sfv/junit.xml k8sfv/output/

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -26,6 +26,9 @@
 # Tell this script to wait before cleaning up the test containers -
 # e.g. to allow investigation of Felix logs.
 : ${SLEEP_BEFORE_CLEANUP:=0}
+#
+# Felix logging level.
+: ${FELIX_LOG_LEVEL:=info}
 
 # Generate a unique prefix for the names of the containers that we
 # will create.
@@ -80,7 +83,7 @@ done
 # Run Felix.
 mkdir -p k8sfv/output
 docker run --detach --privileged --name ${prefix}-felix \
-       -e FELIX_LOGSEVERITYSCREEN=info \
+       -e FELIX_LOGSEVERITYSCREEN=${FELIX_LOG_LEVEL} \
        -e FELIX_DATASTORETYPE=kubernetes \
        -e FELIX_PROMETHEUSMETRICSENABLED=true \
        -e FELIX_USAGEREPORTINGENABLED=false \

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -1,0 +1,83 @@
+#!/bin/bash -ex
+
+# Run the 'k8sfv' test suite, a functional and scale test of Felix
+# running with the Kubernetes datastore driver, driven by CRUD
+# operations through the k8s API server.
+
+# Config.
+#
+# What version of the k8s API server to use.
+: ${K8S_VERSION:=1.5.3}
+#
+# A string to insert into the container names that we use; a calling
+# script can set this to something to make the container names unique,
+# and hence to allow multiple copies of this script to run in
+# parallel.
+: ${UNIQUE:=}
+
+# Generate a unique prefix for the names of the containers that we
+# will create.
+prefix=k8sfv${UNIQUE}
+
+# Arrange to always clean up the containers that we create.
+function cleanup {
+    # Clean up the containers that this script generates.
+    docker rm -f ${prefix}-felix || true
+    docker rm -f ${prefix}-apiserver || true
+    docker rm -f ${prefix}-etcd || true
+    # List all remaining containers.
+    docker ps -a
+}
+trap cleanup EXIT SIGINT SIGQUIT
+
+# Utility - get a container's IP address.
+function get_container_ip {
+    docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $1
+}
+
+# Just in case containers already exist with the same names, clean
+# them up.
+cleanup
+
+# Run etcd.
+docker run --detach --name ${prefix}-etcd \
+       quay.io/coreos/etcd \
+       etcd \
+       --advertise-client-urls "http://127.0.0.1:2379,http://127.0.0.1:4001" \
+       --listen-client-urls "http://0.0.0.0:2379,http://0.0.0.0:4001"
+etcd_ip=$(get_container_ip ${prefix}-etcd)
+
+# Run k8s API server.
+docker run --detach --name ${prefix}-apiserver \
+       gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
+       /hyperkube apiserver \
+       --etcd-servers=http://${etcd_ip}:2379 \
+       --service-cluster-ip-range=10.101.0.0/16 -v=10
+k8s_ip=$(get_container_ip ${prefix}-apiserver)
+k8s_api_endpoint=https://${k8s_ip}:6443
+
+# Wait until the newly launched API server can respond to a request,
+# before continuing.
+while ! curl -k ${k8s_api_endpoint}/apis/extensions/v1beta1/thirdpartyresources; do
+    sleep 2
+done
+
+# Run Felix.
+mkdir -p k8sfv/output
+docker run --detach --privileged --name ${prefix}-felix \
+       -e FELIX_LOGSEVERITYSCREEN=info \
+       -e FELIX_DATASTORETYPE=kubernetes \
+       -e FELIX_PROMETHEUSMETRICSENABLED=true \
+       -e FELIX_USAGEREPORTINGENABLED=false \
+       -e FELIX_DEBUGMEMORYPROFILEPATH="heap-<timestamp>" \
+       -e K8S_API_ENDPOINT=${k8s_api_endpoint} \
+       -e K8S_INSECURE_SKIP_TLS_VERIFY=true \
+       -v ${PWD}:/testcode \
+       -w /testcode/k8sfv/output \
+       calico/felix \
+       /bin/sh -c "for n in 1 2; do calico-felix; done"
+felix_ip=$(get_container_ip ${prefix}-felix)
+
+# Run the test suite.
+docker exec ${prefix}-felix /bin/sh -c \
+       "cd /testcode/k8sfv/output && /testcode/bin/k8sfv.test -ginkgo.v ${k8s_api_endpoint} ${felix_ip}"

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -14,6 +14,14 @@
 # and hence to allow multiple copies of this script to run in
 # parallel.
 : ${UNIQUE:=}
+#
+# URL of a Prometheus push gateway that k8sfv should push metrics to.
+: ${PROMPG_URL:=}
+#
+# Code level to report for the metrics that this test run generates.
+# A CI job that regularly tests a particular (checked in) code branch
+# should set this to the name of that branch, e.g. 'master'.
+: ${CODE_LEVEL:=dev}
 
 # Generate a unique prefix for the names of the containers that we
 # will create.
@@ -80,4 +88,4 @@ felix_ip=$(get_container_ip ${prefix}-felix)
 
 # Run the test suite.
 docker exec ${prefix}-felix /bin/sh -c \
-       "cd /testcode/k8sfv/output && /testcode/bin/k8sfv.test -ginkgo.v ${k8s_api_endpoint} ${felix_ip}"
+       "cd /testcode/k8sfv/output && /testcode/bin/k8sfv.test -ginkgo.v ${k8s_api_endpoint} ${felix_ip} \"${PROMPG_URL}\" \"${CODE_LEVEL}\""

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -116,9 +116,11 @@ felix_ip=$(get_container_ip ${prefix}-felix)
 felix_hostname=$(get_container_hostname ${prefix}-felix)
 
 # Run the test suite.
-args=-ginkgo.v
+run="cd /testcode/k8sfv/output && /testcode/bin/k8sfv.test -ginkgo.v"
 if test -n "${GINKGO_FOCUS}"; then
-    args="${args} -ginkgo.focus"
+    docker exec ${prefix}-felix /bin/sh -c \
+	   "${run} -ginkgo.focus \"${GINKGO_FOCUS}\" ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} \"${PROMPG_URL}\" \"${CODE_LEVEL}\""
+else
+    docker exec ${prefix}-felix /bin/sh -c \
+	   "${run} ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} \"${PROMPG_URL}\" \"${CODE_LEVEL}\""
 fi
-docker exec ${prefix}-felix /bin/sh -c \
-       "cd /testcode/k8sfv/output && /testcode/bin/k8sfv.test ${args} \"${GINKGO_FOCUS}\" ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} \"${PROMPG_URL}\" \"${CODE_LEVEL}\""

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -102,15 +102,15 @@ felix_ip=$(get_container_ip ${prefix}-felix)
 felix_hostname=$(get_container_hostname ${prefix}-felix)
 
 # Run the test suite.
-args=-v
+args=-ginkgo.v
 if test -n "${GINKGO_FOCUS}"; then
-    args="${args} -focus"
+    args="${args} -ginkgo.focus"
 fi
 set +e
-ginkgo ${args} "${GINKGO_FOCUS[@]}" k8sfv -- ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} "${PROMPG_URL}" "${CODE_LEVEL}"
+docker exec ${prefix}-felix /bin/sh -c \
+       "cd /testcode/k8sfv/output && /testcode/bin/k8sfv.test ${args} \"${GINKGO_FOCUS}\" ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} \"${PROMPG_URL}\" \"${CODE_LEVEL}\""
 test_result=$?
 set -e
-mv k8sfv/junit.xml k8sfv/output/
 
 # Sleep before cleanup.
 sleep ${SLEEP_BEFORE_CLEANUP}

--- a/k8sfv/scale_test.go
+++ b/k8sfv/scale_test.go
@@ -46,11 +46,13 @@ var _ = Context("with a k8s clientset", func() {
 	)
 
 	BeforeEach(func() {
+		log.Info(">>> BeforeEach <<<")
 		clientset = initialize(k8sServerEndpoint)
 		nsPrefix = getNamespacePrefix()
 	})
 
 	AfterEach(func() {
+		log.Info(">>> AfterEach <<<")
 		time.Sleep(10 * time.Second)
 		cleanupAll(clientset, nsPrefix)
 	})
@@ -58,6 +60,7 @@ var _ = Context("with a k8s clientset", func() {
 	Context("with 1 remote node", func() {
 
 		BeforeEach(func() {
+			log.Info(">>> BeforeEach <<<")
 			d = NewDeployment(clientset, 1, false)
 		})
 
@@ -153,6 +156,7 @@ var _ = Context("with a k8s clientset", func() {
 	Context("with 1 local node", func() {
 
 		BeforeEach(func() {
+			log.Info(">>> BeforeEach <<<")
 			d = NewDeployment(clientset, 0, true)
 		})
 
@@ -183,6 +187,7 @@ var _ = Context("with a k8s clientset", func() {
 	Context("with 1 local and 9 remote nodes", func() {
 
 		BeforeEach(func() {
+			log.Info(">>> BeforeEach <<<")
 			d = NewDeployment(clientset, 9, true)
 		})
 

--- a/k8sfv/scale_test.go
+++ b/k8sfv/scale_test.go
@@ -58,7 +58,7 @@ var _ = Context("with a k8s clientset", func() {
 	Context("with 1 remote node", func() {
 
 		BeforeEach(func() {
-			d = NewDeployment(1, false)
+			d = NewDeployment(clientset, 1, false)
 		})
 
 		It("should create 10k endpoints", func() {
@@ -153,7 +153,7 @@ var _ = Context("with a k8s clientset", func() {
 	Context("with 1 local node", func() {
 
 		BeforeEach(func() {
-			d = NewDeployment(0, true)
+			d = NewDeployment(clientset, 0, true)
 		})
 
 		It("should handle a local endpoint", func() {
@@ -183,7 +183,7 @@ var _ = Context("with a k8s clientset", func() {
 	Context("with 1 local and 9 remote nodes", func() {
 
 		BeforeEach(func() {
-			d = NewDeployment(9, true)
+			d = NewDeployment(clientset, 9, true)
 		})
 
 		It("should add and remove 1000 pods, of which about 100 on local node", func() {


### PR DESCRIPTION
This PR contains the test-side changes that we need for useful ongoing CI.  By 'test-side' I mean everything that is required for the test and runs on the machine where the test is executed: the test program, Felix, API server and etcd.  The other pieces - Prometheus, push gateway and Grafana - are 'server-side' and in some senses more optional.

This PR has options to allow k8sfv to connect to those server-side pieces.  I'm now going to work on setting up those pieces for our nightly CI, and then on making it trivial for a developer to set up those pieces for themselves.