### PR TITLE
Avoid reconnecting just to check the ready flag.

### DIFF
--- a/felix.go
+++ b/felix.go
@@ -170,6 +170,16 @@ func main() {
 	var numClientsCreated int
 configRetry:
 	for {
+		if numClientsCreated > 60 {
+			// We don't have a way to close datastore connection so, if we reconnected after
+			// a failure to load config, restart felix to avoid leaking connections.
+			// Use Panic to flush the log buffer.  Use defer to control the exit RC.
+			func() { // closure avoids a linter false positive.
+				defer os.Exit(configChangedRC)
+				log.Panic("Restarting to avoid leaking datastore connections")
+			}()
+		}
+
 		// Load locally-defined config, including the datastore connection
 		// parameters. First the environment variables.
 		configParams = config.New()

--- a/fv/config_update_test.go
+++ b/fv/config_update_test.go
@@ -137,7 +137,7 @@ var _ = Context("Config update tests, after starting felix", func() {
 
 	shouldExitAfterADelay := func() {
 		Consistently(getFelixPIDs, "1s", "100ms").Should(ContainElement(felixPID))
-		Eventually(getFelixPIDs, "5s", "100ms").ShouldNot(ContainElement(felixPID))
+		Eventually(getFelixPIDs, "10s", "100ms").ShouldNot(ContainElement(felixPID))
 	}
 
 	Context("after updating config that should trigger a restart", func() {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

During v2 -> v3 upgrade, Felix can be waiting for the ready flag to be true for a considerable length of time.  Erik found that we were leaking connections in that case. 

This change re-uses the same connection when rechecking the ready flag and adds a restart if we detect that we've leaked too many connections.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
