### PR TITLE
Explicitly allow IPIP packets from/to Calico hosts.

### DIFF
--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -19,6 +19,7 @@ RUN apk --no-cache add wget ca-certificates libgcc && \
 RUN apk --no-cache add ip6tables ipset iputils iproute2 conntrack-tools 
 
 ADD felix.cfg /etc/calico/felix.cfg
+ADD calico-felix-wrapper usr/bin
 
 # Put out binary in /code rather than directly in /usr/bin.  This allows the downstream builds
 # to more easily extract the Felix build artefacts from the container.
@@ -28,4 +29,4 @@ WORKDIR /code
 RUN ln -s /code/calico-felix /usr/bin
 
 # Run felix by default
-CMD ["calico-felix"]
+CMD ["calico-felix-wrapper"]

--- a/docker-image/calico-felix-wrapper
+++ b/docker-image/calico-felix-wrapper
@@ -1,0 +1,42 @@
+#!/bin/ash
+
+# Copyright (c) 2017 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This wrapper script  runs the calico-felix binary and restarts it if it
+# exits for a config change, which is signalled by an exit code of 129,
+# as used by SIGHUP.
+
+# Pass signals sent to this script through to Felix.
+trap 'echo "SIGINT received, passing on to calico-felix"; kill -INT $pid' SIGINT
+trap 'echo "SIGTERM received, passing on to calico-felix"; kill -TERM $pid' SIGTERM
+trap 'echo "SIGHUP received, passing on to calico-felix"; kill -HUP $pid' SIGHUP
+
+rc=unknown
+
+while true; do
+  echo "Starting calico-felix"
+  calico-felix &
+  pid=$!
+  echo "Started calico-felix, PID=$pid"
+  wait $pid
+  rc=$?
+  echo "Process stopped, RC=$rc"
+  if [ "$rc" == "129" ]; then
+    echo "Restarting calico-felix for config reload"
+    continue
+  fi
+  echo "Exiting due to non-config shutdown RC=$rc"
+  break
+done

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -271,52 +271,34 @@ func RunFelix(etcdIP string) *Container {
 
 // StartSingleNodeEtcdTopology starts an etcd container and a single Felix container; it initialises
 // the datastore and installs a Node resource for the Felix node.
-func StartSingleNodeEtcdTopology() (felix, etcd *Container, client client.Interface) {
-	log.Info("Starting a single-node etcd topology.")
-	success := false
-	defer func() {
-		if !success {
-			log.Error("Failed to start topology, tearing down containers")
-			felix.Stop()
-			etcd.Stop()
-		}
-	}()
-
-	// First start etcd.
-	etcd = RunEtcd()
-
-	// Connect to etcd.
-	client = utils.GetEtcdClient(etcd.IP)
-	Eventually(func() error {
-		log.Info("Initializing the datastore...")
-		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-		err := client.EnsureInitialized(
-			ctx,
-			"test-version",
-			"felix-fv",
-		)
-		log.WithError(err).Info("EnsureInitialized result")
-		return err
-	}).ShouldNot(HaveOccurred())
-
-	// Then start Felix and create a node for it.
-	felix = RunFelix(etcd.IP)
-
-	felixNode := api.NewNode()
-	felixNode.Name = felix.Hostname
-	Eventually(func() error {
-		_, err := client.Nodes().Create(utils.Ctx, felixNode, utils.NoOptions)
-		return err
-	}, "10s", "500ms").ShouldNot(HaveOccurred())
-
-	success = true
+func StartSingleNodeEtcdTopology() (felix, etcd *Container, calicoClient client.Interface) {
+	felixes, etcd, calicoClient := StartNNodeEtcdTopology(1)
+	felix = felixes[0]
 	return
 }
 
-// StartSingleNodeEtcdTopology starts an etcd container and a single Felix container; it initialises
-// the datastore and installs a Node resource for the Felix node.
-func StartTwoNodeEtcdIPIPTopology() (felixes []*Container, etcd *Container, client client.Interface) {
-	log.Info("Starting a single-node etcd topology.")
+// StartTwoNodeEtcdTopology starts an etcd container and a pair of Felix hosts connected
+// with IPIP.
+//
+// - Configures an IPAM pool for 10.65.0.0/16 (so that Felix programs the all-IPAM blocks IP set)
+//   but (for simplicity) we don't actually use IPAM to assign IPs.
+// - Configures routes between the two "hosts", giving each host 10.65.x.0/24, where x is the
+//   index in the returned array.  When creating workloads, use IPs from the relevant block.
+// - Configures the Tunnel IP as 10.65.x.1
+func StartTwoNodeEtcdTopology() (felixes []*Container, etcd *Container, client client.Interface) {
+	return StartNNodeEtcdTopology(2)
+}
+
+// StartNNodeEtcdTopology starts an etcd container and a set of Felix hosts.  If n > 1, sets
+// up IPIP, otherwise this is skipped.
+//
+// - Configures an IPAM pool for 10.65.0.0/16 (so that Felix programs the all-IPAM blocks IP set)
+//   but (for simplicity) we don't actually use IPAM to assign IPs.
+// - Configures routes between the hosts, giving each host 10.65.x.0/24, where x is the
+//   index in the returned array.  When creating workloads, use IPs from the relevant block.
+// - Configures the Tunnel IP for each host as 10.65.x.1.
+func StartNNodeEtcdTopology(n int) (felixes []*Container, etcd *Container, client client.Interface) {
+	log.Infof("Starting a %d-node etcd topology.", n)
 	success := false
 	var err error
 	defer func() {
@@ -334,39 +316,32 @@ func StartTwoNodeEtcdIPIPTopology() (felixes []*Container, etcd *Container, clie
 
 	// Connect to etcd.
 	client = utils.GetEtcdClient(etcd.IP)
-	Eventually(func() error {
-		log.Info("Initializing the datastore...")
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		err = client.EnsureInitialized(
-			ctx,
-			"test-version",
-			"felix-fv",
-		)
-		log.WithError(err).Info("EnsureInitialized result")
-		if err != nil {
-			log.WithError(err).Warn("EnsureInitialized failed")
-			return err
-		}
-		ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		ipPool := api.NewIPPool()
-		ipPool.Name = "test-pool"
-		ipPool.Spec.CIDR = "10.65.0.0/16"
-		ipPool.Spec.IPIPMode = api.IPIPModeAlways
-		_, err = client.IPPools().Create(ctx, ipPool, options.SetOptions{})
-		return err
-	}).ShouldNot(HaveOccurred())
+	mustInitDatastore(client)
 
-	for i := 0; i < 2; i++ {
+	if n > 1 {
+		Eventually(func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			ipPool := api.NewIPPool()
+			ipPool.Name = "test-pool"
+			ipPool.Spec.CIDR = "10.65.0.0/16"
+			ipPool.Spec.IPIPMode = api.IPIPModeAlways
+			_, err = client.IPPools().Create(ctx, ipPool, options.SetOptions{})
+			return err
+		}).ShouldNot(HaveOccurred())
+	}
+
+	for i := 0; i < n; i++ {
 		// Then start Felix and create a node for it.
 		felix := RunFelix(etcd.IP)
 
 		felixNode := api.NewNode()
 		felixNode.Name = felix.Hostname
-		felixNode.Spec.BGP = &api.NodeBGPSpec{
-			IPv4Address:        felix.IP,
-			IPv4IPIPTunnelAddr: fmt.Sprintf("10.65.%d.1", i),
+		if n > 1 {
+			felixNode.Spec.BGP = &api.NodeBGPSpec{
+				IPv4Address:        felix.IP,
+				IPv4IPIPTunnelAddr: fmt.Sprintf("10.65.%d.1", i),
+			}
 		}
 		Eventually(func() error {
 			_, err = client.Nodes().Create(utils.Ctx, felixNode, utils.NoOptions)
@@ -379,6 +354,8 @@ func StartTwoNodeEtcdIPIPTopology() (felixes []*Container, etcd *Container, clie
 		felixes = append(felixes, felix)
 	}
 
+	// Set up routes between the hosts, note: we're not using IPAM here but we set up similar
+	// CIDR-based routes.
 	for i, iFelix := range felixes {
 		for j, jFelix := range felixes {
 			if i == j {
@@ -392,4 +369,18 @@ func StartTwoNodeEtcdIPIPTopology() (felixes []*Container, etcd *Container, clie
 	}
 	success = true
 	return
+}
+
+func mustInitDatastore(client client.Interface) {
+	Eventually(func() error {
+		log.Info("Initializing the datastore...")
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		err := client.EnsureInitialized(
+			ctx,
+			"test-version",
+			"felix-fv",
+		)
+		log.WithError(err).Info("EnsureInitialized result")
+		return err
+	}).ShouldNot(HaveOccurred())
 }

--- a/fv/health_test.go
+++ b/fv/health_test.go
@@ -359,8 +359,8 @@ var _ = Describe("health tests", func() {
 			"-e", "K8S_INSECURE_SKIP_TLS_VERIFY=true",
 			"-e", "FELIX_TYPHAADDR="+typhaAddr,
 			"-v", k8sCertFilename+":/tmp/apiserver.crt",
-			"calico/felix", // TODO Felix version
-			"calico-felix")
+			"calico/felix:latest",
+		)
 		Expect(felixContainer).NotTo(BeNil())
 
 		felixReady = getHealthStatus(felixContainer.IP, "9099", "readiness")

--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -47,7 +47,7 @@ var _ = Context("with etcd IPIP topology before adding host IPs to IP sets", fun
 	)
 
 	BeforeEach(func() {
-		felixes, etcd, client = containers.StartTwoNodeEtcdIPIPTopology()
+		felixes, etcd, client = containers.StartTwoNodeEtcdTopology()
 
 		// Install a default profile that allows all ingress and egress, in the absence of any Policy.
 		defaultProfile := api.NewProfile()
@@ -145,7 +145,7 @@ var _ = Context("with etcd IPIP topology before adding host IPs to IP sets", fun
 		})
 
 		It("should have workload connectivity but not host connectivity", func() {
-			// Host endpoints block host-host traffic.
+			// Host endpoints (with no policies) block host-host traffic due to default drop.
 			cc.ExpectNone(felixes[0], hostW[1])
 			cc.ExpectNone(felixes[1], hostW[0])
 			// But the rules to allow IPIP between our hosts let the workload traffic through.

--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -1,0 +1,178 @@
+// +build fvtests
+
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/projectcalico/felix/fv/containers"
+	"github.com/projectcalico/felix/fv/utils"
+	"github.com/projectcalico/felix/fv/workload"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+)
+
+var _ = Context("with etcd IPIP topology before adding host IPs to IP sets", func() {
+
+	var (
+		etcd    *containers.Container
+		felixes []*containers.Container
+		client  client.Interface
+		w       [2]*workload.Workload
+		hostW   [2]*workload.Workload
+		cc      *workload.ConnectivityChecker
+	)
+
+	BeforeEach(func() {
+		felixes, etcd, client = containers.StartTwoNodeEtcdIPIPTopology()
+
+		// Install a default profile that allows all ingress and egress, in the absence of any Policy.
+		defaultProfile := api.NewProfile()
+		defaultProfile.Name = "default"
+		defaultProfile.Spec.LabelsToApply = map[string]string{"default": ""}
+		defaultProfile.Spec.Egress = []api.Rule{{Action: api.Allow}}
+		defaultProfile.Spec.Ingress = []api.Rule{{Action: api.Allow}}
+		_, err := client.Profiles().Create(utils.Ctx, defaultProfile, utils.NoOptions)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait until the tunl0 device appears; it is created when felix inserts the ipip module
+		// into the kernel.
+		Eventually(func() error {
+			links, err := netlink.LinkList()
+			if err != nil {
+				return err
+			}
+			for _, link := range links {
+				if link.Attrs().Name == "tunl0" {
+					return nil
+				}
+			}
+			return errors.New("tunl0 wasn't auto-created")
+		}).Should(BeNil())
+
+		// Create workloads, using that profile.  One on each "host".
+		for ii := range w {
+			wIP := fmt.Sprintf("10.65.%d.2", ii)
+			wIface := fmt.Sprintf("cali1%d", ii)
+			wName := fmt.Sprintf("w%d", ii)
+			w[ii] = workload.Run(felixes[ii], wName, wIface, wIP, "8055", "tcp")
+			w[ii].Configure(client)
+
+			hostW[ii] = workload.Run(felixes[ii], fmt.Sprintf("host%d", ii), "", felixes[ii].IP, "8055", "tcp")
+		}
+
+		cc = &workload.ConnectivityChecker{}
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			for _, felix := range felixes {
+				felix.Exec("iptables-save", "-c")
+				felix.Exec("ip", "r")
+			}
+		}
+
+		for _, wl := range w {
+			wl.Stop()
+		}
+		for _, wl := range hostW {
+			wl.Stop()
+		}
+		for _, felix := range felixes {
+			felix.Stop()
+		}
+
+		if CurrentGinkgoTestDescription().Failed {
+			etcd.Exec("etcdctl", "ls", "--recursive", "/")
+		}
+		etcd.Stop()
+	})
+
+	It("should have workload to workload connectivity", func() {
+		cc.ExpectSome(w[0], w[1])
+		cc.ExpectSome(w[1], w[0])
+		cc.CheckConnectivity()
+	})
+
+	It("should have host to workload connectivity", func() {
+		cc.ExpectSome(felixes[0], w[1])
+		cc.ExpectSome(felixes[0], w[0])
+		cc.CheckConnectivity()
+	})
+
+	It("should have host to host connectivity", func() {
+		cc.ExpectSome(felixes[0], hostW[1])
+		cc.ExpectSome(felixes[1], hostW[0])
+		cc.CheckConnectivity()
+	})
+
+	Context("with host protection policy in place", func() {
+		BeforeEach(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			for _, f := range felixes {
+				hep := api.NewHostEndpoint()
+				hep.Name = "eth0-" + f.Name
+				hep.Spec.Node = f.Hostname
+				hep.Spec.ExpectedIPs = []string{f.IP}
+				_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		It("should have workload connectivity but not host connectivity", func() {
+			// Host endpoints block host-host traffic.
+			cc.ExpectNone(felixes[0], hostW[1])
+			cc.ExpectNone(felixes[1], hostW[0])
+			// But the rules to allow IPIP between our hosts let the workload traffic through.
+			cc.ExpectSome(w[0], w[1])
+			cc.ExpectSome(w[1], w[0])
+			cc.CheckConnectivity()
+		})
+	})
+
+	Context("after removing BGP address from nodes", func() {
+		// Simulate having a host send IPIP traffic from an unknown source, should get blocked.
+		BeforeEach(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			l, err := client.Nodes().List(ctx, options.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			for _, node := range l.Items {
+				node.Spec.BGP = nil
+				_, err := client.Nodes().Update(ctx, &node, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		It("should have no workload to workload connectivity", func() {
+			cc.ExpectNone(w[0], w[1])
+			cc.ExpectNone(w[1], w[0])
+			cc.CheckConnectivity()
+		})
+	})
+})

--- a/fv/utils/utils.go
+++ b/fv/utils/utils.go
@@ -68,7 +68,8 @@ func run(checkNoError bool, command string, args ...string) error {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"command": command,
-			"args":    args}).WithError(err).Warning("Command failed")
+			"args":    args,
+			"output":  string(outputBytes)}).WithError(err).Warning("Command failed")
 	}
 	if checkNoError {
 		Expect(err).NotTo(HaveOccurred())

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -90,7 +90,7 @@ func Run(c *containers.Container, name, interfaceName, ip, ports string, protoco
 	}
 	w.runCmd = utils.Command("docker", "exec", w.C.Name,
 		"sh", "-c",
-		fmt.Sprintf("echo $$ > /tmp/%v; exec /test-workload %v %v %v %v",
+		fmt.Sprintf("echo $$ > /tmp/%v; exec /test-workload %v '%v' '%v' '%v'",
 			w.Name,
 			udpArg,
 			w.InterfaceName,
@@ -387,4 +387,8 @@ func (c *ConnectivityChecker) ExpectedConnectivity() []string {
 		result[i] = fmt.Sprintf("%s -> %s = %v", exp.from.SourceName(), exp.to.targetName, exp.expected)
 	}
 	return result
+}
+
+func (c *ConnectivityChecker) CheckConnectivity() {
+	EventuallyWithOffset(1, c.ActualConnectivity(), "10s", "100ms").Should(Equal(c.ExpectedConnectivity()))
 }

--- a/iptables/match_builder.go
+++ b/iptables/match_builder.go
@@ -97,6 +97,10 @@ func (m MatchCriteria) SrcAddrType(addrType AddrType, limitIfaceOut bool) MatchC
 	}
 }
 
+func (m MatchCriteria) DestAddrType(addrType AddrType) MatchCriteria {
+	return append(m, fmt.Sprintf("-m addrtype --dst-type %s", addrType))
+}
+
 func (m MatchCriteria) ConntrackState(stateNames string) MatchCriteria {
 	return append(m, fmt.Sprintf("-m conntrack --ctstate %s", stateNames))
 }

--- a/iptables/match_builder_test.go
+++ b/iptables/match_builder_test.go
@@ -45,6 +45,7 @@ var _ = DescribeTable("MatchBuilder",
 	Entry("SrcAddrType no limit iface", Match().SrcAddrType(AddrTypeLocal, false), "-m addrtype --src-type LOCAL"),
 	Entry("NotSrcAddrType limit iface", Match().NotSrcAddrType(AddrTypeLocal, true), "-m addrtype ! --src-type LOCAL --limit-iface-out"),
 	Entry("NotSrcAddrType no limit iface", Match().NotSrcAddrType(AddrTypeLocal, false), "-m addrtype ! --src-type LOCAL"),
+	Entry("DestAddrType no limit iface", Match().DestAddrType(AddrTypeLocal), "-m addrtype --dst-type LOCAL"),
 	// Protocol.
 	Entry("Protocol", Match().Protocol("tcp"), "-p tcp"),
 	Entry("NotProtocol", Match().NotProtocol("tcp"), "! -p tcp"),

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -191,8 +191,7 @@ docker run --detach --privileged --name ${prefix}-felix \
        -e K8SFV_LOG_LEVEL=${K8SFV_LOG_LEVEL} \
        -v ${PWD}:/testcode \
        -w /testcode/k8sfv/output \
-       calico/felix:${FELIX_VERSION} \
-       /bin/sh -c "while true; do calico-felix; done"
+       calico/felix:${FELIX_VERSION}
 felix_ip=$(get_container_ip ${prefix}-felix)
 felix_hostname=$(get_container_hostname ${prefix}-felix)
 

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -210,7 +210,9 @@ type Config struct {
 	OpenStackMetadataPort        uint16
 	OpenStackSpecialCasesEnabled bool
 
-	IPIPEnabled       bool
+	IPIPEnabled bool
+	// IPIPTunnelAddress is an address chosen from an IPAM pool, used as a source address
+	// by the host when sending traffic to a workload over IPIP.
 	IPIPTunnelAddress net.IP
 
 	IptablesLogPrefix         string

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -446,11 +446,71 @@ var _ = Describe("Static", func() {
 			},
 		}
 
+		expOutputChainIPIPV4 := &Chain{
+			Name: "cali-OUTPUT",
+			Rules: []Rule{
+				// Untracked packets already matched in raw table.
+				{Match: Match().MarkSet(0x10),
+					Action: AcceptAction{}},
+
+				// To workload traffic.
+				{Match: Match().OutInterface("cali+").IPVSConnection(), Action: JumpAction{Target: "cali-to-wl-dispatch"}},
+				{Match: Match().OutInterface("cali+"), Action: ReturnAction{}},
+
+				// Auto-allow IPIP traffic to other Calico hosts.
+				{
+					Match: Match().ProtocolNum(4).
+						DestIPSet("cali4-all-hosts").
+						SrcAddrType(AddrTypeLocal, false),
+					Action:  AcceptAction{},
+					Comment: "Allow IPIP packets to other Calico hosts",
+				},
+
+				// Non-workload traffic, send to host chains.
+				{Action: ClearMarkAction{Mark: 0xf0}},
+				{Action: JumpAction{Target: ChainDispatchToHostEndpoint}},
+				{
+					Match:   Match().MarkSet(0x10),
+					Action:  AcceptAction{},
+					Comment: "Host endpoint policy accepted packet.",
+				},
+			},
+		}
+
+		// V6 should be unaffected.
+		expOutputChainIPIPV6 := &Chain{
+			Name: "cali-OUTPUT",
+			Rules: []Rule{
+				// Untracked packets already matched in raw table.
+				{Match: Match().MarkSet(0x10),
+					Action: AcceptAction{}},
+
+				// To workload traffic.
+				{Match: Match().OutInterface("cali+").IPVSConnection(), Action: JumpAction{Target: "cali-to-wl-dispatch"}},
+				{Match: Match().OutInterface("cali+"), Action: ReturnAction{}},
+
+				// Non-workload traffic, send to host chains.
+				{Action: ClearMarkAction{Mark: 0xf0}},
+				{Action: JumpAction{Target: ChainDispatchToHostEndpoint}},
+				{
+					Match:   Match().MarkSet(0x10),
+					Action:  AcceptAction{},
+					Comment: "Host endpoint policy accepted packet.",
+				},
+			},
+		}
+
 		It("IPv4: should include the expected input chain in the filter chains", func() {
 			Expect(findChain(rr.StaticFilterTableChains(4), "cali-INPUT")).To(Equal(expInputChainIPIPV4))
 		})
 		It("IPv6: should include the expected input chain in the filter chains", func() {
 			Expect(findChain(rr.StaticFilterTableChains(6), "cali-INPUT")).To(Equal(expInputChainIPIPV6))
+		})
+		It("IPv4: should include the expected output chain in the filter chains", func() {
+			Expect(findChain(rr.StaticFilterTableChains(4), "cali-OUTPUT")).To(Equal(expOutputChainIPIPV4))
+		})
+		It("IPv6: should include the expected output chain in the filter chains", func() {
+			Expect(findChain(rr.StaticFilterTableChains(6), "cali-OUTPUT")).To(Equal(expOutputChainIPIPV6))
 		})
 		It("IPv4: Should return expected NAT postrouting chain", func() {
 			Expect(rr.StaticNATPostroutingChains(4)).To(Equal([]*Chain{

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -394,8 +394,15 @@ var _ = Describe("Static", func() {
 				{Match: Match().MarkSet(0x10),
 					Action: AcceptAction{}},
 
-				// IPIP rule
-				{Match: Match().ProtocolNum(4).NotSourceIPSet("cali4-all-hosts"),
+				// IPIP rules
+				{Match: Match().
+					ProtocolNum(4).
+					SourceIPSet("cali4-all-hosts").
+					DestAddrType("LOCAL"),
+
+					Action:  AcceptAction{},
+					Comment: "Allow IPIP packets from Calico hosts"},
+				{Match: Match().ProtocolNum(4),
 					Action:  DropAction{},
 					Comment: "Drop IPIP packets from non-Calico hosts"},
 


### PR DESCRIPTION
## Description
Rather than fixing https://github.com/projectcalico/calico/issues/888 by doccing that a rule is needed, maybe we should make felix auto-generate the rule?  WDYT?

This removes the need for an explicit policy rule when using IPIP and host protection together.

Fixes https://github.com/projectcalico/calico/issues/888
Fixes https://github.com/projectcalico/calico/issues/1357

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation - checked the host protection guide, doesn't mention IPIP
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
When IPIP is enabled, Calico now installs an explicit allow rule for its IPIP traffic.  This removes the need to manually add such a rule when using host protection policy. 
```
