### PR TITLE
Add static check for Typha pin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,9 +358,24 @@ go-meta-linter: vendor/.up-to-date $(GENERATED_GO_FILES)
 	                                --enable=goimports \
 	                                --vendor ./...
 
+.PHONY: check-typha-pins
+check-typha-pins: vendor/.up-to-date
+	@echo "Checking Typha's libcalico-go pin matches ours (so that any datamodel"
+	@echo "changes are reflected in the Typha-Felix API)."
+	@echo
+	@echo "Felix's libcalico-go pin:"
+	@grep libcalico-go glide.lock -A 5 | grep 'version:' | head -n 1
+	@echo "Typha's libcalico-go pin:"
+	@grep libcalico-go vendor/github.com/projectcalico/typha/glide.lock -A 5 | grep 'version:' | head -n 1
+	if [ "`grep libcalico-go glide.lock -A 5 | grep 'version:' | head -n 1`" != \
+	     "`grep libcalico-go vendor/github.com/projectcalico/typha/glide.lock -A 5 | grep 'version:' | head -n 1`" ]; then \
+	     echo "Typha and Felix libcalico-go pins differ."; \
+	     false; \
+	fi
+
 .PHONY: static-checks
 static-checks:
-	$(MAKE) go-meta-linter check-licenses
+	$(MAKE) check-typha-pins go-meta-linter check-licenses
 
 .PHONY: ut-no-cover
 ut-no-cover: vendor/.up-to-date $(FELIX_GO_FILES)


### PR DESCRIPTION
Prevent Felix and Typha from being pinned to different libcalico-go versions, which would be a problem if the datamodel changed.

## Description

If the datamodel changes to add a new field and we only update Felix, but not Typha, then Typha will send Felix updates without the new field, which would be very confusing.  Add a static check to make sure that the version of Typha that Felix is pinned against uses the same libcalico-go pin.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
