### PR TITLE
Do not depend on the returned text string of iptables -w.

### DIFF
--- a/fv/iptables_lock_test.go
+++ b/fv/iptables_lock_test.go
@@ -115,7 +115,7 @@ var _ = Describe("with running container", func() {
 		It("iptables should succeed in getting the lock after 3s", func() {
 			iptCmd := cmdInContainer("iptables", "-w", "3", "-A", "FORWARD")
 			out, err := iptCmd.CombinedOutput()
-			Expect(string(out)).To(ContainSubstring("Another app is currently holding the xtables lock"))
+			log.Printf("iptables output='%s'", out)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/fv/iptables_lock_test.go
+++ b/fv/iptables_lock_test.go
@@ -115,7 +115,7 @@ var _ = Describe("with running container", func() {
 		It("iptables should succeed in getting the lock after 3s", func() {
 			iptCmd := cmdInContainer("iptables", "-w", "3", "-A", "FORWARD")
 			out, err := iptCmd.CombinedOutput()
-			log.Printf("iptables output='%s'", out)
+			log.Infof("iptables output='%s'", out)
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
The iptables_lock_test is looking for a specific text string to be
returned by iptables. Unfortunately the output string varies depending
on version. Checking the returned status is sufficient for this test.
This problem was seen on a ppc64le. I verified the change with "make
fv" on both x86 and ppc64le.

Signed-off-by: David Wilder <wilder@us.ibm.com>
