### PR TITLE
Split calc graph FV resource definitions into their own files.

### DIFF
--- a/calc/calc_graph_fv_test.go
+++ b/calc/calc_graph_fv_test.go
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package calc_test
-
 // This file tests the mapping from datastore content - expressed as KVUpdates using model.* objects
-// - to proto.* messages.  'model' is a dot-import in this file, so non-namespaced type names that
-// look like Calico objects are probably coming from the 'model' package.
+// - to proto.* messages.
+
+package calc_test
 
 import (
 	. "github.com/projectcalico/felix/calc"
 
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -34,782 +32,9 @@ import (
 	"github.com/projectcalico/felix/dispatcher"
 	"github.com/projectcalico/felix/proto"
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
-	. "github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/health"
-	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/set"
 )
-
-// Canned hostnames.
-
-const localHostname = "localhostname"
-const remoteHostname = "remotehostname"
-
-// Canned selectors.
-
-var (
-	allSelector         = "all()"
-	allSelectorId       = selectorId(allSelector)
-	bEpBSelector        = "b == 'b'"
-	bEqBSelectorId      = selectorId(bEpBSelector)
-	tagSelector         = "has(tag-1)"
-	tagSelectorId       = selectorId(tagSelector)
-	tagFoobarSelector   = "tag-1 == 'foobar'"
-	tagFoobarSelectorId = selectorId(tagFoobarSelector)
-)
-
-// Canned workload endpoints.
-
-var localWlEpKey1 = WorkloadEndpointKey{localHostname, "orch", "wl1", "ep1"}
-var remoteWlEpKey1 = WorkloadEndpointKey{remoteHostname, "orch", "wl1", "ep1"}
-var localWlEp1Id = "orch/wl1/ep1"
-var localWlEpKey2 = WorkloadEndpointKey{localHostname, "orch", "wl2", "ep2"}
-var localWlEp2Id = "orch/wl2/ep2"
-
-var localWlEp1 = WorkloadEndpoint{
-	State:      "active",
-	Name:       "cali1",
-	Mac:        mustParseMac("01:02:03:04:05:06"),
-	ProfileIDs: []string{"prof-1", "prof-2", "prof-missing"},
-	IPv4Nets: []net.IPNet{mustParseNet("10.0.0.1/32"),
-		mustParseNet("10.0.0.2/32")},
-	IPv6Nets: []net.IPNet{mustParseNet("fc00:fe11::1/128"),
-		mustParseNet("fc00:fe11::2/128")},
-	Labels: map[string]string{
-		"id": "loc-ep-1",
-		"a":  "a",
-		"b":  "b",
-	},
-}
-
-var localWlEp1NoProfiles = WorkloadEndpoint{
-	State: "active",
-	Name:  "cali1",
-	Mac:   mustParseMac("01:02:03:04:05:06"),
-	IPv4Nets: []net.IPNet{mustParseNet("10.0.0.1/32"),
-		mustParseNet("10.0.0.2/32")},
-	IPv6Nets: []net.IPNet{mustParseNet("fc00:fe11::1/128"),
-		mustParseNet("fc00:fe11::2/128")},
-}
-
-var localWlEp1DifferentIPs = WorkloadEndpoint{
-	State:      "active",
-	Name:       "cali1",
-	Mac:        mustParseMac("01:02:03:04:05:06"),
-	ProfileIDs: []string{"prof-1", "prof-2", "prof-missing"},
-	IPv4Nets: []net.IPNet{mustParseNet("11.0.0.1/32"),
-		mustParseNet("11.0.0.2/32")},
-	IPv6Nets: []net.IPNet{mustParseNet("fc00:fe12::1/128"),
-		mustParseNet("fc00:fe12::2/128")},
-	Labels: map[string]string{
-		"id": "loc-ep-1",
-		"a":  "a",
-		"b":  "b",
-	},
-}
-
-var ep1IPs = []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // shared with ep2
-	"fc00:fe11::2",
-}
-
-var localWlEp2 = WorkloadEndpoint{
-	State:      "active",
-	Name:       "cali2",
-	ProfileIDs: []string{"prof-2", "prof-3"},
-	IPv4Nets: []net.IPNet{mustParseNet("10.0.0.2/32"),
-		mustParseNet("10.0.0.3/32")},
-	IPv6Nets: []net.IPNet{mustParseNet("fc00:fe11::2/128"),
-		mustParseNet("fc00:fe11::3/128")},
-	Labels: map[string]string{
-		"id": "loc-ep-2",
-		"a":  "a",
-		"b":  "b2",
-	},
-}
-
-var localWlEp2NoProfiles = WorkloadEndpoint{
-	State: "active",
-	Name:  "cali2",
-	IPv4Nets: []net.IPNet{mustParseNet("10.0.0.2/32"),
-		mustParseNet("10.0.0.3/32")},
-	IPv6Nets: []net.IPNet{mustParseNet("fc00:fe11::2/128"),
-		mustParseNet("fc00:fe11::3/128")},
-}
-
-var hostEpWithName = HostEndpoint{
-	Name:       "eth1",
-	ProfileIDs: []string{"prof-1", "prof-2", "prof-missing"},
-	ExpectedIPv4Addrs: []net.IP{mustParseIP("10.0.0.1"),
-		mustParseIP("10.0.0.2")},
-	ExpectedIPv6Addrs: []net.IP{mustParseIP("fc00:fe11::1"),
-		mustParseIP("fc00:fe11::2")},
-	Labels: map[string]string{
-		"id": "loc-ep-1",
-		"a":  "a",
-		"b":  "b",
-	},
-}
-
-var hostEpWithNameKey = HostEndpointKey{
-	Hostname:   localHostname,
-	EndpointID: "named",
-}
-var hostEpWithNameId = "named"
-
-var hostEp2NoName = HostEndpoint{
-	ProfileIDs: []string{"prof-2", "prof-3"},
-	ExpectedIPv4Addrs: []net.IP{mustParseIP("10.0.0.2"),
-		mustParseIP("10.0.0.3")},
-	ExpectedIPv6Addrs: []net.IP{mustParseIP("fc00:fe11::2"),
-		mustParseIP("fc00:fe11::3")},
-	Labels: map[string]string{
-		"id": "loc-ep-2",
-		"a":  "a",
-		"b":  "b2",
-	},
-}
-
-var hostEp2NoNameKey = HostEndpointKey{
-	Hostname:   localHostname,
-	EndpointID: "unnamed",
-}
-var hostEpNoNameId = "unnamed"
-
-// Canned tiers/policies.
-
-var order10 = float64(10)
-var order20 = float64(20)
-var order30 = float64(30)
-
-var policy1_order20 = Policy{
-	Order:    &order20,
-	Selector: "a == 'a'",
-	InboundRules: []Rule{
-		{SrcSelector: allSelector},
-	},
-	OutboundRules: []Rule{
-		{SrcSelector: bEpBSelector},
-	},
-	Types: []string{"ingress", "egress"},
-}
-
-var policy1_order20_ingress_only = Policy{
-	Order:    &order20,
-	Selector: "a == 'a'",
-	InboundRules: []Rule{
-		{SrcSelector: allSelector},
-	},
-	Types: []string{"ingress"},
-}
-
-var policy1_order20_egress_only = Policy{
-	Order:    &order20,
-	Selector: "a == 'a'",
-	OutboundRules: []Rule{
-		{SrcSelector: bEpBSelector},
-	},
-	Types: []string{"egress"},
-}
-
-var policy1_order20_untracked = Policy{
-	Order:    &order20,
-	Selector: "a == 'a'",
-	InboundRules: []Rule{
-		{SrcSelector: allSelector},
-	},
-	OutboundRules: []Rule{
-		{SrcSelector: bEpBSelector},
-	},
-	DoNotTrack: true,
-}
-
-var policy1_order20_pre_dnat = Policy{
-	Order:    &order20,
-	Selector: "a == 'a'",
-	InboundRules: []Rule{
-		{SrcSelector: allSelector},
-	},
-	PreDNAT: true,
-}
-
-var profileRules1 = ProfileRules{
-	InboundRules: []Rule{
-		{SrcSelector: allSelector},
-	},
-	OutboundRules: []Rule{
-		{SrcTag: "tag-1"},
-	},
-}
-
-var profileRulesWithTagInherit = ProfileRules{
-	InboundRules: []Rule{
-		{SrcSelector: tagSelector},
-	},
-	OutboundRules: []Rule{
-		{SrcSelector: tagFoobarSelector},
-	},
-}
-
-var profileRules1TagUpdate = ProfileRules{
-	InboundRules: []Rule{
-		{SrcSelector: bEpBSelector},
-	},
-	OutboundRules: []Rule{
-		{SrcTag: "tag-2"},
-	},
-}
-
-var profileRules1NegatedTagSelUpdate = ProfileRules{
-	InboundRules: []Rule{
-		{NotSrcSelector: bEpBSelector},
-	},
-	OutboundRules: []Rule{
-		{NotSrcTag: "tag-2"},
-	},
-}
-
-var profileTags1 = []string{"tag-1"}
-var profileLabels1 = map[string]string{
-	"profile": "prof-1",
-}
-var profileLabelsTag1 = map[string]string{
-	"tag-1": "foobar",
-}
-
-var tag1LabelID = ipSetIDForTag("tag-1")
-var tag2LabelID = ipSetIDForTag("tag-2")
-
-// Pre-defined datastore states.  Each State object wraps up the complete state
-// of the datastore as well as the expected state of the dataplane.  The state
-// of the dataplane *should* depend only on the current datastore state, not on
-// the path taken to get there.  Therefore, it's always a valid test to move
-// from any state to any other state (by feeding in the corresponding
-// datastore updates) and then assert that the dataplane matches the resulting
-// state.
-
-// empty is the base state, with nothing in the datastore or dataplane.
-var empty = NewState().withName("<empty>")
-
-// initialisedStore builds on empty, adding in the ready flag and global config.
-var initialisedStore = empty.withKVUpdates(
-	KVPair{Key: GlobalConfigKey{Name: "InterfacePrefix"}, Value: "cali"},
-	KVPair{Key: ReadyFlagKey{}, Value: true},
-).withName("<initialised>")
-
-// withPolicy adds a tier and policy containing selectors for all and b=="b"
-var withPolicy = initialisedStore.withKVUpdates(
-	KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policy1_order20},
-).withName("with policy")
-
-// withPolicyIngressOnly adds a tier and ingress policy containing selectors for all
-var withPolicyIngressOnly = initialisedStore.withKVUpdates(
-	KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policy1_order20_ingress_only},
-).withName("with ingress-only policy")
-
-// withPolicyEgressOnly adds a tier and egress policy containing selectors for b=="b"
-var withPolicyEgressOnly = initialisedStore.withKVUpdates(
-	KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policy1_order20_egress_only},
-).withName("with egress-only policy")
-
-// withUntrackedPolicy adds a tier and policy containing selectors for all and b=="b"
-var withUntrackedPolicy = initialisedStore.withKVUpdates(
-	KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policy1_order20_untracked},
-).withName("with untracked policy")
-
-// withPreDNATPolicy adds a tier and policy containing selectors for all and a=="a"
-var withPreDNATPolicy = initialisedStore.withKVUpdates(
-	KVPair{Key: PolicyKey{Name: "pre-dnat-pol-1"}, Value: &policy1_order20_pre_dnat},
-).withName("with pre-DNAT policy")
-
-// localEp1WithPolicy adds a local endpoint to the mix.  It matches all and b=="b".
-var localEp1WithPolicy = withPolicy.withKVUpdates(
-	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
-).withIPSet(allSelectorId, []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-}).withIPSet(bEqBSelectorId, []string{
-	"10.0.0.1",
-	"fc00:fe11::1",
-	"10.0.0.2",
-	"fc00:fe11::2",
-}).withActivePolicies(
-	proto.PolicyID{"default", "pol-1"},
-).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-missing"},
-).withEndpoint(
-	localWlEp1Id,
-	[]tierInfo{
-		{"default", []string{"pol-1"}, []string{"pol-1"}},
-	},
-).withName("ep1 local, policy")
-
-// localEp1WithIngressPolicy is as above except ingress policy only.
-var localEp1WithIngressPolicy = withPolicyIngressOnly.withKVUpdates(
-	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
-).withIPSet(allSelectorId, []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-}).withActivePolicies(
-	proto.PolicyID{"default", "pol-1"},
-).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-missing"},
-).withEndpoint(
-	localWlEp1Id,
-	[]tierInfo{
-		{"default", []string{"pol-1"}, nil},
-	},
-).withName("ep1 local, ingress-only policy")
-
-var hostEp1WithPolicy = withPolicy.withKVUpdates(
-	KVPair{Key: hostEpWithNameKey, Value: &hostEpWithName},
-).withIPSet(allSelectorId, []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-}).withIPSet(bEqBSelectorId, []string{
-	"10.0.0.1",
-	"fc00:fe11::1",
-	"10.0.0.2",
-	"fc00:fe11::2",
-}).withActivePolicies(
-	proto.PolicyID{"default", "pol-1"},
-).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-missing"},
-).withEndpoint(
-	hostEpWithNameId,
-	[]tierInfo{
-		{"default", []string{"pol-1"}, []string{"pol-1"}},
-	},
-).withName("host ep1, policy")
-
-var hostEp1WithIngressPolicy = withPolicyIngressOnly.withKVUpdates(
-	KVPair{Key: hostEpWithNameKey, Value: &hostEpWithName},
-).withIPSet(allSelectorId, []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-}).withActivePolicies(
-	proto.PolicyID{"default", "pol-1"},
-).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-missing"},
-).withEndpoint(
-	hostEpWithNameId,
-	[]tierInfo{
-		{"default", []string{"pol-1"}, nil},
-	},
-).withName("host ep1, ingress-only policy")
-
-var hostEp1WithEgressPolicy = withPolicyEgressOnly.withKVUpdates(
-	KVPair{Key: hostEpWithNameKey, Value: &hostEpWithName},
-).withIPSet(bEqBSelectorId, []string{
-	"10.0.0.1",
-	"fc00:fe11::1",
-	"10.0.0.2",
-	"fc00:fe11::2",
-}).withActivePolicies(
-	proto.PolicyID{"default", "pol-1"},
-).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-missing"},
-).withEndpoint(
-	hostEpWithNameId,
-	[]tierInfo{
-		{"default", nil, []string{"pol-1"}},
-	},
-).withName("host ep1, egress-only policy")
-
-var hostEp1WithUntrackedPolicy = withUntrackedPolicy.withKVUpdates(
-	KVPair{Key: hostEpWithNameKey, Value: &hostEpWithName},
-).withIPSet(allSelectorId, []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-}).withIPSet(bEqBSelectorId, []string{
-	"10.0.0.1",
-	"fc00:fe11::1",
-	"10.0.0.2",
-	"fc00:fe11::2",
-}).withActivePolicies(
-	proto.PolicyID{"default", "pol-1"},
-).withUntrackedPolicies(
-	proto.PolicyID{"default", "pol-1"},
-).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-missing"},
-).withEndpointUntracked(
-	hostEpWithNameId,
-	[]tierInfo{},
-	[]tierInfo{
-		{"default", []string{"pol-1"}, []string{"pol-1"}},
-	},
-	[]tierInfo{},
-).withName("host ep1, untracked policy")
-
-var hostEp1WithPreDNATPolicy = withPreDNATPolicy.withKVUpdates(
-	KVPair{Key: hostEpWithNameKey, Value: &hostEpWithName},
-).withIPSet(allSelectorId, []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-}).withActivePolicies(
-	proto.PolicyID{"default", "pre-dnat-pol-1"},
-).withPreDNATPolicies(
-	proto.PolicyID{"default", "pre-dnat-pol-1"},
-).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-missing"},
-).withEndpointUntracked(
-	hostEpWithNameId,
-	[]tierInfo{},
-	[]tierInfo{},
-	[]tierInfo{
-		{"default", []string{"pre-dnat-pol-1"}, nil},
-	},
-).withName("host ep1, pre-DNAT policy")
-
-var hostEp1WithTrackedAndUntrackedPolicy = hostEp1WithUntrackedPolicy.withKVUpdates(
-	KVPair{Key: PolicyKey{Name: "pol-2"}, Value: &policy1_order20},
-).withActivePolicies(
-	proto.PolicyID{"default", "pol-1"},
-	proto.PolicyID{"default", "pol-2"},
-).withEndpointUntracked(
-	hostEpWithNameId,
-	[]tierInfo{
-		{"default", []string{"pol-2"}, []string{"pol-2"}},
-	},
-	[]tierInfo{
-		{"default", []string{"pol-1"}, []string{"pol-1"}},
-	},
-	[]tierInfo{},
-).withName("host ep1, tracked+untracked policy")
-
-var hostEp2WithPolicy = withPolicy.withKVUpdates(
-	KVPair{Key: hostEp2NoNameKey, Value: &hostEp2NoName},
-).withIPSet(allSelectorId, []string{
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-	"10.0.0.3", // ep2
-	"fc00:fe11::3",
-}).withIPSet(bEqBSelectorId, []string{}).withActivePolicies(
-	proto.PolicyID{"default", "pol-1"},
-).withActiveProfiles(
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-3"},
-).withEndpoint(
-	hostEpNoNameId,
-	[]tierInfo{
-		{"default", []string{"pol-1"}, []string{"pol-1"}},
-	},
-).withName("host ep2, policy")
-
-// Policy ordering tests.  We keep the names of the policies the same but we
-// change their orders to check that order trumps name.
-var localEp1WithOneTierPolicy123 = policyOrderState(
-	[3]float64{order10, order20, order30},
-	[3]string{"pol-1", "pol-2", "pol-3"},
-)
-var localEp1WithOneTierPolicy321 = policyOrderState(
-	[3]float64{order30, order20, order10},
-	[3]string{"pol-3", "pol-2", "pol-1"},
-)
-var localEp1WithOneTierPolicyAlpha = policyOrderState(
-	[3]float64{order10, order10, order10},
-	[3]string{"pol-1", "pol-2", "pol-3"},
-)
-
-func policyOrderState(policyOrders [3]float64, expectedOrder [3]string) State {
-	policies := [3]Policy{}
-	for i := range policies {
-		policies[i] = Policy{
-			Order:         &policyOrders[i],
-			Selector:      "a == 'a'",
-			InboundRules:  []Rule{{SrcSelector: allSelector}},
-			OutboundRules: []Rule{{SrcSelector: bEpBSelector}},
-		}
-	}
-	state := initialisedStore.withKVUpdates(
-		KVPair{Key: localWlEpKey1, Value: &localWlEp1},
-		KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policies[0]},
-		KVPair{Key: PolicyKey{Name: "pol-2"}, Value: &policies[1]},
-		KVPair{Key: PolicyKey{Name: "pol-3"}, Value: &policies[2]},
-	).withIPSet(allSelectorId, []string{
-		"10.0.0.1", // ep1
-		"fc00:fe11::1",
-		"10.0.0.2", // ep1 and ep2
-		"fc00:fe11::2",
-	}).withIPSet(bEqBSelectorId, []string{
-		"10.0.0.1",
-		"fc00:fe11::1",
-		"10.0.0.2",
-		"fc00:fe11::2",
-	}).withActivePolicies(
-		proto.PolicyID{"default", "pol-1"},
-		proto.PolicyID{"default", "pol-2"},
-		proto.PolicyID{"default", "pol-3"},
-	).withActiveProfiles(
-		proto.ProfileID{"prof-1"},
-		proto.ProfileID{"prof-2"},
-		proto.ProfileID{"prof-missing"},
-	).withEndpoint(
-		localWlEp1Id,
-		[]tierInfo{
-			{"default", expectedOrder[:], expectedOrder[:]},
-		},
-	).withName(fmt.Sprintf("ep1 local, 1 tier, policies %v", expectedOrder[:]))
-	return state
-}
-
-// localEp2WithPolicy adds a different endpoint that doesn't match b=="b".
-// This tests an empty IP set.
-var localEp2WithPolicy = withPolicy.withKVUpdates(
-	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
-).withIPSet(allSelectorId, []string{
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-	"10.0.0.3", // ep2
-	"fc00:fe11::3",
-}).withIPSet(
-	bEqBSelectorId, []string{},
-).withActivePolicies(
-	proto.PolicyID{"default", "pol-1"},
-).withActiveProfiles(
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-3"},
-).withEndpoint(
-	localWlEp2Id,
-	[]tierInfo{
-		{"default", []string{"pol-1"}, []string{"pol-1"}},
-	},
-).withName("ep2 local, policy")
-
-// localEpsWithPolicy contains both of the above endpoints, which have some
-// overlapping IPs.  When we sequence this with the states above, we test
-// overlapping IP addition and removal.
-var localEpsWithPolicy = withPolicy.withKVUpdates(
-	// Two local endpoints with overlapping IPs.
-	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
-	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
-).withIPSet(allSelectorId, []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-	"10.0.0.3", // ep2
-	"fc00:fe11::3",
-}).withIPSet(bEqBSelectorId, []string{
-	"10.0.0.1",
-	"fc00:fe11::1",
-	"10.0.0.2",
-	"fc00:fe11::2",
-}).withActivePolicies(
-	proto.PolicyID{"default", "pol-1"},
-).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-3"},
-	proto.ProfileID{"prof-missing"},
-).withEndpoint(
-	localWlEp1Id,
-	[]tierInfo{
-		{"default", []string{"pol-1"}, []string{"pol-1"}},
-	},
-).withEndpoint(
-	localWlEp2Id,
-	[]tierInfo{
-		{"default", []string{"pol-1"}, []string{"pol-1"}},
-	},
-).withName("2 local, overlapping IPs & a policy")
-
-// localEpsWithPolicyUpdatedIPs, when used with localEpsWithPolicy checks
-// correct handling of IP address updates.  We add and remove some IPs from
-// endpoint 1 and check that only its non-shared IPs are removed from the IP
-// sets.
-var localEpsWithPolicyUpdatedIPs = localEpsWithPolicy.withKVUpdates(
-	KVPair{Key: localWlEpKey1, Value: &localWlEp1DifferentIPs},
-	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
-).withIPSet(allSelectorId, []string{
-	"11.0.0.1", // ep1
-	"fc00:fe12::1",
-	"11.0.0.2",
-	"fc00:fe12::2",
-	"10.0.0.2", // now ep2 only
-	"fc00:fe11::2",
-	"10.0.0.3", // ep2
-	"fc00:fe11::3",
-}).withIPSet(bEqBSelectorId, []string{
-	"11.0.0.1", // ep1
-	"fc00:fe12::1",
-	"11.0.0.2",
-	"fc00:fe12::2",
-})
-
-// withProfile adds a profile to the initialised state.
-var withProfile = initialisedStore.withKVUpdates(
-	KVPair{Key: ProfileRulesKey{ProfileKey{"prof-1"}}, Value: &profileRules1},
-	KVPair{Key: ProfileTagsKey{ProfileKey{"prof-1"}}, Value: profileTags1},
-	KVPair{Key: ProfileLabelsKey{ProfileKey{"prof-1"}}, Value: profileLabels1},
-).withName("profile")
-
-// localEpsWithProfile contains a pair of overlapping IP endpoints and a profile
-// that matches them both.
-var localEpsWithProfile = withProfile.withKVUpdates(
-	// Two local endpoints with overlapping IPs.
-	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
-	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
-).withIPSet(allSelectorId, []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-	"10.0.0.3", // ep2
-	"fc00:fe11::3",
-}).withIPSet(tag1LabelID, []string{
-	"10.0.0.1",
-	"fc00:fe11::1",
-	"10.0.0.2",
-	"fc00:fe11::2",
-}).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-3"},
-	proto.ProfileID{"prof-missing"},
-).withEndpoint(
-	localWlEp1Id,
-	[]tierInfo{},
-).withEndpoint(
-	localWlEp2Id,
-	[]tierInfo{},
-).withName("2 local, overlapping IPs & a profile")
-
-// localEpsWithNonMatchingProfile contains a pair of overlapping IP endpoints and a profile
-// that matches them both.
-var localEpsWithNonMatchingProfile = withProfile.withKVUpdates(
-	// Two local endpoints with overlapping IPs.
-	KVPair{Key: localWlEpKey1, Value: &localWlEp1NoProfiles},
-	KVPair{Key: localWlEpKey2, Value: &localWlEp2NoProfiles},
-).withEndpoint(
-	localWlEp1Id,
-	[]tierInfo{},
-).withEndpoint(
-	localWlEp2Id,
-	[]tierInfo{},
-).withName("2 local, overlapping IPs & a non-matching profile")
-
-// localEpsWithUpdatedProfile Follows on from localEpsWithProfile, changing the
-// profile to use a different tag and selector.
-var localEpsWithUpdatedProfile = localEpsWithProfile.withKVUpdates(
-	KVPair{Key: ProfileRulesKey{ProfileKey{"prof-1"}}, Value: &profileRules1TagUpdate},
-).withIPSet(
-	tag1LabelID, nil,
-).withIPSet(
-	allSelectorId, nil,
-).withIPSet(bEqBSelectorId, []string{
-	"10.0.0.1",
-	"fc00:fe11::1",
-	"10.0.0.2",
-	"fc00:fe11::2",
-}).withIPSet(
-	tag2LabelID, []string{},
-).withEndpoint(
-	localWlEp1Id,
-	[]tierInfo{},
-).withEndpoint(
-	localWlEp2Id,
-	[]tierInfo{},
-).withName("2 local, overlapping IPs & updated profile")
-
-var localEpsWithUpdatedProfileNegatedTags = localEpsWithUpdatedProfile.withKVUpdates(
-	KVPair{Key: ProfileRulesKey{ProfileKey{"prof-1"}}, Value: &profileRules1NegatedTagSelUpdate},
-)
-
-// withProfileTagInherit adds a profile that includes rules that match on
-// tags as labels.  I.e. a tag of name foo should be equivalent to label foo=""
-var withProfileTagInherit = initialisedStore.withKVUpdates(
-	KVPair{Key: ProfileRulesKey{ProfileKey{"prof-1"}}, Value: &profileRulesWithTagInherit},
-	KVPair{Key: ProfileTagsKey{ProfileKey{"prof-1"}}, Value: profileTags1},
-	KVPair{Key: ProfileLabelsKey{ProfileKey{"prof-1"}}, Value: profileLabels1},
-).withName("profile")
-
-var localEpsWithTagInheritProfile = withProfileTagInherit.withKVUpdates(
-	// Two local endpoints with overlapping IPs.
-	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
-	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
-).withIPSet(tagSelectorId, []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-}).withIPSet(tagFoobarSelectorId, []string{}).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-3"},
-	proto.ProfileID{"prof-missing"},
-).withEndpoint(
-	localWlEp1Id,
-	[]tierInfo{},
-).withEndpoint(
-	localWlEp2Id,
-	[]tierInfo{},
-).withName("2 local, overlapping IPs & a tag inherit profile")
-
-var withProfileTagOverriden = initialisedStore.withKVUpdates(
-	KVPair{Key: ProfileRulesKey{ProfileKey{"prof-1"}}, Value: &profileRulesWithTagInherit},
-	KVPair{Key: ProfileTagsKey{ProfileKey{"prof-1"}}, Value: profileTags1},
-	KVPair{Key: ProfileLabelsKey{ProfileKey{"prof-1"}}, Value: profileLabelsTag1},
-).withName("profile")
-
-// localEpsWithTagOverriddenProfile Checks that tags-inherited labels can be
-// overridden by explicit labels on the profile.
-var localEpsWithTagOverriddenProfile = withProfileTagOverriden.withKVUpdates(
-	// Two local endpoints with overlapping IPs.
-	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
-	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
-).withIPSet(tagSelectorId, []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-}).withIPSet(tagFoobarSelectorId, []string{
-	"10.0.0.1", // ep1
-	"fc00:fe11::1",
-	"10.0.0.2", // ep1 and ep2
-	"fc00:fe11::2",
-}).withActiveProfiles(
-	proto.ProfileID{"prof-1"},
-	proto.ProfileID{"prof-2"},
-	proto.ProfileID{"prof-3"},
-	proto.ProfileID{"prof-missing"},
-).withEndpoint(
-	localWlEp1Id,
-	[]tierInfo{},
-).withEndpoint(
-	localWlEp2Id,
-	[]tierInfo{},
-).withName("2 local, overlapping IPs & a tag inherit profile")
 
 // Each entry in baseTests contains a series of states to move through.  Apart
 // from running each of these, we'll also expand each of them by passing it
