### PR TITLE
Improve the performance of dockerd during iptables_lock_test.

### DIFF
--- a/fv/iptables_lock_test.go
+++ b/fv/iptables_lock_test.go
@@ -74,9 +74,10 @@ var _ = Describe("with running container", func() {
 			if strings.Contains(string(out), containerName) {
 				break
 			}
-			if time.Since(start) > 10*time.Second {
+			if time.Since(start) > 60*time.Second {
 				log.Panic("Timed out waiting for container to be listed.")
 			}
+			time.Sleep(1000 * time.Millisecond)
 		}
 	})
 	AfterEach(func() {


### PR DESCRIPTION
Adding one a one second sleep inside the tight loop running docker
commands and increasing the time to wait for a container to start
to 60 seconds.

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
Like commit 21cd1cf71776aab8f3ebd0d52ad2b44213171ecf.
When docker commands are run in a tight loop dockerd performance can be impacted causing time-outs and other issues.  

## Todos
none

## Release Note
```release-note
None required
```
