### PR TITLE
2.6.x: Handle config changes for ClusterGUID, ClusterType, CalicoVersion.

### DIFF
--- a/calc/event_sequencer.go
+++ b/calc/event_sequencer.go
@@ -200,7 +200,7 @@ func (buf *EventSequencer) flushConfigUpdate() {
 	}
 	if globalChanged || hostChanged {
 		rawConfig := buf.config.RawValues()
-		log.WithField("merged", rawConfig).Warn("Config changed. Sending ConfigUpdate message.")
+		log.WithField("merged", rawConfig).Info("Config changed. Sending ConfigUpdate message.")
 		buf.Callback(&proto.ConfigUpdate{
 			Config: rawConfig,
 		})

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -163,10 +163,12 @@ type Config struct {
 	FailsafeInboundHostPorts  []ProtoPort `config:"port-list;tcp:22,udp:68;die-on-fail"`
 	FailsafeOutboundHostPorts []ProtoPort `config:"port-list;tcp:2379,tcp:2380,tcp:4001,tcp:7001,udp:53,udp:67;die-on-fail"`
 
-	UsageReportingEnabled bool   `config:"bool;true"`
-	ClusterGUID           string `config:"string;baddecaf"`
-	ClusterType           string `config:"string;"`
-	CalicoVersion         string `config:"string;"`
+	UsageReportingEnabled          bool          `config:"bool;true"`
+	UsageReportingInitialDelaySecs time.Duration `config:"seconds;300"`
+	UsageReportingIntervalSecs     time.Duration `config:"seconds;86400"`
+	ClusterGUID                    string        `config:"string;baddecaf"`
+	ClusterType                    string        `config:"string;"`
+	CalicoVersion                  string        `config:"string;"`
 
 	DebugMemoryProfilePath          string        `config:"file;;"`
 	DebugDisableLogDropping         bool          `config:"bool;false"`

--- a/felix.go
+++ b/felix.go
@@ -405,11 +405,12 @@ configRetry:
 			}
 		}()
 
