### PR TITLE
k8sfv.test updated to use image definitions from the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,10 @@ k8sfv-test: calico/felix k8sfv-test-existing-felix
 # container image.  To use some existing Felix version other than
 # 'latest', do 'FELIX_VERSION=<...> make k8sfv-test-existing-felix'.
 k8sfv-test-existing-felix: bin/k8sfv.test
-	TYPHA_VERSION=$(TYPHA_VERSION) k8sfv/run-test
+	FV_ETCDIMAGE=$(FV_ETCDIMAGE) \
+	FV_TYPHAIMAGE=$(FV_TYPHAIMAGE) \
+	FV_K8SIMAGE=$(FV_K8SIMAGE) \
+	k8sfv/run-test
 
 PROMETHEUS_DATA_DIR := $$HOME/prometheus-data
 K8SFV_PROMETHEUS_DATA_DIR := $(PROMETHEUS_DATA_DIR)/k8sfv

--- a/Makefile
+++ b/Makefile
@@ -49,15 +49,13 @@ ARCH?=amd64
 ifeq ($(ARCH),amd64)
 	ARCHTAG?=
 	GO_BUILD_VER?=v0.9
-	TYPHA_VERSION?=v0.6.0-alpha1-17-gc6c5726
-	FV_TYPHAIMAGE?=calico/typha:$(TYPHA_VERSION)
+	FV_TYPHAIMAGE?=calico/typha:v0.6.0-alpha1-17-gc6c5726
 endif
 
 ifeq ($(ARCH),ppc64le)
 	ARCHTAG:=-ppc64le
 	GO_BUILD_VER?=latest
-	TYPHA_VERSION?=latest
-	FV_TYPHAIMAGE?=calico/typha-ppc64le:$(TYPHA_VERSION)
+	FV_TYPHAIMAGE?=calico/typha-ppc64le:latest
 endif
 
 GO_BUILD_CONTAINER?=calico/go-build$(ARCHTAG):$(GO_BUILD_VER)

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -10,7 +10,7 @@
 : ${FELIX_VERSION:=latest}
 #
 # What version of the k8s API server to use.
-: ${K8S_VERSION:=1.7.3}
+# Update: See FV_K8SIMAGE in the Makefile for version information.
 #
 # A string to insert into the container names that we use; a calling
 # script can set this to something to make the container names unique,
@@ -54,7 +54,7 @@
 : ${USE_TYPHA:=true}
 #
 # What version of Typha (container image) to use.
-: ${TYPHA_VERSION:=latest}
+# Update: See FV_TYPHAIMAGE in the Makefile for version information.
 #
 # Typha logging level.
 : ${TYPHA_LOG_LEVEL:=info}
@@ -99,7 +99,7 @@ sudo modprobe ip6_tables
 
 # Run etcd.
 docker run --detach --name ${prefix}-etcd \
-       quay.io/coreos/etcd \
+       $FV_ETCDIMAGE \
        etcd \
        --advertise-client-urls "http://127.0.0.1:2379,http://127.0.0.1:4001" \
        --listen-client-urls "http://0.0.0.0:2379,http://0.0.0.0:4001"
@@ -117,7 +117,7 @@ etcd_ip=$(get_container_ip ${prefix}-etcd)
 # gives the "system:anonymous" user unlimited power (aka the
 # "cluster-admin" role).
 docker run --detach --name ${prefix}-apiserver \
-       gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
+       $FV_K8SIMAGE \
        /hyperkube apiserver \
        --etcd-servers=http://${etcd_ip}:2379 \
        --service-cluster-ip-range=10.101.0.0/16 -v=10 \
@@ -163,7 +163,7 @@ if ${USE_TYPHA}; then
 	   -e K8S_CA_FILE=/testcode/k8sfv/output/apiserver.crt \
 	   -v ${PWD}:/testcode \
 	   -w /testcode/k8sfv/output \
-	   calico/typha:${TYPHA_VERSION} \
+	   $FV_TYPHAIMAGE \
 	   /bin/sh -c "for n in 1 2; do calico-typha; done"
     typha_ip=$(get_container_ip ${prefix}-typha)
     typha_hostname=$(get_container_hostname ${prefix}-typha)

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -9,8 +9,10 @@
 # What version of Felix (container image) to use.
 : ${FELIX_VERSION:=latest}
 #
-# What version of the k8s API server to use.
-# Update: See FV_K8SIMAGE in the Makefile for version information.
+if ! test -n "${FV_K8SIMAGE}"; then
+    echo FV_K8SIMAGE must be set to indicate the hyperkube image to use.
+    exit -1
+fi
 #
 # A string to insert into the container names that we use; a calling
 # script can set this to something to make the container names unique,
@@ -53,8 +55,10 @@
 # Whether to tell Felix to go via Typha.
 : ${USE_TYPHA:=true}
 #
-# What version of Typha (container image) to use.
-# Update: See FV_TYPHAIMAGE in the Makefile for version information.
+if  ${USE_TYPHA} && test -z "${FV_TYPHAIMAGE}" ; then
+	echo FV_TYPHAIMAGE must be set to indicate the hyperkube image to use.
+	exit -1
+fi
 #
 # Typha logging level.
 : ${TYPHA_LOG_LEVEL:=info}


### PR DESCRIPTION
Container versions previously defined in k8sfv.test are replace by
image names:tags as defined in the Makefile with the variables:
FV_ETCDIMAGE, FV_TYPHAIMAGE and FV_K8SIMAGE.

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
Currently the etcd, typha and hyperkube images used by the k8sfv-test are defined in the k8sfv-test script and in the case of amd64 are different than the version used during fv. This patch moves these definitions into the Makefile by using the already existing environment variables FV_TYPHAIMAGE, FV_ETCDIMAGE, FV_K8SIMAGE.  This provides two advantages:

- The same images are used in both fv and k8sfv-test.
- The images names and tags are defined for the specific architecture under test.

Note: For amd64 the default version of hyperkube changes from v1.7.3 to 1.7.5. The default version of TYPHA changes from "latest" to v0.6.0-alpha1-17-gc6c5726 (in the current Makefile).

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
