### PR TITLE
Prep for a subset of k8sfv to run in semaphore CI

### DIFF
--- a/iptables/table.go
+++ b/iptables/table.go
@@ -17,6 +17,7 @@ package iptables
 import (
 	"bytes"
 	"fmt"
+	"os/exec"
 	"reflect"
 	"regexp"
 	"strings"
@@ -548,7 +549,11 @@ func (t *Table) getHashesFromDataplane() map[string][]string {
 		output, err := cmd.Output()
 		if err != nil {
 			countNumSaveErrors.Inc()
-			t.logCxt.WithError(err).Warnf("%s command failed", t.iptablesSaveCmd)
+			var stderr string
+			if ee, ok := err.(*exec.ExitError); ok {
+				stderr = string(ee.Stderr)
+			}
+			t.logCxt.WithError(err).WithField("stderr", stderr).Warnf("%s command failed", t.iptablesSaveCmd)
 			if retries > 0 {
 				retries--
 				t.timeSleep(retryDelay)

--- a/k8sfv/deployment.go
+++ b/k8sfv/deployment.go
@@ -20,8 +20,9 @@ import (
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 type host struct {
@@ -79,7 +80,7 @@ func (d *localPlusRemotes) ensureNodeDefined(
 			hostCIDR = GetNextRemoteHostCIDR()
 		}
 		node_in := &v1.Node{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: hostName,
 				Annotations: map[string]string{
 					"projectcalico.org/IPv4Address": hostCIDR,
@@ -111,7 +112,7 @@ func (d *localPlusRemotes) ChooseHost(clientset *kubernetes.Clientset) (h host) 
 
 func cleanupAllNodes(clientset *kubernetes.Clientset) {
 	log.Info("Cleaning up all nodes...")
-	nodeList, err := clientset.Nodes().List(v1.ListOptions{})
+	nodeList, err := clientset.Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		panic(err)
 	}

--- a/k8sfv/k8sfv.go
+++ b/k8sfv/k8sfv.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	capi "github.com/projectcalico/libcalico-go/lib/api"
-	"github.com/projectcalico/libcalico-go/lib/backend/k8s"
 	"github.com/projectcalico/libcalico-go/lib/client"
 )
 
@@ -155,7 +154,7 @@ func initializeCalicoDeployment(k8sServerEndpoint string) {
 	c, err := client.New(capi.CalicoAPIConfig{
 		Spec: capi.CalicoAPIConfigSpec{
 			DatastoreType: capi.Kubernetes,
-			KubeConfig: k8s.KubeConfig{
+			KubeConfig: capi.KubeConfig{
 				K8sAPIEndpoint:           k8sServerEndpoint,
 				K8sInsecureSkipTLSVerify: true,
 			},

--- a/k8sfv/namespace.go
+++ b/k8sfv/namespace.go
@@ -23,11 +23,8 @@ import (
 	"github.com/projectcalico/felix/k8sfv/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions"
-
-	"github.com/projectcalico/felix/k8sfv/internalversion"
 )
 
 var nsPrefixNum = 0
@@ -59,7 +56,7 @@ func createNamespaceInt(
 	isolation string,
 ) {
 	ns_in := &v1.Namespace{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: labels,
 		},
@@ -82,7 +79,7 @@ func createNamespaceInt(
 
 func cleanupAllNamespaces(clientset *kubernetes.Clientset, nsPrefix string) {
 	log.Info("Cleaning up all namespaces...")
-	nsList, err := clientset.Namespaces().List(v1.ListOptions{})
+	nsList, err := clientset.Namespaces().List(metav1.ListOptions{})
 	if err != nil {
 		panic(err)
 	}
@@ -105,7 +102,7 @@ func cleanupAllNamespaces(clientset *kubernetes.Clientset, nsPrefix string) {
 func createNetworkPolicy(clientset *kubernetes.Clientset, namespace string) {
 	npInterface := internalversion.NewNetworkPolicies(clientset.ExtensionsV1beta1Client, namespace)
 	np := extensions.NetworkPolicy{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      "test-syncer-basic-net-policy",
 		},

--- a/k8sfv/pod.go
+++ b/k8sfv/pod.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/vishvananda/netlink"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 
@@ -65,7 +66,7 @@ func createPod(clientset *kubernetes.Clientset, d deployment, nsName string, spe
 		ip = GetNextPodAddr()
 	}
 	pod_in := &v1.Pod{
-		ObjectMeta: v1.ObjectMeta{Name: name},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: v1.PodSpec{Containers: []v1.Container{{
 			Name:  fmt.Sprintf("container-%s", name),
 			Image: "ignore",
@@ -201,7 +202,7 @@ var GetNextPodAddr = ipAddrAllocator("10.28.%d.%d")
 
 func cleanupAllPods(clientset *kubernetes.Clientset, nsPrefix string) {
 	log.WithField("nsPrefix", nsPrefix).Info("Cleaning up all pods...")
-	nsList, err := clientset.Namespaces().List(v1.ListOptions{})
+	nsList, err := clientset.Namespaces().List(metav1.ListOptions{})
 	if err != nil {
 		panic(err)
 	}
@@ -215,7 +216,7 @@ func cleanupAllPods(clientset *kubernetes.Clientset, nsPrefix string) {
 		go func() {
 			admission <- 1
 			if strings.HasPrefix(nsName, nsPrefix) {
-				podList, err := clientset.Pods(nsName).List(v1.ListOptions{})
+				podList, err := clientset.Pods(nsName).List(metav1.ListOptions{})
 				if err != nil {
 					panic(err)
 				}
@@ -239,7 +240,7 @@ func cleanupAllPods(clientset *kubernetes.Clientset, nsPrefix string) {
 
 var zeroGracePeriod int64 = 0
 
-var deleteImmediately = &v1.DeleteOptions{GracePeriodSeconds: &zeroGracePeriod}
+var deleteImmediately = &metav1.DeleteOptions{GracePeriodSeconds: &zeroGracePeriod}
 
 func runCommand(command string, args ...string) error {
 	cmd := exec.Command(command, args...)

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -46,6 +46,9 @@
 #
 # k8sfv logging level.
 : ${K8SFV_LOG_LEVEL:=info}
+#
+# Only run the tests that complete in a minute or less.
+: ${JUST_A_MINUTE:=false}
 
 # Generate a unique prefix for the names of the containers that we
 # will create.
@@ -131,6 +134,14 @@ run="cd /testcode/k8sfv/output && /testcode/bin/k8sfv.test -ginkgo.v"
 if test -n "${GINKGO_FOCUS}"; then
     docker exec ${prefix}-felix /bin/sh -c \
 	   "${run} -ginkgo.focus \"${GINKGO_FOCUS}\" ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} \"${PROMPG_URL}\" \"${CODE_LEVEL}\""
+elif ${JUST_A_MINUTE}; then
+    # Run all the tests that are _not_ marked as "[slow]", and fail
+    # the test if any of those takes longer than 2 minutes.  A k8sfv
+    # test should be marked as "[slow]" if it normally takes longer
+    # than 1 minute - so this allows a buffer of 1 extra minute to
+    # allow for executor slowness.
+    docker exec ${prefix}-felix /bin/sh -c \
+	   "${run} -ginkgo.skip \"\\[slow\\]\" -ginkgo.slowSpecThreshold 120 ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} \"${PROMPG_URL}\" \"${CODE_LEVEL}\"" | perl -pe 'END { exit $status } $status=1 if /SLOW TEST|FAIL!/;'
 else
     docker exec ${prefix}-felix /bin/sh -c \
 	   "${run} ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} \"${PROMPG_URL}\" \"${CODE_LEVEL}\""

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -88,14 +88,29 @@ docker run --detach --name ${prefix}-etcd \
        --listen-client-urls "http://0.0.0.0:2379,http://0.0.0.0:4001"
 etcd_ip=$(get_container_ip ${prefix}-etcd)
 
-# Run k8s API server.
+# Run k8s API server.  The clients in this test - Felix, Typha, the
+# k8sfv test code, and individual commands in this script - all
+# connect anonymously to the API server, because (a) they aren't
+# running in pods in a proper Kubernetes cluster, and (b) they don't
+# provide client TLS certificates, and (c) they don't use any of the
+# other non-anonymous mechanisms that Kubernetes supports.  But, as of
+# 1.6, the API server doesn't allow anonymous users with the default
+# "AlwaysAllow" authorization mode.  So we specify the "RBAC"
+# authorization mode instead, and create a ClusterRoleBinding that
+# gives the "system:anonymous" user unlimited power (aka the
+# "cluster-admin" role).
 docker run --detach --name ${prefix}-apiserver \
        gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
        /hyperkube apiserver \
        --etcd-servers=http://${etcd_ip}:2379 \
-       --service-cluster-ip-range=10.101.0.0/16 -v=10
+       --service-cluster-ip-range=10.101.0.0/16 -v=10 \
+       --authorization-mode=RBAC
 k8s_ip=$(get_container_ip ${prefix}-apiserver)
 k8s_api_endpoint=https://${k8s_ip}:6443
+
+while ! docker exec ${prefix}-apiserver kubectl create clusterrolebinding anonymous-admin --clusterrole=cluster-admin --user=system:anonymous; do
+    sleep 2
+done
 
 # Wait until the newly launched API server can respond to a request,
 # before continuing.
@@ -103,9 +118,13 @@ while ! curl -k ${k8s_api_endpoint}/apis/extensions/v1beta1/thirdpartyresources;
     sleep 2
 done
 
-# Get the API server's (self-signed) TLS certificate.
+# Get the API server's (self-signed) TLS certificate.  (This is needed
+# for the clients to authenticate the _API_server_ - which is entirely
+# independent of the _client_ authorization discussed above.)
 mkdir -p k8sfv/output
-docker cp ${prefix}-apiserver:/var/run/kubernetes/apiserver.crt k8sfv/output/
+while ! docker cp ${prefix}-apiserver:/var/run/kubernetes/apiserver.crt k8sfv/output/; do
+    sleep 2
+done
 
 # Run Felix.
 #

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -82,7 +82,7 @@ cleanup
 
 # Ensure that ip6_tables module is loaded.  The ip6tables-save command
 # needs this.
-#sudo modprobe ip6_tables
+sudo modprobe ip6_tables
 
 # Run etcd.
 docker run --detach --name ${prefix}-etcd \

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -80,6 +80,10 @@ function get_container_hostname {
 # them up.
 cleanup
 
+# Ensure that ip6_tables module is loaded.  The ip6tables-save command
+# needs this.
+sudo modprobe ip6_tables
+
 # Run etcd.
 docker run --detach --name ${prefix}-etcd \
        quay.io/coreos/etcd \

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -82,7 +82,7 @@ cleanup
 
 # Ensure that ip6_tables module is loaded.  The ip6tables-save command
 # needs this.
-sudo modprobe ip6_tables
+#sudo modprobe ip6_tables
 
 # Run etcd.
 docker run --detach --name ${prefix}-etcd \

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -48,7 +48,7 @@
 : ${K8SFV_LOG_LEVEL:=info}
 #
 # Only run the tests that complete in a minute or less.
-: ${JUST_A_MINUTE:=false}
+: ${JUST_A_MINUTE:=true}
 
 # Generate a unique prefix for the names of the containers that we
 # will create.

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -169,3 +169,18 @@ else
     docker exec ${prefix}-felix /bin/sh -c \
 	   "${run} ${k8s_api_endpoint} ${felix_ip} ${felix_hostname} \"${PROMPG_URL}\" \"${CODE_LEVEL}\""
 fi
+
+# Save the status of the test run.
+STATUS=$?
+
+# Check that the Felix container is still running.  It's important to
+# do this check, because the test run just above can exit with a
+# successful status (0) if Felix dies prematurely.
+if docker ps | grep ${prefix}-felix; then
+    # Good, still running.
+    exit ${STATUS}
+else
+    # No, it has died.  Dump logs and exit with a failure status.
+    docker logs ${prefix}-felix
+    exit 1
+fi

--- a/k8sfv/scale_test.go
+++ b/k8sfv/scale_test.go
@@ -64,12 +64,14 @@ var _ = Context("with a k8s clientset", func() {
 			d = NewDeployment(clientset, 1, false)
 		})
 
-		It("should create 10k endpoints", func() {
+		// Slow: takes about 3 minutes.
+		It("should create 10k endpoints [slow]", func() {
 			addNamespaces(clientset, nsPrefix)
 			addEndpoints(clientset, nsPrefix, d, 10000)
 		})
 
-		It("should not leak memory", func() {
+		// Slow: takes more than 1 hour.
+		It("should not leak memory [slow]", func() {
 			const (
 				cycles = 20
 				ignore = 12
@@ -203,7 +205,8 @@ var _ = Context("with a k8s clientset", func() {
 			d = NewDeployment(clientset, 9, true)
 		})
 
-		It("should add and remove 1000 pods, of which about 100 on local node", func() {
+		// Slow: takes about 15 minutes.
+		It("should add and remove 1000 pods, of which about 100 on local node [slow]", func() {
 			createNamespace(clientset, nsPrefix+"scale", nil)
 			for cycle := 0; cycle < 10; cycle++ {
 				for ii := 0; ii < 1000; ii++ {


### PR DESCRIPTION
Adds a way of identifying tests that take longer than a minute, and a "JUST_A_MINUTE" setting that means to skip those tests.  So, once this has merged, the semaphore CI can do `JUST_A_MINUTE=true make k8sfv-test`

Also:
- fixes up k8sfv imports following recent client-go/apimachinery moves
- fixes up how clients are authorized by the API server, following jump from API server 1.5.3 to 1.6.4.