### PR TITLE
Measure occupancy with large numbers of allowed/denied packets

### DIFF
--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -114,6 +114,7 @@ docker run --detach --privileged --name ${prefix}-felix \
        -e FELIX_LOGSEVERITYSCREEN=${FELIX_LOG_LEVEL} \
        -e FELIX_DATASTORETYPE=kubernetes \
        -e FELIX_PROMETHEUSMETRICSENABLED=true \
+       -e FELIX_PROMETHEUSREPORTERENABLED=true \
        -e FELIX_USAGEREPORTINGENABLED=false \
        -e FELIX_DEBUGMEMORYPROFILEPATH="heap-<timestamp>" \
        -e K8S_API_ENDPOINT=${k8s_api_endpoint} \
@@ -122,7 +123,7 @@ docker run --detach --privileged --name ${prefix}-felix \
        -v ${PWD}:/testcode \
        -w /testcode/k8sfv/output \
        calico/felix:${FELIX_VERSION} \
-       /bin/sh -c "for n in 1 2; do calico-felix; done"
+       /bin/sh -c "apk --no-cache add nmap; for n in 1 2; do calico-felix; done"
 felix_ip=$(get_container_ip ${prefix}-felix)
 felix_hostname=$(get_container_hostname ${prefix}-felix)
 


### PR DESCRIPTION
This commit adds a scenario where we generate large numbers of packets
between 2 pods, and in alternate cycles those packets are either allowed
or denied.  We measure any associated occupancy impact.
