### PR TITLE
Support workload ingress policy for kube-proxy running in ipvs mode.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -125,7 +125,8 @@ type Config struct {
 	MetadataAddr string `config:"hostname;127.0.0.1;die-on-fail"`
 	MetadataPort int    `config:"int(0,65535);8775;die-on-fail"`
 
-	InterfacePrefix string `config:"iface-list;cali;non-zero,die-on-fail"`
+	InterfacePrefix  string `config:"iface-list;cali;non-zero,die-on-fail"`
+	InterfaceExclude string `config:"iface-list;kube-ipvs0"`
 
 	ChainInsertMode             string `config:"oneof(insert,append);insert;non-zero,die-on-fail"`
 	DefaultEndpointToHostAction string `config:"oneof(DROP,RETURN,ACCEPT);DROP;non-zero,die-on-fail"`
@@ -215,6 +216,10 @@ func (config *Config) UpdateFrom(rawData map[string]string, source Source) (chan
 
 func (c *Config) InterfacePrefixes() []string {
 	return strings.Split(c.InterfacePrefix, ",")
+}
+
+func (c *Config) InterfaceExcludes() []string {
+	return strings.Split(c.InterfaceExclude, ",")
 }
 
 func (config *Config) OpenstackActive() bool {

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -71,6 +71,8 @@ var _ = DescribeTable("Config parsing",
 
 	Entry("InterfacePrefix", "InterfacePrefix", "tap", "tap"),
 	Entry("InterfacePrefix list", "InterfacePrefix", "tap,cali", "tap,cali"),
+	Entry("InterfaceExclude", "InterfaceExclude", "kube-ipvs0", "kube-ipvs0"),
+	Entry("InterfaceExclude list", "InterfaceExclude", "kube-ipvs0,dummy", "kube-ipvs0,dummy"),
 
 	Entry("ChainInsertMode append", "ChainInsertMode", "append", "append"),
 

--- a/felix.go
+++ b/felix.go
@@ -45,6 +45,7 @@ import (
 	"github.com/projectcalico/felix/config"
 	_ "github.com/projectcalico/felix/config"
 	"github.com/projectcalico/felix/extdataplane"
+	"github.com/projectcalico/felix/ifacemonitor"
 	"github.com/projectcalico/felix/intdataplane"
 	"github.com/projectcalico/felix/ipsets"
 	"github.com/projectcalico/felix/logutils"
@@ -250,6 +251,9 @@ configRetry:
 			"scratch1Mark": markScratch1,
 		}).Info("Calculated iptables mark bits")
 		dpConfig := intdataplane.Config{
+			IfaceMonitorConfig: ifacemonitor.Config{
+				InterfaceExcludes: configParams.InterfaceExcludes(),
+			},
 			RulesConfig: rules.Config{
 				WorkloadIfacePrefixes: configParams.InterfacePrefixes(),
 

--- a/intdataplane/int_dataplane.go
+++ b/intdataplane/int_dataplane.go
@@ -110,6 +110,8 @@ type Config struct {
 
 	RulesConfig rules.Config
 
+	IfaceMonitorConfig ifacemonitor.Config
+
 	StatusReportingInterval time.Duration
 
 	PostInSyncCallback func()
@@ -212,7 +214,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		fromDataplane:     make(chan interface{}, 100),
 		ruleRenderer:      ruleRenderer,
 		interfacePrefixes: config.RulesConfig.WorkloadIfacePrefixes,
-		ifaceMonitor:      ifacemonitor.New(),
+		ifaceMonitor:      ifacemonitor.New(config.IfaceMonitorConfig),
 		ifaceUpdates:      make(chan *ifaceUpdate, 100),
 		ifaceAddrUpdates:  make(chan *ifaceAddrsUpdate, 100),
 		config:            config,

--- a/intdataplane/int_dataplane_test.go
+++ b/intdataplane/int_dataplane_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/felix/config"
+	"github.com/projectcalico/felix/ifacemonitor"
 	"github.com/projectcalico/felix/intdataplane"
 	"github.com/projectcalico/felix/ipsets"
 	"github.com/projectcalico/felix/rules"
@@ -35,6 +36,9 @@ var _ = Describe("Constructor test", func() {
 	JustBeforeEach(func() {
 		configParams = config.New()
 		dpConfig = intdataplane.Config{
+			IfaceMonitorConfig: ifacemonitor.Config{
+				InterfaceExcludes: configParams.InterfaceExcludes(),
+			},
 			RulesConfig: rules.Config{
 				WorkloadIfacePrefixes: configParams.InterfacePrefixes(),
 

--- a/iptables/match_builder.go
+++ b/iptables/match_builder.go
@@ -67,6 +67,14 @@ func (m MatchCriteria) RPFCheckFailed() MatchCriteria {
 	return append(m, "-m rpfilter --invert")
 }
 
+func (m MatchCriteria) IPVSConnection() MatchCriteria {
+	return append(m, "-m ipvs --ipvs")
+}
+
+func (m MatchCriteria) NotIPVSConnection() MatchCriteria {
+	return append(m, "-m ipvs ! --ipvs")
+}
+
 type AddrType string
 
 const (

--- a/iptables/match_builder_test.go
+++ b/iptables/match_builder_test.go
@@ -81,4 +81,7 @@ var _ = DescribeTable("MatchBuilder",
 	// Check multiple match criteria are joined correctly.
 	Entry("Protocol and ports", Match().Protocol("tcp").SourcePorts(1234).DestPorts(8080),
 		"-p tcp -m multiport --source-ports 1234 -m multiport --destination-ports 8080"),
+	// IPVS.
+	Entry("IPVSConnection", Match().IPVSConnection(), "-m ipvs --ipvs"),
+	Entry("NotIPVSConnection", Match().NotIPVSConnection(), "-m ipvs ! --ipvs"),
 )

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -131,7 +131,8 @@ var _ = Describe("Static", func() {
 							{Match: Match().MarkSet(0x10),
 								Action: AcceptAction{}},
 
-							// Return if to workload.
+							// To workload traffic.
+							{Match: Match().OutInterface("cali+").IPVSConnection(), Action: JumpAction{Target: "cali-to-wl-dispatch"}},
 							{Match: Match().OutInterface("cali+"), Action: ReturnAction{}},
 
 							// Non-workload traffic, send to host chains.
@@ -545,7 +546,8 @@ var _ = Describe("Static", func() {
 						{Match: Match().MarkSet(0x10),
 							Action: AcceptAction{}},
 
-						// Return if to workload.
+						// To workload traffic.
+						{Match: Match().OutInterface("cali+").IPVSConnection(), Action: JumpAction{Target: "cali-to-wl-dispatch"}},
 						{Match: Match().OutInterface("cali+"), Action: ReturnAction{}},
 
 						// Non-workload traffic, send to host chains.


### PR DESCRIPTION
## Description
Added workload ingress policy support for kube-proxy running in ipvs mode.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

