### PR TITLE
Updated default IpInIpMtu to 1430.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -136,7 +136,7 @@ type Config struct {
 	LogSeveritySys    string `config:"oneof(DEBUG,INFO,WARNING,ERROR,CRITICAL);INFO"`
 
 	IpInIpEnabled    bool   `config:"bool;false"`
-	IpInIpMtu        int    `config:"int;1440;non-zero"`
+	IpInIpMtu        int    `config:"int;1430;non-zero"`
 	IpInIpTunnelAddr net.IP `config:"ipv4;"`
 
 	ReportingIntervalSecs time.Duration `config:"seconds;30"`


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
documentation & bug fix

- some details on _why_ this PR should be merged
Based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_openstack_platform/7/html/networking_guide/sec-mtu, in Openstack with vxlan environment, the default MTU is 1450 which is even less than GCE 1460, so the default MTU for the IP-in-IP should be update to 1430.

The proposal is adding a new line for OpenStack VXLAN and set the default MTU for Ip-in-Ip as 1430.

- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [X] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Updated default IpInIpMtu to 1430.
```

Fixed https://github.com/projectcalico/felix/issues/1532
