### PR TITLE
Cherry pick Typha client timeouts to 2.5.x-series.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -102,9 +102,11 @@ type Config struct {
 	EtcdCaFile    string   `config:"file(must-exist);;local"`
 	EtcdEndpoints []string `config:"endpoint-list;;local"`
 
-	TyphaAddr           string `config:"authority;;"`
-	TyphaK8sServiceName string `config:"string;"`
-	TyphaK8sNamespace   string `config:"string;kube-system;non-zero"`
+	TyphaAddr           string        `config:"authority;;"`
+	TyphaK8sServiceName string        `config:"string;"`
+	TyphaK8sNamespace   string        `config:"string;kube-system;non-zero"`
+	TyphaReadTimeout    time.Duration `config:"seconds;30"`
+	TyphaWriteTimeout   time.Duration `config:"seconds;10"`
 
 	Ipv6Support    bool `config:"bool;true"`
 	IgnoreLooseRPF bool `config:"bool;false"`

--- a/felix.go
+++ b/felix.go
@@ -346,6 +346,10 @@ configRetry:
 			fmt.Sprintf("Revision: %s; Build date: %s",
 				buildinfo.GitRevision, buildinfo.BuildDate),
 			syncerToValidator,
+			&syncclient.Options{
+				ReadTimeout:  configParams.TyphaReadTimeout,
+				WriteTimeout: configParams.TyphaWriteTimeout,
+			},
 		)
 	} else {
 		// Use the syncer locally.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3070e4b7ed9bcdcd2fe9a0840c87db05de1f4a45e22fc8ebfffa26696b6db594
-updated: 2017-08-15T17:55:46.307177891-07:00
+hash: 24009873f64f16cea9114bf21159475d6aef004a40aa0d7da0ae8a42d796cc29
+updated: 2017-08-30T10:19:36.907767338Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -45,7 +45,7 @@ imports:
   - httputil
   - timeutil
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
   subpackages:
   - spew
 - name: github.com/docker/distribution
@@ -82,7 +82,7 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
+  version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
   subpackages:
   - proto
 - name: github.com/google/gofuzz
@@ -186,7 +186,7 @@ imports:
   - lib/testutils
   - lib/validator
 - name: github.com/projectcalico/typha
-  version: da7479a93f30a6dd3fcfd683e409af4dbf381ea0
+  version: 71413e6c4e8f903f899429329cf3e38e17633ba5
   subpackages:
   - pkg/syncclient
   - pkg/syncproto
@@ -201,13 +201,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  version: 61f87aac8082fa8c3c5655c7608d7478d46ac2ad
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell
@@ -229,7 +229,7 @@ imports:
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: 8ba1072b58e0c2a240eb5f6120165c7776c3e7b8
+  version: 86bef332bfc3b59b7624a600bd53009ce91a9829
 - name: golang.org/x/crypto
   version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:
@@ -254,7 +254,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: ab9e364efd8b52800ff7ee48a9ffba4e0ed78dfb
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -295,7 +295,7 @@ imports:
   - internal/urlfetch
   - urlfetch
 - name: gopkg.in/go-playground/validator.v8
-  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
+  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tchap/go-patricia.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,7 +44,7 @@ import:
 - package: k8s.io/client-go
   version: 4a3ab2f5be5177366f8206fd79ce55ca80e417fa
 - package: github.com/projectcalico/typha
-  version: v0.4.0
+  version: 0.4.1
   subpackages:
   - pkg/syncclient
 - package: github.com/emicklei/go-restful


### PR DESCRIPTION
## Description
Backport of #1538 for 2.5.x-series.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add timeout to Typha/Felix connection to spot severed TCP connections.
```