@@ -893,16 +118,6 @@ var baseTests = []StateList{
 	// TODO(smc): Test rule conversions
 }
 
-type StateList []State
-
-func (l StateList) String() string {
-	names := make([]string, 0)
-	for _, state := range l {
-		names = append(names, state.String())
-	}
-	return "[" + strings.Join(names, ", ") + "]"
-}
-
 var testExpanders = []func(baseTest StateList) (desc string, mappedTests []StateList){
 	identity,
 	reverseKVOrder,
@@ -910,98 +125,6 @@ var testExpanders = []func(baseTest StateList) (desc string, mappedTests []State
 	insertEmpties,
 	splitStates,
 	squashStates,
-}
-
-// identity is a test expander that returns the test unaltered.
-func identity(baseTest StateList) (string, []StateList) {
-	return "in normal ordering", []StateList{baseTest}
-}
-
-// reverseStateOrder returns a StateList containing the same states in
-// reverse order.
-func reverseStateOrder(baseTest StateList) (desc string, mappedTests []StateList) {
-	desc = "with order of states reversed"
-	palindrome := true
-	mappedTest := StateList{}
-	for ii := 0; ii < len(baseTest); ii++ {
-		mappedTest = append(mappedTest, baseTest[len(baseTest)-ii-1])
-		if &baseTest[len(baseTest)-1-ii] != &baseTest[ii] {
-			palindrome = false
-		}
-	}
-	if palindrome {
-		// Test was a palindrome so there's no point in reversing it.
-		return
-	}
-	mappedTests = []StateList{mappedTest}
-	return
-}
-
-// reverseKVOrder returns a StateList containing the states in the same order
-// but with their DataStore key order reversed.
-func reverseKVOrder(baseTests StateList) (desc string, mappedTests []StateList) {
-	desc = "with order of KVs reversed within each state"
-	mappedTest := StateList{}
-	for _, test := range baseTests {
-		mappedState := test.Copy()
-		state := mappedState.DatastoreState
-		for ii := 0; ii < len(state)/2; ii++ {
-			jj := len(state) - ii - 1
-			state[ii], state[jj] = state[jj], state[ii]
-		}
-		mappedTest = append(mappedTest, mappedState)
-	}
-	mappedTests = []StateList{mappedTest}
-	return
-}
-
-// insertEmpties inserts an empty state between each state in the base test.
-func insertEmpties(baseTest StateList) (desc string, mappedTests []StateList) {
-	desc = "with empty state inserted between each state"
-	mappedTest := StateList{}
-	for _, state := range baseTest {
-		mappedTest = append(mappedTest, state)
-		mappedTest = append(mappedTest, empty)
-	}
-	mappedTests = append(mappedTests, mappedTest)
-	return
-}
-
-func splitStates(baseTest StateList) (desc string, mappedTests []StateList) {
-	desc = "with individual states broken out"
-	if len(baseTest) <= 1 {
-		// No point in splitting a single-item test.
-		return
-	}
-	for _, state := range baseTest {
-		mappedTests = append(mappedTests, StateList{state})
-	}
-	return
-}
-
-// squash returns a StateList with all the states squashed into one (which may
-// include some deletions in the DatastoreState.
-func squashStates(baseTests StateList) (desc string, mappedTests []StateList) {
-	mappedTest := StateList{}
-	desc = "all states squashed into one"
-	if len(baseTests) == 0 {
-		return
-	}
-	kvs := make([]KVPair, 0)
-	mappedState := baseTests[len(baseTests)-1].Copy()
-	lastTest := empty
-	for _, test := range baseTests {
-		for _, update := range test.KVDeltas(lastTest) {
-			kvs = append(kvs, update.KVPair)
-		}
-		lastTest = test
-	}
-	mappedState.DatastoreState = kvs
-	mappedState.ExpectedEndpointPolicyOrder = lastTest.ExpectedEndpointPolicyOrder
-	mappedState.Name = fmt.Sprintf("squashed(%v)", baseTests)
-	mappedTest = append(mappedTest, mappedState)
-	mappedTests = []StateList{mappedTest}
-	return
 }
 
 // These tests drive the calculation graph directly (and synchronously).
@@ -1097,7 +220,7 @@ var _ = Describe("Async calculation graph state sequencing tests:", func() {
 					}()
 
 					// Now drain the output from the output channel.
-					tracker := newStateTracker()
+					tracker := newMockDataplane()
 					inSyncReceived := false
 				readLoop:
 					for {
@@ -1166,14 +289,14 @@ const (
 func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 	var validationFilter *ValidationFilter
 	var calcGraph *dispatcher.Dispatcher
-	var tracker *stateTracker
+	var tracker *mockDataplane
 	var eventBuf *EventSequencer
 	var lastState State
 	var state State
 	var sentInSync bool
 
 	BeforeEach(func() {
-		tracker = newStateTracker()
+		tracker = newMockDataplane()
 		eventBuf = NewEventBuffer(tracker)
 		eventBuf.Callback = tracker.onEvent
 		calcGraph = NewCalculationGraph(eventBuf, localHostname)
@@ -1256,7 +379,7 @@ func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 	}))
 }
 
-type stateTracker struct {
+type mockDataplane struct {
 	ipsets                         map[string]set.Set
 	activePolicies                 set.Set
 	activeUntrackedPolicies        set.Set
@@ -1268,8 +391,8 @@ type stateTracker struct {
 	config                         map[string]string
 }
 
-func newStateTracker() *stateTracker {
-	s := &stateTracker{
+func newMockDataplane() *mockDataplane {
+	s := &mockDataplane{
 		ipsets:                         make(map[string]set.Set),
 		activePolicies:                 set.New(),
 		activeProfiles:                 set.New(),
@@ -1282,7 +405,7 @@ func newStateTracker() *stateTracker {
 	return s
 }
 
-func (s *stateTracker) onEvent(event interface{}) {
+func (s *mockDataplane) onEvent(event interface{}) {
 	evType := reflect.TypeOf(event).String()
 	fmt.Fprintf(GinkgoWriter, "       <- Event: %v %v\n", evType, event)
 	Expect(event).NotTo(BeNil())
@@ -1397,11 +520,11 @@ func (s *stateTracker) onEvent(event interface{}) {
 	}
 }
 
-func (s *stateTracker) UpdateFrom(map[string]string, config.Source) (changed bool, err error) {
+func (s *mockDataplane) UpdateFrom(map[string]string, config.Source) (changed bool, err error) {
 	return
 }
 
-func (s *stateTracker) RawValues() map[string]string {
+func (s *mockDataplane) RawValues() map[string]string {
 	return s.config
 }
 

--- a/calc/resources_for_test.go
+++ b/calc/resources_for_test.go
@@ -1,0 +1,265 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calc_test
+
+// This file contains canned backend model values for use in tests.  Note the "." import of
+// the model package.
+
+import (
+	. "github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+// Canned hostnames.
+
+const localHostname = "localhostname"
+const remoteHostname = "remotehostname"
+
+// Canned selectors.
+
+var (
+	allSelector         = "all()"
+	allSelectorId       = selectorId(allSelector)
+	bEpBSelector        = "b == 'b'"
+	bEqBSelectorId      = selectorId(bEpBSelector)
+	tagSelector         = "has(tag-1)"
+	tagSelectorId       = selectorId(tagSelector)
+	tagFoobarSelector   = "tag-1 == 'foobar'"
+	tagFoobarSelectorId = selectorId(tagFoobarSelector)
+)
+
+// Canned workload endpoints.
+
+var localWlEpKey1 = WorkloadEndpointKey{localHostname, "orch", "wl1", "ep1"}
+var remoteWlEpKey1 = WorkloadEndpointKey{remoteHostname, "orch", "wl1", "ep1"}
+var localWlEp1Id = "orch/wl1/ep1"
+var localWlEpKey2 = WorkloadEndpointKey{localHostname, "orch", "wl2", "ep2"}
+var localWlEp2Id = "orch/wl2/ep2"
+
+var localWlEp1 = WorkloadEndpoint{
+	State:      "active",
+	Name:       "cali1",
+	Mac:        mustParseMac("01:02:03:04:05:06"),
+	ProfileIDs: []string{"prof-1", "prof-2", "prof-missing"},
+	IPv4Nets: []net.IPNet{mustParseNet("10.0.0.1/32"),
+		mustParseNet("10.0.0.2/32")},
+	IPv6Nets: []net.IPNet{mustParseNet("fc00:fe11::1/128"),
+		mustParseNet("fc00:fe11::2/128")},
+	Labels: map[string]string{
+		"id": "loc-ep-1",
+		"a":  "a",
+		"b":  "b",
+	},
+}
+
+var localWlEp1NoProfiles = WorkloadEndpoint{
+	State: "active",
+	Name:  "cali1",
+	Mac:   mustParseMac("01:02:03:04:05:06"),
+	IPv4Nets: []net.IPNet{mustParseNet("10.0.0.1/32"),
+		mustParseNet("10.0.0.2/32")},
+	IPv6Nets: []net.IPNet{mustParseNet("fc00:fe11::1/128"),
+		mustParseNet("fc00:fe11::2/128")},
+}
+
+var localWlEp1DifferentIPs = WorkloadEndpoint{
+	State:      "active",
+	Name:       "cali1",
+	Mac:        mustParseMac("01:02:03:04:05:06"),
+	ProfileIDs: []string{"prof-1", "prof-2", "prof-missing"},
+	IPv4Nets: []net.IPNet{mustParseNet("11.0.0.1/32"),
+		mustParseNet("11.0.0.2/32")},
+	IPv6Nets: []net.IPNet{mustParseNet("fc00:fe12::1/128"),
+		mustParseNet("fc00:fe12::2/128")},
+	Labels: map[string]string{
+		"id": "loc-ep-1",
+		"a":  "a",
+		"b":  "b",
+	},
+}
+
+var ep1IPs = []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // shared with ep2
+	"fc00:fe11::2",
+}
+
+var localWlEp2 = WorkloadEndpoint{
+	State:      "active",
+	Name:       "cali2",
+	ProfileIDs: []string{"prof-2", "prof-3"},
+	IPv4Nets: []net.IPNet{mustParseNet("10.0.0.2/32"),
+		mustParseNet("10.0.0.3/32")},
+	IPv6Nets: []net.IPNet{mustParseNet("fc00:fe11::2/128"),
+		mustParseNet("fc00:fe11::3/128")},
+	Labels: map[string]string{
+		"id": "loc-ep-2",
+		"a":  "a",
+		"b":  "b2",
+	},
+}
+
+var localWlEp2NoProfiles = WorkloadEndpoint{
+	State: "active",
+	Name:  "cali2",
+	IPv4Nets: []net.IPNet{mustParseNet("10.0.0.2/32"),
+		mustParseNet("10.0.0.3/32")},
+	IPv6Nets: []net.IPNet{mustParseNet("fc00:fe11::2/128"),
+		mustParseNet("fc00:fe11::3/128")},
+}
+
+var hostEpWithName = HostEndpoint{
+	Name:       "eth1",
+	ProfileIDs: []string{"prof-1", "prof-2", "prof-missing"},
+	ExpectedIPv4Addrs: []net.IP{mustParseIP("10.0.0.1"),
+		mustParseIP("10.0.0.2")},
+	ExpectedIPv6Addrs: []net.IP{mustParseIP("fc00:fe11::1"),
+		mustParseIP("fc00:fe11::2")},
+	Labels: map[string]string{
+		"id": "loc-ep-1",
+		"a":  "a",
+		"b":  "b",
+	},
+}
+
+var hostEpWithNameKey = HostEndpointKey{
+	Hostname:   localHostname,
+	EndpointID: "named",
+}
+var hostEpWithNameId = "named"
+
+var hostEp2NoName = HostEndpoint{
+	ProfileIDs: []string{"prof-2", "prof-3"},
+	ExpectedIPv4Addrs: []net.IP{mustParseIP("10.0.0.2"),
+		mustParseIP("10.0.0.3")},
+	ExpectedIPv6Addrs: []net.IP{mustParseIP("fc00:fe11::2"),
+		mustParseIP("fc00:fe11::3")},
+	Labels: map[string]string{
+		"id": "loc-ep-2",
+		"a":  "a",
+		"b":  "b2",
+	},
+}
+
+var hostEp2NoNameKey = HostEndpointKey{
+	Hostname:   localHostname,
+	EndpointID: "unnamed",
+}
+var hostEpNoNameId = "unnamed"
+
+// Canned tiers/policies.
+
+var order10 = float64(10)
+var order20 = float64(20)
+var order30 = float64(30)
+
+var policy1_order20 = Policy{
+	Order:    &order20,
+	Selector: "a == 'a'",
+	InboundRules: []Rule{
+		{SrcSelector: allSelector},
+	},
+	OutboundRules: []Rule{
+		{SrcSelector: bEpBSelector},
+	},
+	Types: []string{"ingress", "egress"},
+}
+
+var policy1_order20_ingress_only = Policy{
+	Order:    &order20,
+	Selector: "a == 'a'",
+	InboundRules: []Rule{
+		{SrcSelector: allSelector},
+	},
+	Types: []string{"ingress"},
+}
+
+var policy1_order20_egress_only = Policy{
+	Order:    &order20,
+	Selector: "a == 'a'",
+	OutboundRules: []Rule{
+		{SrcSelector: bEpBSelector},
+	},
+	Types: []string{"egress"},
+}
+
+var policy1_order20_untracked = Policy{
+	Order:    &order20,
+	Selector: "a == 'a'",
+	InboundRules: []Rule{
+		{SrcSelector: allSelector},
+	},
+	OutboundRules: []Rule{
+		{SrcSelector: bEpBSelector},
+	},
+	DoNotTrack: true,
+}
+
+var policy1_order20_pre_dnat = Policy{
+	Order:    &order20,
+	Selector: "a == 'a'",
+	InboundRules: []Rule{
+		{SrcSelector: allSelector},
+	},
+	PreDNAT: true,
+}
+
+var profileRules1 = ProfileRules{
+	InboundRules: []Rule{
+		{SrcSelector: allSelector},
+	},
+	OutboundRules: []Rule{
+		{SrcTag: "tag-1"},
+	},
+}
+
+var profileRulesWithTagInherit = ProfileRules{
+	InboundRules: []Rule{
+		{SrcSelector: tagSelector},
+	},
+	OutboundRules: []Rule{
+		{SrcSelector: tagFoobarSelector},
+	},
+}
+
+var profileRules1TagUpdate = ProfileRules{
+	InboundRules: []Rule{
+		{SrcSelector: bEpBSelector},
+	},
+	OutboundRules: []Rule{
+		{SrcTag: "tag-2"},
+	},
+}
+
+var profileRules1NegatedTagSelUpdate = ProfileRules{
+	InboundRules: []Rule{
+		{NotSrcSelector: bEpBSelector},
+	},
+	OutboundRules: []Rule{
+		{NotSrcTag: "tag-2"},
+	},
+}
+
+var profileTags1 = []string{"tag-1"}
+var profileLabels1 = map[string]string{
+	"profile": "prof-1",
+}
+var profileLabelsTag1 = map[string]string{
+	"tag-1": "foobar",
+}
+
+var tag1LabelID = ipSetIDForTag("tag-1")
+var tag2LabelID = ipSetIDForTag("tag-2")

--- a/calc/states_for_test.go
+++ b/calc/states_for_test.go
@@ -1,0 +1,654 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calc_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/projectcalico/felix/proto"
+	. "github.com/projectcalico/libcalico-go/lib/backend/model"
+)
+
+// Pre-defined datastore states.  Each State object wraps up the complete state
+// of the datastore as well as the expected state of the dataplane.  The state
+// of the dataplane *should* depend only on the current datastore state, not on
+// the path taken to get there.  Therefore, it's always a valid test to move
+// from any state to any other state (by feeding in the corresponding
+// datastore updates) and then assert that the dataplane matches the resulting
+// state.
+
+// empty is the base state, with nothing in the datastore or dataplane.
+var empty = NewState().withName("<empty>")
+
+// initialisedStore builds on empty, adding in the ready flag and global config.
+var initialisedStore = empty.withKVUpdates(
+	KVPair{Key: GlobalConfigKey{Name: "InterfacePrefix"}, Value: "cali"},
+	KVPair{Key: ReadyFlagKey{}, Value: true},
+).withName("<initialised>")
+
+// withPolicy adds a tier and policy containing selectors for all and b=="b"
+var withPolicy = initialisedStore.withKVUpdates(
+	KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policy1_order20},
+).withName("with policy")
+
+// withPolicyIngressOnly adds a tier and ingress policy containing selectors for all
+var withPolicyIngressOnly = initialisedStore.withKVUpdates(
+	KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policy1_order20_ingress_only},
+).withName("with ingress-only policy")
+
+// withPolicyEgressOnly adds a tier and egress policy containing selectors for b=="b"
+var withPolicyEgressOnly = initialisedStore.withKVUpdates(
+	KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policy1_order20_egress_only},
+).withName("with egress-only policy")
+
+// withUntrackedPolicy adds a tier and policy containing selectors for all and b=="b"
+var withUntrackedPolicy = initialisedStore.withKVUpdates(
+	KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policy1_order20_untracked},
+).withName("with untracked policy")
+
+// withPreDNATPolicy adds a tier and policy containing selectors for all and a=="a"
+var withPreDNATPolicy = initialisedStore.withKVUpdates(
+	KVPair{Key: PolicyKey{Name: "pre-dnat-pol-1"}, Value: &policy1_order20_pre_dnat},
+).withName("with pre-DNAT policy")
+
+// localEp1WithPolicy adds a local endpoint to the mix.  It matches all and b=="b".
+var localEp1WithPolicy = withPolicy.withKVUpdates(
+	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+}).withIPSet(bEqBSelectorId, []string{
+	"10.0.0.1",
+	"fc00:fe11::1",
+	"10.0.0.2",
+	"fc00:fe11::2",
+}).withActivePolicies(
+	proto.PolicyID{"default", "pol-1"},
+).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-missing"},
+).withEndpoint(
+	localWlEp1Id,
+	[]tierInfo{
+		{"default", []string{"pol-1"}, []string{"pol-1"}},
+	},
+).withName("ep1 local, policy")
+
+// localEp1WithIngressPolicy is as above except ingress policy only.
+var localEp1WithIngressPolicy = withPolicyIngressOnly.withKVUpdates(
+	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+}).withActivePolicies(
+	proto.PolicyID{"default", "pol-1"},
+).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-missing"},
+).withEndpoint(
+	localWlEp1Id,
+	[]tierInfo{
+		{"default", []string{"pol-1"}, nil},
+	},
+).withName("ep1 local, ingress-only policy")
+
+var hostEp1WithPolicy = withPolicy.withKVUpdates(
+	KVPair{Key: hostEpWithNameKey, Value: &hostEpWithName},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+}).withIPSet(bEqBSelectorId, []string{
+	"10.0.0.1",
+	"fc00:fe11::1",
+	"10.0.0.2",
+	"fc00:fe11::2",
+}).withActivePolicies(
+	proto.PolicyID{"default", "pol-1"},
+).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-missing"},
+).withEndpoint(
+	hostEpWithNameId,
+	[]tierInfo{
+		{"default", []string{"pol-1"}, []string{"pol-1"}},
+	},
+).withName("host ep1, policy")
+
+var hostEp1WithIngressPolicy = withPolicyIngressOnly.withKVUpdates(
+	KVPair{Key: hostEpWithNameKey, Value: &hostEpWithName},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+}).withActivePolicies(
+	proto.PolicyID{"default", "pol-1"},
+).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-missing"},
+).withEndpoint(
+	hostEpWithNameId,
+	[]tierInfo{
+		{"default", []string{"pol-1"}, nil},
+	},
+).withName("host ep1, ingress-only policy")
+
+var hostEp1WithEgressPolicy = withPolicyEgressOnly.withKVUpdates(
+	KVPair{Key: hostEpWithNameKey, Value: &hostEpWithName},
+).withIPSet(bEqBSelectorId, []string{
+	"10.0.0.1",
+	"fc00:fe11::1",
+	"10.0.0.2",
+	"fc00:fe11::2",
+}).withActivePolicies(
+	proto.PolicyID{"default", "pol-1"},
+).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-missing"},
+).withEndpoint(
+	hostEpWithNameId,
+	[]tierInfo{
+		{"default", nil, []string{"pol-1"}},
+	},
+).withName("host ep1, egress-only policy")
+
+var hostEp1WithUntrackedPolicy = withUntrackedPolicy.withKVUpdates(
+	KVPair{Key: hostEpWithNameKey, Value: &hostEpWithName},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+}).withIPSet(bEqBSelectorId, []string{
+	"10.0.0.1",
+	"fc00:fe11::1",
+	"10.0.0.2",
+	"fc00:fe11::2",
+}).withActivePolicies(
+	proto.PolicyID{"default", "pol-1"},
+).withUntrackedPolicies(
+	proto.PolicyID{"default", "pol-1"},
+).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-missing"},
+).withEndpointUntracked(
+	hostEpWithNameId,
+	[]tierInfo{},
+	[]tierInfo{
+		{"default", []string{"pol-1"}, []string{"pol-1"}},
+	},
+	[]tierInfo{},
+).withName("host ep1, untracked policy")
+
+var hostEp1WithPreDNATPolicy = withPreDNATPolicy.withKVUpdates(
+	KVPair{Key: hostEpWithNameKey, Value: &hostEpWithName},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+}).withActivePolicies(
+	proto.PolicyID{"default", "pre-dnat-pol-1"},
+).withPreDNATPolicies(
+	proto.PolicyID{"default", "pre-dnat-pol-1"},
+).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-missing"},
+).withEndpointUntracked(
+	hostEpWithNameId,
+	[]tierInfo{},
+	[]tierInfo{},
+	[]tierInfo{
+		{"default", []string{"pre-dnat-pol-1"}, nil},
+	},
+).withName("host ep1, pre-DNAT policy")
+
+var hostEp1WithTrackedAndUntrackedPolicy = hostEp1WithUntrackedPolicy.withKVUpdates(
+	KVPair{Key: PolicyKey{Name: "pol-2"}, Value: &policy1_order20},
+).withActivePolicies(
+	proto.PolicyID{"default", "pol-1"},
+	proto.PolicyID{"default", "pol-2"},
+).withEndpointUntracked(
+	hostEpWithNameId,
+	[]tierInfo{
+		{"default", []string{"pol-2"}, []string{"pol-2"}},
+	},
+	[]tierInfo{
+		{"default", []string{"pol-1"}, []string{"pol-1"}},
+	},
+	[]tierInfo{},
+).withName("host ep1, tracked+untracked policy")
+
+var hostEp2WithPolicy = withPolicy.withKVUpdates(
+	KVPair{Key: hostEp2NoNameKey, Value: &hostEp2NoName},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+	"10.0.0.3", // ep2
+	"fc00:fe11::3",
+}).withIPSet(bEqBSelectorId, []string{}).withActivePolicies(
+	proto.PolicyID{"default", "pol-1"},
+).withActiveProfiles(
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-3"},
+).withEndpoint(
+	hostEpNoNameId,
+	[]tierInfo{
+		{"default", []string{"pol-1"}, []string{"pol-1"}},
+	},
+).withName("host ep2, policy")
+
+// Policy ordering tests.  We keep the names of the policies the same but we
+// change their orders to check that order trumps name.
+var localEp1WithOneTierPolicy123 = policyOrderState(
+	[3]float64{order10, order20, order30},
+	[3]string{"pol-1", "pol-2", "pol-3"},
+)
+var localEp1WithOneTierPolicy321 = policyOrderState(
+	[3]float64{order30, order20, order10},
+	[3]string{"pol-3", "pol-2", "pol-1"},
+)
+var localEp1WithOneTierPolicyAlpha = policyOrderState(
+	[3]float64{order10, order10, order10},
+	[3]string{"pol-1", "pol-2", "pol-3"},
+)
+
+func policyOrderState(policyOrders [3]float64, expectedOrder [3]string) State {
+	policies := [3]Policy{}
+	for i := range policies {
+		policies[i] = Policy{
+			Order:         &policyOrders[i],
+			Selector:      "a == 'a'",
+			InboundRules:  []Rule{{SrcSelector: allSelector}},
+			OutboundRules: []Rule{{SrcSelector: bEpBSelector}},
+		}
+	}
+	state := initialisedStore.withKVUpdates(
+		KVPair{Key: localWlEpKey1, Value: &localWlEp1},
+		KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policies[0]},
+		KVPair{Key: PolicyKey{Name: "pol-2"}, Value: &policies[1]},
+		KVPair{Key: PolicyKey{Name: "pol-3"}, Value: &policies[2]},
+	).withIPSet(allSelectorId, []string{
+		"10.0.0.1", // ep1
+		"fc00:fe11::1",
+		"10.0.0.2", // ep1 and ep2
+		"fc00:fe11::2",
+	}).withIPSet(bEqBSelectorId, []string{
+		"10.0.0.1",
+		"fc00:fe11::1",
+		"10.0.0.2",
+		"fc00:fe11::2",
+	}).withActivePolicies(
+		proto.PolicyID{"default", "pol-1"},
+		proto.PolicyID{"default", "pol-2"},
+		proto.PolicyID{"default", "pol-3"},
+	).withActiveProfiles(
+		proto.ProfileID{"prof-1"},
+		proto.ProfileID{"prof-2"},
+		proto.ProfileID{"prof-missing"},
+	).withEndpoint(
+		localWlEp1Id,
+		[]tierInfo{
+			{"default", expectedOrder[:], expectedOrder[:]},
+		},
+	).withName(fmt.Sprintf("ep1 local, 1 tier, policies %v", expectedOrder[:]))
+	return state
+}
+
+// localEp2WithPolicy adds a different endpoint that doesn't match b=="b".
+// This tests an empty IP set.
+var localEp2WithPolicy = withPolicy.withKVUpdates(
+	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+	"10.0.0.3", // ep2
+	"fc00:fe11::3",
+}).withIPSet(
+	bEqBSelectorId, []string{},
+).withActivePolicies(
+	proto.PolicyID{"default", "pol-1"},
+).withActiveProfiles(
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-3"},
+).withEndpoint(
+	localWlEp2Id,
+	[]tierInfo{
+		{"default", []string{"pol-1"}, []string{"pol-1"}},
+	},
+).withName("ep2 local, policy")
+
+// localEpsWithPolicy contains both of the above endpoints, which have some
+// overlapping IPs.  When we sequence this with the states above, we test
+// overlapping IP addition and removal.
+var localEpsWithPolicy = withPolicy.withKVUpdates(
+	// Two local endpoints with overlapping IPs.
+	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
+	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+	"10.0.0.3", // ep2
+	"fc00:fe11::3",
+}).withIPSet(bEqBSelectorId, []string{
+	"10.0.0.1",
+	"fc00:fe11::1",
+	"10.0.0.2",
+	"fc00:fe11::2",
+}).withActivePolicies(
+	proto.PolicyID{"default", "pol-1"},
+).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-3"},
+	proto.ProfileID{"prof-missing"},
+).withEndpoint(
+	localWlEp1Id,
+	[]tierInfo{
+		{"default", []string{"pol-1"}, []string{"pol-1"}},
+	},
+).withEndpoint(
+	localWlEp2Id,
+	[]tierInfo{
+		{"default", []string{"pol-1"}, []string{"pol-1"}},
+	},
+).withName("2 local, overlapping IPs & a policy")
+
+// localEpsWithPolicyUpdatedIPs, when used with localEpsWithPolicy checks
+// correct handling of IP address updates.  We add and remove some IPs from
+// endpoint 1 and check that only its non-shared IPs are removed from the IP
+// sets.
+var localEpsWithPolicyUpdatedIPs = localEpsWithPolicy.withKVUpdates(
+	KVPair{Key: localWlEpKey1, Value: &localWlEp1DifferentIPs},
+	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
+).withIPSet(allSelectorId, []string{
+	"11.0.0.1", // ep1
+	"fc00:fe12::1",
+	"11.0.0.2",
+	"fc00:fe12::2",
+	"10.0.0.2", // now ep2 only
+	"fc00:fe11::2",
+	"10.0.0.3", // ep2
+	"fc00:fe11::3",
+}).withIPSet(bEqBSelectorId, []string{
+	"11.0.0.1", // ep1
+	"fc00:fe12::1",
+	"11.0.0.2",
+	"fc00:fe12::2",
+})
+
+// withProfile adds a profile to the initialised state.
+var withProfile = initialisedStore.withKVUpdates(
+	KVPair{Key: ProfileRulesKey{ProfileKey{"prof-1"}}, Value: &profileRules1},
+	KVPair{Key: ProfileTagsKey{ProfileKey{"prof-1"}}, Value: profileTags1},
+	KVPair{Key: ProfileLabelsKey{ProfileKey{"prof-1"}}, Value: profileLabels1},
+).withName("profile")
+
+// localEpsWithProfile contains a pair of overlapping IP endpoints and a profile
+// that matches them both.
+var localEpsWithProfile = withProfile.withKVUpdates(
+	// Two local endpoints with overlapping IPs.
+	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
+	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
+).withIPSet(allSelectorId, []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+	"10.0.0.3", // ep2
+	"fc00:fe11::3",
+}).withIPSet(tag1LabelID, []string{
+	"10.0.0.1",
+	"fc00:fe11::1",
+	"10.0.0.2",
+	"fc00:fe11::2",
+}).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-3"},
+	proto.ProfileID{"prof-missing"},
+).withEndpoint(
+	localWlEp1Id,
+	[]tierInfo{},
+).withEndpoint(
+	localWlEp2Id,
+	[]tierInfo{},
+).withName("2 local, overlapping IPs & a profile")
+
+// localEpsWithNonMatchingProfile contains a pair of overlapping IP endpoints and a profile
+// that matches them both.
+var localEpsWithNonMatchingProfile = withProfile.withKVUpdates(
+	// Two local endpoints with overlapping IPs.
+	KVPair{Key: localWlEpKey1, Value: &localWlEp1NoProfiles},
+	KVPair{Key: localWlEpKey2, Value: &localWlEp2NoProfiles},
+).withEndpoint(
+	localWlEp1Id,
+	[]tierInfo{},
+).withEndpoint(
+	localWlEp2Id,
+	[]tierInfo{},
+).withName("2 local, overlapping IPs & a non-matching profile")
+
+// localEpsWithUpdatedProfile Follows on from localEpsWithProfile, changing the
+// profile to use a different tag and selector.
+var localEpsWithUpdatedProfile = localEpsWithProfile.withKVUpdates(
+	KVPair{Key: ProfileRulesKey{ProfileKey{"prof-1"}}, Value: &profileRules1TagUpdate},
+).withIPSet(
+	tag1LabelID, nil,
+).withIPSet(
+	allSelectorId, nil,
+).withIPSet(bEqBSelectorId, []string{
+	"10.0.0.1",
+	"fc00:fe11::1",
+	"10.0.0.2",
+	"fc00:fe11::2",
+}).withIPSet(
+	tag2LabelID, []string{},
+).withEndpoint(
+	localWlEp1Id,
+	[]tierInfo{},
+).withEndpoint(
+	localWlEp2Id,
+	[]tierInfo{},
+).withName("2 local, overlapping IPs & updated profile")
+
+var localEpsWithUpdatedProfileNegatedTags = localEpsWithUpdatedProfile.withKVUpdates(
+	KVPair{Key: ProfileRulesKey{ProfileKey{"prof-1"}}, Value: &profileRules1NegatedTagSelUpdate},
+)
+
+// withProfileTagInherit adds a profile that includes rules that match on
+// tags as labels.  I.e. a tag of name foo should be equivalent to label foo=""
+var withProfileTagInherit = initialisedStore.withKVUpdates(
+	KVPair{Key: ProfileRulesKey{ProfileKey{"prof-1"}}, Value: &profileRulesWithTagInherit},
+	KVPair{Key: ProfileTagsKey{ProfileKey{"prof-1"}}, Value: profileTags1},
+	KVPair{Key: ProfileLabelsKey{ProfileKey{"prof-1"}}, Value: profileLabels1},
+).withName("profile")
+
+var localEpsWithTagInheritProfile = withProfileTagInherit.withKVUpdates(
+	// Two local endpoints with overlapping IPs.
+	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
+	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
+).withIPSet(tagSelectorId, []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+}).withIPSet(tagFoobarSelectorId, []string{}).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-3"},
+	proto.ProfileID{"prof-missing"},
+).withEndpoint(
+	localWlEp1Id,
+	[]tierInfo{},
+).withEndpoint(
+	localWlEp2Id,
+	[]tierInfo{},
+).withName("2 local, overlapping IPs & a tag inherit profile")
+
+var withProfileTagOverriden = initialisedStore.withKVUpdates(
+	KVPair{Key: ProfileRulesKey{ProfileKey{"prof-1"}}, Value: &profileRulesWithTagInherit},
+	KVPair{Key: ProfileTagsKey{ProfileKey{"prof-1"}}, Value: profileTags1},
+	KVPair{Key: ProfileLabelsKey{ProfileKey{"prof-1"}}, Value: profileLabelsTag1},
+).withName("profile")
+
+// localEpsWithTagOverriddenProfile Checks that tags-inherited labels can be
+// overridden by explicit labels on the profile.
+var localEpsWithTagOverriddenProfile = withProfileTagOverriden.withKVUpdates(
+	// Two local endpoints with overlapping IPs.
+	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
+	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
+).withIPSet(tagSelectorId, []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+}).withIPSet(tagFoobarSelectorId, []string{
+	"10.0.0.1", // ep1
+	"fc00:fe11::1",
+	"10.0.0.2", // ep1 and ep2
+	"fc00:fe11::2",
+}).withActiveProfiles(
+	proto.ProfileID{"prof-1"},
+	proto.ProfileID{"prof-2"},
+	proto.ProfileID{"prof-3"},
+	proto.ProfileID{"prof-missing"},
+).withEndpoint(
+	localWlEp1Id,
+	[]tierInfo{},
+).withEndpoint(
+	localWlEp2Id,
+	[]tierInfo{},
+).withName("2 local, overlapping IPs & a tag inherit profile")
+
+type StateList []State
+
+func (l StateList) String() string {
+	names := make([]string, 0)
+	for _, state := range l {
+		names = append(names, state.String())
+	}
+	return "[" + strings.Join(names, ", ") + "]"
+}
+
+// identity is a test expander that returns the test unaltered.
+func identity(baseTest StateList) (string, []StateList) {
+	return "in normal ordering", []StateList{baseTest}
+}
+
+// reverseStateOrder returns a StateList containing the same states in
+// reverse order.
+func reverseStateOrder(baseTest StateList) (desc string, mappedTests []StateList) {
+	desc = "with order of states reversed"
+	palindrome := true
+	mappedTest := StateList{}
+	for ii := 0; ii < len(baseTest); ii++ {
+		mappedTest = append(mappedTest, baseTest[len(baseTest)-ii-1])
+		if &baseTest[len(baseTest)-1-ii] != &baseTest[ii] {
+			palindrome = false
+		}
+	}
+	if palindrome {
+		// Test was a palindrome so there's no point in reversing it.
+		return
+	}
+	mappedTests = []StateList{mappedTest}
+	return
+}
+
+// reverseKVOrder returns a StateList containing the states in the same order
+// but with their DataStore key order reversed.
+func reverseKVOrder(baseTests StateList) (desc string, mappedTests []StateList) {
+	desc = "with order of KVs reversed within each state"
+	mappedTest := StateList{}
+	for _, test := range baseTests {
+		mappedState := test.Copy()
+		state := mappedState.DatastoreState
+		for ii := 0; ii < len(state)/2; ii++ {
+			jj := len(state) - ii - 1
+			state[ii], state[jj] = state[jj], state[ii]
+		}
+		mappedTest = append(mappedTest, mappedState)
+	}
+	mappedTests = []StateList{mappedTest}
+	return
+}
+
+// insertEmpties inserts an empty state between each state in the base test.
+func insertEmpties(baseTest StateList) (desc string, mappedTests []StateList) {
+	desc = "with empty state inserted between each state"
+	mappedTest := StateList{}
+	for _, state := range baseTest {
+		mappedTest = append(mappedTest, state)
+		mappedTest = append(mappedTest, empty)
+	}
+	mappedTests = append(mappedTests, mappedTest)
+	return
+}
+
+func splitStates(baseTest StateList) (desc string, mappedTests []StateList) {
+	desc = "with individual states broken out"
+	if len(baseTest) <= 1 {
+		// No point in splitting a single-item test.
+		return
+	}
+	for _, state := range baseTest {
+		mappedTests = append(mappedTests, StateList{state})
+	}
+	return
+}
+
+// squash returns a StateList with all the states squashed into one (which may
+// include some deletions in the DatastoreState.
+func squashStates(baseTests StateList) (desc string, mappedTests []StateList) {
+	mappedTest := StateList{}
+	desc = "all states squashed into one"
+	if len(baseTests) == 0 {
+		return
+	}
+	kvs := make([]KVPair, 0)
+	mappedState := baseTests[len(baseTests)-1].Copy()
+	lastTest := empty
+	for _, test := range baseTests {
+		for _, update := range test.KVDeltas(lastTest) {
+			kvs = append(kvs, update.KVPair)
+		}
+		lastTest = test
+	}
+	mappedState.DatastoreState = kvs
+	mappedState.ExpectedEndpointPolicyOrder = lastTest.ExpectedEndpointPolicyOrder
+	mappedState.Name = fmt.Sprintf("squashed(%v)", baseTests)
+	mappedTest = append(mappedTest, mappedState)
+	mappedTests = []StateList{mappedTest}
+	return
+}


### PR DESCRIPTION
Found the single file was simply too big and hard to navigate while developing the named ports additions to it.  This PR breaks that file up into three:

- resources_for_test.go contains canned model KV pairs
- states_for_test.go contains states built from the resources
- calc_graph_fv_test.go contains the test logic

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
