### PR TITLE
Add a grace period before deleting routes

### DIFF
--- a/routetable/testing_shims.go
+++ b/routetable/testing_shims.go
@@ -17,10 +17,9 @@ package routetable
 import (
 	"net"
 	"os/exec"
+	"time"
 
 	. "github.com/vishvananda/netlink"
-
-	"time"
 
 	"github.com/projectcalico/felix/conntrack"
 	"github.com/projectcalico/felix/ip"
@@ -73,7 +72,7 @@ func (r realDataplane) RemoveConntrackFlows(ipVersion uint8, ipAddr net.IP) {
 
 var _ dataplaneIface = realDataplane{}
 
-// timeIface is our shim interface the time package.
+// timeIface is our shim interface to the time package.
 type timeIface interface {
 	Now() time.Time
 	Since(t time.Time) time.Duration

--- a/routetable/testing_shims.go
+++ b/routetable/testing_shims.go
@@ -20,6 +20,8 @@ import (
 
 	. "github.com/vishvananda/netlink"
 
+	"time"
+
 	"github.com/projectcalico/felix/conntrack"
 	"github.com/projectcalico/felix/ip"
 )
@@ -70,3 +72,22 @@ func (r realDataplane) RemoveConntrackFlows(ipVersion uint8, ipAddr net.IP) {
 }
 
 var _ dataplaneIface = realDataplane{}
+
+// timeIface is our shim interface the time package.
+type timeIface interface {
+	Now() time.Time
+	Since(t time.Time) time.Duration
+}
+
+// realTime is the real implementation of timeIface, which calls through to the real time package.
+type realTime struct{}
+
+func (_ realTime) Now() time.Time {
+	return time.Now()
+}
+
+func (_ realTime) Since(t time.Time) time.Duration {
+	return time.Since(t)
+}
+
+var _ timeIface = realTime{}


### PR DESCRIPTION
## Description
Fixed up version of #1487.

The CNI plugin pre-adds the routes for containers that it networks. This can lead to flapping the route when Felix spots the interface before it hears about the endpoint. Add a grace period before cleaning up the route to avoid this.

## Release Note
```
Improve pod network startup time by not flapping routes when the CNI plugin creates a veth before Felix learns about it
```