### PR TITLE
Add support for named ports with duplicate names.

### DIFF
--- a/calc/calc_graph_fv_test.go
+++ b/calc/calc_graph_fv_test.go
@@ -96,6 +96,7 @@ var baseTests = []StateList{
 	// Named ports. Simple cases.
 	{localEp1WithNamedPortPolicy},
 	{localEp1WithNamedPortPolicyUDP},
+	{localEpsAndNamedPortPolicyDuplicatePorts},
 	{localEp1WithNamedPortPolicyNoSelector},
 	{localEp1WithNegatedNamedPortPolicyNoSelector},
 	{localEp1WithNegatedNamedPortPolicy},
@@ -129,6 +130,15 @@ var baseTests = []StateList{
 		localEpsAndNamedPortPolicyNoLongerMatchingInheritedLabelOnEP2,
 		// Ditto for EP1.  Now matches none of the EPs.
 		localEpsAndNamedPortPolicyNoLongerMatchingInheritedLabelOnEP1},
+	// This scenario introduces ports with duplicate names.
+	{
+		// Start with endpoints and policy.
+		localEpsAndNamedPortPolicyMatchingInheritedLabelBothEPs,
+		// Adjust workload 1 to have duplicate ports.
+		localEpsAndNamedPortPolicyDuplicatePorts,
+		// Then go back...
+		localEpsAndNamedPortPolicyMatchingInheritedLabelBothEPs,
+	},
 	// In this scenario, we remove the profiles from the endpoints rather than changing the labels.
 	{
 		// Start with both matching, as in the middle of the above test.

--- a/calc/resources_for_test.go
+++ b/calc/resources_for_test.go
@@ -98,6 +98,27 @@ var localWlEp1WithLabelsButNoProfiles = WorkloadEndpoint{
 	},
 }
 
+var localWlEp1WithDupeNamedPorts = WorkloadEndpoint{
+	State:      "active",
+	Name:       "cali1",
+	Mac:        mustParseMac("01:02:03:04:05:06"),
+	ProfileIDs: []string{"prof-1", "prof-2", "prof-missing"},
+	IPv4Nets: []net.IPNet{mustParseNet("10.0.0.1/32"),
+		mustParseNet("10.0.0.2/32")},
+	IPv6Nets: []net.IPNet{mustParseNet("fc00:fe11::1/128"),
+		mustParseNet("fc00:fe11::2/128")},
+	Labels: map[string]string{
+		"id": "loc-ep-1",
+		"a":  "a",
+		"b":  "b",
+	},
+	Ports: []EndpointPort{
+		{Name: "tcpport", Protocol: numorstring.ProtocolFromString("tcp"), Port: 8080},
+		{Name: "tcpport", Protocol: numorstring.ProtocolFromString("tcp"), Port: 8081},
+		{Name: "tcpport", Protocol: numorstring.ProtocolFromString("tcp"), Port: 8082},
+	},
+}
+
 var localWlEp1NoProfiles = WorkloadEndpoint{
 	State: "active",
 	Name:  "cali1",

--- a/calc/states_for_test.go
+++ b/calc/states_for_test.go
@@ -578,6 +578,28 @@ var localEpsAndNamedPortPolicyMatchingInheritedLabelBothEPs = localEpsAndNamedPo
 	"fc00:fe11::3,tcp:8080",
 }).withName("2 local WEPs with policy matching inherited label on both WEPs")
 
