### PR TITLE
Fix OpenStack detection heuristic to ignore 'none'.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -219,14 +219,19 @@ func (c *Config) InterfacePrefixes() []string {
 
 func (config *Config) OpenstackActive() bool {
 	if strings.Contains(strings.ToLower(config.ClusterType), "openstack") {
+		// OpenStack is explicitly known to be present.  Newer versions of the OpenStack plugin
+		// set this flag.
 		log.Debug("Cluster type contains OpenStack")
 		return true
 	}
-	if config.MetadataAddr != "127.0.0.1" {
+	// If we get here, either OpenStack isn't present or we're running against an old version
+	// of the OpenStack plugin, which doesn't set the flag.  Use heuristics based on the
+	// presence of the OpenStack-related parameters.
+	if config.MetadataAddr != "" && config.MetadataAddr != "127.0.0.1" {
 		log.Debug("OpenStack metadata IP set to non-default, assuming OpenStack active")
 		return true
 	}
-	if config.MetadataPort != 8775 {
+	if config.MetadataPort != 0 && config.MetadataPort != 8775 {
 		log.Debug("OpenStack metadata port set to non-default, assuming OpenStack active")
 		return true
 	}


### PR DESCRIPTION
## Description
Fixes #1554 and adds UTs for that that code to verify the different cases.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) Not needed
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
