### PR TITLE
Disable node polling if IPIP is disabled.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -370,6 +370,13 @@ func (config *Config) DatastoreConfig() api.CalicoAPIConfig {
 	if cfg.Spec.DatastoreType == "etcdv2" {
 		cfg.Spec.DatastoreType = api.DatastoreType(config.DatastoreType)
 	}
+
+	if !config.IpInIpEnabled {
+		// Polling k8s for node updates is expensive (because we get many superfluous
+		// updates) so disable if we don't need it.
+		log.Info("IPIP disabled, disabling node poll (if KDD is in use).")
+		cfg.Spec.K8sDisableNodePoll = true
+	}
 	return *cfg
 }
 

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"reflect"
 
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
@@ -209,3 +210,27 @@ var _ = DescribeTable("Next mark bit calculation tests",
 	Entry("7th bit in 0xf00f", "0xf00f", 8, uint32(0x8000)),
 	Entry("0th bit of 0xff000000", "0xff000000", 1, uint32(0x01000000)),
 )
+
+var _ = Describe("DatastoreConfig tests", func() {
+	var c *Config
+	Describe("with IPIP enabled", func() {
+		BeforeEach(func() {
+			c = New()
+			c.DatastoreType = "k8s"
+			c.IpInIpEnabled = true
+		})
+		It("should leave node polling enabled", func() {
+			Expect(c.DatastoreConfig().Spec.K8sDisableNodePoll).To(BeFalse())
+		})
+	})
+	Describe("with IPIP disabled", func() {
+		BeforeEach(func() {
+			c = New()
+			c.DatastoreType = "k8s"
+			c.IpInIpEnabled = false
+		})
+		It("should leave node polling enabled", func() {
+			Expect(c.DatastoreConfig().Spec.K8sDisableNodePoll).To(BeTrue())
+		})
+	})
+})

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d8792fca9ff6d6f56e0ee95d464b9ea1bd21eb244ee78767a1062db1b8aaebbe
-updated: 2017-04-20T08:36:47.784309561-07:00
+hash: 18a0faa41b2e9df7757c328286ae6585f89ec367fe01445857acc214aa653f0b
+updated: 2017-05-04T17:04:44.36093005Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -13,12 +13,12 @@ imports:
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/containernetworking/cni
-  version: 4a2f3ddd5d5626e883af9b3485be123f30beb5b2
+  version: 231f6c4c5346c8cc56190bd46d4fa8a103b21d4b
   subpackages:
   - pkg/ns
   - pkg/types
 - name: github.com/coreos/etcd
-  version: 17ae440991da3bdb2df4309936dd2074f66ec394
+  version: 505bf8c7089a292e0166a8141c6bce85e172bc3e
   subpackages:
   - client
   - pkg/pathutil
@@ -82,7 +82,7 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: 18c9bb3261723cd5401db4d0c9fbc5c3b6c70fe8
   subpackages:
   - proto
 - name: github.com/google/gofuzz
@@ -98,7 +98,7 @@ imports:
 - name: github.com/kardianos/osext
   version: 9d302b58e975387d0b4d9be876622c86cefe64be
 - name: github.com/kelseyhightower/envconfig
-  version: 8bf4bbfc795e2c7c8a5ea47b707453ed019e2ad4
+  version: b6fde1625d631a48340817849a547164f395d9eb
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -143,7 +143,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 341b130b8c7ec018d4b60bcf7c124f97a0fe5f39
+  version: fbc28ba73774c7e7700a3269e9e379cebc2c09d1
   subpackages:
   - lib
   - lib/api
@@ -174,6 +174,7 @@ imports:
   subpackages:
   - prometheus
   - prometheus/promhttp
+  - prometheus/push
 - name: github.com/prometheus/client_model
   version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
@@ -193,9 +194,9 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
-  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
+  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/Sirupsen/logrus
-  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+  version: 5b60b3d3ee017ed00bcd0225fcca7acab767844b
 - name: github.com/spf13/pflag
   version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/ugorji/go
@@ -203,7 +204,7 @@ imports:
   subpackages:
   - codec
 - name: github.com/vishvananda/netlink
-  version: fe3b5664d23a11b52ba59bece4ff29c52772a56b
+  version: 1e045880fbc2f6703d3c771db56cfb0351208637
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
@@ -229,7 +230,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 21f2569f6feb83b68a25c98c1b20eca5d4e1e6ae
+  version: 9ccfe848b9db8435a24c424abbc07a921adf1df5
   subpackages:
   - unix
 - name: golang.org/x/text

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,7 +21,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: v1.2.1-rc3
+  version: v1.2.1-rc6
   subpackages:
   - lib
 - package: github.com/Sirupsen/logrus


### PR DESCRIPTION
## Description
This PR improves scale/perf when using KDD with IPIP disabled.  With IPIP disabled, Felix doesn't make use of the Host IP updates from KDD (and they're expensive because the objects churn a lot in ways that we don't care about) so it makes sense to disable them.

## Todos
- [x] Unit tests (full coverage)