### PR TITLE
Update to libcalico v1.6.0 and typha v0.4.0.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,11 @@
-hash: 55b1bb6ca3ac60a923e1997963a2e8735895191745dcf8e55d3f2246c7d49a94
-updated: 2017-08-07T10:04:37.816424735-07:00
+hash: 3070e4b7ed9bcdcd2fe9a0840c87db05de1f4a45e22fc8ebfffa26696b6db594
+updated: 2017-08-15T17:55:46.307177891-07:00
 imports:
+- name: cloud.google.com/go
+  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
+  subpackages:
+  - compute/metadata
+  - internal
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
@@ -19,6 +24,14 @@ imports:
   - pkg/tlsutil
   - pkg/transport
   - pkg/types
+- name: github.com/coreos/go-oidc
+  version: be73733bb8cc830d0205609b95d125215f8e9c70
+  subpackages:
+  - http
+  - jose
+  - key
+  - oauth2
+  - oidc
 - name: github.com/coreos/go-systemd
   version: 2688e91251d9d8e404e86dd8f096e23b2f086958
   subpackages:
@@ -32,7 +45,7 @@ imports:
   - httputil
   - timeutil
 - name: github.com/davecgh/go-spew
-  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/docker/distribution
@@ -52,7 +65,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-ini/ini
-  version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
+  version: 20b96f641a5ea98f2f8619ff4f3e061cff4833bd
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -69,7 +82,7 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 748d386b5c1ea99658fd69fe9f03991ce86a90c1
+  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
   subpackages:
   - proto
 - name: github.com/google/gofuzz
@@ -78,6 +91,8 @@ imports:
   version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
+- name: github.com/jonboulle/clockwork
+  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kardianos/osext
@@ -140,7 +155,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: d57562ced98d850282636bb5da16c840ea74b7df
+  version: 25a8c377d7b3299a50197a92704d606f5f5ca691
   subpackages:
   - lib
   - lib/api
@@ -150,8 +165,8 @@ imports:
   - lib/backend/compat
   - lib/backend/etcd
   - lib/backend/k8s
+  - lib/backend/k8s/custom
   - lib/backend/k8s/resources
-  - lib/backend/k8s/thirdparty
   - lib/backend/model
   - lib/client
   - lib/converter
@@ -171,7 +186,7 @@ imports:
   - lib/testutils
   - lib/validator
 - name: github.com/projectcalico/typha
-  version: 5e3fcf3a305f8e24a27aa663323eddf54b0a515a
+  version: da7479a93f30a6dd3fcfd683e409af4dbf381ea0
   subpackages:
   - pkg/syncclient
   - pkg/syncproto
@@ -186,13 +201,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 61f87aac8082fa8c3c5655c7608d7478d46ac2ad
+  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  version: a1dba9ce8baed984a2495b658c82687f8157b98f
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell
@@ -210,11 +225,11 @@ imports:
   subpackages:
   - codec
 - name: github.com/vishvananda/netlink
-  version: 70cf3c74a89e4ca3847f109e77490a40e5639965
+  version: f5a6f697a596c788d474984a38a0ac4ba0719e93
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: 86bef332bfc3b59b7624a600bd53009ce91a9829
+  version: 8ba1072b58e0c2a240eb5f6120165c7776c3e7b8
 - name: golang.org/x/crypto
   version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:
@@ -223,6 +238,7 @@ imports:
   version: 3da985ce5951d99de868be4385f21ea6c2b22f24
   subpackages:
   - context
+  - context/ctxhttp
   - html
   - html/atom
   - html/charset
@@ -230,8 +246,15 @@ imports:
   - http2/hpack
   - idna
   - lex/httplex
+- name: golang.org/x/oauth2
+  version: 3c3a985cb79f52a3190fbc056984415ca6763d01
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
 - name: golang.org/x/sys
-  version: d8f5ea21b9295e315e612b4bcf4bedea93454d4d
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -259,8 +282,20 @@ imports:
   - unicode/bidi
   - unicode/norm
   - width
+- name: google.golang.org/appengine
+  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
+  subpackages:
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
 - name: gopkg.in/go-playground/validator.v8
-  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
+  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tchap/go-patricia.v2
@@ -380,8 +415,12 @@ imports:
   - pkg/util
   - pkg/util/parsers
   - pkg/version
+  - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
   - rest
   - rest/watch
+  - third_party/forked/golang/template
   - tools/auth
   - tools/cache
   - tools/clientcmd
@@ -395,4 +434,5 @@ imports:
   - util/flowcontrol
   - util/homedir
   - util/integer
+  - util/jsonpath
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,7 +26,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: v1.5.2
+  version: v1.6.0
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus
@@ -44,7 +44,7 @@ import:
 - package: k8s.io/client-go
   version: 4a3ab2f5be5177366f8206fd79ce55ca80e417fa
 - package: github.com/projectcalico/typha
-  version: 5e3fcf3a305f8e24a27aa663323eddf54b0a515a
+  version: v0.4.0
   subpackages:
   - pkg/syncclient
 - package: github.com/emicklei/go-restful

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -10,7 +10,7 @@
 : ${FELIX_VERSION:=latest}
 #
 # What version of the k8s API server to use.
-: ${K8S_VERSION:=1.6.4}
+: ${K8S_VERSION:=1.7.3}
 #
 # A string to insert into the container names that we use; a calling
 # script can set this to something to make the container names unique,
@@ -58,6 +58,9 @@
 #
 # Typha logging level.
 : ${TYPHA_LOG_LEVEL:=info}
+#
+# CRD Manifest to use
+: ${CRD_URL:=https://raw.githubusercontent.com/projectcalico/libcalico-go/master/test/crds.yaml}
 
 # Generate a unique prefix for the names of the containers that we
 # will create.
@@ -126,9 +129,8 @@ while ! docker exec ${prefix}-apiserver kubectl create clusterrolebinding anonym
     sleep 2
 done
 
-# Wait until the newly launched API server can respond to a request,
-# before continuing.
-while ! curl -k ${k8s_api_endpoint}/apis/extensions/v1beta1/thirdpartyresources; do
+# Apply CRD manifest to pre-create resource definitions
+while ! docker exec ${prefix}-apiserver kubectl apply -f ${CRD_URL}; do
     sleep 2
 done
 


### PR DESCRIPTION
## Description
Update to libcalico v1.6.0 and typha v0.4.0.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
