### PR TITLE
Fix AllowAction flags behavior, so it replaces all ALLOWs with RETURNs.

### DIFF
--- a/rules/static.go
+++ b/rules/static.go
@@ -44,7 +44,7 @@ func (r *DefaultRuleRenderer) acceptAlreadyAccepted() []Rule {
 	return []Rule{
 		{
 			Match:  Match().MarkSet(r.IptablesMarkAccept),
-			Action: AcceptAction{},
+			Action: r.filterAllowAction,
 		},
 	}
 }
@@ -122,7 +122,7 @@ func (r *DefaultRuleRenderer) filterWorkloadToHostChain(ipVersion uint8) *Chain 
 				Match: Match().
 					ProtocolNum(ProtoICMPv6).
 					ICMPV6Type(icmpType),
-				Action: AcceptAction{},
+				Action: r.filterAllowAction,
 			})
 		}
 	}
@@ -267,11 +267,11 @@ func (r *DefaultRuleRenderer) StaticFilterForwardChains() []*Chain {
 		rules = append(rules,
 			Rule{
 				Match:  Match().InInterface(ifaceMatch),
-				Action: AcceptAction{},
+				Action: r.filterAllowAction,
 			},
 			Rule{
 				Match:  Match().OutInterface(ifaceMatch),
-				Action: AcceptAction{},
+				Action: r.filterAllowAction,
 			},
 		)
 	}

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -509,9 +509,9 @@ var _ = Describe("Static", func() {
 
 						// Accept if workload policy matched.
 						{Match: Match().InInterface("cali+"),
-							Action: AcceptAction{}},
+							Action: ReturnAction{}},
 						{Match: Match().OutInterface("cali+"),
-							Action: AcceptAction{}},
+							Action: ReturnAction{}},
 
 						// Non-workload through-traffic, pass to host endpoint chains.
 						{Action: ClearMarkAction{Mark: 0xe0}},
@@ -533,7 +533,7 @@ var _ = Describe("Static", func() {
 					Rules: []Rule{
 						// Untracked packets already matched in raw table.
 						{Match: Match().MarkSet(0x10),
-							Action: AcceptAction{}},
+							Action: ReturnAction{}},
 
 						// Per-prefix workload jump rules.  Note use of goto so that we
 						// don't return here.
@@ -557,7 +557,7 @@ var _ = Describe("Static", func() {
 					Rules: []Rule{
 						// Untracked packets already matched in raw table.
 						{Match: Match().MarkSet(0x10),
-							Action: AcceptAction{}},
+							Action: ReturnAction{}},
 
 						// Return if to workload.
 						{Match: Match().OutInterface("cali+"), Action: ReturnAction{}},


### PR DESCRIPTION
## Description
This PR fixes the `IptablesFilterAllowAction` and `IptablesMangleAllowAction` flags so they return all packets when they're set to RETURN.

As discussed on Slack, the original intent of these flags is to allow operators to insert their own iptables rules in the top-level iptables chains after the Calico chains, to do further filtering or manipulation of the packets. Therefore, Calico should return all allowed packets to the original chain, instead of outright accepting them.

Unfortunately, setting the flags to RETURN only change some ACCEPTs to RETURNs, but not all, so most of the traffic is still ACCEPTed by Calico, making the flags not very useful.

This PR fixes the flags so all the allowed Calico traffic gets returned to the top-level iptables chains.

The only exception is the failsafe traffic. Calico still ACCEPTs it. It can be changed to RETURN too, but:
- it would require the cali-failsafe chains to return the acceptance status via a mark bit, like the policy chains do, incurring in extra load.
- The failsafe wouldn't protect against user misconfigurations in their own rules. (Maybe that's OK since it's outside Calico's responsibility)

IMO this is not a big deal, if you want all traffic to hit your chains you can just disable the failsafe.

To be more specific, this PR ensure that Calico behavior is the following: 

- If IptablesAllowAction == ACCEPT, the cali-INPUT, cali-OUTPUT, cali-FORWARD chains in the filter table should:
  - ACCEPT packets allowed by calico failsafe
  - ACCEPT packets accepted by calico policy
  - DROP packets denied by calico policy
  - RETURN packets for endpoints not managed by calico

- If IptablesAllowAction == RETURN, the cali-INPUT, cali-OUTPUT, cali-FORWARD chains in the filter table should:
  - ACCEPT packets allowed by calico failsafe
  - RETURN packets accepted by calico policy
  - DROP packets denied by calico policy
  - RETURN packets for endpoints not managed by calico
- Same for the chains in the mangle table.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed the behavior when setting IptablesFilterAllowAction or IptablesMangleAllowAction to RETURN: now all packets allowed by Calico are returned to the top-level chains for further processing.
```
