### PR TITLE
Fix config batcher: unset dirty flag after flush.

### DIFF
--- a/calc/config_batcher.go
+++ b/calc/config_batcher.go
@@ -57,24 +57,30 @@ func (cb *ConfigBatcher) OnUpdate(update api.Update) (filterOut bool) {
 			filterOut = true
 			return
 		}
-		log.Infof("Host config update for this host: %v", update)
 		if value, ok := update.Value.(string); value != cb.hostConfig[key.Name] {
+			log.Infof("Host config update for this host: %v", update)
 			if ok {
 				cb.hostConfig[key.Name] = value
 			} else {
 				delete(cb.hostConfig, key.Name)
 			}
 			cb.configDirty = true
+		} else {
+			log.Debugf("Ignoring no-op host config update for this host: %v", update)
+			return
 		}
 	case model.GlobalConfigKey:
-		log.Infof("Global config update: %v", update)
 		if value, ok := update.Value.(string); value != cb.globalConfig[key.Name] {
+			log.Infof("Global config update: %v", update)
 			if ok {
 				cb.globalConfig[key.Name] = value
 			} else {
 				delete(cb.globalConfig, key.Name)
 			}
 			cb.configDirty = true
+		} else {
+			log.Debugf("Ignoring no-op global config update: %v", update)
+			return
 		}
 	case model.ReadyFlagKey:
 		if update.Value != true {
@@ -117,4 +123,5 @@ func (cb *ConfigBatcher) maybeSendCachedConfig() {
 		cb.callbacks.OnDatastoreNotReady()
 	}
 	cb.callbacks.OnConfigUpdate(globalConfigCopy, hostConfigCopy)
+	cb.configDirty = false
 }

