### PR TITLE
Produce junit reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 /python/
 /version.txt
 /.dir-locals.el
+junit.xml
 # Old go sub-dir, used to be where we kept go source.
 /go/
 

--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,7 @@ clean:
 	       .go-pkg-cache \
 	       check-licenses/dependency-licenses.txt \
 	       release-notes-*
+	find . -name "junit.xml" -type f -delete
 	find . -name "*.coverprofile" -type f -delete
 	find . -name "coverage.xml" -type f -delete
 	find . -name ".coverage" -type f -delete

--- a/calc/calc_suite_test.go
+++ b/calc/calc_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/onsi/ginkgo/reporters"
 
 	"github.com/projectcalico/felix/logutils"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
@@ -34,5 +35,6 @@ func init() {
 
 func TestCalculationGraph(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Calculation graph Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Calculation graph Suite", []Reporter{junitReporter})
 }

--- a/config/config_suite_test.go
+++ b/config/config_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Config Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Config Suite", []Reporter{junitReporter})
 }

--- a/conntrack/conntrack_suite_test.go
+++ b/conntrack/conntrack_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestConntrack(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Conntrack Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Conntrack Suite", []Reporter{junitReporter})
 }

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -88,6 +88,7 @@ gofmt_failed=false
 go_apache_check_failed=false
 logrus_hook_check_failed=false
 focussing_check_failed=false
+junit_hook_check_failed=false
 
 for filename in $changed_go_files; do
   if [ ! -e  "${filename}" ]; then
@@ -105,6 +106,10 @@ for filename in $changed_go_files; do
     if ! grep -q 'HookLogrus' "$filename"; then
       echo "  Test suite doesn't call HookLogrusForGinkgo(): $filename"
       logrus_hook_check_failed=true
+    fi
+    if ! grep -q 'NewJUnitReporter' "$filename"; then
+      echo "  Test suite doesn't call NewJUnitReporter(): $filename"
+      junit_hook_check_failed=true
     fi
   fi
   if echo $filename | grep -q '_test.go'; then
@@ -152,7 +157,19 @@ if $logrus_hook_check_failed; then
   echo '	testutils.HookLogrusForGinkgo()'
   echo '}'
 fi
-
+if $junit_hook_check_failed; then
+  echo
+  echo "One or more test suites don't call NewJUnitReporter()."
+  echo "If a suite doesn't call NewJUnitReporter() then it won't generate "
+  echo "a junit report during UT runs.  Example:"
+  echo
+  echo 'import "github.com/onsi/ginkgo/reporters"'
+  echo 'func TestFoo(t *testing.T) {'
+  echo '	RegisterFailHandler(Fail)'
+  echo '	junitReporter := reporters.NewJUnitReporter("junit.xml")'
+  echo '	RunSpecsWithDefaultAndCustomReporters(t, "Foo Suite", []Reporter{junitReporter})'
+  echo '}'
+fi
 if $go_copyright_check_failed; then
   echo
   echo "Copyright statement should match"
@@ -186,7 +203,8 @@ fi
 
 if $go_apache_check_failed || $go_copyright_check_failed || \
    $py_apache_check_failed || $py_copyright_check_failed || \
-   $logrus_hook_check_failed || $focussing_check_failed; then
+   $logrus_hook_check_failed || $focussing_check_failed || \
+   $junit_hook_check_failed ; then
   exit 1
 fi
 

--- a/hashutils/hashutils_suite_test.go
+++ b/hashutils/hashutils_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestHashutils(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Hashutils Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Hashutils Suite", []Reporter{junitReporter})
 }

--- a/ifacemonitor/ifacemonitor_suite_test.go
+++ b/ifacemonitor/ifacemonitor_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestIfacemonitor(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Ifacemonitor Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Ifacemonitor Suite", []Reporter{junitReporter})
 }

--- a/intdataplane/intdataplane_fv_suite_test.go
+++ b/intdataplane/intdataplane_fv_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestIntdataplane(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Intdataplane Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Intdataplane Suite", []Reporter{junitReporter})
 }

