### PR TITLE
Use the v2 backend API to load configuration.

### DIFF
--- a/felix.go
+++ b/felix.go
@@ -725,11 +725,11 @@ func convertV2ConfigToMap(configType string, v2Config *model.KVPair) (map[string
 		logCxt.Info("No config of this type")
 		return nil, nil
 	}
-	// Re-use the update processor logic implemented for hte syncer.  We give it a v2 config
+	// Re-use the update processor logic implemented for the Syncer.  We give it a v2 config
 	// object in a KVPair and it uses the annotations defined on it to split it into v1-style
 	// KV pairs.
-	configConvertor := updateprocessors.NewFelixConfigUpdateProcessor()
-	v1kvs, err := configConvertor.Process(v2Config)
+	configConverter := updateprocessors.NewFelixConfigUpdateProcessor()
+	v1kvs, err := configConverter.Process(v2Config)
 	if err != nil {
 		logCxt.WithError(err).Error("Failed to convert configuration")
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7946220ff8306b2a13738092d703ef95114146803480b569f3b78ffe8e413c0c
-updated: 2017-10-20T00:01:35.408288963Z
+hash: 514e8da2412a0c34c2d89fac6bc0c95b4afc7d6ec38937b892338242689060b4
+updated: 2017-10-20T09:24:57.201011976Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -189,7 +189,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: e661addd9596b291db14c489f6e56575d493982f
+  version: 470ff5ce834e1cfa500966ed1888e391d1fbd4b9
   subpackages:
   - lib
   - lib/apiconfig

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 514e8da2412a0c34c2d89fac6bc0c95b4afc7d6ec38937b892338242689060b4
-updated: 2017-10-20T09:24:57.201011976Z
+hash: dcd2bd90743587805d8c5b23220f4653642c4b8770e20debbccc28f34423cb87
+updated: 2017-10-20T14:49:20.061898767Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -230,7 +230,7 @@ imports:
   - lib/validator
   - lib/watch
 - name: github.com/projectcalico/typha
-  version: b085d3ae58eaed8230f83a0847dc78b20c79775f
+  version: 592b1d9d3165423118f0f56791849488c5ffccc3
   subpackages:
   - pkg/syncclient
   - pkg/syncproto

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,7 +44,7 @@ import:
 - package: k8s.io/client-go
   version: 82aa063804cf055e16e8911250f888bc216e8b61
 - package: github.com/projectcalico/typha
-  version: b085d3ae58eaed8230f83a0847dc78b20c79775f
+  version: 592b1d9d3165423118f0f56791849488c5ffccc3
   subpackages:
   - pkg/syncclient
 - package: github.com/emicklei/go-restful

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,7 +26,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: e661addd9596b291db14c489f6e56575d493982f
+  version: 470ff5ce834e1cfa500966ed1888e391d1fbd4b9
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus


### PR DESCRIPTION
## Description
The v2 backend API no longer supports listing the old models.  Get the new models and run them through the update processor, which is already used by the syncer, to convert them to v1 KVs.  Then extract the KVs as we used to.

I needed to rev libcalico-go to pick up some fixes that came in overnight (the etcdv3 key templates were changed).  I've manually kicked the tyres on this by using calicoctl to write some config and checking felix could load it but it could probably do with an FV.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
