### PR TITLE
Rev go build to v0.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ ARCH?=amd64
 ARCHTAG?=
 
 ifeq ($(ARCH),amd64)
-GO_BUILD_VER:=v0.6
+GO_BUILD_VER:=v0.9
 endif
 
 ifeq ($(ARCH),ppc64le)

--- a/calc/async_calc_graph.go
+++ b/calc/async_calc_graph.go
@@ -21,8 +21,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/gavv/monotime"
-
 	"github.com/projectcalico/felix/config"
 	"github.com/projectcalico/felix/dispatcher"
 	"github.com/projectcalico/felix/proto"
@@ -140,10 +138,9 @@ func (acg *AsyncCalcGraph) loop() {
 			case []api.Update:
 				// Update; send it to the dispatcher.
 				log.Debug("Pulled []KVPair off channel")
-				updStartTime := monotime.Now()
+				updStartTime := time.Now()
 				acg.Dispatcher.OnUpdates(update)
-				updEndTime := monotime.Now()
-				summaryUpdateTime.Observe((updEndTime - updStartTime).Seconds())
+				summaryUpdateTime.Observe(time.Since(updStartTime).Seconds())
 				// Record stats for the number of messages processed.
 				for _, upd := range update {
 					typeName := reflect.TypeOf(upd.Key).Name()

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2cd48b39b637a8d6deb9c44283cd299569591535faffee1b341aa199a5a3a2cc
-updated: 2017-10-28T15:10:47.147703453Z
+hash: e882063c2e773906795ce0e3b27f012f7b6f313872f8720b108c3ffcb8b99fd9
+updated: 2017-10-31T14:44:39.887813554Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -47,8 +47,6 @@ imports:
   - log
 - name: github.com/emicklei/go-restful-swagger12
   version: dcef7f55730566d41eae5db10e7d6981829720f6
-- name: github.com/gavv/monotime
-  version: 6f8212e8d10df7383609d3c377ca08884d8f3ec0
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-ini/ini

--- a/glide.yaml
+++ b/glide.yaml
@@ -38,7 +38,6 @@ import:
 - package: github.com/gogo/protobuf
   version: ^0.3.0
 - package: github.com/vishvananda/netlink
-- package: github.com/gavv/monotime
 - package: github.com/onsi/ginkgo
   version: f40a49d81e5c12e90400620b6242fb29a8e7c9
 - package: k8s.io/client-go

--- a/intdataplane/int_dataplane.go
+++ b/intdataplane/int_dataplane.go
@@ -696,7 +696,7 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 
 				// Record stats.
 				applyTime := time.Since(applyStart)
-				summaryApplyTime.Observe(time.Since(applyStart).Seconds())
+				summaryApplyTime.Observe(applyTime.Seconds())
 
 				if d.dataplaneNeedsSync {
 					// Dataplane is still dirty, record an error.

--- a/intdataplane/int_dataplane.go
+++ b/intdataplane/int_dataplane.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gavv/monotime"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
@@ -76,7 +75,7 @@ var (
 			"values indicate we're doing more batching to try to keep up.",
 	})
 
-	processStartTime time.Duration
+	processStartTime time.Time
 )
 
 func init() {
@@ -86,7 +85,7 @@ func init() {
 	prometheus.MustRegister(summaryBatchSize)
 	prometheus.MustRegister(summaryIfaceBatchSize)
 	prometheus.MustRegister(summaryAddrBatchSize)
-	processStartTime = monotime.Now()
+	processStartTime = time.Now()
 }
 
 type Config struct {
@@ -580,7 +579,7 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 		}
 		switch msg.(type) {
 		case *proto.InSync:
-			log.WithField("timeSinceStart", monotime.Since(processStartTime)).Info(
+			log.WithField("timeSinceStart", time.Since(processStartTime)).Info(
 				"Datastore in sync, flushing the dataplane for the first time...")
 			datastoreInSync = true
 		}
@@ -690,14 +689,14 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 					beingThrottled = false
 				}
 				log.Info("Applying dataplane updates")
-				applyStart := monotime.Now()
+				applyStart := time.Now()
 
 				// Actually apply the changes to the dataplane.
 				d.apply()
 
 				// Record stats.
-				applyTime := monotime.Since(applyStart)
-				summaryApplyTime.Observe(applyTime.Seconds())
+				applyTime := time.Since(applyStart)
+				summaryApplyTime.Observe(time.Since(applyStart).Seconds())
 
 				if d.dataplaneNeedsSync {
 					// Dataplane is still dirty, record an error.
@@ -708,7 +707,7 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 
 				if !d.doneFirstApply {
 					log.WithField(
-						"secsSinceStart", monotime.Since(processStartTime).Seconds(),
+						"secsSinceStart", time.Since(processStartTime).Seconds(),
 					).Info("Completed first update to dataplane.")
 					d.doneFirstApply = true
 					if d.config.PostInSyncCallback != nil {
@@ -927,7 +926,7 @@ func (d *InternalDataplane) loopReportingStatus() {
 	// Wait before first report so that we don't check in if we're in a tight cyclic restart.
 	time.Sleep(10 * time.Second)
 	for {
-		uptimeSecs := monotime.Since(processStartTime).Seconds()
+		uptimeSecs := time.Since(processStartTime).Seconds()
 		d.fromDataplane <- &proto.ProcessStatusUpdate{
 			IsoTimestamp: time.Now().UTC().Format(time.RFC3339),
 			Uptime:       uptimeSecs,

--- a/ipsets/ipsets.go
+++ b/ipsets/ipsets.go
@@ -25,8 +25,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/gavv/monotime"
-
 	"github.com/projectcalico/libcalico-go/lib/set"
 )
 
@@ -331,13 +329,13 @@ func (s *IPSets) tryResync() (numProblems int, err error) {
 	// Capture error output into a buffer.
 	var stderr bytes.Buffer
 	cmd.SetStderr(&stderr)
-	execStartTime := monotime.Now()
+	execStartTime := time.Now()
 	err = cmd.Start()
 	if err != nil {
 		s.logCxt.WithError(err).Error("Failed to start 'ipset list'")
 		return
 	}
-	summaryExecStart.Observe(float64(monotime.Since(execStartTime).Nanoseconds()) / 1000.0)
+	summaryExecStart.Observe(float64(time.Since(execStartTime).Nanoseconds()) / 1000.0)
 	// Clear the set of known IP sets names, we'll fill it back in as we scan.
 	s.existingIPSetNames.Clear()
 	// Use a scanner to chunk the input into lines.
@@ -578,7 +576,7 @@ func (s *IPSets) tryUpdates() error {
 	defer s.stdoutCopy.Reset()
 
 	// Actually start the child process.
-	startTime := monotime.Now()
+	startTime := time.Now()
 	err = cmd.Start()
 	if err != nil {
 		s.logCxt.WithError(err).Error("Failed to start ipset restore.")
@@ -589,7 +587,7 @@ func (s *IPSets) tryUpdates() error {
 		}
 		return err
 	}
-	summaryExecStart.Observe(float64(monotime.Since(startTime).Nanoseconds()) / 1000.0)
+	summaryExecStart.Observe(float64(time.Since(startTime).Nanoseconds()) / 1000.0)
 
 	// Ask each dirty IP set to write its updates to the stream.
 	var writeErr error

--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -22,7 +22,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gavv/monotime"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -233,7 +232,7 @@ func (r *RouteTable) closeNetlinkHandle() {
 
 func (r *RouteTable) Apply() error {
 	if !r.inSync {
-		listStartTime := monotime.Now()
+		listStartTime := time.Now()
 
 		nl, err := r.getNetlinkHandle()
 		if err != nil {
@@ -279,7 +278,7 @@ func (r *RouteTable) Apply() error {
 		}
 		r.inSync = true
 
-		listIfaceTime.Observe(monotime.Since(listStartTime).Seconds())
+		listIfaceTime.Observe(time.Since(listStartTime).Seconds())
 	}
 
 	graceIfaces := 0
@@ -331,9 +330,9 @@ func (r *RouteTable) Apply() error {
 }
 
 func (r *RouteTable) syncRoutesForLink(ifaceName string) error {
-	startTime := monotime.Now()
+	startTime := time.Now()
 	defer func() {
-		perIfaceSyncTime.Observe(monotime.Since(startTime).Seconds())
+		perIfaceSyncTime.Observe(time.Since(startTime).Seconds())
 	}()
 	logCxt := r.logCxt.WithField("ifaceName", ifaceName)
 	logCxt.Debug("Syncing interface routes")


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

- Pull in go 1.9.2.
- Close some CVEs.
- Remove monotime dependency since go 1.9's time implementation has monotonic comparisons.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix is now built against go 1.9.2.
```
