### PR TITLE
Rev go-build to v0.6 to pick up go 1.8.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ help:
 all: deb rpm calico/felix
 test: ut
 
-GO_BUILD_CONTAINER?=calico/go-build:v0.5
+GO_BUILD_CONTAINER?=calico/go-build:v0.6
 
 # Figure out version information.  To support builds from release tarballs, we default to
 # <unknown> if this isn't a git checkout.


### PR DESCRIPTION
etcd client dependency now depends on 1.8.1 for a bugfix so we need to rev go-build before we can rev that.
