### PR TITLE
[WiP] Add a grace period before deleting routes.

### DIFF
--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -27,11 +27,15 @@ import (
 	"github.com/gavv/monotime"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"time"
+
 	"github.com/projectcalico/felix/conntrack"
 	"github.com/projectcalico/felix/ifacemonitor"
 	"github.com/projectcalico/felix/ip"
 	"github.com/projectcalico/felix/set"
 )
+
+const cleanupGracePeriod = 10 * time.Second
 
 var (
 	GetFailed       = errors.New("netlink get operation failed")
@@ -73,6 +77,7 @@ type RouteTable struct {
 	ifacePrefixRegexp *regexp.Regexp
 
 	ifaceNameToTargets        map[string][]Target
+	ifaceNameToFirstSeen      map[string]time.Time
 	pendingIfaceNameToTargets map[string][]Target
 
 	inSync bool
@@ -80,14 +85,16 @@ type RouteTable struct {
 	// dataplane is our shim for the netlink/arp interface.  In production, it maps directly
 	// through to calls to the netlink package and the arp command.
 	dataplane dataplaneIface
+	// time is our shim for the time package, allowing it to be mocked for UT.
+	time timeIface
 }
 
 func New(interfacePrefixes []string, ipVersion uint8) *RouteTable {
-	return NewWithShims(interfacePrefixes, ipVersion, realDataplane{conntrack: conntrack.New()})
+	return NewWithShims(interfacePrefixes, ipVersion, realDataplane{conntrack: conntrack.New()}, realTime{})
 }
 
 // NewWithShims is a test constructor, which allows netlink to be replaced by a shim.
-func NewWithShims(interfacePrefixes []string, ipVersion uint8, nl dataplaneIface) *RouteTable {
+func NewWithShims(interfacePrefixes []string, ipVersion uint8, dpShim dataplaneIface, timeShim timeIface) *RouteTable {
 	prefixSet := set.New()
 	regexpParts := []string{}
 	for _, prefix := range interfacePrefixes {
@@ -114,9 +121,11 @@ func NewWithShims(interfacePrefixes []string, ipVersion uint8, nl dataplaneIface
 		ifacePrefixes:             prefixSet,
 		ifacePrefixRegexp:         regexp.MustCompile(ifaceNamePattern),
 		ifaceNameToTargets:        map[string][]Target{},
+		ifaceNameToFirstSeen:      map[string]time.Time{},
 		pendingIfaceNameToTargets: map[string][]Target{},
 		dirtyIfaces:               set.New(),
-		dataplane:                 nl,
+		dataplane:                 dpShim,
+		time:                      timeShim,
 	}
 }
 
@@ -129,7 +138,15 @@ func (r *RouteTable) OnIfaceStateChanged(ifaceName string, state ifacemonitor.St
 	if state == ifacemonitor.StateUp {
 		logCxt.Debug("Interface up, marking for route sync")
 		r.dirtyIfaces.Add(ifaceName)
+		r.onIfaceSeen(ifaceName)
 	}
+}
+
+func (r *RouteTable) onIfaceSeen(ifaceName string) {
+	if _, ok := r.ifaceNameToFirstSeen[ifaceName]; ok {
+		return
+	}
+	r.ifaceNameToFirstSeen[ifaceName] = r.time.Now()
 }
 
 func (r *RouteTable) SetRoutes(ifaceName string, targets []Target) {
@@ -163,7 +180,20 @@ func (r *RouteTable) Apply() error {
 				r.logCxt.WithField("ifaceName", ifaceName).Debug(
 					"Resync: found calico-owned interface")
 				r.dirtyIfaces.Add(ifaceName)
+				r.onIfaceSeen(ifaceName)
 			}
+		}
+		// Clean up first-seen timestamps for old interfaces.
+		for name, t := range r.ifaceNameToFirstSeen {
+			if r.dirtyIfaces.Contains(name) {
+				continue
+			}
+			if time.Since(t) < cleanupGracePeriod {
+				continue
+			}
+			log.WithField("ifaceName", name).Debug(
+				"Cleaning up timestamp for removed interface.")
+			delete(r.ifaceNameToFirstSeen, name)
 		}
 		r.inSync = true
 
@@ -216,9 +246,17 @@ func (r *RouteTable) syncRoutesForLink(ifaceName string) error {
 	logCxt := r.logCxt.WithField("ifaceName", ifaceName)
 	logCxt.Debug("Syncing interface routes")
 
+	// In order to allow Calico to run without Felix in an emergency, the CNI plugin pre-adds
+	// the route to the interface.  To avoid flapping the route, we give each interface a
+	// grace period after we first see it before we remove routes that we're not expecting.
+	// Check whether the grace period applies to this interface.
+	inGracePeriod := r.time.Since(r.ifaceNameToFirstSeen[ifaceName]) < cleanupGracePeriod
+
 	// If this is a modify or delete, grab a copy of the existing targets so we can clean up
 	// conntrack entries even if the routes have been removed.  We'll remove any still-required
-	// CIDRs from this set below.
+	// CIDRs from this set below.  We don't apply the grace period to this calculation because
+	// it only removes routes that the datamodel previously said were there and then were
+	// removed.  In that case, we know we're in sync.
 	oldCIDRs := set.New()
 	if updatedTargets, ok := r.pendingIfaceNameToTargets[ifaceName]; ok {
 		logCxt.Debug("Have updated targets.")
@@ -293,22 +331,28 @@ func (r *RouteTable) syncRoutesForLink(ifaceName string) error {
 		if route.Dst != nil {
 			dest = ip.CIDRFromIPNet(route.Dst)
 		}
-		if !expectedCIDRs.Contains(dest) {
-			logCxt := logCxt.WithField("dest", dest)
-			logCxt.Info("Syncing routes: removing old route.")
-			if err := r.dataplane.RouteDel(&route); err != nil {
-				// Probably a race with the interface being deleted.
-				logCxt.WithError(err).Info(
-					"Route deletion failed, assuming someone got there first.")
-				updatesFailed = true
-			}
-			if dest != nil {
-				// Collect any old route CIDRs that we find in the dataplane so we
-				// can remove their conntrack entries later.
-				oldCIDRs.Add(dest)
-			}
-		}
+		logCxt := logCxt.WithField("dest", dest)
 		seenCIDRs.Add(dest)
+		if expectedCIDRs.Contains(dest) {
+			logCxt.Debug("Syncing routes: Found expected route.")
+			continue
+		}
+		if inGracePeriod {
+			logCxt.Info("Syncing routes: found unexpected route; ignoring due to grace period.")
+			continue
+		}
+		logCxt.Info("Syncing routes: removing old route.")
+		if err := r.dataplane.RouteDel(&route); err != nil {
+			// Probably a race with the interface being deleted.
+			logCxt.WithError(err).Info(
+				"Route deletion failed, assuming someone got there first.")
+			updatesFailed = true
+		}
+		if dest != nil {
+			// Collect any old route CIDRs that we find in the dataplane so we
+			// can remove their conntrack entries later.
+			oldCIDRs.Add(dest)
+		}
 	}
 	for _, target := range expectedTargets {
 		cidr := target.CIDR

--- a/routetable/route_table_test.go
+++ b/routetable/route_table_test.go
@@ -33,6 +33,8 @@ import (
 
 	"strings"
 
+	"time"
+
 	"github.com/projectcalico/felix/ifacemonitor"
 )
 
@@ -53,6 +55,7 @@ var (
 
 var _ = Describe("RouteTable", func() {
 	var dataplane *mockDataplane
+	var t *mockTime
 	var rt *RouteTable
 
 	BeforeEach(func() {
@@ -62,7 +65,15 @@ var _ = Describe("RouteTable", func() {
 			addedRouteKeys:   set.New(),
 			deletedRouteKeys: set.New(),
 		}
-		rt = NewWithShims([]string{"cali"}, 4, dataplane)
+		startTime, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+		Expect(err).NotTo(HaveOccurred())
+		t = &mockTime{
+			currentTime: startTime,
+			// Setting a large auto-increment effectively disables the grace period
+			// for these tests.
+			autoIncrement: 11 * time.Second,
+		}
+		rt = NewWithShims([]string{"cali"}, 4, dataplane, t)
 	})
 
 	It("should be constructable", func() {
@@ -525,4 +536,18 @@ func (l *mockLink) Attrs() *netlink.LinkAttrs {
 
 func (l *mockLink) Type() string {
 	return "not-implemented"
+}
+
+type mockTime struct {
+	currentTime   time.Time
+	autoIncrement time.Duration
+}
+
+func (m *mockTime) Now() time.Time {
+	t := m.currentTime
+	m.currentTime = m.currentTime.Add(m.autoIncrement)
+	return t
+}
+func (m *mockTime) Since(t time.Time) time.Duration {
+	return m.Now().Sub(t)
 }

--- a/routetable/testing_shims.go
+++ b/routetable/testing_shims.go
@@ -20,6 +20,8 @@ import (
 
 	. "github.com/vishvananda/netlink"
 
+	"time"
+
 	"github.com/projectcalico/felix/conntrack"
 	"github.com/projectcalico/felix/ip"
 )
@@ -70,3 +72,22 @@ func (r realDataplane) RemoveConntrackFlows(ipVersion uint8, ipAddr net.IP) {
 }
 
 var _ dataplaneIface = realDataplane{}
+
+// timeIface is our shim interface the time package.
+type timeIface interface {
+	Now() time.Time
+	Since(t time.Time) time.Duration
+}
+
+// realTime is the real implementation of timeIface, which calls through to the real time package.
+type realTime struct{}
+
+func (_ realTime) Now() time.Time {
+	return time.Now()
+}
+
+func (_ realTime) Since(t time.Time) time.Duration {
+	return time.Since(t)
+}
+
+var _ timeIface = realTime{}


### PR DESCRIPTION
## Description
The CNI plugin pre-adds the routes for containers that it networks.  This can lead to flapping the route when Felix spots the interface before it hears about the endpoint.  Add a grace period before cleaning up the route to avoid this.

## Todos
- [ ] Check IP re-use cases work; do we need to bypass the grace period if the IP is added to another endpoint?
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
