### PR TITLE
Deduplicate doc on package publication

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -76,6 +76,11 @@ To build Debian and RPM packages for a release:
 
       FORCE_VERSION=<new version> make deb rpm
 
-  to rebuild packages with those changes in.
+  to rebuild packages with those changes in.  (Where `<new version>` is exactly
+  the same as when you ran `make release VERSION=<new version>` above.)
 
 - Once the changes are approved and any testing looks good, merge the PR.
+
+Tigera note: the wider Calico process release, including how to publish those
+packages, is now documented in
+[Confluence](https://tigera.atlassian.net/wiki/spaces/ENG/pages/17039710/Release+Process).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,60 +54,28 @@ So, to make a Felix release:
   expects a version number of the form "2.0.0", with optional suffixes
   such as "-beta1-rc3".
 
-# Felix packages for Calico with OpenStack
+# Felix packages for OpenStack and Host Protection deployments
 
 Apart from OpenStack, the platforms that Calico targets are container-based, so
 the container image artifacts already documented above are appropriate for
 installing Felix on those platforms.  OpenStack installations, however, are
 commonly based on packages, so for Calico with OpenStack we provide packages
 for the OS platforms that are popular for OpenStack installs: Debian packages
-for Ubuntu Trusty and Xenial, and RPM packages for CentOS 7 or RHEL 7.
+for Ubuntu Trusty and Xenial, and RPM packages for CentOS 7 or RHEL 7.  These
+packages can also be used for [Host Protection
+deployments](https://docs.projectcalico.org/master/getting-started/bare-metal/bare-metal#installing-felix).
 
 To build Debian and RPM packages for a release:
 
 - Following the above, run `make deb rpm`.  You should see debian/changelog and
   rpm/felix.spec being updated with the new version number and release notes,
-  and packages built under `dist/`.  If you then publish those packages (for
-  which see below), you should also commit and push those changes, so that we
-  have a record of when and how the packages were built.
+  and packages built under `dist/`.
 
-To build Debian and RPM packages for any Git HEAD:
+- Create a PR to get those changes, in particular the release notes, reviewed.
+  If you need to make changes, do so, and run
 
-- Run `make deb rpm`.  You should see changes similar to the release case
-  above, except that you probably don't want to save the temporary
-  debian/changelog and rpm/felix.spec updates that are made.
+      FORCE_VERSION=<new version> make deb rpm
 
-To publish Debian packages:
+  to rebuild packages with those changes in.
 
-- We publish Debian packages for Calico with OpenStack, on Ubuntu Trusty and
-  Xenial, to PPAs (personal package archives) at
-  https://launchpad.net/~project-calico.  This requires source packages to be
-  signed with a GPG key of one of the members of "Project Calico", then
-  uploaded to the PPA with "dput".  The steps are as follows.
-
-- Become a member of "Project Calico" and upload your GPG key, if you
-  aren't/haven't already.
-
-- `debsign -k<KEY_ID> dist/{trusty,xenial}/*_source.changes`, where `<KEY_ID>`
-  is enough of your GPG key name to uniquely identify it.
-
-- `dput ppa:project-calico/<PPA> dist/{trusty,xenial}/*_source.changes`, where
-  `<PPA>` is the target PPA, such as 'calico-1.4'.
-
-To publish RPM packages:
-
-- We publish RPM packages for Calico with OpenStack, on CentOS 7 or RHEL 7, to
-  repositories on binaries.projectcalico.org.  Each package must be signed with
-  the GPG key for the repository that it is being published in, as indicated by
-  the 'key' file in the repository root.  (Recently this has been the key
-  BCBB6892, for which the signing key is available on jenkins-slave1.)  The
-  steps are as follows.
-
-- `rpm --define '_gpg_name <KEY_ID>' --resign dist/rpms/RPMS/*/*.rpm`, where
-  `<KEY_ID>` is enough of the GPG signing key name to uniquely identify it.
-
-- Copy signed RPMs to the appropriate place under
-  `/usr/share/nginx/html/rpm/<REPO_NAME>` on binaries.projectcalico.org.
-
-- Run `createrepo .` in `/usr/share/nginx/html/rpm/<REPO_NAME>` on
-  binaries.projectcalico.org, to update the repository's metadata.
+- Once the changes are approved and any testing looks good, merge the PR.


### PR DESCRIPTION
Remove Tigera-specific package publication details from RELEASING.md.
Also remove the para on building development packages, as this is
unrelated to releasing.
