### PR TITLE
scrape just the most recent Version: when inferring version

### DIFF
--- a/rpm/build-rpms
+++ b/rpm/build-rpms
@@ -26,7 +26,7 @@ cd SPECS
 cp -a ${repo}/rpm/$spec .
 
 # Infer the version that the spec wants to build.
-version=`grep Version: $spec | awk '{print $2;}'`
+version=`grep Version: $spec | head -1 | awk '{print $2;}'`
 
 # Link patches into ../SOURCES.
 cd ../SOURCES


### PR DESCRIPTION
## Description
If the release notes have an extra match for "Version:", build-rpm incorrectly grabs that line as well which breaks the build.

## Todos

## Release Note

```release-note
None required
```
