### PR TITLE
Always return a slice from GetPIDs.

### DIFF
--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -180,8 +180,10 @@ func (c *Container) GetHostname() string {
 
 func (c *Container) GetPIDs(processName string) []int {
 	out, err := c.ExecOutput("pgrep", fmt.Sprintf("^%s$", processName))
-	Expect(err).NotTo(HaveOccurred())
-	Expect(out).NotTo(BeEmpty())
+	if err != nil {
+		log.WithError(err).Warn("pgrep failed, assuming no PIDs")
+		return nil
+	}
 	var pids []int
 	for _, line := range strings.Split(out, "\n") {
 		if line == "" {


### PR DESCRIPTION
Previously, we'd fail if there were no PIDs because felix was restarting.  The calling code is expecting to be able to call GetPIDs during that case.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
