### PR TITLE
deb + rpm packages for felix 2.6.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+felix (2.6.4~__STREAM__) __STREAM__; urgency=low
+
+  * Felix 2.6.4 (from Git commit c299bcc).
+    [Changes recorded in 2.6.4 tag]
+    - Report ready to kubernetes when the ready flag is false. #1676
+
+ -- Neil Jerram <neil@tigera.io>  Fri, 22 Dec 2017 17:01:53 -0800
+
 felix (2.6.3~__STREAM__) __STREAM__; urgency=low
 
   * Felix 2.6.3 (from Git commit 7f8f06c).

--- a/rpm/felix.spec
+++ b/rpm/felix.spec
@@ -2,7 +2,7 @@
 
 Name:           felix
 Summary:        Project Calico virtual networking for cloud data centers
-Version:        2.6.3
+Version:        2.6.4
 Release:        1%{?dist}
 License:        Apache-2
 URL:            http://projectcalico.org
@@ -151,6 +151,11 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Fri Dec 22 2017 Neil Jerram <neil@tigera.io> 2.6.4-1
+  - Felix 2.6.4 (from Git commit c299bcc).
+    [Changes recorded in 2.6.4 tag]
+    - Report ready to kubernetes when the ready flag is false. #1676
+
 * Wed Dec 20 2017 Neil Jerram <neil@tigera.io> 2.6.3-1
   - Felix 2.6.3 (from Git commit 7f8f06c).
     [Changes recorded in 2.6.3 tag]


### PR DESCRIPTION
## Description
deb + rpm packages for felix 2.6.4

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
