### PR TITLE
Add config options for disabling Golang and process metrics

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -139,8 +139,10 @@ type Config struct {
 
 	DisableConntrackInvalidCheck bool `config:"bool;false"`
 
-	PrometheusMetricsEnabled bool `config:"bool;false"`
-	PrometheusMetricsPort    int  `config:"int(0,65535);9091"`
+	PrometheusMetricsEnabled        bool `config:"bool;false"`
+	PrometheusMetricsPort           int  `config:"int(0,65535);9091"`
+	PrometheusGoMetricsEnabled      bool `config:"bool;true"`
+	PrometheusProcessMetricsEnabled bool `config:"bool;true"`
 
 	FailsafeInboundHostPorts  []ProtoPort `config:"port-list;tcp:22,udp:68;die-on-fail"`
 	FailsafeOutboundHostPorts []ProtoPort `config:"port-list;tcp:2379,tcp:2380,tcp:4001,tcp:7001,udp:53,udp:67;die-on-fail"`

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -107,6 +107,8 @@ var _ = DescribeTable("Config parsing",
 
 	Entry("PrometheusMetricsEnabled", "PrometheusMetricsEnabled", "true", true),
 	Entry("PrometheusMetricsPort", "PrometheusMetricsPort", "1234", int(1234)),
+	Entry("PrometheusGoMetricsEnabled", "PrometheusGoMetricsEnabled", "false", false),
+	Entry("PrometheusProcessMetricsEnabled", "PrometheusProcessMetricsEnabled", "false", false),
 
 	Entry("FailsafeInboundHostPorts old syntax", "FailsafeInboundHostPorts", "1,2,3,4",
 		[]ProtoPort{


### PR DESCRIPTION
Allow new runtime parameter to include or not Golang GC metrics

Default is kept unchanged aka keep Golang metrics