--- a/calc/config_batcher_test.go
+++ b/calc/config_batcher_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calc_test
+
+import (
+	. "github.com/projectcalico/felix/calc"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+)
+
+var _ = Describe("ConfigBatcher", func() {
+	var cb *ConfigBatcher
+	var recorder *configRecorder
+
+	BeforeEach(func() {
+		recorder = &configRecorder{}
+		cb = NewConfigBatcher("myhost", recorder)
+	})
+
+	sendHostUpdate := func(name string, value interface{}) {
+		cb.OnUpdate(api.Update{
+			KVPair: model.KVPair{
+				Key:   model.HostConfigKey{Name: name, Hostname: "myhost"},
+				Value: value,
+			},
+		})
+	}
+	sendGlobalUpdate := func(name string, value interface{}) {
+		cb.OnUpdate(api.Update{
+			KVPair: model.KVPair{
+				Key:   model.GlobalConfigKey{Name: name},
+				Value: value,
+			},
+		})
+	}
+	sendReady := func(ready interface{}) {
+		cb.OnUpdate(api.Update{
+			KVPair: model.KVPair{
+				Key:   model.ReadyFlagKey{},
+				Value: ready,
+			},
+		})
+	}
+
+	Context("after sending some updates", func() {
+		BeforeEach(func() {
+			sendHostUpdate("foo", "bar")
+			sendGlobalUpdate("biff", "bop")
+			sendReady(true)
+		})
+		It("shouldn't emit anything yet", func() {
+			Expect(recorder.Updates).To(BeEmpty())
+			Expect(recorder.NotReady).To(BeFalse())
+		})
+
+		Context("after sending the in-sync", func() {
+			BeforeEach(func() {
+				cb.OnDatamodelStatus(api.InSync)
+			})
+			It("should emit one event", func() {
+				Expect(recorder.Updates).To(ConsistOf(configUpdate{
+					host: map[string]string{
+						"foo": "bar",
+					},
+					global: map[string]string{
+						"biff": "bop",
+					},
+				}))
+				Expect(recorder.NotReady).To(BeFalse())
+			})
+
+			Context("after sending in more config", func() {
+				BeforeEach(func() {
+					recorder.Reset()
+					sendHostUpdate("foo", "biz")
+				})
+				It("should emit one event", func() {
+					Expect(recorder.Updates).To(ConsistOf(configUpdate{
+						host: map[string]string{
+							"foo": "biz",
+						},
+						global: map[string]string{
+							"biff": "bop",
+						},
+					}))
+					Expect(recorder.NotReady).To(BeFalse())
+				})
+			})
+
+			Context("after deleting a key", func() {
+				BeforeEach(func() {
+					recorder.Reset()
+					sendHostUpdate("foo", nil)
+				})
+				It("should emit one event", func() {
+					Expect(recorder.Updates).To(ConsistOf(configUpdate{
+						host: map[string]string{},
+						global: map[string]string{
+							"biff": "bop",
+						},
+					}))
+					Expect(recorder.NotReady).To(BeFalse())
+				})
+				Context("after deleting a global key", func() {
+					BeforeEach(func() {
+						recorder.Reset()
+						sendGlobalUpdate("biff", nil)
+					})
+					It("should emit one event", func() {
+						Expect(recorder.Updates).To(ConsistOf(configUpdate{
+							host:   map[string]string{},
+							global: map[string]string{},
+						}))
+						Expect(recorder.NotReady).To(BeFalse())
+					})
+				})
+			})
+
+			Context("after sending in no-op updates", func() {
+				BeforeEach(func() {
+					recorder.Reset()
+					sendHostUpdate("foo", "bar")
+					sendGlobalUpdate("biff", "bop")
+					sendReady(true)
+					sendHostUpdate("fooble", nil)
+					sendGlobalUpdate("biffle", nil)
+				})
+				It("should swallow the events", func() {
+					Expect(recorder.Updates).To(BeEmpty())
+					Expect(recorder.NotReady).To(BeFalse())
+				})
+			})
+
+			Context("after deleting ready flag", func() {
+				BeforeEach(func() {
+					recorder.Reset()
+					sendReady(nil)
+				})
+				It("should emit a not ready", func() {
+					Expect(recorder.NotReady).To(BeTrue())
+				})
+			})
+
+			Context("after setting ready flag to false", func() {
+				BeforeEach(func() {
+					recorder.Reset()
+					sendReady(false)
+				})
+				It("should emit a not ready", func() {
+					Expect(recorder.NotReady).To(BeTrue())
+				})
+			})
+		})
+	})
+
+	Context("after sending in-sync with no config", func() {
+		BeforeEach(func() {
+			cb.OnDatamodelStatus(api.InSync)
+		})
+		It("should emit a not-ready and empty config", func() {
+			Expect(recorder.NotReady).To(BeTrue())
+			Expect(recorder.Updates).To(ConsistOf(configUpdate{
+				host:   map[string]string{},
+				global: map[string]string{},
+			}))
+		})
+	})
+})
+
+type configUpdate struct {
+	host   map[string]string
+	global map[string]string
+}
+
+type configRecorder struct {
+	Updates  []configUpdate
+	NotReady bool
+}
+
+func (cr *configRecorder) OnConfigUpdate(globalConfig, hostConfig map[string]string) {
+	cr.Updates = append(cr.Updates, configUpdate{
+		host:   hostConfig,
+		global: globalConfig,
+	})
+}
+
+func (cr *configRecorder) OnDatastoreNotReady() {
+	cr.NotReady = true
+}
+
+func (cr *configRecorder) Reset() {
+	cr.Updates = nil
+}

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -256,6 +256,17 @@ func (c *Container) ExecMayFail(cmd ...string) error {
 	return utils.RunMayFail("docker", arg...)
 }
 
+func (c *Container) ExecOutput(args ...string) (string, error) {
+	arg := []string{"exec", c.Name}
+	arg = append(arg, args...)
+	cmd := exec.Command("docker", arg...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
 func (c *Container) SourceName() string {
 	return c.Name
 }


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Forward port of #1633 

- Reset the config batcher's dirty flag after sending updates.
- Tune logs to avoid Info-level spam for no-op updates.
- Add UT for ConfigBatcher.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [x] Backport
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix log spam from Felix caused by no-op config changes.
```
