### PR TITLE
Adding support for ppc64le.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,26 @@
 #            +----------------------------+    +--------------+
 #
 #
+#
+###############################################################################
+# The build architecture is select by setting the ARCH variable.
+# For example: When building on ppc64le you could use ARCH=ppc64le make <....>.
+# When ARCH is undefined it defaults to amd64.
+ifdef ARCH
+	ARCHTAG:=-$(ARCH)
+endif
+ARCH?=amd64
+ARCHTAG?=
+
+ifeq ($(ARCH),amd64)
+GO_BUILD_VER:=v0.6
+endif
+
+ifeq ($(ARCH),ppc64le)
+GO_BUILD_VER:=latest
+endif
+
+GO_BUILD_CONTAINER?=calico/go-build$(ARCHTAG):$(GO_BUILD_VER)
 
 help:
 	@echo "Felix Makefile"
@@ -80,8 +100,6 @@ help:
 all: deb rpm calico/felix
 test: ut fv
 
-GO_BUILD_CONTAINER?=calico/go-build:v0.6
-
 # Figure out version information.  To support builds from release tarballs, we default to
 # <unknown> if this isn't a git checkout.
 GIT_COMMIT:=$(shell git rev-parse HEAD || echo '<unknown>')
@@ -115,12 +133,12 @@ MY_GID:=$(shell id -g)
 # Build a docker image used for building debs for trusty.
 .PHONY: calico-build/trusty
 calico-build/trusty:
-	cd docker-build-images && docker build -f ubuntu-trusty-build.Dockerfile -t calico-build/trusty .
+	cd docker-build-images && docker build -f ubuntu-trusty-build.Dockerfile$(ARCHTAG) -t calico-build/trusty .
 
 # Build a docker image used for building debs for xenial.
 .PHONY: calico-build/xenial
 calico-build/xenial:
-	cd docker-build-images && docker build -f ubuntu-xenial-build.Dockerfile -t calico-build/xenial .
+	cd docker-build-images && docker build -f ubuntu-xenial-build.Dockerfile$(ARCHTAG) -t calico-build/xenial .
 
 # Construct a docker image for building Centos 7 RPMs.
 .PHONY: calico-build/centos7
@@ -129,8 +147,16 @@ calico-build/centos7:
 	  docker build \
 	  --build-arg=UID=$(MY_UID) \
 	  --build-arg=GID=$(MY_GID) \
-	  -f centos7-build.Dockerfile \
+	  -f centos7-build.Dockerfile$(ARCHTAG) \
 	  -t calico-build/centos7 .
+
+ifeq ("$(ARCH)","ppc64le")
+	# Some commands that would typically be run at container build time must be run in a privileged container.
+	@-docker rm -f centos7Tmp
+	docker run --privileged --name=centos7Tmp calico-build/centos7 \
+		/bin/bash -c "/setup-user; /install-centos-build-deps"
+	docker commit centos7Tmp calico-build/centos7:latest
+endif
 
 # Construct a docker image for building Centos 6 RPMs.
 .PHONY: calico-build/centos6
@@ -139,7 +165,7 @@ calico-build/centos6:
 	  docker build \
 	  --build-arg=UID=$(MY_UID) \
 	  --build-arg=GID=$(MY_GID) \
-	  -f centos6-build.Dockerfile \
+	  -f centos6-build.Dockerfile$(ARCHTAG) \
 	  -t calico-build/centos6 .
 
 # Build the calico/felix docker image, which contains only Felix.
@@ -148,7 +174,7 @@ calico/felix: bin/calico-felix
 	rm -rf docker-image/bin
 	mkdir -p docker-image/bin
 	cp bin/calico-felix docker-image/bin/
-	docker build --pull -t calico/felix docker-image
+	docker build --pull -t calico/felix$(ARCHTAG) --file ./docker-image/Dockerfile$(ARCHTAG) docker-image 
 
 # Targets for Felix testing with the k8s backend and a k8s API server,
 # with k8s model resources being injected by a separate test client.
@@ -241,7 +267,9 @@ ifeq ($(GIT_COMMIT),<unknown>)
 	$(error Package builds must be done from a git working copy in order to calculate version numbers.)
 endif
 	$(MAKE) calico-build/centos7
+ifneq ("$(ARCH)","ppc64le") # no ppc64le support in centos6
 	$(MAKE) calico-build/centos6
+endif
 	utils/make-packages.sh rpm
 
 .PHONY: protobuf
@@ -250,7 +278,7 @@ protobuf: proto/felixbackend.pb.go
 # Generate the protobuf bindings for go.
 proto/felixbackend.pb.go: proto/felixbackend.proto
 	$(DOCKER_RUN_RM) -v $${PWD}/proto:/src:rw \