+// Adjust workload 1 so it has duplicate named ports.
+var localEpsAndNamedPortPolicyDuplicatePorts = localEpsAndNamedPortPolicyMatchingInheritedLabelBothEPs.withKVUpdates(
+	KVPair{Key: localWlEpKey1, Value: &localWlEp1WithDupeNamedPorts},
+).withIPSet(namedPortInheritIPSetID, []string{
+	"10.0.0.1,tcp:8080", // ep1
+	"fc00:fe11::1,tcp:8080",
+	"10.0.0.1,tcp:8081", // ep1
+	"fc00:fe11::1,tcp:8081",
+	"10.0.0.1,tcp:8082", // ep1
+	"fc00:fe11::1,tcp:8082",
+	"10.0.0.2,tcp:8081", // ep1
+	"fc00:fe11::2,tcp:8081",
+	"10.0.0.2,tcp:8082", // ep1
+	"fc00:fe11::2,tcp:8082",
+
+	"10.0.0.2,tcp:8080", // ep1 and ep2
+	"fc00:fe11::2,tcp:8080",
+
+	"10.0.0.3,tcp:8080", // ep2
+	"fc00:fe11::3,tcp:8080",
+}).withName("2 local WEPs with policy and duplicate named port on WEP1")
+
 // Then, change the label on EP2 so it no-longer matches.
 var localEpsAndNamedPortPolicyNoLongerMatchingInheritedLabelOnEP2 = localEpsAndNamedPortPolicyMatchingInheritedLabelBothEPs.withKVUpdates(
 	KVPair{Key: ProfileLabelsKey{ProfileKey{"prof-2"}}, Value: profileLabels2},

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7f4f050e089fe79b0fbb78a8b36ca90d2cf7da924c54867b7af58e141fe51a50
-updated: 2017-10-20T13:40:38.834059422Z
+hash: 0546bf48d5babec9b49e486dc07ece4a936a20f68e02d00c15c8480807df1cfb
+updated: 2017-10-20T15:13:37.979804384Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -171,8 +171,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 03c3eb1480219150e5b88529c8b76d5372ea143e
-  repo: http://github.com/fasaxc/libcalico-go.git
+  version: febb01a4b32897dd1ab2064958c54a1cf84ea652
   subpackages:
   - lib
   - lib/api

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2dd3dbe86aaa882014f76ca679837dcc1ba06113fdf16ff46c2ca0f617bfb256
-updated: 2017-10-13T13:11:00.818429475Z
+hash: 7f4f050e089fe79b0fbb78a8b36ca90d2cf7da924c54867b7af58e141fe51a50
+updated: 2017-10-20T13:40:38.834059422Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -65,15 +65,15 @@ imports:
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-ini/ini
-  version: 20b96f641a5ea98f2f8619ff4f3e061cff4833bd
+  version: 5b3e00af70a9484542169a976dcab8d03e601a17
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
   version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
 - name: github.com/go-openapi/spec
-  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+  version: 7abd5745472fff5eb3685386d5fb8bf38683154d
 - name: github.com/go-openapi/swag
-  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
+  version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
 - name: github.com/gogo/protobuf
   version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
   subpackages:
@@ -116,7 +116,7 @@ imports:
 - name: github.com/kelseyhightower/envconfig
   version: f611eb38b3875cc3bd991ca91c51d06446afa14c
 - name: github.com/mailru/easyjson
-  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
+  version: 2f5df55504ebc322e4d52d34df6a1f5b503bf26d
   subpackages:
   - buffer
   - jlexer
@@ -171,7 +171,8 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: cc6687459006bd22a2ddc6b1f3d70d77ab5d0b1e
+  version: 03c3eb1480219150e5b88529c8b76d5372ea143e
+  repo: http://github.com/fasaxc/libcalico-go.git
   subpackages:
   - lib
   - lib/api
@@ -224,7 +225,7 @@ imports:
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell
@@ -273,7 +274,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 43eea11bc92608addb41b8a406b0407495c106f6
+  version: 8dbc5d05d6edcc104950cc299a1ce6641235bc86
   subpackages:
   - unix
 - name: golang.org/x/text

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,7 +26,8 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: cc6687459006bd22a2ddc6b1f3d70d77ab5d0b1e
+  version: 03c3eb1480219150e5b88529c8b76d5372ea143e
+  repo: http://github.com/fasaxc/libcalico-go.git
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,8 +26,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: 03c3eb1480219150e5b88529c8b76d5372ea143e
-  repo: http://github.com/fasaxc/libcalico-go.git
+  version: febb01a4b32897dd1ab2064958c54a1cf84ea652
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus


### PR DESCRIPTION
This was found to be required in the real world.

Note: PR is against the pre-v2 branch, which is simply a cut of master before v2 was merged.  The desire is to have a  known-good version of felix to run through Lance's tests before we switch to the v2 datamodel.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [ ] Backport -- Will also need to merge to master
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
