### PR TITLE
Plumb through configuration for the post-write check interval.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -109,7 +109,7 @@ type Config struct {
 	Ipv6Support    bool `config:"bool;true"`
 	IgnoreLooseRPF bool `config:"bool;false"`
 
-	IptablesRefreshInterval            int           `config:"int;10"`
+	IptablesRefreshInterval            time.Duration `config:"seconds;10"`
 	IptablesPostWriteCheckIntervalSecs time.Duration `config:"seconds;1"`
 
 	MetadataAddr string `config:"hostname;127.0.0.1;die-on-fail"`
@@ -131,11 +131,11 @@ type Config struct {
 	IpInIpMtu        int    `config:"int;1440;non-zero"`
 	IpInIpTunnelAddr net.IP `config:"ipv4;"`
 
-	ReportingIntervalSecs int `config:"int;30"`
-	ReportingTTLSecs      int `config:"int;90"`
+	ReportingIntervalSecs time.Duration `config:"seconds;30"`
+	ReportingTTLSecs      time.Duration `config:"seconds;90"`
 
-	EndpointReportingEnabled   bool    `config:"bool;false"`
-	EndpointReportingDelaySecs float64 `config:"float;1.0"`
+	EndpointReportingEnabled   bool          `config:"bool;false"`
+	EndpointReportingDelaySecs time.Duration `config:"seconds;1"`
 
 	MaxIpsetSize int `config:"int;1048576;non-zero"`
 
@@ -330,10 +330,6 @@ func (config *Config) resolve() (changed bool, err error) {
 	changed = !reflect.DeepEqual(newRawValues, config.rawValues)
 	config.rawValues = newRawValues
 	return
-}
-
-func (config *Config) EndpointReportingDelay() time.Duration {
-	return time.Duration(config.EndpointReportingDelaySecs*1000000) * time.Microsecond
 }
 
 func (config *Config) DatastoreConfig() api.CalicoAPIConfig {

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -109,7 +109,8 @@ type Config struct {
 	Ipv6Support    bool `config:"bool;true"`
 	IgnoreLooseRPF bool `config:"bool;false"`
 
-	IptablesRefreshInterval int `config:"int;10"`
+	IptablesRefreshInterval            int           `config:"int;10"`
+	IptablesPostWriteCheckIntervalSecs time.Duration `config:"seconds;1"`
 
 	MetadataAddr string `config:"hostname;127.0.0.1;die-on-fail"`
 	MetadataPort int    `config:"int(0,65535);8775;die-on-fail"`
@@ -456,6 +457,8 @@ func loadParams() {
 			param = &MarkBitmaskParam{}
 		case "float":
 			param = &FloatParam{}
+		case "seconds":
+			param = &SecondsParam{}
 		case "iface-list":
 			param = &RegexpParam{Regexp: IfaceListRegexp,
 				Msg: "invalid Linux interface name"}

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -107,15 +107,15 @@ var _ = DescribeTable("Config parsing",
 	Entry("IpInIpTunnelAddr", "IpInIpTunnelAddr",
 		"10.0.0.1", net.ParseIP("10.0.0.1")),
 
-	Entry("ReportingIntervalSecs", "ReportingIntervalSecs", "31", int(31)),
-	Entry("ReportingTTLSecs", "ReportingTTLSecs", "91", int(91)),
+	Entry("ReportingIntervalSecs", "ReportingIntervalSecs", "31", 31*time.Second),
+	Entry("ReportingTTLSecs", "ReportingTTLSecs", "91", 91*time.Second),
 
 	Entry("EndpointReportingEnabled", "EndpointReportingEnabled",
 		"true", true),
 	Entry("EndpointReportingEnabled", "EndpointReportingEnabled",
 		"yes", true),
 	Entry("EndpointReportingDelaySecs", "EndpointReportingDelaySecs",
-		"10", float64(10)),
+		"10", 10*time.Second),
 
 	Entry("MaxIpsetSize", "MaxIpsetSize", "12345", int(12345)),
 	Entry("IptablesMarkMask", "IptablesMarkMask", "0xf0f0", uint32(0xf0f0)),

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -19,6 +19,7 @@ import (
 
 	"net"
 	"reflect"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -30,7 +31,10 @@ var _ = DescribeTable("Config parsing",
 		config := New()
 		config.UpdateFrom(map[string]string{key: value},
 			EnvironmentVariable)
-		newVal := reflect.ValueOf(config).Elem().FieldByName(key).Interface()
+		configPtr := reflect.ValueOf(config)
+		configElem := configPtr.Elem()
+		fieldRef := configElem.FieldByName(key)
+		newVal := fieldRef.Interface()
 		Expect(newVal).To(Equal(expected))
 		if len(errorExpected) > 0 && errorExpected[0] {
 			Expect(config.Err).To(HaveOccurred())
@@ -69,6 +73,9 @@ var _ = DescribeTable("Config parsing",
 	Entry("InterfacePrefix list", "InterfacePrefix", "tap,cali", "tap,cali"),
 
 	Entry("ChainInsertMode append", "ChainInsertMode", "append", "append"),
+
+	Entry("IptablesPostWriteCheckIntervalSecs", "IptablesPostWriteCheckIntervalSecs",
+		"1.5", 1500*time.Millisecond),
 
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",
 		"RETURN", "RETURN"),

--- a/config/param_types.go
+++ b/config/param_types.go
@@ -26,6 +26,8 @@ import (
 	"strconv"
 	"strings"
 
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/kardianos/osext"
 )
@@ -121,6 +123,20 @@ func (p *FloatParam) Parse(raw string) (result interface{}, err error) {
 		err = p.parseFailed(raw, "invalid float")
 		return
 	}
+	return
+}
+
+type SecondsParam struct {
+	Metadata
+}
+
+func (p *SecondsParam) Parse(raw string) (result interface{}, err error) {
+	seconds, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		err = p.parseFailed(raw, "invalid float")
+		return
+	}
+	result = time.Duration(seconds * float64(time.Second))
 	return
 }
 

--- a/felix.go
+++ b/felix.go
@@ -276,12 +276,13 @@ configRetry:
 
 				DisableConntrackInvalid: configParams.DisableConntrackInvalidCheck,
 			},
-			IPIPMTU:                 configParams.IpInIpMtu,
-			IptablesRefreshInterval: time.Duration(configParams.IptablesRefreshInterval) * time.Second,
-			IptablesInsertMode:      configParams.ChainInsertMode,
-			MaxIPSetSize:            configParams.MaxIpsetSize,
-			IgnoreLooseRPF:          configParams.IgnoreLooseRPF,
-			IPv6Enabled:             configParams.Ipv6Support,
+			IPIPMTU:                        configParams.IpInIpMtu,
+			IptablesRefreshInterval:        time.Duration(configParams.IptablesRefreshInterval) * time.Second,
+			IptablesPostWriteCheckInterval: configParams.IptablesPostWriteCheckIntervalSecs,
+			IptablesInsertMode:             configParams.ChainInsertMode,
+			MaxIPSetSize:                   configParams.MaxIpsetSize,
+			IgnoreLooseRPF:                 configParams.IgnoreLooseRPF,
+			IPv6Enabled:                    configParams.Ipv6Support,
 			StatusReportingInterval: time.Duration(configParams.ReportingIntervalSecs) *
 				time.Second,
 

--- a/felix.go
+++ b/felix.go
@@ -277,14 +277,13 @@ configRetry:
 				DisableConntrackInvalid: configParams.DisableConntrackInvalidCheck,
 			},
 			IPIPMTU:                        configParams.IpInIpMtu,
-			IptablesRefreshInterval:        time.Duration(configParams.IptablesRefreshInterval) * time.Second,
+			IptablesRefreshInterval:        configParams.IptablesRefreshInterval,
 			IptablesPostWriteCheckInterval: configParams.IptablesPostWriteCheckIntervalSecs,
 			IptablesInsertMode:             configParams.ChainInsertMode,
 			MaxIPSetSize:                   configParams.MaxIpsetSize,
 			IgnoreLooseRPF:                 configParams.IgnoreLooseRPF,
 			IPv6Enabled:                    configParams.Ipv6Support,
-			StatusReportingInterval: time.Duration(configParams.ReportingIntervalSecs) *
-				time.Second,
+			StatusReportingInterval:        configParams.ReportingIntervalSecs,
 
 			PostInSyncCallback: func() { dumpHeapMemoryProfile(configParams) },
 		}
@@ -404,7 +403,7 @@ configRetry:
 	log.Infof("Started the datastore Syncer/processing graph")
 	var stopSignalChans []chan<- bool
 	if configParams.EndpointReportingEnabled {
-		delay := configParams.EndpointReportingDelay()
+		delay := configParams.EndpointReportingDelaySecs
 		log.WithField("delay", delay).Info(
 			"Endpoint status reporting enabled, starting status reporter")
 		dpConnector.statusReporter = statusrep.NewEndpointStatusReporter(
@@ -734,7 +733,7 @@ func (fc *DataplaneConnector) handleProcessStatusUpdate(msg *proto.ProcessStatus
 	kv := model.KVPair{
 		Key:   model.ActiveStatusReportKey{Hostname: fc.config.FelixHostname},
 		Value: &statusReport,
-		TTL:   time.Duration(fc.config.ReportingTTLSecs) * time.Second,
+		TTL:   fc.config.ReportingTTLSecs,
 	}
 	_, err := fc.datastore.Apply(&kv)
 	if err != nil {

--- a/intdataplane/int_dataplane.go
+++ b/intdataplane/int_dataplane.go
@@ -96,8 +96,9 @@ type Config struct {
 
 	MaxIPSetSize int
 
-	IptablesRefreshInterval time.Duration
-	IptablesInsertMode      string
+	IptablesRefreshInterval        time.Duration
+	IptablesPostWriteCheckInterval time.Duration
+	IptablesInsertMode             string
 
 	RulesConfig rules.Config
 
@@ -203,6 +204,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			ExtraCleanupRegexPattern: rules.HistoricInsertedNATRuleRegex,
 			InsertMode:               config.IptablesInsertMode,
 			RefreshInterval:          config.IptablesRefreshInterval,
+			PostWriteInterval:        config.IptablesPostWriteCheckInterval,
 		},
 	)
 	rawTableV4 := iptables.NewTable(
@@ -213,6 +215,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 			InsertMode:            config.IptablesInsertMode,
 			RefreshInterval:       config.IptablesRefreshInterval,
+			PostWriteInterval:     config.IptablesPostWriteCheckInterval,
 		})
 	filterTableV4 := iptables.NewTable(
 		"filter",
@@ -222,6 +225,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 			InsertMode:            config.IptablesInsertMode,
 			RefreshInterval:       config.IptablesRefreshInterval,
+			PostWriteInterval:     config.IptablesPostWriteCheckInterval,
 		})
 	ipSetsConfigV4 := config.RulesConfig.IPSetConfigV4
 	ipSetsV4 := ipsets.NewIPSets(ipSetsConfigV4)
@@ -262,6 +266,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				ExtraCleanupRegexPattern: rules.HistoricInsertedNATRuleRegex,
 				InsertMode:               config.IptablesInsertMode,
 				RefreshInterval:          config.IptablesRefreshInterval,
+				PostWriteInterval:        config.IptablesPostWriteCheckInterval,
 			},
 		)
 		rawTableV6 := iptables.NewTable(
@@ -272,6 +277,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 				InsertMode:            config.IptablesInsertMode,
 				RefreshInterval:       config.IptablesRefreshInterval,
+				PostWriteInterval:     config.IptablesPostWriteCheckInterval,
 			},
 		)
 		filterTableV6 := iptables.NewTable(
@@ -282,6 +288,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 				InsertMode:            config.IptablesInsertMode,
 				RefreshInterval:       config.IptablesRefreshInterval,
+				PostWriteInterval:     config.IptablesPostWriteCheckInterval,
 			},
 		)
 

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	MaxChainNameLength       = 28
-	defaultPostWriteInterval = 50 * time.Millisecond
+	MaxChainNameLength   = 28
+	minPostWriteInterval = 50 * time.Millisecond
 )
 
 var (
@@ -294,12 +294,12 @@ func NewTable(
 		log.WithField("insertMode", options.InsertMode).Panic("Unknown insert mode")
 	}
 
-	if options.PostWriteInterval <= defaultPostWriteInterval {
+	if options.PostWriteInterval <= minPostWriteInterval {
 		log.WithFields(log.Fields{
 			"setValue": options.PostWriteInterval,
-			"default":  defaultPostWriteInterval,
-		}).Info("Defaulting PostWriteInterval.")
-		options.PostWriteInterval = defaultPostWriteInterval
+			"default":  minPostWriteInterval,
+		}).Info("PostWriteInterval too small, defaulting.")
+		options.PostWriteInterval = minPostWriteInterval
 	}
 
 	// Allow override of exec.Command() and time.Sleep() for test purposes.


### PR DESCRIPTION
## Description
Make the post-write iptables check interval configurable.  I suspect that the previous default of 50ms is too aggressive, resulting in high CPU usage.

## Todos
- [x] Unit tests (full coverage)
- [ ] Documentation
