### PR TITLE
Update libcalico and corresponding label / profile names

### DIFF
--- a/fv/host_port_test.go
+++ b/fv/host_port_test.go
@@ -122,14 +122,13 @@ var _ = Context("with initialized Felix and etcd datastore", func() {
 		Context("with pre-DNAT policy defined", func() {
 
 			BeforeEach(func() {
-				policy := api.NewNetworkPolicy()
-				policy.Namespace = "fv"
+				policy := api.NewGlobalNetworkPolicy()
 				policy.Name = "pre-dnat-policy-1"
 				policy.Spec.PreDNAT = true
 				policy.Spec.ApplyOnForward = true
 				protocol := numorstring.ProtocolFromString("tcp")
 				allowMetricsPortRule := api.Rule{
-					Action:   "allow",
+					Action:   api.Allow,
 					Protocol: &protocol,
 					Destination: api.EntityRule{
 						Ports: []numorstring.Port{numorstring.SinglePort(uint16(metrics.Port))},
@@ -137,7 +136,7 @@ var _ = Context("with initialized Felix and etcd datastore", func() {
 				}
 				policy.Spec.IngressRules = []api.Rule{allowMetricsPortRule}
 				policy.Spec.Selector = "host-endpoint=='true'"
-				_, err := client.NetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+				_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/fv/ingress_egress_test.go
+++ b/fv/ingress_egress_test.go
@@ -49,10 +49,10 @@ var _ = Context("with initialized Felix, etcd datastore, 3 workloads", func() {
 		defaultProfile := api.NewProfile()
 		defaultProfile.Name = "default"
 		defaultProfile.Spec.LabelsToApply = map[string]string{"default": ""}
-		defaultProfile.Spec.EgressRules = []api.Rule{{Action: "allow"}}
+		defaultProfile.Spec.EgressRules = []api.Rule{{Action: api.Allow}}
 		defaultProfile.Spec.IngressRules = []api.Rule{{
-			Action: "allow",
-			Source: api.EntityRule{Tag: "default"},
+			Action: api.Allow,
+			Source: api.EntityRule{Selector: "default == ''"},
 		}}
 		_, err := client.Profiles().Create(utils.Ctx, defaultProfile, utils.NoOptions)
 		Expect(err).NotTo(HaveOccurred())
@@ -97,7 +97,7 @@ var _ = Context("with initialized Felix, etcd datastore, 3 workloads", func() {
 			policy.Namespace = "fv"
 			policy.Name = "policy-1"
 			allowFromW1 := api.Rule{
-				Action: "allow",
+				Action: api.Allow,
 				Source: api.EntityRule{
 					Selector: w[1].NameSelector(),
 				},
@@ -123,7 +123,7 @@ var _ = Context("with initialized Felix, etcd datastore, 3 workloads", func() {
 			policy.Namespace = "fv"
 			policy.Name = "policy-1"
 			allowToW1 := api.Rule{
-				Action: "allow",
+				Action: api.Allow,
 				Destination: api.EntityRule{
 					Selector: w[1].NameSelector(),
 				},
@@ -149,7 +149,7 @@ var _ = Context("with initialized Felix, etcd datastore, 3 workloads", func() {
 			policy.Namespace = "fv"
 			policy.Name = "policy-1"
 			allowFromW1 := api.Rule{
-				Action: "allow",
+				Action: api.Allow,
 				Source: api.EntityRule{
 					Selector: w[1].NameSelector(),
 				},
@@ -177,13 +177,13 @@ var _ = Context("with initialized Felix, etcd datastore, 3 workloads", func() {
 			policy.Namespace = "fv"
 			policy.Name = "policy-1"
 			allowFromW1 := api.Rule{
-				Action: "allow",
+				Action: api.Allow,
 				Source: api.EntityRule{
 					Selector: w[1].NameSelector(),
 				},
 			}
 			policy.Spec.IngressRules = []api.Rule{allowFromW1}
-			policy.Spec.EgressRules = []api.Rule{{Action: "deny"}}
+			policy.Spec.EgressRules = []api.Rule{{Action: api.Deny}}
 			policy.Spec.Selector = w[0].NameSelector()
 		})
 

--- a/fv/named_ports_test.go
+++ b/fv/named_ports_test.go
@@ -747,17 +747,17 @@ var _ = Describe("with a simulated kubernetes nginx and client", func() {
 		// Create a default deny policy (but we don't actually write it to the datastore yet).
 		defaultDenyPolicy = api.NewNetworkPolicy()
 		defaultDenyPolicy.Namespace = "fv"
-		defaultDenyPolicy.Name = "knp.default.test.default-deny"
+		defaultDenyPolicy.Name = "knp.default.default-deny"
 		thousand := 1000.0
 		defaultDenyPolicy.Spec.Order = &thousand
-		defaultDenyPolicy.Spec.Selector = "projectcalico.org/namespace == 'test' && name == 'nginx'"
+		defaultDenyPolicy.Spec.Selector = "name == 'nginx'"
 		defaultDenyPolicy.Spec.Types = []api.PolicyType{api.PolicyTypeIngress}
 
 		// Create a policy that opens up the HTTP named port (but we don't actually write it to the
 		// datastore yet).
 		allowHTTPPolicy = api.NewNetworkPolicy()
 		allowHTTPPolicy.Namespace = "fv"
-		allowHTTPPolicy.Name = "knp.default.test.access-nginx"
+		allowHTTPPolicy.Name = "knp.default.access-nginx"
 		protoStruct := numorstring.ProtocolFromString("tcp")
 		apiRule := api.Rule{
 			Action:   api.Allow,
@@ -772,7 +772,7 @@ var _ = Describe("with a simulated kubernetes nginx and client", func() {
 			apiRule,
 		}
 		allowHTTPPolicy.Spec.Order = &thousand
-		allowHTTPPolicy.Spec.Selector = "projectcalico.org/namespace == 'test' && name == 'nginx'"
+		allowHTTPPolicy.Spec.Selector = "name == 'nginx'"
 		allowHTTPPolicy.Spec.Types = []api.PolicyType{api.PolicyTypeIngress}
 
 		cc = &workload.ConnectivityChecker{}
@@ -895,7 +895,7 @@ var _ = Describe("tests with mixed TCP/UDP", func() {
 		// Create a policy that tries to open up the TCP named port over UDP and vice/versa.
 		allowConfusedProtocolPolicy = api.NewNetworkPolicy()
 		allowConfusedProtocolPolicy.Namespace = "fv"
-		allowConfusedProtocolPolicy.Name = "knp.default.test.confused"
+		allowConfusedProtocolPolicy.Name = "knp.default.confused"
 		protoUDPStruct := numorstring.ProtocolFromString("udp")
 		protoTCPStruct := numorstring.ProtocolFromString("tcp")
 		allowConfusedProtocolPolicy.Spec.IngressRules = []api.Rule{
@@ -918,7 +918,7 @@ var _ = Describe("tests with mixed TCP/UDP", func() {
 				},
 			},
 		}
-		allowConfusedProtocolPolicy.Spec.Selector = "projectcalico.org/namespace == 'test' && name == 'nginx'"
+		allowConfusedProtocolPolicy.Spec.Selector = "name == 'nginx'"
 		allowConfusedProtocolPolicy.Spec.Types = []api.PolicyType{api.PolicyTypeIngress}
 
 		udpCC = &workload.ConnectivityChecker{Protocol: "udp"}

--- a/fv/named_ports_test.go
+++ b/fv/named_ports_test.go
@@ -87,10 +87,10 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 		defaultProfile := api.NewProfile()
 		defaultProfile.Name = "default"
 		defaultProfile.Spec.LabelsToApply = map[string]string{"default": ""}
-		defaultProfile.Spec.EgressRules = []api.Rule{{Action: "allow"}}
+		defaultProfile.Spec.EgressRules = []api.Rule{{Action: api.Allow}}
 		defaultProfile.Spec.IngressRules = []api.Rule{{
-			Action: "allow",
-			Source: api.EntityRule{Tag: "default"},
+			Action: api.Allow,
+			Source: api.EntityRule{Selector: "default == ''"},
 		}}
 		_, err := client.Profiles().Create(utils.Ctx, defaultProfile, utils.NoOptions)
 		Expect(err).NotTo(HaveOccurred())
@@ -232,7 +232,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 			}
 			protoStruct := numorstring.ProtocolFromString(protocol)
 			apiRule := api.Rule{
-				Action:   "allow",
+				Action:   api.Allow,
 				Protocol: &protoStruct,
 			}
 			if testSourcePorts {
@@ -401,7 +401,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 
 			protoStruct := numorstring.ProtocolFromString(protocol)
 			apiRule := api.Rule{
-				Action:   "allow",
+				Action:   api.Allow,
 				Protocol: &protoStruct,
 			}
 			if testSourcePorts {
@@ -702,10 +702,10 @@ var _ = Describe("with a simulated kubernetes nginx and client", func() {
 
 		// Create a namespace profile and write to the datastore.
 		defaultProfile := api.NewProfile()
-		defaultProfile.Name = "k8s_ns.test"
+		defaultProfile.Name = "kns.test"
 		defaultProfile.Labels = map[string]string{"name": "test"}
-		defaultProfile.Spec.EgressRules = []api.Rule{{Action: "allow"}}
-		defaultProfile.Spec.IngressRules = []api.Rule{{Action: "allow"}}
+		defaultProfile.Spec.EgressRules = []api.Rule{{Action: api.Allow}}
+		defaultProfile.Spec.IngressRules = []api.Rule{{Action: api.Allow}}
 		_, err := client.Profiles().Create(utils.Ctx, defaultProfile, utils.NoOptions)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -719,8 +719,7 @@ var _ = Describe("with a simulated kubernetes nginx and client", func() {
 			"tcp",
 		)
 		nginx.WorkloadEndpoint.Labels = map[string]string{
-			"calico/k8s_ns": "test",
-			"name":          "nginx",
+			"name": "nginx",
 		}
 		nginx.WorkloadEndpoint.Spec.Ports = []api.EndpointPort{
 			{
@@ -729,7 +728,7 @@ var _ = Describe("with a simulated kubernetes nginx and client", func() {
 				Protocol: numorstring.ProtocolFromString("tcp"),
 			},
 		}
-		nginx.WorkloadEndpoint.Spec.Profiles = []string{"k8s_ns.test"}
+		nginx.WorkloadEndpoint.Spec.Profiles = []string{"kns.test"}
 		nginx.DefaultPort = "80"
 		nginx.Configure(client)
 
@@ -742,7 +741,7 @@ var _ = Describe("with a simulated kubernetes nginx and client", func() {
 			"1000",
 			"tcp",
 		)
-		nginxClient.WorkloadEndpoint.Spec.Profiles = []string{"k8s_ns.test"}
+		nginxClient.WorkloadEndpoint.Spec.Profiles = []string{"kns.test"}
 		nginxClient.Configure(client)
 
 		// Create a default deny policy (but we don't actually write it to the datastore yet).
@@ -751,7 +750,7 @@ var _ = Describe("with a simulated kubernetes nginx and client", func() {
 		defaultDenyPolicy.Name = "knp.default.test.default-deny"
 		thousand := 1000.0
 		defaultDenyPolicy.Spec.Order = &thousand
-		defaultDenyPolicy.Spec.Selector = "calico/k8s_ns == 'test' && name == 'nginx'"
+		defaultDenyPolicy.Spec.Selector = "projectcalico.org/namespace == 'test' && name == 'nginx'"
 		defaultDenyPolicy.Spec.Types = []api.PolicyType{api.PolicyTypeIngress}
 
 		// Create a policy that opens up the HTTP named port (but we don't actually write it to the
@@ -761,7 +760,7 @@ var _ = Describe("with a simulated kubernetes nginx and client", func() {
 		allowHTTPPolicy.Name = "knp.default.test.access-nginx"
 		protoStruct := numorstring.ProtocolFromString("tcp")
 		apiRule := api.Rule{
-			Action:   "allow",
+			Action:   api.Allow,
 			Protocol: &protoStruct,
 			Destination: api.EntityRule{
 				Ports: []numorstring.Port{
@@ -773,7 +772,7 @@ var _ = Describe("with a simulated kubernetes nginx and client", func() {
 			apiRule,
 		}
 		allowHTTPPolicy.Spec.Order = &thousand
-		allowHTTPPolicy.Spec.Selector = "calico/k8s_ns == 'test' && name == 'nginx'"
+		allowHTTPPolicy.Spec.Selector = "projectcalico.org/namespace == 'test' && name == 'nginx'"
 		allowHTTPPolicy.Spec.Types = []api.PolicyType{api.PolicyTypeIngress}
 
 		cc = &workload.ConnectivityChecker{}
@@ -843,8 +842,8 @@ var _ = Describe("tests with mixed TCP/UDP", func() {
 		// Create a profile that opens up traffic by default.
 		defaultProfile := api.NewProfile()
 		defaultProfile.Name = "open"
-		defaultProfile.Spec.EgressRules = []api.Rule{{Action: "allow"}}
-		defaultProfile.Spec.IngressRules = []api.Rule{{Action: "allow"}}
+		defaultProfile.Spec.EgressRules = []api.Rule{{Action: api.Allow}}
+		defaultProfile.Spec.IngressRules = []api.Rule{{Action: api.Allow}}
 		_, err := client.Profiles().Create(utils.Ctx, defaultProfile, utils.NoOptions)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -859,8 +858,7 @@ var _ = Describe("tests with mixed TCP/UDP", func() {
 				protocol,
 			)
 			w.WorkloadEndpoint.Labels = map[string]string{
-				"calico/k8s_ns": "test",
-				"name":          "nginx",
+				"name": "nginx",
 			}
 			w.WorkloadEndpoint.Spec.Ports = []api.EndpointPort{
 				{
@@ -902,7 +900,7 @@ var _ = Describe("tests with mixed TCP/UDP", func() {
 		protoTCPStruct := numorstring.ProtocolFromString("tcp")
 		allowConfusedProtocolPolicy.Spec.IngressRules = []api.Rule{
 			{
-				Action:   "allow",
+				Action:   api.Allow,
 				Protocol: &protoTCPStruct,
 				Destination: api.EntityRule{
 					Ports: []numorstring.Port{
@@ -911,7 +909,7 @@ var _ = Describe("tests with mixed TCP/UDP", func() {
 				},
 			},
 			{
-				Action:   "allow",
+				Action:   api.Allow,
 				Protocol: &protoUDPStruct,
 				Destination: api.EntityRule{
 					Ports: []numorstring.Port{
@@ -920,7 +918,7 @@ var _ = Describe("tests with mixed TCP/UDP", func() {
 				},
 			},
 		}
-		allowConfusedProtocolPolicy.Spec.Selector = "calico/k8s_ns == 'test' && name == 'nginx'"
+		allowConfusedProtocolPolicy.Spec.Selector = "projectcalico.org/namespace == 'test' && name == 'nginx'"
 		allowConfusedProtocolPolicy.Spec.Types = []api.PolicyType{api.PolicyTypeIngress}
 
 		udpCC = &workload.ConnectivityChecker{Protocol: "udp"}

--- a/fv/pre_dnat_test.go
+++ b/fv/pre_dnat_test.go
@@ -56,8 +56,8 @@ var _ = Context("with initialized Felix, etcd datastore, 2 workloads", func() {
 		defaultProfile := api.NewProfile()
 		defaultProfile.Name = "default"
 		defaultProfile.Spec.LabelsToApply = map[string]string{"default": ""}
-		defaultProfile.Spec.EgressRules = []api.Rule{{Action: "allow"}}
-		defaultProfile.Spec.IngressRules = []api.Rule{{Action: "allow"}}
+		defaultProfile.Spec.EgressRules = []api.Rule{{Action: api.Allow}}
+		defaultProfile.Spec.IngressRules = []api.Rule{{Action: api.Allow}}
 		_, err := client.Profiles().Create(utils.Ctx, defaultProfile, utils.NoOptions)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -122,16 +122,15 @@ var _ = Context("with initialized Felix, etcd datastore, 2 workloads", func() {
 		Context("with pre-DNAT policy to prevent access from outside", func() {
 
 			BeforeEach(func() {
-				policy := api.NewNetworkPolicy()
-				policy.Namespace = "fv"
+				policy := api.NewGlobalNetworkPolicy()
 				policy.Name = "deny-ingress"
 				order := float64(20)
 				policy.Spec.Order = &order
 				policy.Spec.PreDNAT = true
 				policy.Spec.ApplyOnForward = true
-				policy.Spec.IngressRules = []api.Rule{{Action: "deny"}}
+				policy.Spec.IngressRules = []api.Rule{{Action: api.Deny}}
 				policy.Spec.Selector = "has(host-endpoint)"
-				_, err := client.NetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+				_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
 				Expect(err).NotTo(HaveOccurred())
 
 				hostEp := api.NewHostEndpoint()
@@ -155,8 +154,7 @@ var _ = Context("with initialized Felix, etcd datastore, 2 workloads", func() {
 			Context("with pre-DNAT policy to open pinhole to 32010", func() {
 
 				BeforeEach(func() {
-					policy := api.NewNetworkPolicy()
-					policy.Namespace = "fv"
+					policy := api.NewGlobalNetworkPolicy()
 					policy.Name = "allow-ingress-32010"
 					order := float64(10)
 					policy.Spec.Order = &order
@@ -165,14 +163,14 @@ var _ = Context("with initialized Felix, etcd datastore, 2 workloads", func() {
 					protocol := numorstring.ProtocolFromString("tcp")
 					ports := numorstring.SinglePort(32010)
 					policy.Spec.IngressRules = []api.Rule{{
-						Action:   "allow",
+						Action:   api.Allow,
 						Protocol: &protocol,
 						Destination: api.EntityRule{Ports: []numorstring.Port{
 							ports,
 						}},
 					}}
 					policy.Spec.Selector = "has(host-endpoint)"
-					_, err := client.NetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+					_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -189,8 +187,7 @@ var _ = Context("with initialized Felix, etcd datastore, 2 workloads", func() {
 			Context("with pre-DNAT policy to open pinhole to 8055", func() {
 
 				BeforeEach(func() {
-					policy := api.NewNetworkPolicy()
-					policy.Namespace = "fv"
+					policy := api.NewGlobalNetworkPolicy()
 					policy.Name = "allow-ingress-8055"
 					order := float64(10)
 					policy.Spec.Order = &order
@@ -199,14 +196,14 @@ var _ = Context("with initialized Felix, etcd datastore, 2 workloads", func() {
 					protocol := numorstring.ProtocolFromString("tcp")
 					ports := numorstring.SinglePort(8055)
 					policy.Spec.IngressRules = []api.Rule{{
-						Action:   "allow",
+						Action:   api.Allow,
 						Protocol: &protocol,
 						Destination: api.EntityRule{Ports: []numorstring.Port{
 							ports,
 						}},
 					}}
 					policy.Spec.Selector = "has(host-endpoint)"
-					_, err := client.NetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+					_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
 					Expect(err).NotTo(HaveOccurred())
 				})
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3cafe1ef2d39ed746e0bed2d1ea3294dcee3ec2e00687dd7449a0b9ed3326899
-updated: 2017-10-20T20:52:48.772430839-07:00
+hash: 4b864279207c3888efc89530d7e5054da317cc9dd054f6e8ae59fcdf098ac5a1
+updated: 2017-10-23T13:22:53.80721714-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -189,7 +189,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 12032b32ae3f84f17cc483c5df6216a097a610fe
+  version: 80853cf81b74dbde7b6c55dae0d52cfe8e0001c9
   subpackages:
   - lib
   - lib/apiconfig
@@ -206,9 +206,7 @@ imports:
   - lib/backend/syncersv1/felixsyncer
   - lib/backend/syncersv1/updateprocessors
   - lib/backend/watchersyncer
-  - lib/client
   - lib/clientv2
-  - lib/converter
   - lib/errors
   - lib/hash
   - lib/health
@@ -229,7 +227,7 @@ imports:
   - lib/validator
   - lib/watch
 - name: github.com/projectcalico/typha
-  version: d8ea09216e271d8da2815f0c295ad405457df5d1
+  version: 6580ff9d65a34687b4e835a400a2977ec01462e7
   subpackages:
   - pkg/syncclient
   - pkg/syncproto
@@ -272,7 +270,7 @@ imports:
 - name: github.com/whyrusleeping/go-logging
   version: 0457bb6b88fc1973573aaf6b5145d8d3ae972390
 - name: golang.org/x/crypto
-  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
+  version: 541b9d50ad47e36efd8fb423e938e59ff1691f68
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -327,7 +325,7 @@ imports:
   - unicode/norm
   - width
 - name: google.golang.org/appengine
-  version: a2e0dc829727a4f957a7428b1f322805cfc1f362
+  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
   subpackages:
   - internal
   - internal/app_identity

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,7 +26,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: 12032b32ae3f84f17cc483c5df6216a097a610fe
+  version: 80853cf81b74dbde7b6c55dae0d52cfe8e0001c9
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus
@@ -44,7 +44,7 @@ import:
 - package: k8s.io/client-go
   version: 82aa063804cf055e16e8911250f888bc216e8b61
 - package: github.com/projectcalico/typha
-  version: d8ea09216e271d8da2815f0c295ad405457df5d1
+  version: 6580ff9d65a34687b4e835a400a2977ec01462e7
   subpackages:
   - pkg/syncclient
 - package: github.com/emicklei/go-restful

--- a/k8sfv/namespace.go
+++ b/k8sfv/namespace.go
@@ -105,21 +105,14 @@ func createNetworkPolicy(clientset *kubernetes.Clientset, namespace string) {
 			Name:      "test-syncer-basic-net-policy",
 		},
 		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{"calico/k8s_ns": namespace},
-			},
+			// An empty PodSelector selects all pods in this Namespace.
+			PodSelector: metav1.LabelSelector{},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{
 				networkingv1.NetworkPolicyIngressRule{
-					Ports: []networkingv1.NetworkPolicyPort{
-						networkingv1.NetworkPolicyPort{},
-					},
 					From: []networkingv1.NetworkPolicyPeer{
 						networkingv1.NetworkPolicyPeer{
-							PodSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"calico/k8s_ns": namespace,
-								},
-							},
+							// An empty PodSelector selects all pods in this Namespace.
+							PodSelector: &metav1.LabelSelector{},
 						},
 					},
 				},


### PR DESCRIPTION
## Description

This updates to the latest libcalico, which uses slightly modified names for k8s profile's and namespace labels.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