-		go usagerep.PeriodicallyReportUsage(
+		usageRep := usagerep.New(
 			24*time.Hour,
 			statsChanOut,
 			configUpdChan,
 		)
+		go usageRep.PeriodicallyReportUsage(context.Background())
 	} else {
 		// Usage reporting disabled, but we still want a stats collector for the
 		// felix_cluster_* metrics.  Register a no-op function as the callback.

--- a/fv/config_update_test.go
+++ b/fv/config_update_test.go
@@ -1,0 +1,175 @@
+// +build fvtests
+
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"time"
+
+	"github.com/projectcalico/felix/fv/containers"
+	"github.com/projectcalico/felix/fv/metrics"
+	"github.com/projectcalico/felix/fv/utils"
+	"github.com/projectcalico/felix/fv/workload"
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/client"
+)
+
+var _ = Context("Config update tests, after starting felix", func() {
+
+	var (
+		etcd            *containers.Container
+		felix           *containers.Container
+		felixInitialPID int
+		client          *client.Client
+		w               [3]*workload.Workload
+	)
+
+	getFelixPIDs := func() []int {
+		return felix.GetPIDs("calico-felix")
+	}
+
+	BeforeEach(func() {
+		etcd = containers.RunEtcd()
+
+		client = utils.GetEtcdClient(etcd.IP)
+		Eventually(client.EnsureInitialized, "10s", "1s").ShouldNot(HaveOccurred())
+
+		felix = containers.RunFelix(etcd.IP)
+
+		felixNode := api.NewNode()
+		felixNode.Metadata.Name = felix.Hostname
+		_, err := client.Nodes().Create(felixNode)
+		Expect(err).NotTo(HaveOccurred())
+
+		start := time.Now()
+		for {
+			pids := getFelixPIDs()
+			Expect(pids).NotTo(BeEmpty())
+			if len(pids) == 1 {
+				felixInitialPID = pids[0]
+				break
+			}
+			Expect(time.Since(start)).To(BeNumerically("<", time.Second))
+		}
+	})
+
+	AfterEach(func() {
+
+		if CurrentGinkgoTestDescription().Failed {
+			felix.Exec("iptables-save", "-c")
+			felix.Exec("ip", "r")
+		}
+
+		for ii := range w {
+			w[ii].Stop()
+		}
+		felix.Stop()
+
+		if CurrentGinkgoTestDescription().Failed {
+			etcd.Exec("etcdctl", "ls", "--recursive", "/")
+		}
+		etcd.Stop()
+	})
+
+	shouldStayUp := func() {
+		// Felix has a 2s timer before it restarts so need to monitor for > 2s.
+		// We use ContainElement because Felix regularly forks off subprocesses and those
+		// subprocesses initially have name "calico-felix".
+		Consistently(getFelixPIDs, "3s", "200ms").Should(ContainElement(felixInitialPID))
+		// We know the initial PID has continued to be active, check that none of the extra
+		// transientPIDs we see are long-lived.
+		Eventually(getFelixPIDs).Should(ConsistOf(felixInitialPID))
+	}
+
+	It("should stay up >2s", shouldStayUp)
+
+	updateConfig := func() {
+		err := client.Config().SetFelixConfig("ClusterGUID", "", "foobarbaz")
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Config().SetFelixConfig("ClusterType", "", "felix-fv,something-new")
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Config().SetFelixConfig("CalicoVersion", "", "v3.0")
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Config().SetFelixConfig("ClusterGUID", felix.Hostname, "foobarbaz")
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Config().SetFelixConfig("ClusterType", felix.Hostname, "felix-fv,something-new")
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Config().SetFelixConfig("CalicoVersion", felix.Hostname, "v3.0")
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	Context("after updating config that felix can handle", func() {
+		BeforeEach(updateConfig)
+
+		It("should stay up >2s", shouldStayUp)
+
+		Context("after deleteing config that felix can handle", func() {
+			BeforeEach(func() {
+				err := client.Config().SetFelixConfig("ClusterGUID", "", "")
+				Expect(err).NotTo(HaveOccurred())
+				err = client.Config().SetFelixConfig("ClusterType", "", "")
+				Expect(err).NotTo(HaveOccurred())
+				err = client.Config().SetFelixConfig("CalicoVersion", "", "")
+				Expect(err).NotTo(HaveOccurred())
+				err = client.Config().SetFelixConfig("ClusterGUID", felix.Hostname, "")
+				Expect(err).NotTo(HaveOccurred())
+				err = client.Config().SetFelixConfig("ClusterType", felix.Hostname, "")
+				Expect(err).NotTo(HaveOccurred())
+				err = client.Config().SetFelixConfig("CalicoVersion", felix.Hostname, "")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should stay up >2s", shouldStayUp)
+		})
+	})
+
+	Context("after waiting for felix to come into sync and then updating config", func() {
+		BeforeEach(func() {
+			waitForFelixInSync(felix)
+			updateConfig()
+		})
+
+		It("should stay up >2s", shouldStayUp)
+	})
+
+	Context("after updating config that should trigger a restart", func() {
+		BeforeEach(func() {
+			err := client.Config().SetFelixConfig("InterfacePrefix", "", "foo")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should exit after a delay", func() {
+			// Felix has a 2s timer before it restarts so we should see the same PID for a while.
+			Consistently(getFelixPIDs, "1s", "100ms").Should(ContainElement(felixInitialPID))
+			// TODO(smc) When porting this test to v3.0, need to check felix restarts without killing container.
+			Eventually(felix.Stopped, "2s", "100ms").Should(BeTrue())
+		})
+	})
+})
+
+func waitForFelixInSync(felix *containers.Container) {
+	// The datastore should transition to in-sync.
+	Eventually(func() (int, error) {
+		return metrics.GetFelixMetricInt(felix.IP, "felix_resync_state")
+	}).Should(Equal(3 /* in-sync */))
+	// And then we should see at least one apply to the dataplane.
+	Eventually(func() (int, error) {
+		return metrics.GetFelixMetricInt(felix.IP, "felix_int_dataplane_apply_time_seconds_count")
+	}).Should(BeNumerically(">", 0))
+}

--- a/fv/config_update_test.go
+++ b/fv/config_update_test.go
@@ -160,7 +160,7 @@ var _ = Context("Config update tests, after starting felix", func() {
 			// Felix has a 2s timer before it restarts so we should see the same PID for a while.
 			Consistently(getFelixPIDs, "1s", "100ms").Should(ContainElement(felixInitialPID))
 			// TODO(smc) When porting this test to v3.0, need to check felix restarts without killing container.
-			Eventually(felix.Stopped, "5s", "100ms").Should(BeTrue())
+			Eventually(felix.ListedInDockerPS, "5s", "100ms").Should(BeFalse())
 		})
 	})
 })

