### PR TITLE
Fix felix_cluster_* metrics when usage reporting disabled

### DIFF
--- a/felix.go
+++ b/felix.go
@@ -314,6 +314,13 @@ configRetry:
 			configParams.ClusterType,
 			statsChanOut,
 		)
+	} else {
+		// Usage reporting disabled, but we still want a stats collector for the
+		// felix_cluster_* metrics.  Register a no-op function as the callback.
+		statsCollector := calc.NewStatsCollector(func(stats calc.StatsUpdate) error {
+			return nil
+		})
+		statsCollector.RegisterWith(asyncCalcGraph.Dispatcher)
 	}
 
 	// Create the validator, which sits between the syncer and the


### PR DESCRIPTION
If we add this fix to 2.1.x-series, we should then be able to run the k8sfv test against 2.1.x.  Specifically, this fix is needed for the 'should delete a pod whose IP has been cleared' test.