### PR TITLE
Ensure our Docker image runs with a sane init daemon.

### DIFF
--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -1,6 +1,10 @@
 FROM alpine:3.4
 MAINTAINER Shaun Crampton <shaun@tigera.io>
 
+# Since our binary isn't designed to run as PID 1, run it via the tini init daemon.
+RUN apk --no-cache add --update tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
 # Download and install glibc in one layer
 RUN apk --no-cache add wget ca-certificates libgcc && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \


### PR DESCRIPTION
## Description
Previously Felix ran as PID 1 inside our container.  That is not sensible because PID 1 has responsibilities; it must:

- reap zombie processes
- handle and fan out signals correctly (e.g. to make Ctrl-C work)

This PR adds the `tini` init daemon to wrap Felix.  `tini` is designed for precisely this purpose (to handle the responsibilities of PID 1 while running exactly one child process).