### PR TITLE
[WiP] Add support for network sets

### DIFF
--- a/calc/async_calc_graph.go
+++ b/calc/async_calc_graph.go
@@ -84,7 +84,7 @@ type AsyncCalcGraph struct {
 }
 
 func NewAsyncCalcGraph(conf *config.Config, outputEvents chan<- interface{}) *AsyncCalcGraph {
-	eventBuffer := NewEventBuffer(conf)
+	eventBuffer := NewEventSequencer(conf)
 	disp := NewCalculationGraph(eventBuffer, conf.FelixHostname)
 	g := &AsyncCalcGraph{
 		inputEvents:  make(chan interface{}, 10),

--- a/calc/calc_graph.go
+++ b/calc/calc_graph.go
@@ -45,8 +45,8 @@ func init() {
 
 type ipSetUpdateCallbacks interface {
 	OnIPSetAdded(setID string)
-	OnIPAdded(setID string, ip ip.Addr)
-	OnIPRemoved(setID string, ip ip.Addr)
+	OnCIDRAdded(setID string, ip ip.CIDR)
+	OnCIDRRemoved(setID string, ip ip.CIDR)
 	OnIPSetRemoved(setID string)
 }
 

--- a/calc/calc_graph_fv_test.go
+++ b/calc/calc_graph_fv_test.go
@@ -1020,7 +1020,7 @@ func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 
 	BeforeEach(func() {
 		tracker = newStateTracker()
-		eventBuf = NewEventBuffer(tracker)
+		eventBuf = NewEventSequencer(tracker)
 		eventBuf.Callback = tracker.onEvent
 		calcGraph = NewCalculationGraph(eventBuf, localHostname)
 		validationFilter = NewValidationFilter(calcGraph)

--- a/calc/calc_graph_test.go
+++ b/calc/calc_graph_test.go
@@ -39,7 +39,7 @@ var testIPAs4 = net.IP{testIP.To4()}
 var _ = DescribeTable("Calculation graph pass-through tests",
 	func(key model.Key, input interface{}, expUpdate interface{}, expRemove interface{}) {
 		// Create a calculation graph/event buffer combo.
-		eb := NewEventBuffer(nil)
+		eb := NewEventSequencer(nil)
 		var messageReceived interface{}
 		eb.Callback = func(message interface{}) {
 			logrus.WithField("message", message).Info("Received message")
@@ -123,7 +123,7 @@ var _ = Describe("Host IP duplicate squashing test", func() {
 
 	BeforeEach(func() {
 		// Create a calculation graph/event buffer combo.
-		eb = NewEventBuffer(nil)
+		eb = NewEventSequencer(nil)
 		messagesReceived = nil
 		eb.Callback = func(message interface{}) {
 			logrus.WithField("message", message).Info("Received message")

--- a/calc/event_sequencer.go
+++ b/calc/event_sequencer.go
@@ -82,7 +82,7 @@ type EventSequencer struct {
 //
 //}
 
-func NewEventBuffer(conf configInterface) *EventSequencer {
+func NewEventSequencer(conf configInterface) *EventSequencer {
 	buf := &EventSequencer{
 		config:               conf,
 		pendingAddedIPSets:   set.New(),
@@ -138,27 +138,27 @@ func (buf *EventSequencer) OnIPSetRemoved(setID string) {
 	buf.pendingRemovedIPs.DiscardKey(setID)
 }
 
-func (buf *EventSequencer) OnIPAdded(setID string, ip ip.Addr) {
-	log.Debugf("IP set %v now contains %v", setID, ip)
+func (buf *EventSequencer) OnCIDRAdded(setID string, cidr ip.CIDR) {
+	log.Debugf("IP set %v now contains %v", setID, cidr)
 	if !buf.sentIPSets.Contains(setID) && !buf.pendingAddedIPSets.Contains(setID) {
-		log.WithField("setID", setID).Panic("IP added to unknown IP set")
+		log.WithField("setID", setID).Panic("CIDR added to unknown IP set")
 	}
-	if buf.pendingRemovedIPs.Contains(setID, ip) {
-		buf.pendingRemovedIPs.Discard(setID, ip)
+	if buf.pendingRemovedIPs.Contains(setID, cidr) {
+		buf.pendingRemovedIPs.Discard(setID, cidr)
 	} else {
-		buf.pendingAddedIPs.Put(setID, ip)
+		buf.pendingAddedIPs.Put(setID, cidr)
 	}
 }
 
-func (buf *EventSequencer) OnIPRemoved(setID string, ip ip.Addr) {
-	log.Debugf("IP set %v no longer contains %v", setID, ip)
+func (buf *EventSequencer) OnCIDRRemoved(setID string, cidr ip.CIDR) {
+	log.Debugf("IP set %v no longer contains %v", setID, cidr)
 	if !buf.sentIPSets.Contains(setID) && !buf.pendingAddedIPSets.Contains(setID) {
-		log.WithField("setID", setID).Panic("IP removed from unknown IP set")
+		log.WithField("setID", setID).Panic("CIDR removed from unknown IP set")
 	}
-	if buf.pendingAddedIPs.Contains(setID, ip) {
-		buf.pendingAddedIPs.Discard(setID, ip)
+	if buf.pendingAddedIPs.Contains(setID, cidr) {
+		buf.pendingAddedIPs.Discard(setID, cidr)
 	} else {
-		buf.pendingRemovedIPs.Put(setID, ip)
+		buf.pendingRemovedIPs.Put(setID, cidr)
 	}
 }
 
@@ -493,7 +493,7 @@ func (buf *EventSequencer) flushAddedIPSets() {
 		log.WithField("setID", setID).Debug("Flushing added IP set")
 		members := make([]string, 0)
 		buf.pendingAddedIPs.Iter(setID, func(value interface{}) {
-			members = append(members, value.(ip.Addr).String())
+			members = append(members, value.(ip.CIDR).String())
 		})
 		buf.pendingAddedIPs.DiscardKey(setID)
 		buf.Callback(&proto.IPSetUpdate{
@@ -560,11 +560,11 @@ func (buf *EventSequencer) flushAddsOrRemoves(setID string) {
 		Id: setID,
 	}
 	buf.pendingAddedIPs.Iter(setID, func(item interface{}) {
-		addrStr := item.(ip.Addr).String()
+		addrStr := item.(ip.CIDR).String()
 		deltaUpdate.AddedMembers = append(deltaUpdate.AddedMembers, addrStr)
 	})
 	buf.pendingRemovedIPs.Iter(setID, func(item interface{}) {
-		addrStr := item.(ip.Addr).String()
+		addrStr := item.(ip.CIDR).String()
 		deltaUpdate.RemovedMembers = append(deltaUpdate.RemovedMembers, addrStr)
 	})
 	buf.pendingAddedIPs.DiscardKey(setID)

--- a/calc/ipset_member_calc.go
+++ b/calc/ipset_member_calc.go
@@ -26,8 +26,8 @@ import (
 )
 
 type IPAddRemoveCallbacks interface {
-	OnIPAdded(ipSetID string, ip ip.Addr)
-	OnIPRemoved(ipSetID string, ip ip.Addr)
+	OnCIDRAdded(ipSetID string, ip ip.CIDR)
+	OnCIDRRemoved(ipSetID string, ip ip.CIDR)
 }
 
 // MemberCalculator calculates the actual IPs that should be in each IP set.  As input, it
@@ -41,18 +41,18 @@ type IPAddRemoveCallbacks interface {
 // want to generate only one "IP added" event.  We also need to wait for both endpoints to be
 // removed before generating the "IP removed" event.
 type MemberCalculator struct {
-	keyToIPs              map[model.Key][]ip.Addr
+	keyToCIDRs            map[model.Key][]ip.CIDR
 	keyToMatchingIPSetIDs multidict.IfaceToString
-	ipSetIDToIPToKey      map[string]map[ip.Addr][]model.Key
+	ipSetIDToCIDRToKey    map[string]map[ip.CIDR][]model.Key
 
 	callbacks IPAddRemoveCallbacks
 }
 
 func NewMemberCalculator() *MemberCalculator {
 	calc := &MemberCalculator{
-		keyToIPs:              make(map[model.Key][]ip.Addr),
+		keyToCIDRs:            make(map[model.Key][]ip.CIDR),
 		keyToMatchingIPSetIDs: multidict.NewIfaceToString(),
-		ipSetIDToIPToKey:      make(map[string]map[ip.Addr][]model.Key),
+		ipSetIDToCIDRToKey:    make(map[string]map[ip.CIDR][]model.Key),
 	}
 	return calc
 }
@@ -66,7 +66,7 @@ func (calc *MemberCalculator) RegisterWith(allUpdDispatcher *dispatcher.Dispatch
 func (calc *MemberCalculator) MatchStarted(key model.Key, ipSetID string) {
 	log.Debugf("Adding endpoint %v to IP set %v", key, ipSetID)
 	calc.keyToMatchingIPSetIDs.Put(key, ipSetID)
-	ips := calc.keyToIPs[key]
+	ips := calc.keyToCIDRs[key]
 	calc.addMatchToIndex(ipSetID, key, ips)
 }
 
@@ -74,136 +74,136 @@ func (calc *MemberCalculator) MatchStarted(key model.Key, ipSetID string) {
 func (calc *MemberCalculator) MatchStopped(key model.Key, ipSetID string) {
 	log.Debugf("Removing endpoint %v from IP set %v", key, ipSetID)
 	calc.keyToMatchingIPSetIDs.Discard(key, ipSetID)
-	ips := calc.keyToIPs[key]
+	ips := calc.keyToCIDRs[key]
 	calc.removeMatchFromIndex(ipSetID, key, ips)
 }
 
 func (calc *MemberCalculator) OnUpdate(update api.Update) (filterOut bool) {
 	if update.Value == nil {
-		calc.updateEndpointIPs(update.Key, []ip.Addr{})
+		calc.updateEndpointCIDRs(update.Key, []ip.CIDR{})
 		return
 	}
 	switch update.Key.(type) {
 	case model.WorkloadEndpointKey:
 		ep := update.Value.(*model.WorkloadEndpoint)
-		ips := make([]ip.Addr, 0, len(ep.IPv4Nets)+len(ep.IPv6Nets))
+		cidrs := make([]ip.CIDR, 0, len(ep.IPv4Nets)+len(ep.IPv6Nets))
 		for _, net := range ep.IPv4Nets {
-			ips = append(ips, ip.FromNetIP(net.IP))
+			cidrs = append(cidrs, ip.CIDRFromCalicoNet(net))
 		}
 		for _, net := range ep.IPv6Nets {
-			ips = append(ips, ip.FromNetIP(net.IP))
+			cidrs = append(cidrs, ip.CIDRFromCalicoNet(net))
 		}
-		calc.updateEndpointIPs(update.Key, ips)
+		calc.updateEndpointCIDRs(update.Key, cidrs)
 	case model.HostEndpointKey:
 		ep := update.Value.(*model.HostEndpoint)
-		ips := make([]ip.Addr, 0,
+		cidrs := make([]ip.CIDR, 0,
 			len(ep.ExpectedIPv4Addrs)+len(ep.ExpectedIPv6Addrs))
 		for _, netIP := range ep.ExpectedIPv4Addrs {
-			ips = append(ips, ip.FromNetIP(netIP.IP))
+			cidrs = append(cidrs, ip.CIDRFromNetIP(netIP.IP))
 		}
 		for _, netIP := range ep.ExpectedIPv6Addrs {
-			ips = append(ips, ip.FromNetIP(netIP.IP))
+			cidrs = append(cidrs, ip.CIDRFromNetIP(netIP.IP))
 		}
-		calc.updateEndpointIPs(update.Key, ips)
+		calc.updateEndpointCIDRs(update.Key, cidrs)
 	}
 	return
 }
 
 // UpdateEndpointIPs tells this object that an endpoint has a new set of IP addresses.
-func (calc *MemberCalculator) updateEndpointIPs(endpointKey model.Key, ips []ip.Addr) {
-	log.Debugf("Endpoint %v IPs updated to %v", endpointKey, ips)
-	oldIPs := calc.keyToIPs[endpointKey]
-	if len(ips) == 0 {
-		delete(calc.keyToIPs, endpointKey)
+func (calc *MemberCalculator) updateEndpointCIDRs(endpointKey model.Key, cidrs []ip.CIDR) {
+	log.Debugf("Endpoint %v CIDRs updated to %v", endpointKey, cidrs)
+	oldCIDRs := calc.keyToCIDRs[endpointKey]
+	if len(cidrs) == 0 {
+		delete(calc.keyToCIDRs, endpointKey)
 	} else {
-		calc.keyToIPs[endpointKey] = ips
+		calc.keyToCIDRs[endpointKey] = cidrs
 	}
 
-	oldIPsSet := set.New()
-	for _, ip := range oldIPs {
-		oldIPsSet.Add(ip)
+	oldCIDRsSet := set.New()
+	for _, cidr := range oldCIDRs {
+		oldCIDRsSet.Add(cidr)
 	}
 
-	addedIPs := make([]ip.Addr, 0)
-	currentIPs := set.New()
-	for _, ip := range ips {
-		if !oldIPsSet.Contains(ip) {
-			log.Debugf("Added IP: %v", ip)
-			addedIPs = append(addedIPs, ip)
+	addedCIDRs := make([]ip.CIDR, 0)
+	currentCIDRs := set.New()
+	for _, cidr := range cidrs {
+		if !oldCIDRsSet.Contains(cidr) {
+			log.Debugf("Added CIDR: %v", cidr)
+			addedCIDRs = append(addedCIDRs, cidr)
 		}
-		currentIPs.Add(ip)
+		currentCIDRs.Add(cidr)
 	}
 
-	removedIPs := make([]ip.Addr, 0)
-	for _, ip := range oldIPs {
-		if !currentIPs.Contains(ip) {
-			log.Debugf("Removed IP: %v", ip)
-			removedIPs = append(removedIPs, ip)
+	removedCIDRs := make([]ip.CIDR, 0)
+	for _, cidr := range oldCIDRs {
+		if !currentCIDRs.Contains(cidr) {
+			log.Debugf("Removed CIDR: %v", cidr)
+			removedCIDRs = append(removedCIDRs, cidr)
 		}
 	}
 
 	calc.keyToMatchingIPSetIDs.Iter(endpointKey, func(ipSetID string) {
 		log.Debugf("Updating matching IP set: %v", ipSetID)
-		calc.addMatchToIndex(ipSetID, endpointKey, addedIPs)
-		calc.removeMatchFromIndex(ipSetID, endpointKey, removedIPs)
+		calc.addMatchToIndex(ipSetID, endpointKey, addedCIDRs)
+		calc.removeMatchFromIndex(ipSetID, endpointKey, removedCIDRs)
 	})
 }
 
 func (calc *MemberCalculator) Empty() bool {
-	if len(calc.keyToIPs) != 0 {
+	if len(calc.keyToCIDRs) != 0 {
 		return false
 	}
 	if !calc.keyToMatchingIPSetIDs.Empty() {
 		return false
 	}
-	if len(calc.ipSetIDToIPToKey) != 0 {
+	if len(calc.ipSetIDToCIDRToKey) != 0 {
 		return false
 	}
 	return true
 }
 
-func (calc *MemberCalculator) addMatchToIndex(ipSetID string, key model.Key, ips []ip.Addr) {
-	log.Debugf("IP set %v now matches IPs %v via %v", ipSetID, ips, key)
-	ipToKeys, ok := calc.ipSetIDToIPToKey[ipSetID]
+func (calc *MemberCalculator) addMatchToIndex(ipSetID string, key model.Key, cidrs []ip.CIDR) {
+	log.Debugf("IP set %v now matches CIDRs %v via %v", ipSetID, cidrs, key)
+	cidrToKeys, ok := calc.ipSetIDToCIDRToKey[ipSetID]
 	if !ok {
-		ipToKeys = make(map[ip.Addr][]model.Key, len(ips))
-		calc.ipSetIDToIPToKey[ipSetID] = ipToKeys
+		cidrToKeys = make(map[ip.CIDR][]model.Key, len(cidrs))
+		calc.ipSetIDToCIDRToKey[ipSetID] = cidrToKeys
 	}
 
-ipLoop:
-	for _, theIP := range ips {
-		keys := ipToKeys[theIP]
+cidrLoop:
+	for _, cidr := range cidrs {
+		keys := cidrToKeys[cidr]
 		if keys == nil {
-			log.Debugf("New IP in IP set %v: %v", ipSetID, theIP)
-			calc.callbacks.OnIPAdded(ipSetID, theIP)
+			log.Debugf("New CIDR in IP set %v: %v", ipSetID, cidr)
+			calc.callbacks.OnCIDRAdded(ipSetID, cidr)
 		} else {
 			// Skip the append if the key is already present.
 			for _, k := range keys {
 				if key == k {
-					continue ipLoop
+					continue cidrLoop
 				}
 			}
 		}
-		ipToKeys[theIP] = append(keys, key)
+		cidrToKeys[cidr] = append(keys, key)
 	}
 }
 
-func (calc *MemberCalculator) removeMatchFromIndex(ipSetID string, key model.Key, ips []ip.Addr) {
-	log.Debugf("IP set %v no longer matches IPs %v via %v", ipSetID, ips, key)
-	ipToKeys := calc.ipSetIDToIPToKey[ipSetID]
-	for _, theIP := range ips {
-		keys := ipToKeys[theIP]
+func (calc *MemberCalculator) removeMatchFromIndex(ipSetID string, key model.Key, cidrs []ip.CIDR) {
+	log.Debugf("IP set %v no longer matches CIDRs %v via %v", ipSetID, cidrs, key)
+	cidrToKeys := calc.ipSetIDToCIDRToKey[ipSetID]
+	for _, cidr := range cidrs {
+		keys := cidrToKeys[cidr]
 		for i, k := range keys {
 			if key == k {
 				// found it,
 				if len(keys) == 1 {
 					// It was the only entry, clean it up.
-					delete(ipToKeys, theIP)
-					calc.callbacks.OnIPRemoved(ipSetID, theIP)
+					delete(cidrToKeys, cidr)
+					calc.callbacks.OnCIDRRemoved(ipSetID, cidr)
 				} else {
 					keys[i] = keys[len(keys)-1]
 					keys = keys[:len(keys)-1]
-					ipToKeys[theIP] = keys
+					cidrToKeys[cidr] = keys
 				}
 				break
 			}

--- a/calc/state_test.go
+++ b/calc/state_test.go
@@ -17,11 +17,12 @@ package calc_test
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/projectcalico/felix/proto"
 	"github.com/projectcalico/felix/set"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
-	. "github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
 )
 
 // A state represents a particular state of the datastore and the expected
@@ -30,7 +31,7 @@ type State struct {
 	Name string
 	// List of KVPairs that are in the datastore.  Stored as a list rather
 	// than a map to give us a deterministic ordering of injection.
-	DatastoreState                       []KVPair
+	DatastoreState                       []model.KVPair
 	ExpectedIPSets                       map[string]set.Set
 	ExpectedPolicyIDs                    set.Set
 	ExpectedUntrackedPolicyIDs           set.Set
@@ -48,7 +49,7 @@ func (s State) String() string {
 
 func NewState() State {
 	return State{
-		DatastoreState:                       []KVPair{},
+		DatastoreState:                       []model.KVPair{},
 		ExpectedIPSets:                       make(map[string]set.Set),
 		ExpectedPolicyIDs:                    set.New(),
 		ExpectedUntrackedPolicyIDs:           set.New(),
@@ -83,13 +84,13 @@ func (s State) Copy() State {
 // withKVUpdates returns a deep copy of the state, incorporating the passed KVs.
 // If a new KV is an update to an existing KV, the existing KV is discarded and
 // the new KV is appended.  If the value of a new KV is nil, it is removed.
-func (s State) withKVUpdates(kvs ...KVPair) (newState State) {
+func (s State) withKVUpdates(kvs ...model.KVPair) (newState State) {
 	// Start with a clean copy.
 	newState = s.Copy()
 	// But replace the datastoreState, which we're about to modify.
-	newState.DatastoreState = make([]KVPair, 0, len(kvs)+len(s.DatastoreState))
+	newState.DatastoreState = make([]model.KVPair, 0, len(kvs)+len(s.DatastoreState))
 	// Make a set containing the new keys.
-	newKeys := make(map[Key]bool)
+	newKeys := make(map[model.Key]bool)
 	for _, kv := range kvs {
 		newKeys[kv.Key] = true
 	}
@@ -118,6 +119,13 @@ func (s State) withIPSet(name string, members []string) (newState State) {
 	} else {
 		set := set.New()
 		for _, ip := range members {
+			if !strings.Contains(ip, "/") {
+				if strings.Contains(ip, ":") {
+					ip += "/128"
+				} else {
+					ip += "/32"
+				}
+			}
 			set.Add(ip)
 		}
 		newState.ExpectedIPSets[name] = set
@@ -182,8 +190,8 @@ func (s State) Keys() set.Set {
 	return set
 }
 
-func (s State) KVsCopy() map[Key]interface{} {
-	kvs := make(map[Key]interface{})
+func (s State) KVsCopy() map[model.Key]interface{} {
+	kvs := make(map[model.Key]interface{})
 	for _, kv := range s.DatastoreState {
 		kvs[kv.Key] = kv.Value
 	}
@@ -192,7 +200,7 @@ func (s State) KVsCopy() map[Key]interface{} {
 
 func (s State) KVDeltas(prev State) []api.Update {
 	newAndUpdatedKVs := s.KVsCopy()
-	updatedKVs := make(map[Key]bool)
+	updatedKVs := make(map[model.Key]bool)
 	for _, kv := range prev.DatastoreState {
 		if reflect.DeepEqual(newAndUpdatedKVs[kv.Key], kv.Value) {
 			// Key had same value in both states so we ignore it.
@@ -208,7 +216,7 @@ func (s State) KVDeltas(prev State) []api.Update {
 		if !currentKeys.Contains(kv.Key) {
 			deltas = append(
 				deltas,
-				api.Update{KVPair{Key: kv.Key}, api.UpdateTypeKVDeleted},
+				api.Update{model.KVPair{Key: kv.Key}, api.UpdateTypeKVDeleted},
 			)
 		}
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: aafcc9f46c3998881e27db8c9ace72c1fbb76c6d10a90976ca84945f2939be9d
-updated: 2017-06-16T10:55:07.180304087Z
+hash: 0966f925d544db3f678bec1d03fa4983e0a5f4f5428b6eb264e6d4fca6d008a5
+updated: 2017-06-20T12:36:49.603319668Z
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -95,7 +95,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/mipearson/rfw
-  version: b66ec87bd85055de3f749a8640e9e4c8053052e4
+  version: 6f0a6f3266ba1058df9ef0c94cda1cecd2e62852
 - name: github.com/onsi/ginkgo
   version: f40a49d81e5c12e90400620b6242fb29a8e7c9d9
   subpackages:
@@ -126,7 +126,8 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: e40a090d7d025f7ab60f7a5e5bc362f875116754
+  version: 241d14c64023a36611dc7199c31ec9dc86aa732f
+  repo: http://github.com/fasaxc/libcalico-go.git
   subpackages:
   - lib
   - lib/api
@@ -169,13 +170,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 94eb3fe3a55f1b5d12d335b27a4f6e37cd73ed7e
+  version: 0d0c3d572886e0f2323ed376557f9eb99b97d25b
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a3bfc74126ea9e45ee5d5c6f7fc86191b7d488fb
+  version: 822d4a1f8edcbcbc71e8d1fd6527b12331a6d0ad
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,7 +26,8 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: v1.4.4
+  repo: http://github.com/fasaxc/libcalico-go.git
+  version: cidr-group
   subpackages:
   - lib
 - package: github.com/Sirupsen/logrus

--- a/intdataplane/endpoint_mgr.go
+++ b/intdataplane/endpoint_mgr.go
@@ -438,7 +438,7 @@ func (m *endpointManager) resolveWorkloadEndpoints() {
 				logCxt.Debug("Endpoint up, adding routes")
 				for _, s := range ipStrings {
 					routeTargets = append(routeTargets, routetable.Target{
-						CIDR:    ip.MustParseCIDR(s),
+						CIDR:    ip.MustParseCIDROrIP(s),
 						DestMAC: mac,
 					})
 				}

--- a/intdataplane/endpoint_mgr_test.go
+++ b/intdataplane/endpoint_mgr_test.go
@@ -901,12 +901,12 @@ func endpointManagerTests(ipVersion uint8) func() {
 				It("should set routes", func() {
 					if ipVersion == 6 {
 						routeTable.checkRoutes("cali12345-ab", []routetable.Target{{
-							CIDR:    ip.MustParseCIDR("2001:db8:2::2/128"),
+							CIDR:    ip.MustParseCIDROrIP("2001:db8:2::2/128"),
 							DestMAC: testutils.MustParseMAC("01:02:03:04:05:06"),
 						}})
 					} else {
 						routeTable.checkRoutes("cali12345-ab", []routetable.Target{{
-							CIDR:    ip.MustParseCIDR("10.0.240.0/24"),
+							CIDR:    ip.MustParseCIDROrIP("10.0.240.0/24"),
 							DestMAC: testutils.MustParseMAC("01:02:03:04:05:06"),
 						}})
 					}
@@ -1005,30 +1005,30 @@ func endpointManagerTests(ipVersion uint8) func() {
 							if ipVersion == 6 {
 								routeTable.checkRoutes("cali12345-ab", []routetable.Target{
 									{
-										CIDR:    ip.MustParseCIDR("2001:db8:2::2/128"),
+										CIDR:    ip.MustParseCIDROrIP("2001:db8:2::2/128"),
 										DestMAC: testutils.MustParseMAC("01:02:03:04:05:06"),
 									},
 									{
-										CIDR:    ip.MustParseCIDR("2001:db8:3::2/128"),
+										CIDR:    ip.MustParseCIDROrIP("2001:db8:3::2/128"),
 										DestMAC: testutils.MustParseMAC("01:02:03:04:05:06"),
 									},
 									{
-										CIDR:    ip.MustParseCIDR("2001:db8:4::2/128"),
+										CIDR:    ip.MustParseCIDROrIP("2001:db8:4::2/128"),
 										DestMAC: testutils.MustParseMAC("01:02:03:04:05:06"),
 									},
 								})
 							} else {
 								routeTable.checkRoutes("cali12345-ab", []routetable.Target{
 									{
-										CIDR:    ip.MustParseCIDR("10.0.240.0/24"),
+										CIDR:    ip.MustParseCIDROrIP("10.0.240.0/24"),
 										DestMAC: testutils.MustParseMAC("01:02:03:04:05:06"),
 									},
 									{
-										CIDR:    ip.MustParseCIDR("172.16.1.3/32"),
+										CIDR:    ip.MustParseCIDROrIP("172.16.1.3/32"),
 										DestMAC: testutils.MustParseMAC("01:02:03:04:05:06"),
 									},
 									{
-										CIDR:    ip.MustParseCIDR("172.18.1.4/32"),
+										CIDR:    ip.MustParseCIDROrIP("172.18.1.4/32"),
 										DestMAC: testutils.MustParseMAC("01:02:03:04:05:06"),
 									},
 								})
@@ -1093,12 +1093,12 @@ func endpointManagerTests(ipVersion uint8) func() {
 						It("should have set routes for new iface", func() {
 							if ipVersion == 6 {
 								routeTable.checkRoutes("cali12345-cd", []routetable.Target{{
-									CIDR:    ip.MustParseCIDR("2001:db8:2::2/128"),
+									CIDR:    ip.MustParseCIDROrIP("2001:db8:2::2/128"),
 									DestMAC: testutils.MustParseMAC("01:02:03:04:05:06"),
 								}})
 							} else {
 								routeTable.checkRoutes("cali12345-cd", []routetable.Target{{
-									CIDR:    ip.MustParseCIDR("10.0.240.0/24"),
+									CIDR:    ip.MustParseCIDROrIP("10.0.240.0/24"),
 									DestMAC: testutils.MustParseMAC("01:02:03:04:05:06"),
 								}})
 							}

--- a/intdataplane/ipsets_mgr.go
+++ b/intdataplane/ipsets_mgr.go
@@ -45,7 +45,7 @@ func (m *ipSetsManager) OnUpdate(msg interface{}) {
 	case *proto.IPSetUpdate:
 		log.WithField("ipSetId", msg.Id).Debug("IP set update")
 		metadata := ipsets.IPSetMetadata{
-			Type:    ipsets.IPSetTypeHashIP,
+			Type:    ipsets.IPSetTypeHashNet,
 			SetID:   msg.Id,
 			MaxSize: m.maxSize,
 		}

--- a/ip/ip_addr.go
+++ b/ip/ip_addr.go
@@ -181,6 +181,22 @@ func CIDRFromIPNet(ipNet *net.IPNet) CIDR {
 	}
 }
 
+// CIDRFromNetIP converts the given IP into our CIDR representation as a /32 or /128.
+func CIDRFromNetIP(netIP net.IP) CIDR {
+	ip := FromNetIP(netIP)
+	if ip.Version() == 4 {
+		return V4CIDR{
+			addr:   ip.(V4Addr),
+			prefix: 32,
+		}
+	} else {
+		return V6CIDR{
+			addr:   ip.(V6Addr),
+			prefix: 128,
+		}
+	}
+}
+
 func MustParseCIDR(s string) CIDR {
 	_, ipNet, err := net.ParseCIDR(s)
 	if err != nil {

--- a/ip/ip_addr.go
+++ b/ip/ip_addr.go
@@ -21,13 +21,17 @@
 package ip
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 
 	calinet "github.com/projectcalico/libcalico-go/lib/net"
 )
+
+var ErrInvalidIP = errors.New("Failed to parse IP address")
 
 // Addr represents either an IPv4 or IPv6 IP address.
 type Addr interface {
@@ -37,6 +41,7 @@ type Addr interface {
 	// this object.
 	AsNetIP() net.IP
 	AsCalicoNetIP() calinet.IP
+	AsCIDR() CIDR
 	String() string
 }
 
@@ -52,6 +57,13 @@ func (a V4Addr) AsNetIP() net.IP {
 
 func (a V4Addr) AsCalicoNetIP() calinet.IP {
 	return calinet.IP{IP: a.AsNetIP()}
+}
+
+func (a V4Addr) AsCIDR() CIDR {
+	return V4CIDR{
+		addr:   a,
+		prefix: 32,
+	}
 }
 
 func (a V4Addr) String() string {
@@ -70,6 +82,13 @@ func (a V6Addr) AsNetIP() net.IP {
 
 func (a V6Addr) AsCalicoNetIP() calinet.IP {
 	return calinet.IP{IP: a.AsNetIP()}
+}
+
+func (a V6Addr) AsCIDR() CIDR {
+	return V6CIDR{
+		addr:   a,
+		prefix: 128,
+	}
 }
 
 func (a V6Addr) String() string {
@@ -183,24 +202,32 @@ func CIDRFromIPNet(ipNet *net.IPNet) CIDR {
 
 // CIDRFromNetIP converts the given IP into our CIDR representation as a /32 or /128.
 func CIDRFromNetIP(netIP net.IP) CIDR {
-	ip := FromNetIP(netIP)
-	if ip.Version() == 4 {
-		return V4CIDR{
-			addr:   ip.(V4Addr),
-			prefix: 32,
-		}
-	} else {
-		return V6CIDR{
-			addr:   ip.(V6Addr),
-			prefix: 128,
-		}
-	}
+	return FromNetIP(netIP).AsCIDR()
 }
 
-func MustParseCIDR(s string) CIDR {
-	_, ipNet, err := net.ParseCIDR(s)
+// MustParseCIDROrIP parses the given IP address or CIDR, treating IP addresses as "full length"
+// CIDRs.  For example, "10.0.0.1" is treated as "10.0.0.1/32".  It panics on failure.
+func MustParseCIDROrIP(s string) CIDR {
+	cidr, err := ParseCIDROrIP(s)
 	if err != nil {
 		log.WithError(err).WithField("cidr", s).Panic("Failed to parse CIDR")
 	}
-	return CIDRFromIPNet(ipNet)
+	return cidr
+}
+
+// ParseCIDROrIP parses the given IP address or CIDR, treating IP addresses as "full length"
+// CIDRs.  For example, "10.0.0.1" is treated as "10.0.0.1/32".
+func ParseCIDROrIP(s string) (CIDR, error) {
+	if !strings.Contains(s, "/") {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			return nil, ErrInvalidIP
+		}
+		return CIDRFromNetIP(ip), nil
+	}
+	_, netCIDR, err := net.ParseCIDR(s)
+	if err != nil {
+		return nil, err
+	}
+	return CIDRFromIPNet(netCIDR), nil
 }

--- a/ip/ip_addr_test.go
+++ b/ip/ip_addr_test.go
@@ -45,7 +45,7 @@ var _ = DescribeTable("IpAddr",
 
 var _ = DescribeTable("CIDR",
 	func(version int, inputCIDR, canonical string, bytes []byte, len int) {
-		cidr := MustParseCIDR(inputCIDR)
+		cidr := MustParseCIDROrIP(inputCIDR)
 		Expect([]byte(cidr.Addr().AsNetIP())).To(Equal(bytes))
 		Expect(int(cidr.Prefix())).To(Equal(len))
 		Expect(cidr.String()).To(Equal(canonical))

--- a/ipsets/ipset_defs.go
+++ b/ipsets/ipset_defs.go
@@ -88,8 +88,10 @@ func (t IPSetType) CanonicaliseMember(member string) ipSetMember {
 		}
 		return ipAddr
 	case IPSetTypeHashNet:
-		// Convert the string into our ip.CIDR type, which is backed by a struct.
-		return ip.MustParseCIDR(member)
+		// Convert the string into our ip.CIDR type, which is backed by a struct.  When
+		// pretty-printing, the hash:net ipset type prints IPs with no "/32" or "/128"
+		// suffix.
+		return ip.MustParseCIDROrIP(member)
 	}
 	log.WithField("type", string(t)).Panic("Unknown IPSetType")
 	return nil

--- a/ipsets/ipsets_test.go
+++ b/ipsets/ipsets_test.go
@@ -57,6 +57,9 @@ var _ = Describe("IPSetType", func() {
 	It("should treat hash:net as valid", func() {
 		Expect(IPSetType("hash:net").IsValid()).To(BeTrue())
 	})
+})
+
+var _ = Describe("IPSetTypeHashIP", func() {
 	It("should canonicalise an IPv4", func() {
 		Expect(IPSetTypeHashIP.CanonicaliseMember("10.0.0.1")).
 			To(Equal(ip.FromString("10.0.0.1")))
@@ -65,16 +68,27 @@ var _ = Describe("IPSetType", func() {
 		Expect(IPSetTypeHashIP.CanonicaliseMember("feed:0::beef")).
 			To(Equal(ip.FromString("feed::beef")))
 	})
+	It("should panic on bad IP", func() {
+		Expect(func() { IPSetTypeHashIP.CanonicaliseMember("foobar") }).To(Panic())
+	})
+})
+
+var _ = Describe("IPSetTypeHashNet", func() {
 	It("should canonicalise an IPv4 CIDR", func() {
 		Expect(IPSetTypeHashNet.CanonicaliseMember("10.0.0.1/24")).
-			To(Equal(ip.MustParseCIDR("10.0.0.0/24")))
+			To(Equal(ip.MustParseCIDROrIP("10.0.0.0/24")))
 	})
 	It("should canonicalise an IPv6 CIDR", func() {
 		Expect(IPSetTypeHashNet.CanonicaliseMember("feed::beef/24")).
-			To(Equal(ip.MustParseCIDR("feed::/24")))
+			To(Equal(ip.MustParseCIDROrIP("feed::/24")))
 	})
-	It("should panic on bad IP", func() {
-		Expect(func() { IPSetTypeHashIP.CanonicaliseMember("foobar") }).To(Panic())
+	It("should canonicalise an IPv4 IP as a CIDR", func() {
+		Expect(IPSetTypeHashNet.CanonicaliseMember("10.0.0.1")).
+			To(Equal(ip.MustParseCIDROrIP("10.0.0.1/32")))
+	})
+	It("should canonicalise an IPv6 IP as a CIDR", func() {
+		Expect(IPSetTypeHashNet.CanonicaliseMember("feed::beef")).
+			To(Equal(ip.MustParseCIDROrIP("feed::beef/128")))
 	})
 	It("should panic on bad CIDR", func() {
 		Expect(func() { IPSetTypeHashNet.CanonicaliseMember("foobar") }).To(Panic())

--- a/labelindex/label_inheritance_index.go
+++ b/labelindex/label_inheritance_index.go
@@ -140,6 +140,7 @@ func (l *InheritIndex) RegisterWith(allUpdDispatcher *dispatcher.Dispatcher) {
 	allUpdDispatcher.Register(model.ProfileLabelsKey{}, l.OnUpdate)
 	allUpdDispatcher.Register(model.WorkloadEndpointKey{}, l.OnUpdate)
 	allUpdDispatcher.Register(model.HostEndpointKey{}, l.OnUpdate)
+	allUpdDispatcher.Register(model.NetworkSetKey{}, l.OnUpdate)
 }
 
 // OnUpdate makes LabelInheritanceIndex compatible with the UpdateHandler interface
@@ -165,6 +166,16 @@ func (l *InheritIndex) OnUpdate(update api.Update) (_ bool) {
 			l.UpdateLabels(key, endpoint.Labels, profileIDs)
 		} else {
 			log.Debugf("Deleting host endpoint %v from InheritIndex", key)
+			l.DeleteLabels(key)
+		}
+	case model.NetworkSetKey:
+		if update.Value != nil {
+			// Figure out what's changed and update the cache.
+			log.Debugf("Updating InheritIndex for network set %v", key)
+			ns := update.Value.(*model.NetworkSet)
+			l.UpdateLabels(key, ns.Labels, nil)
+		} else {
+			log.Debugf("Deleting network set %v from InheritIndex", key)
 			l.DeleteLabels(key)
 		}
 	case model.ProfileLabelsKey:

--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -40,7 +40,7 @@ var (
 	IfaceNotPresent = errors.New("interface not present")
 	IfaceDown       = errors.New("interface down")
 
-	ipV6LinkLocalCIDR = ip.MustParseCIDR("fe80::/64")
+	ipV6LinkLocalCIDR = ip.MustParseCIDROrIP("fe80::/64")
 
 	listIfaceTime = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name: "felix_route_table_list_seconds",

--- a/routetable/route_table_test.go
+++ b/routetable/route_table_test.go
@@ -45,10 +45,10 @@ var (
 	mac2 = testutils.MustParseMAC("00:11:22:33:44:52")
 	mac3 = testutils.MustParseMAC("00:11:22:33:44:53")
 
-	ip1  = ip.MustParseCIDR("10.0.0.1/32").ToIPNet()
-	ip2  = ip.MustParseCIDR("10.0.0.2/32").ToIPNet()
-	ip3  = ip.MustParseCIDR("10.0.0.3/32").ToIPNet()
-	ip13 = ip.MustParseCIDR("10.0.1.3/32").ToIPNet()
+	ip1  = ip.MustParseCIDROrIP("10.0.0.1/32").ToIPNet()
+	ip2  = ip.MustParseCIDROrIP("10.0.0.2/32").ToIPNet()
+	ip3  = ip.MustParseCIDROrIP("10.0.0.3/32").ToIPNet()
+	ip13 = ip.MustParseCIDROrIP("10.0.1.3/32").ToIPNet()
 )
 
 var _ = Describe("RouteTable", func() {
@@ -117,13 +117,13 @@ var _ = Describe("RouteTable", func() {
 			Describe(desc, func() {
 				BeforeEach(func() {
 					rt.SetRoutes("cali1", []Target{
-						{CIDR: ip.MustParseCIDR("10.0.0.1/32"), DestMAC: mac1},
+						{CIDR: ip.MustParseCIDROrIP("10.0.0.1/32"), DestMAC: mac1},
 					})
 					rt.SetRoutes("cali2", []Target{
-						{CIDR: ip.MustParseCIDR("10.0.0.2/32"), DestMAC: mac2},
+						{CIDR: ip.MustParseCIDROrIP("10.0.0.2/32"), DestMAC: mac2},
 					})
 					rt.SetRoutes("cali3", []Target{
-						{CIDR: ip.MustParseCIDR("10.0.1.3/32")},
+						{CIDR: ip.MustParseCIDROrIP("10.0.1.3/32")},
 					})
 					dataplane.failuresToSimulate = failFlags
 				})


### PR DESCRIPTION
## Description
This PR adds support for a new datatype to Felix, a "network set".  Network sets contain groups of network addresses (CIDRs) and they can be labeled with key/value pairs (and so take part in label selectors).

## Todos
- [x] Refactor IP set handling to use CIDRs
- [x] Actually add network sets
- [ ] Check RBAC implications
- [ ] Unit tests (full coverage)
- [ ] Integration tests done
  - [ ] calico/node FV
  - [ ] k8s e2es
  - [ ] k8sfv?
- [ ] Documentation
  - [ ] datamodel
  - [ ] getting started