-	              calico/protoc \
+	              calico/protoc$(ARCHTAG) \
 	              --gogofaster_out=. \
 	              felixbackend.proto
 
@@ -288,9 +316,10 @@ bin/calico-felix: $(FELIX_GO_FILES) vendor/.up-to-date
 	@echo Building felix...
 	mkdir -p bin
 	$(DOCKER_GO_BUILD) \
-	    sh -c 'go build -v -i -o $@ -v $(LDFLAGS) "github.com/projectcalico/felix" && \
-               ( ldd bin/calico-felix 2>&1 | grep -q "Not a valid dynamic program" || \
-	             ( echo "Error: bin/calico-felix was not statically linked"; false ) )'
+	   sh -c 'go build -v -i -o $@ -v $(LDFLAGS) "github.com/projectcalico/felix" && \
+		( ldd bin/calico-felix 2>&1 | grep -q -e "Not a valid dynamic program" \
+		-e "not a dynamic executable" || \
+		( echo "Error: bin/calico-felix was not statically linked"; false ) )'
 
 bin/iptables-locker: $(FELIX_GO_FILES) vendor/.up-to-date
 	@echo Building iptables-locker...
@@ -302,8 +331,9 @@ bin/k8sfv.test: $(K8SFV_GO_FILES) vendor/.up-to-date
 	@echo Building $@...
 	$(DOCKER_GO_BUILD) \
 	    sh -c 'go test -c -o $@ ./k8sfv && \
-               ( ldd $@ 2>&1 | grep -q "Not a valid dynamic program" || \
-	             ( echo "Error: $@ was not statically linked"; false ) )'
+		( ldd $@ 2>&1 | grep -q "Not a valid dynamic program" \
+		-e "not a dynamic executable" || \
+		( echo "Error: $@ was not statically linked"; false ) )'
 
 dist/calico-felix/calico-felix: bin/calico-felix
 	mkdir -p dist/calico-felix/
@@ -338,6 +368,8 @@ fv: calico/felix bin/iptables-locker fv/fv.test
 	@echo Running Go FVs.
 	# For now, we pre-build the binary so that we can run it outside a container and allow it
 	# to interact with docker.
+	# fv.test is not expecting a container name with an ARCHTAG.
+	-docker tag calico/felix$(ARCHTAG) calico/felix
 	cd fv && ./fv.test
 
 bin/check-licenses: $(FELIX_GO_FILES)

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ bin/k8sfv.test: $(K8SFV_GO_FILES) vendor/.up-to-date
 	@echo Building $@...
 	$(DOCKER_GO_BUILD) \
 	    sh -c 'go test -c -o $@ ./k8sfv && \
-		( ldd $@ 2>&1 | grep -q "Not a valid dynamic program" \
+		( ldd $@ 2>&1 | grep -q -e "Not a valid dynamic program" \
 		-e "not a dynamic executable" || \
 		( echo "Error: $@ was not statically linked"; false ) )'
 

--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Description: Project Calico virtual networking for cloud data centers.
  This package provides common files.
 
 Package: calico-felix
-Architecture: amd64
+Architecture: amd64 ppc64el
 Depends:
  calico-common (= ${binary:Version}),
  conntrack,

--- a/docker-build-images/centos7-build.Dockerfile-ppc64le
+++ b/docker-build-images/centos7-build.Dockerfile-ppc64le
@@ -1,0 +1,22 @@
+FROM ppc64le/centos:7
+MAINTAINER Shaun Crampton <shaun@tigera.io>
+ENV STREAM el7
+
+ARG UID
+ARG GID
+
+# Some commands that would typically be run at container build time must be run in a privileged container.
+# Therefor, we do a two step image build process, in step 1 (now) scripts are placed in the image, in step 2
+# a privileged container is started and the scripts are executed.
+
+ADD install-centos-build-deps install-centos-build-deps
+
+# rpmbuild requires the current user to exist inside the container, copy in
+# some user/group entries calculated by the makefile.
+# use `--force` and `-o` since tests can run under root and command will fail with duplicate error
+
+RUN echo "#!/usr/bin/env bash" > /setup-user; \
+    echo "groupadd --force --gid=$GID user && useradd -o --home=/ --gid=$GID --uid=$UID user" >> /setup-user; \
+    chmod +x /setup-user
+
+WORKDIR /code

--- a/docker-build-images/centos7-build.Dockerfile-ppc64le
+++ b/docker-build-images/centos7-build.Dockerfile-ppc64le
@@ -6,7 +6,7 @@ ARG UID
 ARG GID
 
 # Some commands that would typically be run at container build time must be run in a privileged container.
-# Therefor, we do a two step image build process, in step 1 (now) scripts are placed in the image, in step 2
+# Therefore, we do a two step image build process, in step 1 (now) scripts are placed in the image, in step 2
 # a privileged container is started and the scripts are executed.
 
 ADD install-centos-build-deps install-centos-build-deps

