### PR TITLE
Allow SNAT to be performed on all fixed IP traffic

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -106,8 +106,9 @@ type Config struct {
 	TyphaK8sServiceName string `config:"string;"`
 	TyphaK8sNamespace   string `config:"string;kube-system;non-zero"`
 
-	Ipv6Support    bool `config:"bool;true"`
-	IgnoreLooseRPF bool `config:"bool;false"`
+	Ipv6Support        bool   `config:"bool;true"`
+	IgnoreLooseRPF     bool   `config:"bool;false"`
+	NatSnatDestination string `config:"oneof(private,any);private;non-zero,die-on-fail"`
 
 	IptablesRefreshInterval            time.Duration `config:"seconds;10"`
 	IptablesPostWriteCheckIntervalSecs time.Duration `config:"seconds;1"`

--- a/felix.go
+++ b/felix.go
@@ -280,6 +280,8 @@ configRetry:
 				FailsafeOutboundHostPorts: configParams.FailsafeOutboundHostPorts,
 
 				DisableConntrackInvalid: configParams.DisableConntrackInvalidCheck,
+
+				NatSnatDestination: configParams.NatSnatDestination,
 			},
 			IPIPMTU:                        configParams.IpInIpMtu,
 			IptablesRefreshInterval:        configParams.IptablesRefreshInterval,

--- a/felix.go
+++ b/felix.go
@@ -239,10 +239,12 @@ configRetry:
 		markAccept := configParams.NextIptablesMark()
 		markPass := configParams.NextIptablesMark()
 		markWorkload := configParams.NextIptablesMark()
+		markSnatSkip := configParams.NextIptablesMark()
 		log.WithFields(log.Fields{
 			"acceptMark":   markAccept,
 			"passMark":     markPass,
 			"workloadMark": markWorkload,
+			"snatSkipMark": markSnatSkip,
 		}).Info("Calculated iptables mark bits")
 		dpConfig := intdataplane.Config{
 			RulesConfig: rules.Config{
@@ -268,6 +270,7 @@ configRetry:
 				IptablesMarkAccept:       markAccept,
 				IptablesMarkPass:         markPass,
 				IptablesMarkFromWorkload: markWorkload,
+				IptablesMarkSnatSkip:     markSnatSkip,
 
 				IPIPEnabled:       configParams.IpInIpEnabled,
 				IPIPTunnelAddress: configParams.IpInIpTunnelAddr,

--- a/intdataplane/floating_ip_mgr.go
+++ b/intdataplane/floating_ip_mgr.go
@@ -149,7 +149,7 @@ func (m *floatingIPManager) CompleteDeferredWork() error {
 		}
 		// Render chains for those NATs.
 		dnatChains := m.ruleRenderer.DNATsToIptablesChains(dnats)
-		snatChains := m.ruleRenderer.SNATsToIptablesChains(snats)
+		snatChains := m.ruleRenderer.SNATsToIptablesChains(snats, m.ipVersion)
 		// Update iptables if they have changed.
 		if !reflect.DeepEqual(m.activeDNATChains, dnatChains) {
 			m.natTable.RemoveChains(m.activeDNATChains)

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -153,7 +153,7 @@ type RuleRenderer interface {
 	NATOutgoingChain(active bool, ipVersion uint8) *iptables.Chain
 
 	DNATsToIptablesChains(dnats map[string]string) []*iptables.Chain
-	SNATsToIptablesChains(snats map[string]string) []*iptables.Chain
+	SNATsToIptablesChains(snats map[string]string, ipVersion uint8) []*iptables.Chain
 }
 
 type DefaultRuleRenderer struct {
@@ -199,6 +199,8 @@ type Config struct {
 	FailsafeOutboundHostPorts []config.ProtoPort
 
 	DisableConntrackInvalid bool
+
+	NatSnatDestination string
 }
 
 func NewRenderer(config Config) RuleRenderer {

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -183,6 +183,7 @@ type Config struct {
 	IptablesMarkAccept       uint32
 	IptablesMarkPass         uint32
 	IptablesMarkFromWorkload uint32
+	IptablesMarkSnatSkip     uint32
 
 	OpenStackMetadataIP          net.IP
 	OpenStackMetadataPort        uint16


### PR DESCRIPTION
## Description
Previously SNAT was only being perfomed on traffic from the fixed IP to itself. This doesn't perform full aliasing on the fixed IP address which is expected by most floating IP implementations as this allows them to reach the external networks without any further instance configuration.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Documentation
