### PR TITLE
Adjust timeouts and parallel executions in FVs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ fv: calico/felix bin/iptables-locker bin/test-workload bin/test-connection $(FV_
 	-docker tag calico/felix$(ARCHTAG) calico/felix
 	for t in $(FV_TESTS); do \
 	    cd $(TOPDIR)/`dirname $$t` && \
-	    $(TOPDIR)/bin/ginkgo -slowSpecThreshold 40 -p ./`basename $$t` || exit; \
+	    $(TOPDIR)/bin/ginkgo -slowSpecThreshold 80 -nodes 4 ./`basename $$t` || exit; \
 	done
 
 bin/check-licenses: $(FELIX_GO_FILES)

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -54,7 +54,7 @@ func (c *Container) Stop() {
 	} else {
 		log.WithField("container", c).Info("Stop")
 		c.runCmd.Process.Signal(os.Interrupt)
-		c.WaitNotRunning(10 * time.Second)
+		c.WaitNotRunning(60 * time.Second)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
This patch makes 3 related changes to fv execution.  WDYT?

* Increases the wait time for etcd containers to shutdown (see also PR #1550). Currently the test will panic during cleanup if etcd containers take more than 10 seconds to shutdown down. I have increased the wait time to 60 seconds to prevent this type of failure on some systems. 

*  With the increased wait time (see above) we may see SLOW test warnings. I increased -slowSpecThreshold from 40 seconds to 80 seconds.  This preservers the intent of catching broken or spinning tests, but eliminates the warnings.

* On larger systems I see a number of SLOW test warnings, when I reduce the number of parallel executions the warnings stop. I have been running test on both a 8 cpu x86 box and 16 cpu ppc64le VM.  Ginkgo is run with -p to parallelize the test suite across an auto-detected number of nodes.  The number of nodes to be run is runtime.NumCPU()-1.  My Intel box runs 7 nodes, my ppc VM run 15 nodes.  If the number of executions is limited by running "ginkgo -node 4" then test execution will be more consistent across different platforms.  The negative side effect is a slower overall test execution time.

## What numbers to use?
I selected "-node 4" based on this comment in the ginkgo doc:

"The number of nodes used with -p is runtime.NumCPU() if runtime.NumCPU() <= 4, otherwise it is runtime.NumCPU() - 1 based on a rigorous science based heuristic best characterized as “my gut sense based on a few months of experience”  "

The new timeout values are based on my own experimentation.

## Release Note
```release-note
None required
```
