### PR TITLE
scrape just the most recent Version: when inferring version

### DIFF
--- a/rpm/build-rpms
+++ b/rpm/build-rpms
@@ -26,7 +26,7 @@ cd SPECS
 cp -a ${repo}/rpm/$spec .
 
 # Infer the version that the spec wants to build.
-version=`grep Version: $spec | awk '{print $2;}'`
+version=`grep Version: $spec | head -1 | awk '{print $2;}'`
 
 # Link patches into ../SOURCES.
 cd ../SOURCES


### PR DESCRIPTION
## Description
If the release notes have an extra match for "Version:", build-rpm incorrectly grabs that line as well which breaks the build.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
