### PR TITLE
Replace log.Fatal with log.Panic in most cases.

### DIFF
--- a/calc/active_rules_calculator.go
+++ b/calc/active_rules_calculator.go
@@ -169,7 +169,7 @@ func (arc *ActiveRulesCalculator) OnUpdate(update api.Update) (_ bool) {
 			// longer matches.
 			sel, err := selector.Parse(policy.Selector)
 			if err != nil {
-				log.Fatal(err)
+				log.WithError(err).Panic("Failed to parse selector")
 			}
 			arc.labelIndex.UpdateSelector(key, sel)
 

--- a/calc/async_calc_graph.go
+++ b/calc/async_calc_graph.go
@@ -161,7 +161,7 @@ func (acg *AsyncCalcGraph) loop() {
 				}
 				acg.reportHealth()
 			default:
-				log.Fatalf("Unexpected update: %#v", update)
+				log.Panicf("Unexpected update: %#v", update)
 			}
 			acg.dirty = true
 		case <-acg.flushTicks:

--- a/calc/config_batcher.go
+++ b/calc/config_batcher.go
@@ -86,7 +86,7 @@ func (cb *ConfigBatcher) OnUpdate(update api.Update) (filterOut bool) {
 			cb.datastoreReady = true
 		}
 	default:
-		log.Fatalf("Unexpected update: %#v", update)
+		log.Panicf("Unexpected update: %#v", update)
 	}
 	cb.maybeSendCachedConfig()
 	return

--- a/calc/event_sequencer.go
+++ b/calc/event_sequencer.go
@@ -192,11 +192,11 @@ func (buf *EventSequencer) flushConfigUpdate() {
 	logCxt.Info("Possible config update.")
 	globalChanged, err := buf.config.UpdateFrom(buf.pendingGlobalConfig, config.DatastoreGlobal)
 	if err != nil {
-		logCxt.WithError(err).Fatal("Failed to parse config update")
+		logCxt.WithError(err).Panic("Failed to parse config update")
 	}
 	hostChanged, err := buf.config.UpdateFrom(buf.pendingHostConfig, config.DatastorePerHost)
 	if err != nil {
-		logCxt.WithError(err).Fatal("Failed to parse config update")
+		logCxt.WithError(err).Panic("Failed to parse config update")
 	}
 	if globalChanged || hostChanged {
 		rawConfig := buf.config.RawValues()

--- a/calc/utils_net_test.go
+++ b/calc/utils_net_test.go
@@ -25,7 +25,7 @@ import (
 func mustParseMac(m string) *net.MAC {
 	hwAddr, err := net2.ParseMAC(m)
 	if err != nil {
-		log.Fatalf("Failed to parse MAC: %v; %v", m, err)
+		log.Panicf("Failed to parse MAC: %v; %v", m, err)
 	}
 	return &net.MAC{hwAddr}
 }
@@ -33,7 +33,7 @@ func mustParseMac(m string) *net.MAC {
 func mustParseNet(n string) net.IPNet {
 	_, cidr, err := net.ParseCIDR(n)
 	if err != nil {
-		log.Fatalf("Failed to parse CIDR %v; %v", n, err)
+		log.Panicf("Failed to parse CIDR %v; %v", n, err)
 	}
 	return *cidr
 }

--- a/calc/utils_selector_test.go
+++ b/calc/utils_selector_test.go
@@ -23,7 +23,7 @@ import (
 func selectorId(selStr string) string {
 	sel, err := selector.Parse(selStr)
 	if err != nil {
-		log.Fatalf("Failed to parse %v: %v", selStr, err)
+		log.Panicf("Failed to parse %v: %v", selStr, err)
 	}
 	return sel.UniqueID()
 }

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -94,7 +94,7 @@ func (d *Dispatcher) OnUpdate(update api.Update) (filterOut bool) {
 	keyType := reflect.TypeOf(update.Key)
 	log.Debug("Type: ", keyType)
 	if update.Value != nil && reflect.TypeOf(update.Value).Kind() == reflect.Struct {
-		log.Fatalf("KVPair contained a struct instead of expected pointer: %#v", update)
+		log.Panicf("KVPair contained a struct instead of expected pointer: %#v", update)
 	}
 	typeSpecificHandlers := d.typeToHandler[keyType]
 	log.WithField("typeSpecificHandlers", typeSpecificHandlers).Debug(

--- a/ifacemonitor/iface_monitor.go
+++ b/ifacemonitor/iface_monitor.go
@@ -75,7 +75,7 @@ func (m *InterfaceMonitor) MonitorInterfaces() {
 	updates := make(chan netlink.LinkUpdate, 10)
 	addrUpdates := make(chan netlink.AddrUpdate, 10)
 	if err := m.netlinkStub.Subscribe(updates, addrUpdates); err != nil {
-		log.WithError(err).Fatal("Failed to subscribe to netlink stub")
+		log.WithError(err).Panic("Failed to subscribe to netlink stub")
 	}
 	log.Info("Subscribed to netlink updates.")
 
@@ -84,7 +84,7 @@ func (m *InterfaceMonitor) MonitorInterfaces() {
 	// subscription vs a list operation as used by resync().
 	err := m.resync()
 	if err != nil {
-		log.WithError(err).Fatal("Failed to read link states from netlink.")
+		log.WithError(err).Panic("Failed to read link states from netlink.")
 	}
 
 readLoop:
@@ -113,11 +113,11 @@ readLoop:
 			log.Debug("Resync trigger")
 			err := m.resync()
 			if err != nil {
-				log.WithError(err).Fatal("Failed to read link states from netlink.")
+				log.WithError(err).Panic("Failed to read link states from netlink.")
 			}
 		}
 	}
-	log.Fatal("Failed to read events from Netlink.")
+	log.Panic("Failed to read events from Netlink.")
 }
 
 func (m *InterfaceMonitor) handleNetlinkUpdate(update netlink.LinkUpdate) {

--- a/ifacemonitor/netlink_real.go
+++ b/ifacemonitor/netlink_real.go
@@ -30,11 +30,11 @@ func (nl *netlinkReal) Subscribe(
 	cancel := make(chan struct{})
 
 	if err := netlink.LinkSubscribe(linkUpdates, cancel); err != nil {
-		log.WithError(err).Fatal("Failed to subscribe to link updates")
+		log.WithError(err).Panic("Failed to subscribe to link updates")
 		return err
 	}
 	if err := netlink.AddrSubscribe(addrUpdates, cancel); err != nil {
-		log.WithError(err).Fatal("Failed to subscribe to addr updates")
+		log.WithError(err).Panic("Failed to subscribe to addr updates")
 		return err
 	}
 


### PR DESCRIPTION
Fatal() results in a silent process exit when running under Ginkgo, which
is very annoying to diagnose.

Ginkgo is able to catch panics and logs them sensibly with context.

I didn't remove _all_ uses of Fatal.  The ones in felix.go are appropriate, I think.  I was worried about swapping out the ones in logutils in case there was some unfortunate cycle created.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
