### PR TITLE
Allow override of Typha and Hyperkube images in FVs.

### DIFF
--- a/fv/health_test.go
+++ b/fv/health_test.go
@@ -107,8 +107,7 @@ var _ = BeforeSuite(func() {
 	// authorization mode.  So we specify the "RBAC" authorization mode instead, and create a
 	// ClusterRoleBinding that gives the "system:anonymous" user unlimited power (aka the
 	// "cluster-admin" role).
-	apiServerContainer = containers.Run("apiserver",
-		"gcr.io/google_containers/hyperkube-amd64:v"+utils.Config.K8sVersion,
+	apiServerContainer = containers.Run("apiserver", utils.Config.K8sImage,
 		"/hyperkube", "apiserver",
 		fmt.Sprintf("--etcd-servers=http://%s:2379", etcdContainer.IP),
 		"--service-cluster-ip-range=10.101.0.0/16",
@@ -321,7 +320,7 @@ var _ = Describe("health tests", func() {
 			"-e", "K8S_API_ENDPOINT="+endpoint,
 			"-e", "K8S_INSECURE_SKIP_TLS_VERIFY=true",
 			"-v", k8sCertFilename+":/tmp/apiserver.crt",
-			"calico/typha:"+utils.Config.TyphaVersion,
+			utils.Config.TyphaImage,
 			"calico-typha")
 		Expect(typhaContainer).NotTo(BeNil())
 		typhaReady = getHealthStatus(typhaContainer.IP, "9098", "readiness")

--- a/fv/utils/utils.go
+++ b/fv/utils/utils.go
@@ -32,9 +32,9 @@ import (
 )
 
 type EnvConfig struct {
-	EtcdImage    string `default:"quay.io/coreos/etcd"`
-	K8sVersion   string `default:"1.7.5"`
-	TyphaVersion string `default:"v0.5.1-27-g49eaa9b"`
+	EtcdImage  string `default:"quay.io/coreos/etcd"`
+	K8sImage   string `default:"gcr.io/google_containers/hyperkube-amd64:v1.7.5"`
+	TyphaImage string `default:"calico/typha:v0.5.1-27-g49eaa9b"`
 }
 
 var Config EnvConfig


### PR DESCRIPTION
Continuation of PR #1594 

This PR allows for the typha and hyperkube image names and versions to be overwritten for fv.  Defaults stay the same.    Image names/version can be selected in the Makefile according to the value of ARCH.  See also PR:  #1564.

## Description
This is required for multi-arch support. 
I verified the changes by running fv on both amd64 and ppc64le.

## Release Note
```release-note
None required
```