--- a/docker-build-images/ubuntu-trusty-build.Dockerfile-ppc64le
+++ b/docker-build-images/ubuntu-trusty-build.Dockerfile-ppc64le
@@ -1,0 +1,8 @@
+FROM ppc64le/ubuntu:trusty
+MAINTAINER Shaun Crampton <shaun@tigera.io>
+ENV STREAM trusty
+
+ADD install-ubuntu-build-deps install-ubuntu-build-deps
+RUN ./install-ubuntu-build-deps
+
+WORKDIR /code

--- a/docker-build-images/ubuntu-xenial-build.Dockerfile-ppc64le
+++ b/docker-build-images/ubuntu-xenial-build.Dockerfile-ppc64le
@@ -1,0 +1,8 @@
+FROM ppc64le/ubuntu:xenial
+MAINTAINER Shaun Crampton <shaun@tigera.io>
+ENV STREAM xenial
+
+ADD install-ubuntu-build-deps install-ubuntu-build-deps
+RUN ./install-ubuntu-build-deps
+
+WORKDIR /code

--- a/docker-image/Dockerfile-ppc64le
+++ b/docker-image/Dockerfile-ppc64le
@@ -1,0 +1,21 @@
+FROM ppc64le/alpine:3.6
+MAINTAINER Shaun Crampton <shaun@tigera.io>
+
+# Since our binary isn't designed to run as PID 1, run it via the tini init daemon.
+RUN apk --no-cache add --update tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
+# Install Felix's dependencies.
+RUN apk --no-cache add ip6tables ipset iputils iproute2 conntrack-tools 
+
+ADD felix.cfg /etc/calico/felix.cfg
+
+# Put out binary in /code rather than directly in /usr/bin.  This allows the downstream builds
+# to more easily extract the Felix build artefacts from the container.
+RUN mkdir /code
+ADD bin/calico-felix /code
+WORKDIR /code
+RUN ln -s /code/calico-felix /usr/bin
+
+# Run felix by default
+CMD ["calico-felix"]

--- a/rpm/build-rpms
+++ b/rpm/build-rpms
@@ -51,7 +51,7 @@ tar -czf /tmp/rpmbuild/SOURCES/${dir}.tar.gz $dir
 
 # Build, and fix centos7 putting always '.centos7' in the rpm-name
 cd rpmbuild
-rpmbuild --define '_topdir '`pwd` --define "dist .${EL_VERSION}" -ba SPECS/${spec}
+rpmbuild --target=$(uname -m) --define '_topdir '`pwd` --define "dist .${EL_VERSION}" -ba SPECS/${spec}
 
 case "$EL_VERSION" in
   "el7")

--- a/rpm/felix.spec
+++ b/rpm/felix.spec
@@ -10,7 +10,6 @@ Source0:        felix-%{version}.tar.gz
 Source1:        calico-felix.logrotate
 Source35:       calico-felix.init
 Source45:       calico-felix.service
-BuildArch:      x86_64
 
 
 %define _unpackaged_files_terminate_build 0

--- a/utils/make-packages.sh
+++ b/utils/make-packages.sh
@@ -148,8 +148,10 @@ EOF
 	    fi
 
 		  for elversion in 7 6; do
-		    ${DOCKER_RUN_RM} -e EL_VERSION=el${elversion} \
-		      calico-build/centos${elversion} rpm/build-rpms
+			# Skip the rpm build if we are missing the matching build image.
+			imageid=$(docker images -q calico-build/centos${elversion}:latest)
+			[ -n "$imageid"  ] && ${DOCKER_RUN_RM} -e EL_VERSION=el${elversion} \
+				$imageid rpm/build-rpms
 		  done
 	    ;;
 


### PR DESCRIPTION
The build architecture is select by setting the ARCH environment variable.
For example: When building on ppc64le you could use ARCH=ppc64le make <..>.
When ARCH is undefined the build defaults to amd64.

Based on work by: Hitomi Takahashi

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
Hi -
I have made progress on a ppc64le port and have changes ready for most of the Calico repos.  Let's start with felix so we can review my strategy for non-x86 builds.  This is my approach:

1) The build architecture is select by setting the ARCH environment variable.
For example: When building on ppc64le you could use ARCH=ppc64le make <....>.
When ARCH is undefined builds defaults to amd64.

2) Dockefile names are appended with -$ARCH, for x86 file-names are unchanged.  For example on ppc64le I use Dockerfile-ppc64le.

3) Generated container image names are appended with -$ARCH, for x86 image names are unchanged.  Example calico/felix-ppc64le.

Testing:  
On ppc64le I have verified make targets: clean, all and ut.
fv: is currently failing on ppc64le, I will address that shortly in another pull request.