### PR TITLE
Typha health fv

### DIFF
--- a/fv/health_test.go
+++ b/fv/health_test.go
@@ -17,27 +17,22 @@
 package fv_test
 
 // The tests in this file test Felix's and Typha's health endpoints, http://.../liveness and
-// http://.../readiness.  Felix should report itself as:
+// http://.../readiness.
 //
-// - live, so long as its calc_graph and int_dataplane loops have not died or hung
+// Felix should report itself as live, so long as its calc_graph and int_dataplane loops have not
+// died or hung; and as ready, so long as it has completed its initial dataplane programming, is
+// connected to its datastore, and is not doing a resync (either the initial resync, or a subsequent
+// one).
 //
-// - ready, so long as it has completed its initial dataplane programming, is connected to its
-// datastore, and is not doing a resync (either the initial resync, or a subsequent one).
-//
-// Typha should report itself as:
-//
-// - live, so long as its Felix-serving loop has not died or hung
-//
-// - ready, so long as it is connected to its datastore, and is not doing a resync (either the
+// Typha should report itself as live, so long as its Felix-serving loop has not died or hung; and
+// as ready, so long as it is connected to its datastore, and is not doing a resync (either the
 // initial resync, or a subsequent one).
 //
-// (These reports are useful because k8s handles:
-//
-// - a pod that is consistently non-live, by killing and restarting it
-//
-// - a pod that is non-ready, by (a) not routing Service traffic to it (when that pod is otherwise
-// one of the possible backends for a Service), and (b) not moving on to the next pod, in a rolling
-// upgrade process, until the just-upgraded pod says that it is ready.)
+// (These reports are useful because k8s can detect and handle a pod that is consistently non-live,
+// by killing and restarting it; and can adjust for a pod that is non-ready, by (a) not routing
+// Service traffic to it (when that pod is otherwise one of the possible backends for a Service),
+// and (b) not moving on to the next pod, in a rolling upgrade process, until the just-upgraded pod
+// says that it is ready.)
 
 import (
 	"errors"

--- a/fv/health_test.go
+++ b/fv/health_test.go
@@ -16,6 +16,29 @@
 
 package fv_test
 
+// The tests in this file test Felix's and Typha's health endpoints, http://.../liveness and
+// http://.../readiness.  Felix should report itself as:
+//
+// - live, so long as its calc_graph and int_dataplane loops have not died or hung
+//
+// - ready, so long as it has completed its initial dataplane programming, is connected to its
+// datastore, and is not doing a resync (either the initial resync, or a subsequent one).
+//
+// Typha should report itself as:
+//
+// - live, so long as its Felix-serving loop has not died or hung
+//
+// - ready, so long as it is connected to its datastore, and is not doing a resync (either the
+// initial resync, or a subsequent one).
+//
+// (These reports are useful because k8s handles:
+//
+// - a pod that is consistently non-live, by killing and restarting it
+//
+// - a pod that is non-ready, by (a) not routing Service traffic to it (when that pod is otherwise
+// one of the possible backends for a Service), and (b) not moving on to the next pod, in a rolling
+// upgrade process, until the just-upgraded pod says that it is ready.)
+
 import (
 	"errors"
 	"fmt"

--- a/fv/health_test.go
+++ b/fv/health_test.go
@@ -68,7 +68,7 @@ import (
 
 type EnvConfig struct {
 	K8sVersion   string `default:"1.7.5"`
-	TyphaVersion string `default:"latest"`
+	TyphaVersion string `default:"v0.5.1-3-g00cc5d2"`
 }
 
 var config EnvConfig
@@ -452,8 +452,7 @@ var _ = Describe("health tests", func() {
 			Consistently(typhaReady, "10s", "1s").ShouldNot(BeGood())
 		})
 
-		// Pending because currently fails - investigation needed.
-		PIt("typha should report live", func() {
+		It("typha should report live", func() {
 			Eventually(typhaLiveness, "5s", "100ms").Should(BeGood())
 			Consistently(typhaLiveness, "10s", "1s").Should(BeGood())
 		})

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ae19a6683f4e7b7589fb56478cb4567390928b1da0b7348ddac3f9fad5e32468
-updated: 2017-09-24T18:23:31.096170181-07:00
+hash: 19281dea6207cd67aaa4b361d329318ab386643fda03b49032991e03511e30ee
+updated: 2017-09-26T20:28:46.881846402Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -45,7 +45,7 @@ imports:
   - httputil
   - timeutil
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
   subpackages:
   - spew
 - name: github.com/docker/distribution
@@ -82,7 +82,7 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
   - proto
 - name: github.com/google/gofuzz
@@ -187,7 +187,7 @@ imports:
   - lib/testutils
   - lib/validator
 - name: github.com/projectcalico/typha
-  version: 049f0ad98022129ccb29f7fb3d9859c8dd967728
+  version: 00cc5d2709a6eeae33f6392d66cfc9c977923eb5
   subpackages:
   - pkg/syncclient
   - pkg/syncproto
@@ -202,13 +202,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  version: 2f17f4a9d485bf34b4bfaccc273805040e4f86c8
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell
@@ -296,7 +296,7 @@ imports:
   - internal/urlfetch
   - urlfetch
 - name: gopkg.in/go-playground/validator.v8
-  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
+  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tchap/go-patricia.v2
@@ -436,4 +436,8 @@ imports:
   - util/homedir
   - util/integer
   - util/jsonpath
+- name: k8s.io/kube-openapi
+  version: 868f2f29720b192240e18284659231b440f9cda5
+  subpackages:
+  - pkg/common
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,7 +44,7 @@ import:
 - package: k8s.io/client-go
   version: 4a3ab2f5be5177366f8206fd79ce55ca80e417fa
 - package: github.com/projectcalico/typha
-  version: 049f0ad98022129ccb29f7fb3d9859c8dd967728
+  version: 00cc5d2709a6eeae33f6392d66cfc9c977923eb5
   subpackages:
   - pkg/syncclient
 - package: github.com/emicklei/go-restful


### PR DESCRIPTION
## Description
The spec for Typha liveness and readiness reporting is that Typha should report itself as:
- live, so long as its Felix-serving loop has not died or hung
- ready, so long as it is connected to its datastore, and is not doing a resync (either the initial resync, or a subsequent one).

However, if the datastore is unavailable (for some reason) when Typha is started, Typha does not report itself as live because it gets stuck trying to ensure that the datastore is initialized.  This issue is described  and fixed in the Typha repo at https://github.com/projectcalico/typha/pull/51, which has now been merged.

This PR updates Felix to use a fixed version of the Typha code, and re-enables the FV test that covers this scenario.
