### PR TITLE
Add hostname tagged metric

### DIFF
--- a/felix.go
+++ b/felix.go
@@ -397,6 +397,13 @@ configRetry:
 
 	if configParams.PrometheusMetricsEnabled {
 		log.Info("Prometheus metrics enabled.  Starting server.")
+		gaugeHost := prometheus.NewGauge(prometheus.GaugeOpts{
+			Name:        "felix_host",
+			Help:        "Configured Felix hostname (as a label), typically used in grouping/aggregating stats; the label defaults to the hostname of the host but can be overridden by configuration. The value of the gauge is always set to 1.",
+			ConstLabels: prometheus.Labels{"host": configParams.FelixHostname},
+		})
+		gaugeHost.Set(1)
+		prometheus.MustRegister(gaugeHost)
 		go servePrometheusMetrics(configParams)
 	}
 


### PR DESCRIPTION
This potentially allow prometheus smarter mapping like having:
sum by (host) (felix_active_local_endpoints * on (job, instance) group_left(host) felix_host)
instead of:
sum by (instance) (felix_active_local_endpoints)

because Felix metrics do not include any tags by default and according to
[https://groups.google.com/d/msgid/prometheus-developers/71a37ceb-e4bb-4894-be62-3ffc853c177f%40googlegroups.com](https://groups.google.com/d/msgid/prometheus-developers/71a37ceb-e4bb-4894-be62-3ffc853c177f%40googlegroups.com) adding host tag to all metrics is not the way to go