### PR TITLE
Reinstate health check FVs

### DIFF
--- a/fv/health_test.go
+++ b/fv/health_test.go
@@ -61,7 +61,7 @@ import (
 
 type EnvConfig struct {
 	K8sVersion   string `default:"1.7.5"`
-	TyphaVersion string `default:"latest"`
+	TyphaVersion string `default:"v0.5.1-27-g49eaa9b"`
 }
 
 var config EnvConfig

--- a/fv/slow-iptables-restore
+++ b/fv/slow-iptables-restore
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-sleep 5
+sleep 60
 exec /sbin/xtables-multi iptables-restore $@


### PR DESCRIPTION
## Description

- Rev Typha container.
- Update the slow iptables-restore command to wait longer.
- Force felix to call iptables-restore by making a local pod update.
- Adapt tests to rely on forcing iptables-restore instead of start-of-day call (since Felix no longer blocks waiting for the node config)

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
