### PR TITLE
Improve the performance of dockerd during fv.

### DIFF
--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -153,7 +153,7 @@ func (c *Container) WaitUntilRunning() {
 		if strings.Contains(string(out), c.Name) {
 			break
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(1000 * time.Millisecond)
 	}
 }
 
@@ -176,6 +176,7 @@ func (c *Container) WaitNotRunning(timeout time.Duration) {
 		if time.Since(start) > timeout {
 			log.Panic("Timed out waiting for container not to be listed.")
 		}
+		time.Sleep(1000 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
Adding one a one second sleep inside the for-loop of WaitUntilRunning()
and increasing the sleep time in WaitUntilRunning() to reduce the stress
and on dockerd during parallel testing.

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
Running top during the fv test shows dockerd at times consuming up to 200% of a cpu.
WaitNotRunning() runs "docker ps" in a tight loop, I added a 1 second sleep in the loop and increased the sleep to 1 second in WaitUntilRunning() ), With this change I observered dockerd peek cpu usage dropped to roughly 50% of a cpu.

## release-note
None required
