### PR TITLE
Update ppc64le image to use calico-felix-wrapper.

### DIFF
--- a/docker-image/Dockerfile-ppc64le
+++ b/docker-image/Dockerfile-ppc64le
@@ -9,6 +9,7 @@ ENTRYPOINT ["/sbin/tini", "--"]
 RUN apk --no-cache add ip6tables ipset iputils iproute2 conntrack-tools 
 
 ADD felix.cfg /etc/calico/felix.cfg
+ADD calico-felix-wrapper usr/bin
 
 # Put out binary in /code rather than directly in /usr/bin.  This allows the downstream builds
 # to more easily extract the Felix build artefacts from the container.
@@ -18,4 +19,4 @@ WORKDIR /code
 RUN ln -s /code/calico-felix /usr/bin
 
 # Run felix by default
-CMD ["calico-felix"]
+CMD ["calico-felix-wrapper"]


### PR DESCRIPTION
Updating the docker-image/Dockerfile-ppc64le to match an earlier change made to Dockerfile.

Signed-off-by: David Wilder <wilder@us.ibm.com>

```release-note
None required
```