--- a/intdataplane/intdataplane_ut_suite_test.go
+++ b/intdataplane/intdataplane_ut_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/onsi/ginkgo/reporters"
 
 	"github.com/projectcalico/felix/logutils"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
@@ -34,5 +35,6 @@ func init() {
 
 func TestIntdataplane(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Intdataplane Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Intdataplane Suite", []Reporter{junitReporter})
 }

--- a/ip/ip_suite_test.go
+++ b/ip/ip_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/onsi/ginkgo/reporters"
 
 	"github.com/projectcalico/felix/logutils"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
@@ -28,7 +29,8 @@ import (
 
 func TestIp(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Ip Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "IP Suite", []Reporter{junitReporter})
 }
 
 func init() {

--- a/ipsets/ipsets_suite_test.go
+++ b/ipsets/ipsets_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/onsi/ginkgo/reporters"
 
 	"github.com/projectcalico/felix/logutils"
 	"github.com/projectcalico/libcalico-go/lib/testutils"
@@ -34,5 +35,6 @@ func init() {
 
 func TestCalculationGraph(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "IP sets Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "IP sets Suite", []Reporter{junitReporter})
 }

--- a/iptables/iptables_fv_suite_test.go
+++ b/iptables/iptables_fv_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestIptablesFV(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Iptables Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Iptables Suite", []Reporter{junitReporter})
 }

--- a/iptables/iptables_ut_suite_test.go
+++ b/iptables/iptables_ut_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestIptablesUT(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Iptables Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Iptables Suite", []Reporter{junitReporter})
 }

--- a/jitter/jitter_suite_test.go
+++ b/jitter/jitter_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestJitter(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Jitter Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Jitter Suite", []Reporter{junitReporter})
 }

--- a/labelindex/labelindex_suite_test.go
+++ b/labelindex/labelindex_suite_test.go
@@ -20,6 +20,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestLabels(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Labels Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Labels Suite", []Reporter{junitReporter})
 }

--- a/logutils/logutils_suite_test.go
+++ b/logutils/logutils_suite_test.go
@@ -19,9 +19,22 @@ import (
 	. "github.com/onsi/gomega"
 
 	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/onsi/ginkgo/reporters"
+
+	"github.com/projectcalico/felix/logutils"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+	logrus.AddHook(&logutils.ContextHook{})
+	logrus.SetFormatter(&logutils.Formatter{})
+}
 
 func TestLogutils(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Logutils Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Logutils Suite", []Reporter{junitReporter})
 }

--- a/multidict/multidict_suite_test.go
+++ b/multidict/multidict_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestMultidict(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Multidict Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Multidict Suite", []Reporter{junitReporter})
 }

--- a/routetable/routetable_suite_test.go
+++ b/routetable/routetable_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestRules(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "RouteTable Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "RouteTable Suite", []Reporter{junitReporter})
 }

--- a/rules/rules_suite_test.go
+++ b/rules/rules_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestRules(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Rules Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Rules Suite", []Reporter{junitReporter})
 }

--- a/set/set_suite_test.go
+++ b/set/set_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestSet(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Set Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Set Suite", []Reporter{junitReporter})
 }

--- a/statusrep/statusrep_suite_test.go
+++ b/statusrep/statusrep_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestStatusrep(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Statusrep Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Statusrep Suite", []Reporter{junitReporter})
 }

--- a/stringutils/stringutils_suite_test.go
+++ b/stringutils/stringutils_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestStringutils(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Stringutils Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Stringutils Suite", []Reporter{junitReporter})
 }

--- a/throttle/throttle_suite_test.go
+++ b/throttle/throttle_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestJitter(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Throttle Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Throttle Suite", []Reporter{junitReporter})
 }

--- a/usagerep/usagerep_suite_test.go
+++ b/usagerep/usagerep_suite_test.go
@@ -20,6 +20,8 @@ import (
 
 	"testing"
 
+	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 
@@ -29,5 +31,6 @@ func init() {
 
 func TestUsagerep(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Usagerep Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Usagerep Suite", []Reporter{junitReporter})
 }


### PR DESCRIPTION
Modifies unit test suites to produce junit reports of test results.  

Useful for integration with CI/CD pipelines for spotting flaky tests, determining which tests take the longest, etc.