### PR TITLE
Don't verify endpoints if we haven't configured Felix

### DIFF
--- a/k8sfv/calc_graph.go
+++ b/k8sfv/calc_graph.go
@@ -42,7 +42,7 @@ func rotateLabels(clientset *kubernetes.Clientset, nsPrefix string) error {
 		}
 	}
 
-	d := NewDeployment(clientset, 49, true)
+	d = NewDeployment(clientset, 49, true)
 
 	// Create pods.
 	waiter := sync.WaitGroup{}

--- a/k8sfv/pod_test.go
+++ b/k8sfv/pod_test.go
@@ -29,7 +29,6 @@ var _ = Context("with a k8s clientset", func() {
 	var (
 		clientset *kubernetes.Clientset
 		nsPrefix  string
-		d         deployment
 	)
 
 	BeforeEach(func() {

--- a/k8sfv/scale_test.go
+++ b/k8sfv/scale_test.go
@@ -42,7 +42,6 @@ var _ = Context("with a k8s clientset", func() {
 	var (
 		clientset *kubernetes.Clientset
 		nsPrefix  string
-		d         deployment
 	)
 
 	BeforeEach(func() {


### PR DESCRIPTION
Fixes the flake seen at
https://semaphoreci.com/calico/felix-2/branches/master/builds/476, which
occurs if the first test to run is one that does not fully configure
Felix.