--- a/fv/config_update_test.go
+++ b/fv/config_update_test.go
@@ -160,7 +160,7 @@ var _ = Context("Config update tests, after starting felix", func() {
 			// Felix has a 2s timer before it restarts so we should see the same PID for a while.
 			Consistently(getFelixPIDs, "1s", "100ms").Should(ContainElement(felixInitialPID))
 			// TODO(smc) When porting this test to v3.0, need to check felix restarts without killing container.
-			Eventually(felix.Stopped, "2s", "100ms").Should(BeTrue())
+			Eventually(felix.Stopped, "5s", "100ms").Should(BeTrue())
 		})
 	})
 })

--- a/fv/config_update_test.go
+++ b/fv/config_update_test.go
@@ -57,6 +57,8 @@ var _ = Context("Config update tests, after starting felix", func() {
 		_, err := client.Nodes().Create(felixNode)
 		Expect(err).NotTo(HaveOccurred())
 
+		// Get Felix's PID.  This retry loop ensures that we don't get tripped up if we see multiple
+		// PIDs, which can happen transiently when Felix forks off a subprocess.
 		start := time.Now()
 		for {
 			pids := getFelixPIDs()
@@ -119,7 +121,7 @@ var _ = Context("Config update tests, after starting felix", func() {
 
 		It("should stay up >2s", shouldStayUp)
 
-		Context("after deleteing config that felix can handle", func() {
+		Context("after deleting config that felix can handle", func() {
 			BeforeEach(func() {
 				err := client.Config().SetFelixConfig("ClusterGUID", "", "")
 				Expect(err).NotTo(HaveOccurred())

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -228,7 +228,10 @@ func (c *Container) ExecOutput(args ...string) (string, error) {
 	cmd := exec.Command("docker", arg...)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", err
+		if out == nil {
+			return "", err
+		}
+		return string(out), err
 	}
 	return string(out), nil
 }

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -179,14 +179,18 @@ func (c *Container) Stopped() bool {
 	return c.runCmd == nil
 }
 
+func (c *Container) ListedInDockerPS() bool {
+	cmd := utils.Command("docker", "ps")
+	out, err := cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+	return strings.Contains(string(out), c.Name)
+}
+
 func (c *Container) WaitNotRunning(timeout time.Duration) {
 	log.Info("Wait for container not to be listed in docker ps")
 	start := time.Now()
 	for {
-		cmd := utils.Command("docker", "ps")
-		out, err := cmd.CombinedOutput()
-		Expect(err).NotTo(HaveOccurred())
-		if !strings.Contains(string(out), c.Name) {
+		if !c.ListedInDockerPS() {
 			break
 		}
 		if time.Since(start) > timeout {

--- a/fv/iptables_lock_test.go
+++ b/fv/iptables_lock_test.go
@@ -27,8 +27,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/projectcalico/felix/fv/utils"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/fv/utils"
 )
 
 var _ = Describe("with running container", func() {

--- a/fv/metrics/metrics.go
+++ b/fv/metrics/metrics.go
@@ -56,3 +56,11 @@ func GetFelixMetric(felixIP, name string) (metric string, err error) {
 	err = scanner.Err()
 	return
 }
+
+func GetFelixMetricInt(felixIP, name string) (metric int, err error) {
+	s, err := GetFelixMetric(felixIP, name)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(s)
+}

--- a/fv/pre_dnat_test.go
+++ b/fv/pre_dnat_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/projectcalico/felix/fv/containers"
 	"github.com/projectcalico/felix/fv/utils"
 	"github.com/projectcalico/felix/fv/workload"

--- a/fv/utils/utils.go
+++ b/fv/utils/utils.go
@@ -22,9 +22,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/client"
-	log "github.com/sirupsen/logrus"
 )
 
 func Run(command string, args ...string) {

--- a/usagerep/usagerep.go
+++ b/usagerep/usagerep.go
@@ -15,8 +15,7 @@
 package usagerep
 
 import (
-	"github.com/projectcalico/felix/jitter"
-
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -26,10 +25,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"context"
-
 	"github.com/projectcalico/felix/buildinfo"
 	"github.com/projectcalico/felix/calc"
+	"github.com/projectcalico/felix/jitter"
 )
 
 const (
@@ -96,9 +94,11 @@ func (u *UsageReporter) PeriodicallyReportUsage(ctx context.Context) {
 	for {
 		select {
 		case stats = <-u.statsUpdateC:
+			log.WithField("stats", stats).Debug("Received stats update")
 			receivedFirstStats = true
 			maybeStartInitialDelay()
 		case config = <-u.configUpdateC:
+			log.WithField("config", config).Debug("Received config update")
 			maybeStartInitialDelay()
 		case <-initialDelayDone:
 			log.Info("Initial delay complete, doing first report")
@@ -112,6 +112,7 @@ func (u *UsageReporter) PeriodicallyReportUsage(ctx context.Context) {
 			// Enabled the main ticker loop.
 			tickerC = ticker.C
 		case <-tickerC:
+			log.Debug("Received tick")
 			doReport()
 		case <-ctx.Done():
 			log.Warn("Context stopped")

--- a/usagerep/usagerep_test.go
+++ b/usagerep/usagerep_test.go
@@ -21,13 +21,181 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
 	"github.com/projectcalico/felix/buildinfo"
 	"github.com/projectcalico/felix/calc"
 )
 
-var _ = Describe("Usagerep", func() {
+// These tests start a local HTTP server on a random port and tell the usage reporter to
+// connect to it.  Then we can check that it correctly makes HTTP requests at the right times.
+var _ = Describe("UsageReporter with mocked URL and short interval", func() {
+	var u *UsageReporter
+	var tcpListener net.Listener
+	var httpHandler *requestRecorder
+	var ctx context.Context
+	var cancel context.CancelFunc
+	var statsUpdateC chan calc.StatsUpdate
+	var configUpdateC chan map[string]string
+
+	BeforeEach(func() {
+		// Open a listener on a random local port.
+		var err error
+		tcpListener, err = net.Listen("tcp", ":0")
+		Expect(err).NotTo(HaveOccurred())
+		httpHandler = &requestRecorder{}
+		go func() {
+			defer GinkgoRecover()
+			http.Serve(tcpListener, httpHandler)
+		}()
+
+		// Channels to sent data to the UsageReporter.
+		statsUpdateC = make(chan calc.StatsUpdate)
+		configUpdateC = make(chan map[string]string)
+
+		// Create a usage reporter and override its base URL and initial interval.
+		u = New(1*time.Second, statsUpdateC, configUpdateC)
+		u.InitialDelay = 500 * time.Millisecond
+		port := tcpListener.Addr().(*net.TCPAddr).Port
+		u.BaseURL = fmt.Sprintf("http://localhost:%d/UsageCheck/calicoVersionCheck?", port)
+
+		ctx, cancel = context.WithCancel(context.Background())
+		go u.PeriodicallyReportUsage(ctx)
+	})
+
+	AfterEach(func() {
+		cancel()
+		tcpListener.Close()
+	})
+
+	It("should not check in before receiving config/stats", func() {
+		Consistently(httpHandler.GetRequestURIs, "2s").Should(BeEmpty())
+	})
+
+	Context("after sending config", func() {
+		BeforeEach(func() {
+			configUpdateC <- map[string]string{
+				"ClusterGUID":   "someguid",
+				"ClusterType":   "openstack,k8s,kdd",
+				"CalicoVersion": "v2.6.3",
+			}
+		})
+
+		It("should not check in before receiving stats", func() {
+			Consistently(httpHandler.GetRequestURIs, "2s").Should(BeEmpty())
+		})
+
+		Context("after sending stats", func() {
+			BeforeEach(func() {
+				statsUpdateC <- calc.StatsUpdate{
+					NumHosts:             1,
+					NumHostEndpoints:     2,
+					NumWorkloadEndpoints: 3,
+				}
+			})
+
+			It("should do first check ins correctly", func() {
+				By("checking in within 2s")
+				startTime := time.Now()
+				Eventually(httpHandler.GetRequestURIs, "2s", "100ms").Should(HaveLen(1))
+				By("waiting until after the intial delay")
+				Expect(time.Since(startTime)).To(BeNumerically(">=", 500*time.Millisecond))
+
+				By("including correct URL parameters")
+				uri := httpHandler.GetRequestURIs()[0]
+				url, err := url.Parse(uri)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(url.Path).To(Equal("/UsageCheck/calicoVersionCheck"))
+				q := url.Query()
+				Expect(len(q)).To(Equal(8))
+				Expect(q.Get("guid")).To(Equal("someguid"))
+				Expect(q.Get("type")).To(Equal("openstack,k8s,kdd"))
+				Expect(q.Get("cal_ver")).To(Equal("v2.6.3"))
+				Expect(q.Get("size")).To(Equal("1"))
+				Expect(q.Get("heps")).To(Equal("2"))
+				Expect(q.Get("weps")).To(Equal("3"))
+
+				By("checking in again")
+				Eventually(httpHandler.GetRequestURIs, "2s", "100ms").Should(HaveLen(2))
+				By("waiting until at least initial delay + 90% (due to jitter) of interval for second check in")
+				Expect(time.Since(startTime)).To(BeNumerically(">=", 1400*time.Millisecond))
+			})
+
+			Context("after first report, and sending in config and stat updates", func() {
+				BeforeEach(func() {
+					Eventually(httpHandler.GetRequestURIs, "2s", "100ms").Should(HaveLen(1))
+					statsUpdateC <- calc.StatsUpdate{
+						NumHosts:             10,
+						NumHostEndpoints:     20,
+						NumWorkloadEndpoints: 30,
+					}
+					configUpdateC <- map[string]string{
+						"ClusterGUID":   "someguid2",
+						"ClusterType":   "openstack,k8s,kdd,typha",
+						"CalicoVersion": "v3.0.0",
+					}
+				})
+
+				It("should do second check in correctly", func() {
+					By("checking in within 2s")
+					Eventually(httpHandler.GetRequestURIs, "2s", "100ms").Should(HaveLen(2))
+
+					By("including correct URL parameters")
+					uri := httpHandler.GetRequestURIs()[1]
+					url, err := url.Parse(uri)
+					Expect(err).NotTo(HaveOccurred())
+					q := url.Query()
+					Expect(len(q)).To(Equal(8))
+					Expect(q.Get("guid")).To(Equal("someguid2"))
+					Expect(q.Get("type")).To(Equal("openstack,k8s,kdd,typha"))
+					Expect(q.Get("cal_ver")).To(Equal("v3.0.0"))
+					Expect(q.Get("size")).To(Equal("10"))
+					Expect(q.Get("heps")).To(Equal("20"))
+					Expect(q.Get("weps")).To(Equal("30"))
+				})
+			})
+		})
+	})
+})
+
+type requestRecorder struct {
+	lock             sync.Mutex
+	requestsReceived []string
+}
+
+func (h *requestRecorder) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.requestsReceived = append(h.requestsReceived, req.RequestURI)
+
+	resp.Write([]byte(`{"usage_warning": "Warning!"}`))
+}
+
+func (h *requestRecorder) GetRequestURIs() []string {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	var result []string
+	for _, r := range h.requestsReceived {
+		result = append(result, r)
+	}
+	return result
+}
+
+// These tests create a usage reporter but they don't start it.  Instead they validate its
+// internal calculation methods and and the default configuration.
+var _ = Describe("UsageReporter with default URL", func() {
+	var u *UsageReporter
+
+	BeforeEach(func() {
+		u = New(24*time.Hour, nil, nil)
+	})
+
 	It("should calculate correct URL mainline", func() {
-		rawURL := calculateURL("theguid", "atype", "testVer", calc.StatsUpdate{
+		rawURL := u.calculateURL("theguid", "atype", "testVer", calc.StatsUpdate{
 			NumHostEndpoints:     123,
 			NumWorkloadEndpoints: 234,
 			NumHosts:             10,
@@ -50,7 +218,7 @@ var _ = Describe("Usagerep", func() {
 		Expect(url.Path).To(Equal("/UsageCheck/calicoVersionCheck"))
 	})
 	It("should default cluster type, GUID, and Calico Version", func() {
-		rawURL := calculateURL("", "", "", calc.StatsUpdate{
+		rawURL := u.calculateURL("", "", "", calc.StatsUpdate{
 			NumHostEndpoints:     123,
 			NumWorkloadEndpoints: 234,
 			NumHosts:             10,
@@ -64,20 +232,20 @@ var _ = Describe("Usagerep", func() {
 		Expect(q.Get("cal_ver")).To(Equal("unknown"))
 	})
 	It("should delay at least 5 minutes", func() {
-		Expect(calculateInitialDelay(0)).To(BeNumerically(">=", 5*time.Minute))
-		Expect(calculateInitialDelay(1)).To(BeNumerically(">=", 5*time.Minute))
-		Expect(calculateInitialDelay(1000)).To(BeNumerically(">=", 5*time.Minute))
+		Expect(u.calculateInitialDelay(0)).To(BeNumerically(">=", 5*time.Minute))
+		Expect(u.calculateInitialDelay(1)).To(BeNumerically(">=", 5*time.Minute))
+		Expect(u.calculateInitialDelay(1000)).To(BeNumerically(">=", 5*time.Minute))
 	})
 	It("should delay at most 10000 seconds", func() {
-		Expect(calculateInitialDelay(10000)).To(BeNumerically("<=", 5*time.Minute+10000*time.Second))
-		Expect(calculateInitialDelay(100000)).To(BeNumerically("<=", 5*time.Minute+10000*time.Second))
-		Expect(calculateInitialDelay(1000000)).To(BeNumerically("<=", 5*time.Minute+10000*time.Second))
-		Expect(calculateInitialDelay(10000000)).To(BeNumerically("<=", 5*time.Minute+10000*time.Second))
+		Expect(u.calculateInitialDelay(10000)).To(BeNumerically("<=", 5*time.Minute+10000*time.Second))
+		Expect(u.calculateInitialDelay(100000)).To(BeNumerically("<=", 5*time.Minute+10000*time.Second))
+		Expect(u.calculateInitialDelay(1000000)).To(BeNumerically("<=", 5*time.Minute+10000*time.Second))
+		Expect(u.calculateInitialDelay(10000000)).To(BeNumerically("<=", 5*time.Minute+10000*time.Second))
 	})
 	It("should have a random component", func() {
-		firstDelay := calculateInitialDelay(1000)
+		firstDelay := u.calculateInitialDelay(1000)
 		for i := 0; i < 10; i++ {
-			if calculateInitialDelay(1000) != firstDelay {
+			if u.calculateInitialDelay(1000) != firstDelay {
 				return // Success
 			}
 		}
@@ -87,7 +255,7 @@ var _ = Describe("Usagerep", func() {
 		var total time.Duration
 		// Give it a high but bounded number of iterations to converge.
 		for i := int64(0); i < 100000; i++ {
-			total += calculateInitialDelay(60)
+			total += u.calculateInitialDelay(60)
 			if i > 100 {
 				average := time.Duration(int64(total) / (i + 1))
 				// Delay should an average of 0.5s per host so the average should

--- a/usagerep/usagerep_test.go
+++ b/usagerep/usagerep_test.go
@@ -53,13 +53,12 @@ var _ = Describe("UsageReporter with mocked URL and short interval", func() {
 			http.Serve(tcpListener, httpHandler)
 		}()
 
-		// Channels to sent data to the UsageReporter.
+		// Channels to send data to the UsageReporter.
 		statsUpdateC = make(chan calc.StatsUpdate)
 		configUpdateC = make(chan map[string]string)
 
 		// Create a usage reporter and override its base URL and initial interval.
-		u = New(1*time.Second, statsUpdateC, configUpdateC)
-		u.InitialDelay = 500 * time.Millisecond
+		u = New(500*time.Millisecond, 1*time.Second, statsUpdateC, configUpdateC)
 		port := tcpListener.Addr().(*net.TCPAddr).Port
 		u.BaseURL = fmt.Sprintf("http://localhost:%d/UsageCheck/calicoVersionCheck?", port)
 
@@ -102,7 +101,7 @@ var _ = Describe("UsageReporter with mocked URL and short interval", func() {
 				By("checking in within 2s")
 				startTime := time.Now()
 				Eventually(httpHandler.GetRequestURIs, "2s", "100ms").Should(HaveLen(1))
-				By("waiting until after the intial delay")
+				By("waiting until after the initial delay")
 				Expect(time.Since(startTime)).To(BeNumerically(">=", 500*time.Millisecond))
 
 				By("including correct URL parameters")
@@ -191,7 +190,7 @@ var _ = Describe("UsageReporter with default URL", func() {
 	var u *UsageReporter
 
 	BeforeEach(func() {
-		u = New(24*time.Hour, nil, nil)
+		u = New(5*time.Minute, 24*time.Hour, nil, nil)
 	})
 
 	It("should calculate correct URL mainline", func() {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

- Add whitelist set for config changes that we can handle.
- Implement support for updating those fields.  (Little bit of work but I'm very keen to maintain the invariant that restarting Felix should be a graceful no-op.)

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [x] Backport
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In order to make upgrade from 2.6.x to 3.0 smoother, Felix now handles certain config changes without restarting.
```
