### PR TITLE
Scan iptables-save output when calculating hashes.

### DIFF
--- a/iptables/cmd_shim.go
+++ b/iptables/cmd_shim.go
@@ -25,7 +25,11 @@ type CmdIface interface {
 	SetStdout(io.Writer)
 	SetStderr(io.Writer)
 	Run() error
+	Start() error
+	Kill() error
+	Wait() error
 	Output() ([]byte, error)
+	StdoutPipe() (io.ReadCloser, error)
 	String() string
 }
 
@@ -54,8 +58,24 @@ func (c *cmdAdapter) Run() error {
 	return (*exec.Cmd)(c).Run()
 }
 
+func (c *cmdAdapter) Start() error {
+	return (*exec.Cmd)(c).Start()
+}
+
+func (c *cmdAdapter) Kill() error {
+	return (*exec.Cmd)(c).Process.Kill()
+}
+
+func (c *cmdAdapter) Wait() error {
+	return (*exec.Cmd)(c).Wait()
+}
+
 func (c *cmdAdapter) Output() ([]byte, error) {
 	return (*exec.Cmd)(c).Output()
+}
+
+func (c *cmdAdapter) StdoutPipe() (io.ReadCloser, error) {
+	return (*exec.Cmd)(c).StdoutPipe()
 }
 
 func (c *cmdAdapter) String() string {

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -15,8 +15,10 @@
 package iptables
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os/exec"
 	"reflect"
 	"regexp"
@@ -553,12 +555,11 @@ func (t *Table) expectedHashesForInsertChain(
 func (t *Table) getHashesFromDataplane() map[string][]string {
 	retries := 3
 	retryDelay := 100 * time.Millisecond
+
 	// Retry a few times before we panic.  This deals with any transient errors and it prevents
 	// us from spamming a panic into the log when we're being gracefully shut down by a SIGTERM.
 	for {
-		cmd := t.newCmd(t.iptablesSaveCmd, "-t", t.Name)
-		countNumSaveCalls.Inc()
-		output, err := cmd.Output()
+		hashes, err := t.attemptToGetHashesFromDataplane()
 		if err != nil {
 			countNumSaveErrors.Inc()
 			var stderr string
@@ -575,69 +576,116 @@ func (t *Table) getHashesFromDataplane() map[string][]string {
 			}
 			continue
 		}
-		buf := bytes.NewBuffer(output)
-		return t.getHashesFromBuffer(buf)
+
+		return hashes
 	}
 }
 
-// getHashesFromBuffer parses a buffer containing iptables-save output for this table, extracting
+// attemptToGetHashesFromDataplane starts an iptables-save subprocess and feeds its output to
+// readHashesFrom() via a pipe.  It handles the various error cases.
+func (t *Table) attemptToGetHashesFromDataplane() (hashes map[string][]string, err error) {
+	cmd := t.newCmd(t.iptablesSaveCmd, "-t", t.Name)
+	countNumSaveCalls.Inc()
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return
+	}
+	err = cmd.Start()
+	if err != nil {
+		closeErr := stdout.Close()
+		if closeErr != nil {
+			log.WithError(closeErr).Warn("Error closing stdout after Start() failed.")
+		}
+		return
+	}
+	hashes, err = t.readHashesFrom(stdout)
+	if err != nil {
+		// In case readHashesFrom() returned due to an error that didn't cause the
+		// process to exit, kill it now.
+		log.WithError(err).Warn(
+			"Killing iptables save process after a failure")
+		killErr := cmd.Kill()
+		if killErr != nil {
+			log.WithError(killErr).Error(
+				"Failed to kill iptables save process after failure.")
+		}
+	}
+	waitErr := cmd.Wait()
+	if waitErr != nil {
+		log.WithError(waitErr).Warn("iptables save failed")
+		if err == nil {
+			err = waitErr
+		}
+	}
+	return
+}
+
+// readHashesFrom scans the given reader containing iptables-save output for this table, extracting
 // our rule hashes.  Entries in the returned map are indexed by chain name.  For rules that we
 // wrote, the hash is extracted from a comment that we added to the rule.  For rules written by
 // previous versions of Felix, returns a dummy non-zero value.  For rules not written by Felix,
 // returns a zero string.  Hence, the lengths of the returned values are the lengths of the chains
 // whether written by Felix or not.
-func (t *Table) getHashesFromBuffer(buf *bytes.Buffer) map[string][]string {
-	newHashes := map[string][]string{}
-	for {
+func (t *Table) readHashesFrom(r io.ReadCloser) (hashes map[string][]string, err error) {
+	hashes = map[string][]string{}
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
 		// Read the next line of the output.
-		line, err := buf.ReadString('\n')
-		if err != nil { // EOF
-			break
-		}
+		line := scanner.Bytes()
 
 		// Look for lines of the form ":chain-name - [0:0]", which are forward declarations
 		// for (possibly empty) chains.
-		logCxt := t.logCxt.WithField("line", line)
-		logCxt.Debug("Parsing line")
-		captures := chainCreateRegexp.FindStringSubmatch(line)
+		logCxt := t.logCxt
+		if log.GetLevel() >= log.DebugLevel {
+			// Avoid stringifying the line (and hence copying it) unless we're at debug
+			// level.
+			logCxt = logCxt.WithField("line", string(line))
+			logCxt.Debug("Parsing line")
+		}
+		captures := chainCreateRegexp.FindSubmatch(line)
 		if captures != nil {
 			// Chain forward-reference, make sure the chain exists.
-			chainName := captures[1]
+			chainName := string(captures[1])
 			logCxt.WithField("chainName", chainName).Debug("Found forward-reference")
-			newHashes[chainName] = []string{}
+			hashes[chainName] = []string{}
 			continue
 		}
 
 		// Look for append lines, such as "-A chain-name -m foo --foo bar"; these are the
 		// actual rules.
-		captures = appendRegexp.FindStringSubmatch(line)
+		captures = appendRegexp.FindSubmatch(line)
 		if captures == nil {
 			// Skip any non-append lines.
 			logCxt.Debug("Not an append, skipping")
 			continue
 		}
-		chainName := captures[1]
+		chainName := string(captures[1])
 
 		// Look for one of our hashes on the rule.  We record a zero hash for unknown rules
 		// so that they get cleaned up.  Note: we're implicitly capturing the first match
 		// of the regex.  When writing the rules, we ensure that the hash is written as the
 		// first comment.
 		hash := ""
-		captures = t.hashCommentRegexp.FindStringSubmatch(line)
+		captures = t.hashCommentRegexp.FindSubmatch(line)
 		if captures != nil {
-			hash = captures[1]
+			hash = string(captures[1])
 			logCxt.WithField("hash", hash).Debug("Found hash in rule")
-		} else if t.oldInsertRegexp.FindString(line) != "" {
+		} else if t.oldInsertRegexp.Find(line) != nil {
 			logCxt.WithFields(log.Fields{
 				"rule":      line,
 				"chainName": chainName,
 			}).Info("Found inserted rule from previous Felix version, marking for cleanup.")
 			hash = "OLD INSERT RULE"
 		}
-		newHashes[chainName] = append(newHashes[chainName], hash)
+		hashes[chainName] = append(hashes[chainName], hash)
 	}
-	t.logCxt.Debugf("Read hashes from dataplane: %#v", newHashes)
-	return newHashes
+	if scanner.Err() != nil {
+		log.WithError(scanner.Err()).Error("Failed to read hashes from dataplane")
+		return nil, scanner.Err()
+	}
+	t.logCxt.Debugf("Read hashes from dataplane: %#v", hashes)
+	return hashes, nil
 }
 
 func (t *Table) InvalidateDataplaneCache(reason string) {

--- a/iptables/utils_for_test.go
+++ b/iptables/utils_for_test.go
@@ -49,20 +49,25 @@ type chainMod struct {
 }
 
 type mockDataplane struct {
-	Table           string
-	Chains          map[string][]string
-	FlushedChains   set.Set
-	ChainMods       set.Set
-	DeletedChains   set.Set
-	Cmds            []CmdIface
-	CmdNames        []string
-	FailNextRestore bool
-	FailAllRestores bool
-	OnPreRestore    func()
-	FailNextSave    bool
-	FailAllSaves    bool
-	CumulativeSleep time.Duration
-	Time            time.Time
+	Table                  string
+	Chains                 map[string][]string
+	FlushedChains          set.Set
+	ChainMods              set.Set
+	DeletedChains          set.Set
+	Cmds                   []CmdIface
+	CmdNames               []string
+	FailNextRestore        bool
+	FailAllRestores        bool
+	OnPreRestore           func()
+	FailNextSaveRead       bool
+	FailNextSaveStdoutPipe bool
+	FailNextKill           bool
+	FailAllSaves           bool
+	FailNextPipeClose      bool
+	FailNextStart          bool
+	PipeBuffers            []*closableBuffer
+	CumulativeSleep        time.Duration
+	Time                   time.Time
 }
 
 func (d *mockDataplane) ResetCmds() {
@@ -72,12 +77,16 @@ func (d *mockDataplane) ResetCmds() {
 
 func (d *mockDataplane) newCmd(name string, arg ...string) CmdIface {
 	log.WithFields(log.Fields{
-		"name":            name,
-		"args":            arg,
-		"FailNextRestore": d.FailNextRestore,
-		"FailNextSave":    d.FailNextSave,
-		"FailAllRestores": d.FailAllRestores,
-		"FailAllSaves":    d.FailAllSaves,
+		"name":                   name,
+		"args":                   arg,
+		"FailNextRestore":        d.FailNextRestore,
+		"FailNextSaveRead":       d.FailNextSaveRead,
+		"FailNextStart":          d.FailNextStart,
+		"FailNextKill":           d.FailNextKill,
+		"FailNextSaveStdoutPipe": d.FailNextSaveStdoutPipe,
+		"FailNextPipeClose":      d.FailNextPipeClose,
+		"FailAllRestores":        d.FailAllRestores,
+		"FailAllSaves":           d.FailAllSaves,
 	}).Info("Simulating new command.")
 
 	var cmd CmdIface
@@ -301,7 +310,8 @@ func (d *restoreCmd) Run() error {
 }
 
 type saveCmd struct {
-	Dataplane *mockDataplane
+	Dataplane  *mockDataplane
+	stdoutPipe *closableBuffer
 }
 
 func (d *saveCmd) String() string {
@@ -321,20 +331,31 @@ func (d *saveCmd) SetStderr(w io.Writer) {
 }
 
 func (d *saveCmd) Start() error {
+	if d.Dataplane.FailNextStart {
+		d.Dataplane.FailNextStart = false
+		return errors.New("dummy start failure")
+	}
 	return nil
 }
 
 func (d *saveCmd) Wait() error {
+	if d.stdoutPipe != nil {
+		return d.stdoutPipe.Close()
+	}
 	return nil
 }
 
 func (d *saveCmd) Kill() error {
+	if d.Dataplane.FailNextKill {
+		d.Dataplane.FailNextKill = false
+		return errors.New("kill failed")
+	}
 	return nil
 }
 
 func (d *saveCmd) Output() ([]byte, error) {
-	if d.Dataplane.FailNextSave {
-		d.Dataplane.FailNextSave = false
+	if d.Dataplane.FailNextSaveRead {
+		d.Dataplane.FailNextSaveRead = false
 		return nil, errors.New("Simulated failure")
 	}
 	if d.Dataplane.FailAllSaves {
@@ -362,21 +383,58 @@ func (d *saveCmd) Output() ([]byte, error) {
 }
 
 func (d *saveCmd) StdoutPipe() (io.ReadCloser, error) {
+	var readErr error
+	if d.Dataplane.FailNextSaveRead {
+		d.Dataplane.FailNextSaveRead = false
+		readErr = errors.New("Simulated Read() failure.")
+	}
+
+	if d.Dataplane.FailNextSaveStdoutPipe {
+		d.Dataplane.FailNextSaveStdoutPipe = false
+		return nil, errors.New("Simulated StdoutPipe() failure.")
+	}
+
 	buf, err := d.Output()
 	if err != nil {
 		return nil, err
 	}
-	return (*withDummyClose)(bytes.NewBuffer(buf)), nil
+	var closeErr error
+	if d.Dataplane.FailNextPipeClose {
+		closeErr = errors.New("Dummy deferred flush error")
+		d.Dataplane.FailNextPipeClose = false
+	}
+	cb := &closableBuffer{
+		b:        bytes.NewBuffer(buf),
+		ReadErr:  readErr,
+		CloseErr: closeErr,
+	}
+	d.Dataplane.PipeBuffers = append(d.Dataplane.PipeBuffers, cb)
+	if d.stdoutPipe != nil {
+		Fail("StdoutPipe() called more than once")
+	}
+	d.stdoutPipe = cb
+	return cb, nil
 }
 
-type withDummyClose bytes.Buffer
-
-func (b *withDummyClose) Read(p []byte) (n int, err error) {
-	return (*bytes.Buffer)(b).Read(p)
+type closableBuffer struct {
+	b                 *bytes.Buffer
+	Closed            bool
+	CloseErr, ReadErr error
 }
 
-func (b *withDummyClose) Close() error {
-	return nil
+func (b *closableBuffer) Read(p []byte) (n int, err error) {
+	if b.ReadErr != nil {
+		return 0, b.ReadErr
+	}
+	return b.b.Read(p)
+}
+
+func (b *closableBuffer) Close() error {
+	if b.Closed {
+		Fail("Already closed")
+	}
+	b.Closed = true
+	return b.CloseErr
 }
 
 func (d *saveCmd) Run() error {

--- a/iptables/utils_for_test.go
+++ b/iptables/utils_for_test.go
@@ -154,6 +154,25 @@ func (d *restoreCmd) Output() ([]byte, error) {
 	return nil, errors.New("Not implemented")
 }
 
+func (d *restoreCmd) StdoutPipe() (io.ReadCloser, error) {
+	Fail("Not implemented")
+	return nil, errors.New("Not implemented")
+}
+
+func (d *restoreCmd) Start() error {
+	Fail("Not implemented")
+	return errors.New("Not implemented")
+}
+
+func (d *restoreCmd) Wait() error {
+	Fail("Not implemented")
+	return errors.New("Not implemented")
+}
+
+func (d *restoreCmd) Kill() error {
+	return nil
+}
+
 func (d *restoreCmd) String() string {
 	return fmt.Sprintf("restoreCmd %#v", d.CapturedStdin)
 }
@@ -301,6 +320,18 @@ func (d *saveCmd) SetStderr(w io.Writer) {
 	Fail("Not implemented")
 }
 
+func (d *saveCmd) Start() error {
+	return nil
+}
+
+func (d *saveCmd) Wait() error {
+	return nil
+}
+
+func (d *saveCmd) Kill() error {
+	return nil
+}
+
 func (d *saveCmd) Output() ([]byte, error) {
 	if d.Dataplane.FailNextSave {
 		d.Dataplane.FailNextSave = false
@@ -328,6 +359,24 @@ func (d *saveCmd) Output() ([]byte, error) {
 	log.Debugf("Calculated save output:\n%v", buf.String())
 
 	return buf.Bytes(), nil
+}
+
+func (d *saveCmd) StdoutPipe() (io.ReadCloser, error) {
+	buf, err := d.Output()
+	if err != nil {
+		return nil, err
+	}
+	return (*withDummyClose)(bytes.NewBuffer(buf)), nil
+}
+
+type withDummyClose bytes.Buffer
+
+func (b *withDummyClose) Read(p []byte) (n int, err error) {
+	return (*bytes.Buffer)(b).Read(p)
+}
+
+func (b *withDummyClose) Close() error {
+	return nil
 }
 
 func (d *saveCmd) Run() error {

--- a/k8sfv/namespace.go
+++ b/k8sfv/namespace.go
@@ -26,8 +26,6 @@ import (
 	"k8s.io/client-go/pkg/apis/extensions"
 
 	"github.com/projectcalico/felix/k8sfv/internalversion"
-
-	"github.com/projectcalico/felix/k8sfv/internalversion"
 )
 
 var nsPrefixNum = 0

--- a/k8sfv/namespace.go
+++ b/k8sfv/namespace.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/client-go/pkg/apis/extensions"
 
 	"github.com/projectcalico/felix/k8sfv/internalversion"
+
+	"github.com/projectcalico/felix/k8sfv/internalversion"
 )
 
 var nsPrefixNum = 0


### PR DESCRIPTION
Reduce CPU usage and garbage generated by the iptables read loop.  A bit of profiling last week suggested these improvements:

- Read the input incrementally.
- Avoid copying each line of input to string by using the `[]byte` versions of the regex functions.

## Todos
- [x] Unit tests (full coverage)
- [x] Perf test; does it actually help!?
