### PR TITLE
Minor container FV improvements.  Add multiple port support, parallel conn checker.

### DIFF
--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -23,9 +23,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/felix/fv/utils"
 	"github.com/projectcalico/libcalico-go/lib/set"
-	log "github.com/sirupsen/logrus"
 )
 
 type Container struct {

--- a/fv/host_port_test.go
+++ b/fv/host_port_test.go
@@ -19,6 +19,8 @@ package fv_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/felix/fv/containers"
 	"github.com/projectcalico/felix/fv/metrics"
 	"github.com/projectcalico/felix/fv/utils"
@@ -26,7 +28,6 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/client"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
-	log "github.com/sirupsen/logrus"
 )
 
 func RunEtcd() *containers.Container {
@@ -41,6 +42,7 @@ func RunFelix(etcdIP string) *containers.Container {
 	return containers.Run("felix-fv",
 		"--privileged",
 		"-e", "CALICO_DATASTORE_TYPE=etcdv2",
+		"-e", "FELIX_LOGSEVERITYSCREEN=debug",
 		"-e", "FELIX_DATASTORETYPE=etcdv2",
 		"-e", "FELIX_ETCDENDPOINTS=http://"+etcdIP+":2379",
 		"-e", "FELIX_PROMETHEUSMETRICSENABLED=true",
@@ -143,7 +145,7 @@ var _ = Context("with initialized Felix and etcd datastore", func() {
 	})
 
 	It("with a local workload, port should be reachable", func() {
-		w := workload.Run(felix, "cali12345", "10.65.0.2", "8055")
+		w := workload.Run(felix, "w", "cali12345", "10.65.0.2", "8055")
 		w.Configure(client)
 		Eventually(metricsPortReachable, "10s", "1s").Should(BeTrue())
 		w.Stop()

--- a/fv/ingress_egress_test.go
+++ b/fv/ingress_egress_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/projectcalico/felix/fv/containers"
 	"github.com/projectcalico/felix/fv/utils"
 	"github.com/projectcalico/felix/fv/workload"
@@ -70,7 +71,7 @@ var _ = Context("with initialized Felix, etcd datastore, 3 workloads", func() {
 		// Create three workloads, using that profile.
 		for ii := 0; ii < 3; ii++ {
 			iiStr := strconv.Itoa(ii)
-			w[ii] = workload.Run(felix, "cali1"+iiStr, "10.65.0.1"+iiStr, "8055")
+			w[ii] = workload.Run(felix, "w"+iiStr, "cali1"+iiStr, "10.65.0.1"+iiStr, "8055")
 			w[ii].Configure(client)
 		}
 	})

--- a/fv/test-connection/test-connection.go
+++ b/fv/test-connection/test-connection.go
@@ -24,8 +24,9 @@ import (
 
 	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/docopt/docopt-go"
-	"github.com/projectcalico/felix/fv/utils"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/fv/utils"
 )
 
 const usage = `test-connection: test connection to some target, for Felix FV testing.

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -24,23 +24,25 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/felix/fv/containers"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/client"
 	"github.com/projectcalico/libcalico-go/lib/net"
-	log "github.com/sirupsen/logrus"
 )
 
 type Workload struct {
-	C             *containers.Container
-	Name          string
-	InterfaceName string
-	IP            string
-	Port          string
-	runCmd        *exec.Cmd
-	outPipe       io.ReadCloser
-	errPipe       io.ReadCloser
-	namespacePath string
+	C                *containers.Container
+	Name             string
+	InterfaceName    string
+	IP               string
+	Ports            string
+	runCmd           *exec.Cmd
+	outPipe          io.ReadCloser
+	errPipe          io.ReadCloser
+	namespacePath    string
+	WorkloadEndpoint *api.WorkloadEndpoint
 }
 
 var workloadIdx = 0
@@ -69,16 +71,16 @@ func (w *Workload) Stop() {
 	}
 }
 
-func Run(c *containers.Container, interfaceName, ip, port string) (w *Workload) {
+func Run(c *containers.Container, name, interfaceName, ip, ports string) (w *Workload) {
 
 	// Build unique workload name and struct.
 	workloadIdx++
 	w = &Workload{
 		C:             c,
-		Name:          fmt.Sprintf("w%v", workloadIdx),
+		Name:          fmt.Sprintf("%s-idx%v", name, workloadIdx),
 		InterfaceName: interfaceName,
 		IP:            ip,
-		Port:          port,
+		Ports:         ports,
 	}
 
 	// Ensure that the host has the 'test-workload' binary.
@@ -92,7 +94,7 @@ func Run(c *containers.Container, interfaceName, ip, port string) (w *Workload) 
 			w.Name,
 			w.InterfaceName,
 			w.IP,
-			w.Port))
+			w.Ports))
 	var err error
 	w.outPipe, err = w.runCmd.StdoutPipe()
 	Expect(err).NotTo(HaveOccurred())
@@ -102,16 +104,35 @@ func Run(c *containers.Container, interfaceName, ip, port string) (w *Workload) 
 	Expect(err).NotTo(HaveOccurred())
 
 	// Read the workload's namespace path, which it writes to its standard output.
-	namespacePath, err := bufio.NewReader(w.outPipe).ReadString('\n')
+	stdoutReader := bufio.NewReader(w.outPipe)
+	stderrReader := bufio.NewReader(w.errPipe)
+	namespacePath, err := stdoutReader.ReadString('\n')
 	Expect(err).NotTo(HaveOccurred())
 	w.namespacePath = strings.TrimSpace(namespacePath)
 
+	go func() {
+		for {
+			line, err := stderrReader.ReadString('\n')
+			if err != nil {
+				log.WithError(err).Info("End of workload stderr")
+				return
+			}
+			log.Infof("Workload %s stderr: %s", name, strings.TrimSpace(string(line)))
+		}
+	}()
+	go func() {
+		for {
+			line, err := stdoutReader.ReadString('\n')
+			if err != nil {
+				log.WithError(err).Info("End of workload stdout")
+				return
+			}
+			log.Infof("Workload %s stdout: %s", name, strings.TrimSpace(string(line)))
+		}
+	}()
+
 	log.WithField("workload", w).Info("Workload now running")
 
-	return
-}
-
-func (w *Workload) Configure(client *client.Client) {
 	wep := api.NewWorkloadEndpoint()
 	wep.Metadata.Name = w.Name
 	wep.Metadata.Workload = w.Name
@@ -121,7 +142,13 @@ func (w *Workload) Configure(client *client.Client) {
 	wep.Spec.IPNetworks = []net.IPNet{net.MustParseNetwork(w.IP + "/32")}
 	wep.Spec.InterfaceName = w.InterfaceName
 	wep.Spec.Profiles = []string{"default"}
-	_, err := client.WorkloadEndpoints().Create(wep)
+	w.WorkloadEndpoint = wep
+
+	return
+}
+
+func (w *Workload) Configure(client *client.Client) {
+	_, err := client.WorkloadEndpoints().Apply(w.WorkloadEndpoint)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -157,12 +184,19 @@ func (w *Workload) CanConnectTo(ip, port string) bool {
 	return err == nil
 }
 
+func HaveConnectivityToPort(target *Workload, port uint16) types.GomegaMatcher {
+	return &connectivityMatcher{target.IP, fmt.Sprintf("%d", port), fmt.Sprintf("%s on port %d", target.Name, port)}
+}
+
 func HaveConnectivityTo(target *Workload) types.GomegaMatcher {
-	return &connectivityMatcher{target.IP, target.Port}
+	if strings.Contains(target.Ports, ",") {
+		panic("HaveConnectivityTo only supports a single port")
+	}
+	return &connectivityMatcher{target.IP, target.Ports, target.Name}
 }
 
 type connectivityMatcher struct {
-	ip, port string
+	ip, port, targetName string
 }
 
 func (m *connectivityMatcher) Match(actual interface{}) (success bool, err error) {
@@ -173,12 +207,12 @@ func (m *connectivityMatcher) Match(actual interface{}) (success bool, err error
 
 func (m *connectivityMatcher) FailureMessage(actual interface{}) (message string) {
 	w := actual.(*Workload)
-	message = fmt.Sprintf("Expected %v to have connectivity to %v:%v, but it doesn't", w, m.ip, m.port)
+	message = fmt.Sprintf("Expected %v\n\t%+v\nto have connectivity to %v\n\t%v:%v\nbut it doesn't", w.Name, w, m.targetName, m.ip, m.port)
 	return
 }
 
 func (m *connectivityMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	w := actual.(*Workload)
-	message = fmt.Sprintf("Expected %v not to have connectivity to %v:%v, but it does", w, m.ip, m.port)
+	message = fmt.Sprintf("Expected %v\n\t%+v\nnot to have connectivity to %v\n\t%v:%v\nbut it does", w.Name, w, m.targetName, m.ip, m.port)
 	return
 }

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -53,21 +53,13 @@ func (w *Workload) Stop() {
 	} else {
 		log.WithField("workload", w).Info("Stop")
 		outputBytes, err := exec.Command("docker", "exec", w.C.Name,
-			"cat",
-			fmt.Sprintf("/tmp/%v", w.Name)).CombinedOutput()
+			"cat", fmt.Sprintf("/tmp/%v", w.Name)).CombinedOutput()
 		Expect(err).NotTo(HaveOccurred())
 		pid := strings.TrimSpace(string(outputBytes))
 		err = exec.Command("docker", "exec", w.C.Name, "kill", pid).Run()
 		Expect(err).NotTo(HaveOccurred())
 		w.runCmd.Process.Wait()
-		wOut, err := ioutil.ReadAll(w.outPipe)
-		Expect(err).NotTo(HaveOccurred())
-		wErr, err := ioutil.ReadAll(w.errPipe)
-		Expect(err).NotTo(HaveOccurred())
-		log.WithFields(log.Fields{
-			"workload": w,
-			"stdout":   string(wOut),
-			"stderr":   string(wErr)}).Info("Workload now stopped")
+		log.WithField("workload", w).Info("Workload now stopped")
 	}
 }
 


### PR DESCRIPTION
## Description

Broke this out of my named ports work in the hope of avoiding more conflicts...

- Add support for multiple ports to the container FV framework.
- Add support for explicit names to make diags more meaningful.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
