### PR TITLE
Allow for ready window in health test FV

### DIFF
--- a/fv/health_test.go
+++ b/fv/health_test.go
@@ -103,6 +103,7 @@ var _ = Describe("health tests", func() {
 			AfterEach(removePerNodeConfig)
 
 			It("should never be ready, then die", func() {
+				Eventually(felixReady, "1s", "100ms").ShouldNot(BeGood())
 				Consistently(felixReady, "5s", "100ms").ShouldNot(BeGood())
 				Eventually(felixContainer.Stopped, "5s").Should(BeTrue())
 			})


### PR DESCRIPTION
Since we allowed Felix to report itself as live while waiting for the
datastore, we now have a small 'ready' window between the end of the
config loop and starting up the dataplane (in the case, as in this test,
where the dataplane then decides for some reason that it is not ready).

Adjust the test expectation to allow for this.
