### PR TITLE
Automated update of libcalico-go to 250cb94738bf94032f2af491e362543f346cfac9

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4ad149902316ab15d33ec41f5ec086668918887c292b22a0243f4a375fa8c4ba
-updated: 2017-11-10T20:20:28.690356-08:00
+hash: 77a4e62c477726bce235d40de58b5b0d7d158d090f72c1aa0cb38ac4f120d1c2
+updated: 2017-11-14T11:24:12.13101-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -50,7 +50,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-ini/ini
-  version: f280b3ba517bf5fc98922624f21fb0e7a92adaec
+  version: 7e7da451323b6766da368f8a1e8ec9a88a16b4a0
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -189,7 +189,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: a21bd104b2d077c89737a5b897e3ac817c79957a
+  version: 250cb94738bf94032f2af491e362543f346cfac9
   subpackages:
   - lib
   - lib/apiconfig
@@ -227,7 +227,7 @@ imports:
   - lib/validator
   - lib/watch
 - name: github.com/projectcalico/typha
-  version: 6b0b491018919759f36aa897c0ef8492bfccd714
+  version: 2343517a2f18d4a47216ad93308e6a71ad7e9dc2
   subpackages:
   - pkg/syncclient
   - pkg/syncproto
@@ -242,13 +242,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  version: e3fb1a1acd7605367a2b378bc2e2f893c05174b7
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell
@@ -270,7 +270,7 @@ imports:
 - name: github.com/whyrusleeping/go-logging
   version: 0457bb6b88fc1973573aaf6b5145d8d3ae972390
 - name: golang.org/x/crypto
-  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  version: 9f005a07e0d31d45e6656d241bb5c0f2efd4bc94
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,7 +26,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: a21bd104b2d077c89737a5b897e3ac817c79957a
+  version: 250cb94738bf94032f2af491e362543f346cfac9
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus
@@ -43,7 +43,7 @@ import:
 - package: k8s.io/client-go
   version: 82aa063804cf055e16e8911250f888bc216e8b61
 - package: github.com/projectcalico/typha
-  version: 6b0b491018919759f36aa897c0ef8492bfccd714
+  version: 2343517a2f18d4a47216ad93308e6a71ad7e9dc2
   subpackages:
   - pkg/syncclient
 - package: github.com/emicklei/go-restful


### PR DESCRIPTION
Update libcalico-go to get fix for kdd veth name

```release-note
None required
```
