### PR TITLE
Disable the iptables lock by default.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -113,7 +113,7 @@ type Config struct {
 	IptablesRefreshInterval            time.Duration `config:"seconds;90"`
 	IptablesPostWriteCheckIntervalSecs time.Duration `config:"seconds;30"`
 	IptablesLockFilePath               string        `config:"file;/run/xtables.lock"`
-	IptablesLockTimeoutSecs            time.Duration `config:"seconds;30"`
+	IptablesLockTimeoutSecs            time.Duration `config:"seconds;0"`
 	IptablesLockProbeIntervalMillis    time.Duration `config:"millis;50"`
 	IpsetsRefreshInterval              time.Duration `config:"seconds;10"`
 	MaxIpsetSize                       int           `config:"int;1048576;non-zero"`

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -111,7 +111,7 @@ type Config struct {
 
 	RouteRefreshInterval               time.Duration `config:"seconds;90"`
 	IptablesRefreshInterval            time.Duration `config:"seconds;90"`
-	IptablesPostWriteCheckIntervalSecs time.Duration `config:"seconds;30"`
+	IptablesPostWriteCheckIntervalSecs time.Duration `config:"seconds;1"`
 	IptablesLockFilePath               string        `config:"file;/run/xtables.lock"`
 	IptablesLockTimeoutSecs            time.Duration `config:"seconds;0"`
 	IptablesLockProbeIntervalMillis    time.Duration `config:"millis;50"`


### PR DESCRIPTION
Be more cautious until we understand why iptables has been seen taking a minute or more in real-world scenarios.

## Description
Customer reported seeing 60s iptables-restore calls.  [This talk](https://youtu.be/4-pawkiazEg?t=14m22s) mentions 11m.

## Todos
- [ ] Unit tests (full coverage)
- [x] Documentation in progress: https://github.com/projectcalico/calico/pull/902
- [x] Update release note for iptables lock feature

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
