### PR TITLE
Allow selection of policy allow action

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -119,6 +119,7 @@ type Config struct {
 
 	ChainInsertMode             string `config:"oneof(insert,append);insert;non-zero,die-on-fail"`
 	DefaultEndpointToHostAction string `config:"oneof(DROP,RETURN,ACCEPT);DROP;non-zero,die-on-fail"`
+	IptablesAllowAction         string `config:"oneof(ACCEPT,RETURN);ACCEPT;non-zero,die-on-fail"`
 	LogPrefix                   string `config:"string;calico-packet"`
 
 	LogFilePath string `config:"file;/var/log/calico/felix.log;die-on-fail"`

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -82,6 +82,9 @@ var _ = DescribeTable("Config parsing",
 	Entry("DefaultEndpointToHostAction", "DefaultEndpointToHostAction",
 		"ACCEPT", "ACCEPT"),
 
+	Entry("IptablesAllowAction", "IptablesAllowAction",
+		"RETURN", "RETURN"),
+
 	Entry("LogFilePath", "LogFilePath", "/tmp/felix.log", "/tmp/felix.log"),
 
 	Entry("LogSeverityFile", "LogSeverityFile", "debug", "DEBUG"),

--- a/felix.go
+++ b/felix.go
@@ -270,6 +270,7 @@ configRetry:
 
 				IptablesLogPrefix:    configParams.LogPrefix,
 				EndpointToHostAction: configParams.DefaultEndpointToHostAction,
+				IptablesAllowAction:  configParams.IptablesAllowAction,
 
 				FailsafeInboundHostPorts:  configParams.FailsafeInboundHostPorts,
 				FailsafeOutboundHostPorts: configParams.FailsafeOutboundHostPorts,

--- a/intdataplane/int_dataplane_test.go
+++ b/intdataplane/int_dataplane_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Constructor test", func() {
 				IPIPTunnelAddress: configParams.IpInIpTunnelAddr,
 
 				EndpointToHostAction: configParams.DefaultEndpointToHostAction,
+				IptablesAllowAction:  configParams.IptablesAllowAction,
 			},
 			IPIPMTU: configParams.IpInIpMtu,
 		}

--- a/rules/static.go
+++ b/rules/static.go
@@ -89,7 +89,7 @@ func (r *DefaultRuleRenderer) filterInputChain(ipVersion uint8) *Chain {
 		},
 		Rule{
 			Match:   Match().MarkSet(r.IptablesMarkAccept),
-			Action:  AcceptAction{},
+			Action:  r.iptablesAllowAction,
 			Comment: "Host endpoint policy accepted packet.",
 		},
 	)
@@ -296,7 +296,7 @@ func (r *DefaultRuleRenderer) StaticFilterForwardChains() []*Chain {
 		},
 		Rule{
 			Match:   Match().MarkSet(r.IptablesMarkAccept),
-			Action:  AcceptAction{},
+			Action:  r.iptablesAllowAction,
 			Comment: "Host endpoint policy accepted packet.",
 		},
 	)
@@ -350,7 +350,7 @@ func (r *DefaultRuleRenderer) filterOutputChain() *Chain {
 		},
 		Rule{
 			Match:   Match().MarkSet(r.IptablesMarkAccept),
-			Action:  AcceptAction{},
+			Action:  r.iptablesAllowAction,
 			Comment: "Host endpoint policy accepted packet.",
 		},
 	)


### PR DESCRIPTION
## Description
Allow selection of ACCEPT or RETURN for policy acceptance actions
to take when a security group is permitting the traffic. The
previous ACCEPT-only behavior did not allow for network-wide
policy to be inserted after the felix chains were checked.

RETURN will allow operators to filter traffic after it has passed
through the felix chains.

## Todos
- [x] Unit tests (full coverage)
- [x] Documentation
