### PR TITLE
re-enable k8sfv tests, bump libcalico-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ k8sfv-test: calico/felix k8sfv-test-existing-felix
 # container image.  To use some existing Felix version other than
 # 'latest', do 'FELIX_VERSION=<...> make k8sfv-test-existing-felix'.
 k8sfv-test-existing-felix: bin/k8sfv.test
-	#k8sfv/run-test
+	k8sfv/run-test
 
 PROMETHEUS_DATA_DIR := $$HOME/prometheus-data
 K8SFV_PROMETHEUS_DATA_DIR := $(PROMETHEUS_DATA_DIR)/k8sfv

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 29bdd5d9847a456d10efd8d7e034c85d21b28e0c88e8e59955f562568fa424c6
-updated: 2017-10-20T16:05:58.089345886Z
+hash: 3cafe1ef2d39ed746e0bed2d1ea3294dcee3ec2e00687dd7449a0b9ed3326899
+updated: 2017-10-20T20:52:48.772430839-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -189,7 +189,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 11200bc3dea05305c956d356cd977c90c4cf9097
+  version: 12032b32ae3f84f17cc483c5df6216a097a610fe
   subpackages:
   - lib
   - lib/apiconfig
@@ -198,7 +198,6 @@ imports:
   - lib/apis/v2
   - lib/backend
   - lib/backend/api
-  - lib/backend/compat
   - lib/backend/etcdv3
   - lib/backend/k8s
   - lib/backend/k8s/conversion
@@ -230,7 +229,7 @@ imports:
   - lib/validator
   - lib/watch
 - name: github.com/projectcalico/typha
-  version: eef6ea3331b5ea93789dee12bb4cf618551ec15c
+  version: d8ea09216e271d8da2815f0c295ad405457df5d1
   subpackages:
   - pkg/syncclient
   - pkg/syncproto
@@ -245,13 +244,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 1bab55dd05dbff384524a6a1c99006d9eb5f139b
+  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
+  version: a1dba9ce8baed984a2495b658c82687f8157b98f
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell
@@ -273,7 +272,7 @@ imports:
 - name: github.com/whyrusleeping/go-logging
   version: 0457bb6b88fc1973573aaf6b5145d8d3ae972390
 - name: golang.org/x/crypto
-  version: 541b9d50ad47e36efd8fb423e938e59ff1691f68
+  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,7 +26,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: 11200bc3dea05305c956d356cd977c90c4cf9097
+  version: 12032b32ae3f84f17cc483c5df6216a097a610fe
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus
@@ -44,7 +44,7 @@ import:
 - package: k8s.io/client-go
   version: 82aa063804cf055e16e8911250f888bc216e8b61
 - package: github.com/projectcalico/typha
-  version: eef6ea3331b5ea93789dee12bb4cf618551ec15c
+  version: d8ea09216e271d8da2815f0c295ad405457df5d1
   subpackages:
   - pkg/syncclient
 - package: github.com/emicklei/go-restful

--- a/k8sfv/k8sfv.go
+++ b/k8sfv/k8sfv.go
@@ -27,9 +27,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
-
-	"github.com/projectcalico/libcalico-go/lib/apiconfig"
-	"github.com/projectcalico/libcalico-go/lib/client"
 )
 
 // Global config - these are set by arguments on the ginkgo command line.
@@ -131,8 +128,6 @@ var _ = AfterSuite(func() {
 
 func initialize(k8sServerEndpoint string) (clientset *kubernetes.Clientset) {
 
-	initializeCalicoDeployment(k8sServerEndpoint)
-
 	config, err := clientcmd.NewNonInteractiveClientConfig(*api.NewConfig(),
 		"",
 		&clientcmd.ConfigOverrides{
@@ -154,28 +149,6 @@ func initialize(k8sServerEndpoint string) (clientset *kubernetes.Clientset) {
 	}
 
 	return
-}
-
-func initializeCalicoDeployment(k8sServerEndpoint string) {
-	// Create client into the Kubernetes datastore.
-	c, err := client.New(apiconfig.CalicoAPIConfig{
-		Spec: apiconfig.CalicoAPIConfigSpec{
-			DatastoreType: apiconfig.Kubernetes,
-			KubeConfig: apiconfig.KubeConfig{
-				K8sAPIEndpoint:           k8sServerEndpoint,
-				K8sInsecureSkipTLSVerify: true,
-			},
-		},
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	// Establish the other global config that Calico requires.
-	err = c.EnsureInitialized()
-	if err != nil {
-		panic(err)
-	}
 }
 
 func create1000Pods(clientset *kubernetes.Clientset, nsPrefix string) error {


### PR DESCRIPTION
## Description
re-enable k8sfv tests, bump libcalico-go

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
