### PR TITLE
Update libcalico to v1.4.0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: c75b8d818b34d82e4e923d96a4c53b562e422b3814d5c5a9d5d02a2b61783be9
-updated: 2017-06-05T17:12:04.061799633-07:00
+hash: 3ca990cfd38b922b4535467e7011c424e828cd121a43d3fa659e2a5aa35dd3b2
+updated: 2017-06-06T19:37:04.831860082-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
 - name: github.com/containernetworking/cni
-  version: 98826b72cc3abe31b787da49e6124afd59aa9a44
+  version: 137b4975ecab6e1f0c24c1e3c228a50a3cfba75e
   subpackages:
   - pkg/ns
   - pkg/types
@@ -20,11 +20,10 @@ imports:
   - pkg/transport
   - pkg/types
 - name: github.com/coreos/go-systemd
-  version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
+  version: 2688e91251d9d8e404e86dd8f096e23b2f086958
   subpackages:
-  - daemon
+  - activation
   - journal
-  - util
 - name: github.com/coreos/pkg
   version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
   subpackages:
@@ -127,7 +126,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 050be2ca2d8a88e2d429b4684b8666a48c42f7ae
+  version: b2f24e8a9d01bd21fc066f4bae71fd953921108a
   subpackages:
   - lib
   - lib/api
@@ -155,7 +154,7 @@ imports:
   - lib/testutils
   - lib/validator
 - name: github.com/projectcalico/typha
-  version: 2576a737bda562ab82f117c94e9cc395ae5bbea5
+  version: 1c1ada9b59be34f5eab3272198ae615849d3be78
   subpackages:
   - pkg/syncclient
   - pkg/syncproto

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,7 +22,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: v1.3.0
+  version: v1.4.0
   subpackages:
   - lib
 - package: github.com/Sirupsen/logrus
@@ -39,7 +39,7 @@ import:
 - package: k8s.io/client-go
   version: 4a3ab2f5be5177366f8206fd79ce55ca80e417fa
 - package: github.com/projectcalico/typha
-  version: v0.1.4
+  version: v0.1.5
   subpackages:
   - pkg/syncclient
 testImport:


### PR DESCRIPTION
Updates libcalico-go to v1.4.0 and Typha to v0.1.5