### PR TITLE
2.6.x: Report ready to kubernetes when the ready flag is false

### DIFF
--- a/fv/health_test.go
+++ b/fv/health_test.go
@@ -28,6 +28,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 
+	"time"
+
 	"github.com/projectcalico/felix/fv/containers"
 	"github.com/projectcalico/felix/fv/k8sapiserver"
 	"github.com/projectcalico/libcalico-go/lib/health"
@@ -35,7 +37,7 @@ import (
 
 type EnvConfig struct {
 	K8sVersion   string `default:"1.7.5"`
-	TyphaVersion string `default:"latest"`
+	TyphaVersion string `default:"v0.5.4"`
 }
 
 var config EnvConfig
@@ -53,6 +55,12 @@ var _ = Describe("health tests", func() {
 
 	BeforeEach(func() {
 		k8sAPIServer = k8sapiserver.SetUp(config.K8sVersion)
+	})
+
+	JustBeforeEach(func() {
+		// Since we added liveness reporting to Felix's config loading loop, Felix can flap its
+		// liveness/readiness during its initial loading.  This sleep bypasses that.
+		time.Sleep(1 * time.Second)
 	})
 
 	var felixContainer *containers.Container
@@ -102,10 +110,9 @@ var _ = Describe("health tests", func() {
 			})
 			AfterEach(removePerNodeConfig)
 
-			It("should never be ready, then die", func() {
-				Eventually(felixReady, "1s", "100ms").ShouldNot(BeGood())
-				Consistently(felixReady, "5s", "100ms").ShouldNot(BeGood())
-				Eventually(felixContainer.Stopped, "5s").Should(BeTrue())
+			It("should die", func() {
+				Eventually(felixReady, "5s", "100ms").ShouldNot(BeGood())
+				Eventually(felixContainer.Stopped, "10s").Should(BeTrue())
 			})
 		})
 
@@ -130,7 +137,7 @@ var _ = Describe("health tests", func() {
 			AfterEach(removePerNodeConfig)
 
 			It("should delay readiness", func() {
-				Consistently(felixReady, "5s", "100ms").ShouldNot(BeGood())
+				Consistently(felixReady, "3s", "100ms").ShouldNot(BeGood())
 				Eventually(felixReady, "10s", "100ms").Should(BeGood())
 				Consistently(felixReady, "10s", "1s").Should(BeGood())
 			})


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
