### PR TITLE
k8sfv: wait for Felix metrics to sync after adding/deleting pods.

### DIFF
--- a/k8sfv/k8sfv.go
+++ b/k8sfv/k8sfv.go
@@ -164,6 +164,11 @@ func create1000Pods(clientset *kubernetes.Clientset, nsPrefix string) error {
 	}
 	log.Info("Done")
 
+	Eventually(getNumEndpointsDefault(-1), "30s", "1s").Should(
+		BeNumerically("==", 1000),
+		"Addition of pods wasn't reflected in Felix metrics",
+	)
+
 	return nil
 }
 

--- a/k8sfv/pod.go
+++ b/k8sfv/pod.go
@@ -28,6 +28,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
 )
 
@@ -220,7 +222,8 @@ func cleanupAllPods(clientset *kubernetes.Clientset, nsPrefix string) {
 				if err != nil {
 					panic(err)
 				}
-				log.WithField("count", len(podList.Items)).WithField("namespace", nsName).Debug("Pods present")
+				log.WithField("count", len(podList.Items)).WithField("namespace", nsName).Debug(
+					"Pods present")
 				for _, pod := range podList.Items {
 					err = clientset.CoreV1().Pods(nsName).Delete(pod.ObjectMeta.Name, deleteImmediately)
 					if err != nil {
@@ -235,6 +238,11 @@ func cleanupAllPods(clientset *kubernetes.Clientset, nsPrefix string) {
 		}()
 	}
 	waiter.Wait()
+
+	Eventually(getNumEndpointsDefault(-1), "30s", "1s").Should(
+		BeNumerically("==", 0),
+		"Removal of pods wasn't reflected in Felix metrics",
+	)
 	log.WithField("podsDeleted", podsDeleted).Info("Cleaned up all pods")
 }
 

--- a/k8sfv/scale.go
+++ b/k8sfv/scale.go
@@ -19,6 +19,7 @@ import (
 	"math/rand"
 	"strconv"
 
+	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -70,6 +71,11 @@ func addEndpoints(
 			},
 		})
 	}
+
+	Eventually(getNumEndpointsDefault(-1), "30s", "1s").Should(
+		BeNumerically("==", numEndpoints),
+		"Addition of pods wasn't reflected in Felix metrics",
+	)
 
 	return
 }


### PR DESCRIPTION
## Description
Speculative fix for the intermittent semaphore CI failures.  Ensure we wait for pod creation and tear down to complete before moving on.

We should still catch if Felix gets stuck at a particular value in a stable way.