### PR TITLE
Include port in connectivity diags.

### DIFF
--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -250,7 +250,7 @@ func (c *ConnectivityChecker) ActualConnectivity() []string {
 		go func(i int, exp expectation) {
 			defer wg.Done()
 			hasConnectivity := exp.from.CanConnectTo(exp.to.IP, fmt.Sprint(exp.port))
-			result[i] = fmt.Sprintf("%s -> %s = %v", exp.from.Name, exp.to.Name, hasConnectivity)
+			result[i] = fmt.Sprintf("%s -> %s:%d = %v", exp.from.Name, exp.to.Name, exp.port, hasConnectivity)
 		}(i, exp)
 	}
 	wg.Wait()
@@ -262,7 +262,7 @@ func (c *ConnectivityChecker) ActualConnectivity() []string {
 func (c *ConnectivityChecker) ExpectedConnectivity() []string {
 	result := make([]string, len(c.expectations))
 	for i, exp := range c.expectations {
-		result[i] = fmt.Sprintf("%s -> %s = %v", exp.from.Name, exp.to.Name, exp.expected)
+		result[i] = fmt.Sprintf("%s -> %s:%d = %v", exp.from.Name, exp.to.Name, exp.port, exp.expected)
 	}
 	return result
 }


### PR DESCRIPTION
## Description
Improve the connectivity checker's diags by including the port.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
