### PR TITLE
Enable host endpoint policy with kube-proxy running in IPVS mode

### DIFF
--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -17,6 +17,7 @@
 package dataplane
 
 import (
+	"math/bits"
 	"net"
 	"os/exec"
 
@@ -59,12 +60,15 @@ func StartDataplaneDriver(configParams *config.Config, healthAggregator *health.
 				"MarkMask": configParams.IptablesMarkMask,
 			}).Panic("Not enough mark bits available for endpoint mark.")
 		}
+		// Take first bit position (position 1) from endpoint mark mask as reserved generic endpoint mark.
+		markEndpointMarkGeneric := uint32(1) << uint(bits.TrailingZeros32(markEndpointMark))
 		log.WithFields(log.Fields{
-			"acceptMark":   markAccept,
-			"passMark":     markPass,
-			"scratch0Mark": markScratch0,
-			"scratch1Mark": markScratch1,
-			"endpointMark": markEndpointMark,
+			"acceptMark":          markAccept,
+			"passMark":            markPass,
+			"scratch0Mark":        markScratch0,
+			"scratch1Mark":        markScratch1,
+			"endpointMark":        markEndpointMark,
+			"endpointMarkGeneric": markEndpointMarkGeneric,
 		}).Info("Calculated iptables mark bits")
 
 		dpConfig := intdataplane.Config{
@@ -94,11 +98,12 @@ func StartDataplaneDriver(configParams *config.Config, healthAggregator *health.
 				OpenStackMetadataIP:          net.ParseIP(configParams.MetadataAddr),
 				OpenStackMetadataPort:        uint16(configParams.MetadataPort),
 
-				IptablesMarkAccept:   markAccept,
-				IptablesMarkPass:     markPass,
-				IptablesMarkScratch0: markScratch0,
-				IptablesMarkScratch1: markScratch1,
-				IptablesMarkEndpoint: markEndpointMark,
+				IptablesMarkAccept:          markAccept,
+				IptablesMarkPass:            markPass,
+				IptablesMarkScratch0:        markScratch0,
+				IptablesMarkScratch1:        markScratch1,
+				IptablesMarkEndpoint:        markEndpointMark,
+				IptablesMarkEndpointGeneric: markEndpointMarkGeneric,
 
 				IPIPEnabled:       configParams.IpInIpEnabled,
 				IPIPTunnelAddress: configParams.IpInIpTunnelAddr,

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -60,7 +60,7 @@ func StartDataplaneDriver(configParams *config.Config, healthAggregator *health.
 				"MarkMask": configParams.IptablesMarkMask,
 			}).Panic("Not enough mark bits available for endpoint mark.")
 		}
-		// Take first bit position (position 1) from endpoint mark mask as reserved generic endpoint mark.
+		// Take lowest bit position (position 1) from endpoint mark mask reserved for non-calico endpoint.
 		markEndpointNonCaliEndpoint := uint32(1) << uint(bits.TrailingZeros32(markEndpointMark))
 		log.WithFields(log.Fields{
 			"acceptMark":          markAccept,
@@ -68,7 +68,7 @@ func StartDataplaneDriver(configParams *config.Config, healthAggregator *health.
 			"scratch0Mark":        markScratch0,
 			"scratch1Mark":        markScratch1,
 			"endpointMark":        markEndpointMark,
-			"endpointMarkGeneric": markEndpointNonCaliEndpoint,
+			"endpointMarkNonCali": markEndpointNonCaliEndpoint,
 		}).Info("Calculated iptables mark bits")
 
 		dpConfig := intdataplane.Config{

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -61,14 +61,14 @@ func StartDataplaneDriver(configParams *config.Config, healthAggregator *health.
 			}).Panic("Not enough mark bits available for endpoint mark.")
 		}
 		// Take first bit position (position 1) from endpoint mark mask as reserved generic endpoint mark.
-		markEndpointMarkGeneric := uint32(1) << uint(bits.TrailingZeros32(markEndpointMark))
+		markEndpointNonCaliEndpoint := uint32(1) << uint(bits.TrailingZeros32(markEndpointMark))
 		log.WithFields(log.Fields{
 			"acceptMark":          markAccept,
 			"passMark":            markPass,
 			"scratch0Mark":        markScratch0,
 			"scratch1Mark":        markScratch1,
 			"endpointMark":        markEndpointMark,
-			"endpointMarkGeneric": markEndpointMarkGeneric,
+			"endpointMarkGeneric": markEndpointNonCaliEndpoint,
 		}).Info("Calculated iptables mark bits")
 
 		dpConfig := intdataplane.Config{
@@ -103,7 +103,7 @@ func StartDataplaneDriver(configParams *config.Config, healthAggregator *health.
 				IptablesMarkScratch0:        markScratch0,
 				IptablesMarkScratch1:        markScratch1,
 				IptablesMarkEndpoint:        markEndpointMark,
-				IptablesMarkEndpointGeneric: markEndpointMarkGeneric,
+				IptablesMarkNonCaliEndpoint: markEndpointNonCaliEndpoint,
 
 				IPIPEnabled:       configParams.IpInIpEnabled,
 				IPIPTunnelAddress: configParams.IpInIpTunnelAddr,

--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -78,7 +78,7 @@ var wlDispatchEmpty = []*iptables.Chain{
 			},
 			{
 				Action:  iptables.SetMaskedMarkAction{Mark: 0x0100, Mask: 0xff00},
-				Comment: "Generic endpoint mark",
+				Comment: "Non-Cali endpoint mark",
 			},
 		},
 	},
@@ -446,7 +446,7 @@ func chainsForIfaces(ifaceMetadata []string,
 			},
 			iptables.Rule{
 				Action:  iptables.SetMaskedMarkAction{Mark: 0x0100, Mask: 0xff00},
-				Comment: "Generic endpoint mark",
+				Comment: "Non-Cali endpoint mark",
 			},
 		)
 		epMarkFrom = append(epMarkFrom,

--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -64,8 +64,23 @@ var wlDispatchEmpty = []*iptables.Chain{
 		},
 	},
 	{
-		Name:  "cali-set-endpoint-mark",
-		Rules: []iptables.Rule{},
+		Name: "cali-set-endpoint-mark",
+		Rules: []iptables.Rule{
+			iptables.Rule{
+				Match:   iptables.Match().InInterface("cali+"),
+				Action:  iptables.DropAction{},
+				Comment: "Unknown endpoint",
+			},
+			iptables.Rule{
+				Match:   iptables.Match().InInterface("tap+"),
+				Action:  iptables.DropAction{},
+				Comment: "Unknown endpoint",
+			},
+			{
+				Action:  iptables.SetMaskedMarkAction{Mark: 0x0100, Mask: 0xff00},
+				Comment: "Generic endpoint mark",
+			},
+		},
 	},
 }
 
@@ -137,6 +152,7 @@ func chainsForIfaces(ifaceMetadata []string,
 	epMarkSetName := "cali-set-endpoint-mark"
 	epMarkFromName := "cali-from-endpoint-mark"
 	epMarkSetOnePrefix := "cali-sm-"
+	epmarkFromPrefix := outPrefix[:6]
 
 	if host {
 		hostOrWlLetter = "h"
@@ -147,6 +163,7 @@ func chainsForIfaces(ifaceMetadata []string,
 		}
 		outPrefix = "cali-to-"
 		inPrefix = "cali-from-"
+		epmarkFromPrefix = inPrefix[:6]
 	}
 	for _, ifaceMetadata := range ifaceMetadata {
 		var ifaceName, polName string
@@ -343,6 +360,7 @@ func chainsForIfaces(ifaceMetadata []string,
 				},
 			)
 		}
+
 		if host {
 			dispatchOut = append(dispatchOut,
 				iptables.Rule{
@@ -369,7 +387,9 @@ func chainsForIfaces(ifaceMetadata []string,
 					Action: iptables.GotoAction{Target: inPrefix[:6] + hostOrWlLetter + "-" + ifaceName},
 				},
 			)
+		}
 
+		if tableKind != "preDNAT" && tableKind != "untracked" {
 			chains = append(chains,
 				&iptables.Chain{
 					Name: epMarkSetOnePrefix + ifaceName,
@@ -389,10 +409,11 @@ func chainsForIfaces(ifaceMetadata []string,
 			epMarkFrom = append(epMarkFrom,
 				iptables.Rule{
 					Match:  iptables.Match().MarkMatchesWithMask(epMark, epMarkMapper.GetMask()),
-					Action: iptables.GotoAction{Target: outPrefix[:6] + hostOrWlLetter + "-" + ifaceName},
+					Action: iptables.GotoAction{Target: epmarkFromPrefix + hostOrWlLetter + "-" + ifaceName},
 				},
 			)
 		}
+
 	}
 	if !host {
 		dispatchOut = append(dispatchOut,
@@ -407,6 +428,25 @@ func chainsForIfaces(ifaceMetadata []string,
 				Match:   iptables.Match(),
 				Action:  iptables.DropAction{},
 				Comment: "Unknown interface",
+			},
+		)
+	}
+
+	if tableKind != "preDNAT" && tableKind != "untracked" {
+		epMarkSet = append(epMarkSet,
+			iptables.Rule{
+				Match:   iptables.Match().InInterface("cali+"),
+				Action:  iptables.DropAction{},
+				Comment: "Unknown endpoint",
+			},
+			iptables.Rule{
+				Match:   iptables.Match().InInterface("tap+"),
+				Action:  iptables.DropAction{},
+				Comment: "Unknown endpoint",
+			},
+			iptables.Rule{
+				Action:  iptables.SetMaskedMarkAction{Mark: 0x0100, Mask: 0xff00},
+				Comment: "Generic endpoint mark",
 			},
 		)
 		epMarkFrom = append(epMarkFrom,
@@ -427,6 +467,7 @@ func chainsForIfaces(ifaceMetadata []string,
 			},
 		)
 	}
+
 	if tableKind == "preDNAT" {
 		chains = append(chains,
 			&iptables.Chain{
@@ -446,6 +487,7 @@ func chainsForIfaces(ifaceMetadata []string,
 			},
 		)
 	}
+
 	return chains
 }
 
@@ -513,16 +555,18 @@ func endpointManagerTests(ipVersion uint8) func() {
 
 		BeforeEach(func() {
 			rrConfigNormal = rules.Config{
-				IPIPEnabled:            true,
-				IPIPTunnelAddress:      nil,
-				IPSetConfigV4:          ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, "cali", nil, nil),
-				IPSetConfigV6:          ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, "cali", nil, nil),
-				IptablesMarkAccept:     0x8,
-				IptablesMarkPass:       0x10,
-				IptablesMarkScratch0:   0x20,
-				IptablesMarkScratch1:   0x40,
-				IptablesMarkEndpoint:   0xff00,
-				KubeIPVSSupportEnabled: true,
+				IPIPEnabled:                 true,
+				IPIPTunnelAddress:           nil,
+				IPSetConfigV4:               ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, "cali", nil, nil),
+				IPSetConfigV6:               ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, "cali", nil, nil),
+				IptablesMarkAccept:          0x8,
+				IptablesMarkPass:            0x10,
+				IptablesMarkScratch0:        0x20,
+				IptablesMarkScratch1:        0x40,
+				IptablesMarkEndpoint:        0xff00,
+				IptablesMarkNonCaliEndpoint: 0x0100,
+				KubeIPVSSupportEnabled:      true,
+				WorkloadIfacePrefixes:       []string{"cali", "tap"},
 			}
 			eth0Addrs = set.New()
 			eth0Addrs.Add(ipv4)
@@ -551,7 +595,8 @@ func endpointManagerTests(ipVersion uint8) func() {
 				renderer,
 				routeTable,
 				ipVersion,
-				rules.NewEndpointMarkMapper(rrConfigNormal.IptablesMarkEndpoint),
+				rules.NewEndpointMarkMapper(rrConfigNormal.IptablesMarkEndpoint, rrConfigNormal.IptablesMarkNonCaliEndpoint),
+				rrConfigNormal.KubeIPVSSupportEnabled,
 				[]string{"cali"},
 				statusReportRec.endpointStatusUpdateCallback,
 				mockProcSys.write,

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -207,7 +207,10 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	if ruleRenderer == nil {
 		ruleRenderer = rules.NewRenderer(config.RulesConfig)
 	}
-	epMarkMapper := rules.NewEndpointMarkMapper(config.RulesConfig.IptablesMarkEndpoint)
+	epMarkMapper := rules.NewEndpointMarkMapper(
+		config.RulesConfig.IptablesMarkEndpoint,
+		config.RulesConfig.IptablesMarkEndpointGeneric)
+
 	dp := &InternalDataplane{
 		toDataplane:       make(chan interface{}, msgPeekLimit),
 		fromDataplane:     make(chan interface{}, 100),
@@ -306,6 +309,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		routeTableV4,
 		4,
 		epMarkMapper,
+		config.RulesConfig.KubeIPVSSupportEnabled,
 		config.RulesConfig.WorkloadIfacePrefixes,
 		dp.endpointStatusCombiner.OnEndpointStatusUpdate))
 	dp.RegisterManager(newFloatingIPManager(natTableV4, ruleRenderer, 4))
@@ -371,6 +375,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			routeTableV6,
 			6,
 			epMarkMapper,
+			config.RulesConfig.KubeIPVSSupportEnabled,
 			config.RulesConfig.WorkloadIfacePrefixes,
 			dp.endpointStatusCombiner.OnEndpointStatusUpdate))
 		dp.RegisterManager(newFloatingIPManager(natTableV6, ruleRenderer, 6))

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -209,7 +209,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	}
 	epMarkMapper := rules.NewEndpointMarkMapper(
 		config.RulesConfig.IptablesMarkEndpoint,
-		config.RulesConfig.IptablesMarkEndpointGeneric)
+		config.RulesConfig.IptablesMarkNonCaliEndpoint)
 
 	dp := &InternalDataplane{
 		toDataplane:       make(chan interface{}, msgPeekLimit),

--- a/iptables/match_builder.go
+++ b/iptables/match_builder.go
@@ -76,7 +76,7 @@ func (m MatchCriteria) MarkMatchesWithMask(mark, mask uint32) MatchCriteria {
 	return append(m, fmt.Sprintf("-m mark --mark %#x/%#x", mark, mask))
 }
 
-func (m MatchCriteria) MarkNotMatchesWithMask(mark, mask uint32) MatchCriteria {
+func (m MatchCriteria) NotMarkMatchesWithMask(mark, mask uint32) MatchCriteria {
 	logCxt := log.WithFields(log.Fields{
 		"mark": mark,
 		"mask": mask,

--- a/iptables/match_builder.go
+++ b/iptables/match_builder.go
@@ -76,6 +76,20 @@ func (m MatchCriteria) MarkMatchesWithMask(mark, mask uint32) MatchCriteria {
 	return append(m, fmt.Sprintf("-m mark --mark %#x/%#x", mark, mask))
 }
 
+func (m MatchCriteria) MarkNotMatchesWithMask(mark, mask uint32) MatchCriteria {
+	logCxt := log.WithFields(log.Fields{
+		"mark": mark,
+		"mask": mask,
+	})
+	if mask == 0 {
+		logCxt.Panic("Bug: mask is 0.")
+	}
+	if mark&mask != mark {
+		logCxt.Panic("Bug: mark is not contained in mask")
+	}
+	return append(m, fmt.Sprintf("-m mark ! --mark %#x/%#x", mark, mask))
+}
+
 func (m MatchCriteria) InInterface(ifaceMatch string) MatchCriteria {
 	return append(m, fmt.Sprintf("--in-interface %s", ifaceMatch))
 }

--- a/iptables/match_builder_test.go
+++ b/iptables/match_builder_test.go
@@ -56,6 +56,7 @@ var _ = DescribeTable("MatchBuilder",
 	Entry("MarkClear", Match().MarkNotClear(0x400a), "-m mark ! --mark 0/0x400a"),
 	Entry("MarkSingleBitSet", Match().MarkSingleBitSet(0x4000), "-m mark --mark 0x4000/0x4000"),
 	Entry("MarkMatchesWithMask", Match().MarkMatchesWithMask(0x400a, 0xf00f), "-m mark --mark 0x400a/0xf00f"),
+	Entry("NotMarkMatchesWithMask", Match().NotMarkMatchesWithMask(0x400a, 0xf00f), "-m mark ! --mark 0x400a/0xf00f"),
 	// Conntrack.
 	Entry("ConntrackState", Match().ConntrackState("INVALID"), "-m conntrack --ctstate INVALID"),
 	// Interfaces.

--- a/rules/dispatch_test.go
+++ b/rules/dispatch_test.go
@@ -51,12 +51,12 @@ var _ = Describe("Dispatch chains", func() {
 			Comment: "Unknown interface",
 		}
 
-		var smGenericMarkRule = iptables.Rule{
+		var smNonCaiSetMarkRule = iptables.Rule{
 			Action: iptables.SetMaskedMarkAction{
 				Mark: rrConfigNormal.IptablesMarkNonCaliEndpoint,
 				Mask: rrConfigNormal.IptablesMarkEndpoint,
 			},
-			Comment: "Generic endpoint mark",
+			Comment: "Non-Cali endpoint mark",
 		}
 
 		var epMarkMapper EndpointMarkMapper
@@ -128,9 +128,9 @@ var _ = Describe("Dispatch chains", func() {
 					{
 						Name: "cali-set-endpoint-mark",
 						Rules: []iptables.Rule{
-							smNonCaliDropRule("cali"),
-							smNonCaliDropRule("tap"),
-							smGenericMarkRule,
+							smUnknownEndpointDropRule("cali"),
+							smUnknownEndpointDropRule("tap"),
+							smNonCaiSetMarkRule,
 						},
 					},
 					{
@@ -169,9 +169,9 @@ var _ = Describe("Dispatch chains", func() {
 						Name: "cali-set-endpoint-mark",
 						Rules: []iptables.Rule{
 							inboundGotoRule("cali1234", "cali-sm-cali1234"),
-							smNonCaliDropRule("cali"),
-							smNonCaliDropRule("tap"),
-							smGenericMarkRule,
+							smUnknownEndpointDropRule("cali"),
+							smUnknownEndpointDropRule("tap"),
+							smNonCaiSetMarkRule,
 						},
 					},
 					{
@@ -245,9 +245,9 @@ var _ = Describe("Dispatch chains", func() {
 						Rules: []iptables.Rule{
 							inboundGotoRule("cali1234", "cali-sm-cali1234"),
 							inboundGotoRule("cali2+", "cali-set-endpoint-mark-2"),
-							smNonCaliDropRule("cali"),
-							smNonCaliDropRule("tap"),
-							smGenericMarkRule,
+							smUnknownEndpointDropRule("cali"),
+							smUnknownEndpointDropRule("tap"),
+							smNonCaiSetMarkRule,
 						},
 					},
 					{
@@ -369,9 +369,9 @@ var _ = Describe("Dispatch chains", func() {
 							Rules: []iptables.Rule{
 								inboundGotoRule("cali1+", "cali-set-endpoint-mark-1"),
 								inboundGotoRule("cali2+", "cali-set-endpoint-mark-2"),
-								smNonCaliDropRule("cali"),
-								smNonCaliDropRule("tap"),
-								smGenericMarkRule,
+								smUnknownEndpointDropRule("cali"),
+								smUnknownEndpointDropRule("tap"),
+								smNonCaiSetMarkRule,
 							},
 						},
 						{
@@ -462,9 +462,9 @@ var _ = Describe("Dispatch chains", func() {
 						Name: "cali-set-endpoint-mark",
 						Rules: []iptables.Rule{
 							inboundGotoRule("cali1234", "cali-sm-cali1234"),
-							smNonCaliDropRule("cali"),
-							smNonCaliDropRule("tap"),
-							smGenericMarkRule,
+							smUnknownEndpointDropRule("cali"),
+							smUnknownEndpointDropRule("tap"),
+							smNonCaiSetMarkRule,
 						},
 					},
 					{
@@ -900,7 +900,7 @@ func outboundGotoRule(ifaceMatch string, target string) iptables.Rule {
 	}
 }
 
-func smNonCaliDropRule(ifacePrefix string) iptables.Rule {
+func smUnknownEndpointDropRule(ifacePrefix string) iptables.Rule {
 	return iptables.Rule{
 		Match:   iptables.Match().InInterface(ifacePrefix + "+"),
 		Action:  iptables.DropAction{},

--- a/rules/dispatch_test.go
+++ b/rules/dispatch_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Dispatch chains", func() {
 			Comment: "Unknown interface",
 		}
 
-		var smNonCaiSetMarkRule = iptables.Rule{
+		var smNonCaliSetMarkRule = iptables.Rule{
 			Action: iptables.SetMaskedMarkAction{
 				Mark: rrConfigNormal.IptablesMarkNonCaliEndpoint,
 				Mask: rrConfigNormal.IptablesMarkEndpoint,
@@ -130,7 +130,7 @@ var _ = Describe("Dispatch chains", func() {
 						Rules: []iptables.Rule{
 							smUnknownEndpointDropRule("cali"),
 							smUnknownEndpointDropRule("tap"),
-							smNonCaiSetMarkRule,
+							smNonCaliSetMarkRule,
 						},
 					},
 					{
@@ -171,7 +171,7 @@ var _ = Describe("Dispatch chains", func() {
 							inboundGotoRule("cali1234", "cali-sm-cali1234"),
 							smUnknownEndpointDropRule("cali"),
 							smUnknownEndpointDropRule("tap"),
-							smNonCaiSetMarkRule,
+							smNonCaliSetMarkRule,
 						},
 					},
 					{
@@ -247,7 +247,7 @@ var _ = Describe("Dispatch chains", func() {
 							inboundGotoRule("cali2+", "cali-set-endpoint-mark-2"),
 							smUnknownEndpointDropRule("cali"),
 							smUnknownEndpointDropRule("tap"),
-							smNonCaiSetMarkRule,
+							smNonCaliSetMarkRule,
 						},
 					},
 					{
@@ -371,7 +371,7 @@ var _ = Describe("Dispatch chains", func() {
 								inboundGotoRule("cali2+", "cali-set-endpoint-mark-2"),
 								smUnknownEndpointDropRule("cali"),
 								smUnknownEndpointDropRule("tap"),
-								smNonCaiSetMarkRule,
+								smNonCaliSetMarkRule,
 							},
 						},
 						{
@@ -464,7 +464,7 @@ var _ = Describe("Dispatch chains", func() {
 							inboundGotoRule("cali1234", "cali-sm-cali1234"),
 							smUnknownEndpointDropRule("cali"),
 							smUnknownEndpointDropRule("tap"),
-							smNonCaiSetMarkRule,
+							smNonCaliSetMarkRule,
 						},
 					},
 					{

--- a/rules/dispatch_test.go
+++ b/rules/dispatch_test.go
@@ -32,16 +32,18 @@ var _ = Describe("Dispatch chains", func() {
 	for _, trueOrFalse := range []bool{true, false} {
 		kubeIPVSEnabled := trueOrFalse
 		var rrConfigNormal = Config{
-			IPIPEnabled:            true,
-			IPIPTunnelAddress:      nil,
-			IPSetConfigV4:          ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, "cali", nil, nil),
-			IPSetConfigV6:          ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, "cali", nil, nil),
-			IptablesMarkAccept:     0x8,
-			IptablesMarkPass:       0x10,
-			IptablesMarkScratch0:   0x20,
-			IptablesMarkScratch1:   0x40,
-			IptablesMarkEndpoint:   0xff00,
-			KubeIPVSSupportEnabled: kubeIPVSEnabled,
+			IPIPEnabled:                 true,
+			IPIPTunnelAddress:           nil,
+			IPSetConfigV4:               ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, "cali", nil, nil),
+			IPSetConfigV6:               ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, "cali", nil, nil),
+			IptablesMarkAccept:          0x8,
+			IptablesMarkPass:            0x10,
+			IptablesMarkScratch0:        0x20,
+			IptablesMarkScratch1:        0x40,
+			IptablesMarkEndpoint:        0xff00,
+			IptablesMarkNonCaliEndpoint: 0x0100,
+			WorkloadIfacePrefixes:       []string{"cali", "tap"},
+			KubeIPVSSupportEnabled:      kubeIPVSEnabled,
 		}
 
 		var expDropRule = iptables.Rule{
@@ -49,11 +51,19 @@ var _ = Describe("Dispatch chains", func() {
 			Comment: "Unknown interface",
 		}
 
+		var smGenericMarkRule = iptables.Rule{
+			Action: iptables.SetMaskedMarkAction{
+				Mark: rrConfigNormal.IptablesMarkNonCaliEndpoint,
+				Mask: rrConfigNormal.IptablesMarkEndpoint,
+			},
+			Comment: "Generic endpoint mark",
+		}
+
 		var epMarkMapper EndpointMarkMapper
 		var renderer RuleRenderer
 		BeforeEach(func() {
 			renderer = NewRenderer(rrConfigNormal)
-			epMarkMapper = NewEndpointMarkMapper(rrConfigNormal.IptablesMarkEndpoint)
+			epMarkMapper = NewEndpointMarkMapper(rrConfigNormal.IptablesMarkEndpoint, rrConfigNormal.IptablesMarkNonCaliEndpoint)
 		})
 
 		It("should panic if interface name is empty", func() {
@@ -65,7 +75,7 @@ var _ = Describe("Dispatch chains", func() {
 			input := map[proto.WorkloadEndpointID]*proto.WorkloadEndpoint{
 				endpointID: {},
 			}
-			Expect(func() { renderer.WorkloadDispatchChains(input, epMarkMapper) }).To(Panic())
+			Expect(func() { renderer.WorkloadDispatchChains(input) }).To(Panic())
 		})
 
 		DescribeTable("workload rendering tests",
@@ -86,7 +96,24 @@ var _ = Describe("Dispatch chains", func() {
 					}
 				}
 				// Note: order of chains and rules should be deterministic.
-				Expect(renderer.WorkloadDispatchChains(input, epMarkMapper)).To(Equal(expectedChains[kubeIPVSEnabled]))
+				var result []*iptables.Chain
+				if kubeIPVSEnabled {
+					result = append(renderer.WorkloadDispatchChains(input),
+						renderer.EndpointMarkDispatchChains(epMarkMapper, input, map[string]proto.HostEndpointID{})...)
+				} else {
+					result = renderer.WorkloadDispatchChains(input)
+				}
+
+				mapChain := map[string]*iptables.Chain{}
+				for _, chain := range result {
+					mapChain[chain.Name] = chain
+				}
+
+				for _, chain := range expectedChains[kubeIPVSEnabled] {
+					//log.WithField("chain", *chain).Debug("")
+					Expect(mapChain[chain.Name]).To(Equal(chain))
+				}
+				Expect(result).To(Equal(expectedChains[kubeIPVSEnabled]))
 			},
 			Entry("nil map", nil, map[bool][]*iptables.Chain{
 				true: {
@@ -99,8 +126,12 @@ var _ = Describe("Dispatch chains", func() {
 						Rules: []iptables.Rule{expDropRule},
 					},
 					{
-						Name:  "cali-set-endpoint-mark",
-						Rules: []iptables.Rule{},
+						Name: "cali-set-endpoint-mark",
+						Rules: []iptables.Rule{
+							smNonCaliDropRule("cali"),
+							smNonCaliDropRule("tap"),
+							smGenericMarkRule,
+						},
 					},
 					{
 						Name:  "cali-from-endpoint-mark",
@@ -138,6 +169,9 @@ var _ = Describe("Dispatch chains", func() {
 						Name: "cali-set-endpoint-mark",
 						Rules: []iptables.Rule{
 							inboundGotoRule("cali1234", "cali-sm-cali1234"),
+							smNonCaliDropRule("cali"),
+							smNonCaliDropRule("tap"),
+							smGenericMarkRule,
 						},
 					},
 					{
@@ -176,18 +210,18 @@ var _ = Describe("Dispatch chains", func() {
 						},
 					},
 					{
-						Name: "cali-to-wl-dispatch-2",
-						Rules: []iptables.Rule{
-							outboundGotoRule("cali2333", "cali-tw-cali2333"),
-							outboundGotoRule("cali2444", "cali-tw-cali2444"),
-							expDropRule,
-						},
-					},
-					{
 						Name: "cali-from-wl-dispatch",
 						Rules: []iptables.Rule{
 							inboundGotoRule("cali1234", "cali-fw-cali1234"),
 							inboundGotoRule("cali2+", "cali-from-wl-dispatch-2"),
+							expDropRule,
+						},
+					},
+					{
+						Name: "cali-to-wl-dispatch-2",
+						Rules: []iptables.Rule{
+							outboundGotoRule("cali2333", "cali-tw-cali2333"),
+							outboundGotoRule("cali2444", "cali-tw-cali2444"),
 							expDropRule,
 						},
 					},
@@ -211,6 +245,9 @@ var _ = Describe("Dispatch chains", func() {
 						Rules: []iptables.Rule{
 							inboundGotoRule("cali1234", "cali-sm-cali1234"),
 							inboundGotoRule("cali2+", "cali-set-endpoint-mark-2"),
+							smNonCaliDropRule("cali"),
+							smNonCaliDropRule("tap"),
+							smGenericMarkRule,
 						},
 					},
 					{
@@ -233,18 +270,18 @@ var _ = Describe("Dispatch chains", func() {
 						},
 					},
 					{
-						Name: "cali-to-wl-dispatch-2",
-						Rules: []iptables.Rule{
-							outboundGotoRule("cali2333", "cali-tw-cali2333"),
-							outboundGotoRule("cali2444", "cali-tw-cali2444"),
-							expDropRule,
-						},
-					},
-					{
 						Name: "cali-from-wl-dispatch",
 						Rules: []iptables.Rule{
 							inboundGotoRule("cali1234", "cali-fw-cali1234"),
 							inboundGotoRule("cali2+", "cali-from-wl-dispatch-2"),
+							expDropRule,
+						},
+					},
+					{
+						Name: "cali-to-wl-dispatch-2",
+						Rules: []iptables.Rule{
+							outboundGotoRule("cali2333", "cali-tw-cali2333"),
+							outboundGotoRule("cali2444", "cali-tw-cali2444"),
 							expDropRule,
 						},
 					},
@@ -272,6 +309,22 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
+							Name: "cali-from-wl-dispatch-2",
+							Rules: []iptables.Rule{
+								inboundGotoRule("cali21", "cali-fw-cali21"),
+								inboundGotoRule("cali22", "cali-fw-cali22"),
+								expDropRule,
+							},
+						},
+						{
+							Name: "cali-from-wl-dispatch",
+							Rules: []iptables.Rule{
+								inboundGotoRule("cali1+", "cali-from-wl-dispatch-1"),
+								inboundGotoRule("cali2+", "cali-from-wl-dispatch-2"),
+								expDropRule,
+							},
+						},
+						{
 							Name: "cali-to-wl-dispatch-1",
 							Rules: []iptables.Rule{
 								outboundGotoRule("cali11", "cali-tw-cali11"),
@@ -281,26 +334,10 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
-							Name: "cali-from-wl-dispatch-2",
-							Rules: []iptables.Rule{
-								inboundGotoRule("cali21", "cali-fw-cali21"),
-								inboundGotoRule("cali22", "cali-fw-cali22"),
-								expDropRule,
-							},
-						},
-						{
 							Name: "cali-to-wl-dispatch-2",
 							Rules: []iptables.Rule{
 								outboundGotoRule("cali21", "cali-tw-cali21"),
 								outboundGotoRule("cali22", "cali-tw-cali22"),
-								expDropRule,
-							},
-						},
-						{
-							Name: "cali-from-wl-dispatch",
-							Rules: []iptables.Rule{
-								inboundGotoRule("cali1+", "cali-from-wl-dispatch-1"),
-								inboundGotoRule("cali2+", "cali-from-wl-dispatch-2"),
 								expDropRule,
 							},
 						},
@@ -332,14 +369,17 @@ var _ = Describe("Dispatch chains", func() {
 							Rules: []iptables.Rule{
 								inboundGotoRule("cali1+", "cali-set-endpoint-mark-1"),
 								inboundGotoRule("cali2+", "cali-set-endpoint-mark-2"),
+								smNonCaliDropRule("cali"),
+								smNonCaliDropRule("tap"),
+								smGenericMarkRule,
 							},
 						},
 						{
 							Name: "cali-from-endpoint-mark",
 							Rules: []iptables.Rule{
 								epMarkFromGotoRule(0x200, 0xff00, "cali-fw-cali11"),
-								epMarkFromGotoRule(0x100, 0xff00, "cali-fw-cali12"),
-								epMarkFromGotoRule(0x300, 0xff00, "cali-fw-cali13"),
+								epMarkFromGotoRule(0x300, 0xff00, "cali-fw-cali12"),
+								epMarkFromGotoRule(0x400, 0xff00, "cali-fw-cali13"),
 								epMarkFromGotoRule(0xf700, 0xff00, "cali-fw-cali21"),
 								epMarkFromGotoRule(0xf400, 0xff00, "cali-fw-cali22"),
 								expDropRule,
@@ -357,6 +397,22 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
+							Name: "cali-from-wl-dispatch-2",
+							Rules: []iptables.Rule{
+								inboundGotoRule("cali21", "cali-fw-cali21"),
+								inboundGotoRule("cali22", "cali-fw-cali22"),
+								expDropRule,
+							},
+						},
+						{
+							Name: "cali-from-wl-dispatch",
+							Rules: []iptables.Rule{
+								inboundGotoRule("cali1+", "cali-from-wl-dispatch-1"),
+								inboundGotoRule("cali2+", "cali-from-wl-dispatch-2"),
+								expDropRule,
+							},
+						},
+						{
 							Name: "cali-to-wl-dispatch-1",
 							Rules: []iptables.Rule{
 								outboundGotoRule("cali11", "cali-tw-cali11"),
@@ -366,26 +422,10 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
-							Name: "cali-from-wl-dispatch-2",
-							Rules: []iptables.Rule{
-								inboundGotoRule("cali21", "cali-fw-cali21"),
-								inboundGotoRule("cali22", "cali-fw-cali22"),
-								expDropRule,
-							},
-						},
-						{
 							Name: "cali-to-wl-dispatch-2",
 							Rules: []iptables.Rule{
 								outboundGotoRule("cali21", "cali-tw-cali21"),
 								outboundGotoRule("cali22", "cali-tw-cali22"),
-								expDropRule,
-							},
-						},
-						{
-							Name: "cali-from-wl-dispatch",
-							Rules: []iptables.Rule{
-								inboundGotoRule("cali1+", "cali-from-wl-dispatch-1"),
-								inboundGotoRule("cali2+", "cali-from-wl-dispatch-2"),
 								expDropRule,
 							},
 						},
@@ -422,6 +462,9 @@ var _ = Describe("Dispatch chains", func() {
 						Name: "cali-set-endpoint-mark",
 						Rules: []iptables.Rule{
 							inboundGotoRule("cali1234", "cali-sm-cali1234"),
+							smNonCaliDropRule("cali"),
+							smNonCaliDropRule("tap"),
+							smGenericMarkRule,
 						},
 					},
 					{
@@ -468,7 +511,7 @@ var _ = Describe("Dispatch chains", func() {
 				func(names []string, expectedChains []*iptables.Chain) {
 					input := convertToInput(names, expectedChains)
 					// Note: order of chains and rules should be deterministic.
-					Expect(renderer.FromHostDispatchChains(input, epMarkMapper)).To(Equal(expectedChains))
+					Expect(renderer.FromHostDispatchChains(input)).To(Equal(expectedChains))
 				},
 				Entry("nil map", nil, []*iptables.Chain{
 					{
@@ -532,7 +575,7 @@ var _ = Describe("Dispatch chains", func() {
 				func(names []string, expectedChains []*iptables.Chain) {
 					input := convertToInput(names, expectedChains)
 					// Note: order of chains and rules should be deterministic.
-					Expect(renderer.HostDispatchChains(input, epMarkMapper, false)).To(Equal(expectedChains))
+					Expect(renderer.HostDispatchChains(input, false)).To(Equal(expectedChains))
 				},
 				Entry("nil map", nil, []*iptables.Chain{
 					{
@@ -567,17 +610,17 @@ var _ = Describe("Dispatch chains", func() {
 						},
 					},
 					{
-						Name: "cali-to-host-endpoint-2",
-						Rules: []iptables.Rule{
-							outboundGotoRule("eth2333", "cali-th-eth2333"),
-							outboundGotoRule("eth2444", "cali-th-eth2444"),
-						},
-					},
-					{
 						Name: "cali-from-host-endpoint",
 						Rules: []iptables.Rule{
 							inboundGotoRule("eth1234", "cali-fh-eth1234"),
 							inboundGotoRule("eth2+", "cali-from-host-endpoint-2"),
+						},
+					},
+					{
+						Name: "cali-to-host-endpoint-2",
+						Rules: []iptables.Rule{
+							outboundGotoRule("eth2333", "cali-th-eth2333"),
+							outboundGotoRule("eth2444", "cali-th-eth2444"),
 						},
 					},
 					{
@@ -600,6 +643,20 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
+							Name: "cali-from-host-endpoint-2",
+							Rules: []iptables.Rule{
+								inboundGotoRule("eth21", "cali-fh-eth21"),
+								inboundGotoRule("eth22", "cali-fh-eth22"),
+							},
+						},
+						{
+							Name: "cali-from-host-endpoint",
+							Rules: []iptables.Rule{
+								inboundGotoRule("eth1+", "cali-from-host-endpoint-1"),
+								inboundGotoRule("eth2+", "cali-from-host-endpoint-2"),
+							},
+						},
+						{
 							Name: "cali-to-host-endpoint-1",
 							Rules: []iptables.Rule{
 								outboundGotoRule("eth11", "cali-th-eth11"),
@@ -608,24 +665,10 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
-							Name: "cali-from-host-endpoint-2",
-							Rules: []iptables.Rule{
-								inboundGotoRule("eth21", "cali-fh-eth21"),
-								inboundGotoRule("eth22", "cali-fh-eth22"),
-							},
-						},
-						{
 							Name: "cali-to-host-endpoint-2",
 							Rules: []iptables.Rule{
 								outboundGotoRule("eth21", "cali-th-eth21"),
 								outboundGotoRule("eth22", "cali-th-eth22"),
-							},
-						},
-						{
-							Name: "cali-from-host-endpoint",
-							Rules: []iptables.Rule{
-								inboundGotoRule("eth1+", "cali-from-host-endpoint-1"),
-								inboundGotoRule("eth2+", "cali-from-host-endpoint-2"),
 							},
 						},
 						{
@@ -642,7 +685,7 @@ var _ = Describe("Dispatch chains", func() {
 				func(names []string, expectedChains []*iptables.Chain) {
 					input := convertToInput(names, expectedChains)
 					// Note: order of chains and rules should be deterministic.
-					Expect(renderer.HostDispatchChains(input, epMarkMapper, true)).To(Equal(expectedChains))
+					Expect(renderer.HostDispatchChains(input, true)).To(Equal(expectedChains))
 				},
 				Entry("nil map", nil, []*iptables.Chain{
 					{
@@ -697,17 +740,17 @@ var _ = Describe("Dispatch chains", func() {
 						},
 					},
 					{
-						Name: "cali-to-host-endpoint-2",
-						Rules: []iptables.Rule{
-							outboundGotoRule("eth2333", "cali-th-eth2333"),
-							outboundGotoRule("eth2444", "cali-th-eth2444"),
-						},
-					},
-					{
 						Name: "cali-from-host-endpoint",
 						Rules: []iptables.Rule{
 							inboundGotoRule("eth1234", "cali-fh-eth1234"),
 							inboundGotoRule("eth2+", "cali-from-host-endpoint-2"),
+						},
+					},
+					{
+						Name: "cali-to-host-endpoint-2",
+						Rules: []iptables.Rule{
+							outboundGotoRule("eth2333", "cali-th-eth2333"),
+							outboundGotoRule("eth2444", "cali-th-eth2444"),
 						},
 					},
 					{
@@ -725,17 +768,17 @@ var _ = Describe("Dispatch chains", func() {
 						},
 					},
 					{
-						Name: "cali-to-hep-forward-2",
-						Rules: []iptables.Rule{
-							outboundGotoRule("eth2333", "cali-thfw-eth2333"),
-							outboundGotoRule("eth2444", "cali-thfw-eth2444"),
-						},
-					},
-					{
 						Name: "cali-from-hep-forward",
 						Rules: []iptables.Rule{
 							inboundGotoRule("eth1234", "cali-fhfw-eth1234"),
 							inboundGotoRule("eth2+", "cali-from-hep-forward-2"),
+						},
+					},
+					{
+						Name: "cali-to-hep-forward-2",
+						Rules: []iptables.Rule{
+							outboundGotoRule("eth2333", "cali-thfw-eth2333"),
+							outboundGotoRule("eth2444", "cali-thfw-eth2444"),
 						},
 					},
 					{
@@ -758,6 +801,20 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
+							Name: "cali-from-host-endpoint-2",
+							Rules: []iptables.Rule{
+								inboundGotoRule("eth21", "cali-fh-eth21"),
+								inboundGotoRule("eth22", "cali-fh-eth22"),
+							},
+						},
+						{
+							Name: "cali-from-host-endpoint",
+							Rules: []iptables.Rule{
+								inboundGotoRule("eth1+", "cali-from-host-endpoint-1"),
+								inboundGotoRule("eth2+", "cali-from-host-endpoint-2"),
+							},
+						},
+						{
 							Name: "cali-to-host-endpoint-1",
 							Rules: []iptables.Rule{
 								outboundGotoRule("eth11", "cali-th-eth11"),
@@ -766,24 +823,10 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
-							Name: "cali-from-host-endpoint-2",
-							Rules: []iptables.Rule{
-								inboundGotoRule("eth21", "cali-fh-eth21"),
-								inboundGotoRule("eth22", "cali-fh-eth22"),
-							},
-						},
-						{
 							Name: "cali-to-host-endpoint-2",
 							Rules: []iptables.Rule{
 								outboundGotoRule("eth21", "cali-th-eth21"),
 								outboundGotoRule("eth22", "cali-th-eth22"),
-							},
-						},
-						{
-							Name: "cali-from-host-endpoint",
-							Rules: []iptables.Rule{
-								inboundGotoRule("eth1+", "cali-from-host-endpoint-1"),
-								inboundGotoRule("eth2+", "cali-from-host-endpoint-2"),
 							},
 						},
 						{
@@ -802,6 +845,20 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
+							Name: "cali-from-hep-forward-2",
+							Rules: []iptables.Rule{
+								inboundGotoRule("eth21", "cali-fhfw-eth21"),
+								inboundGotoRule("eth22", "cali-fhfw-eth22"),
+							},
+						},
+						{
+							Name: "cali-from-hep-forward",
+							Rules: []iptables.Rule{
+								inboundGotoRule("eth1+", "cali-from-hep-forward-1"),
+								inboundGotoRule("eth2+", "cali-from-hep-forward-2"),
+							},
+						},
+						{
 							Name: "cali-to-hep-forward-1",
 							Rules: []iptables.Rule{
 								outboundGotoRule("eth11", "cali-thfw-eth11"),
@@ -810,24 +867,10 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
-							Name: "cali-from-hep-forward-2",
-							Rules: []iptables.Rule{
-								inboundGotoRule("eth21", "cali-fhfw-eth21"),
-								inboundGotoRule("eth22", "cali-fhfw-eth22"),
-							},
-						},
-						{
 							Name: "cali-to-hep-forward-2",
 							Rules: []iptables.Rule{
 								outboundGotoRule("eth21", "cali-thfw-eth21"),
 								outboundGotoRule("eth22", "cali-thfw-eth22"),
-							},
-						},
-						{
-							Name: "cali-from-hep-forward",
-							Rules: []iptables.Rule{
-								inboundGotoRule("eth1+", "cali-from-hep-forward-1"),
-								inboundGotoRule("eth2+", "cali-from-hep-forward-2"),
 							},
 						},
 						{
@@ -854,6 +897,14 @@ func outboundGotoRule(ifaceMatch string, target string) iptables.Rule {
 	return iptables.Rule{
 		Match:  iptables.Match().OutInterface(ifaceMatch),
 		Action: iptables.GotoAction{Target: target},
+	}
+}
+
+func smNonCaliDropRule(ifacePrefix string) iptables.Rule {
+	return iptables.Rule{
+		Match:   iptables.Match().InInterface(ifacePrefix + "+"),
+		Action:  iptables.DropAction{},
+		Comment: "Unknown endpoint",
 	}
 }
 

--- a/rules/epmark.go
+++ b/rules/epmark.go
@@ -25,7 +25,8 @@ import (
 )
 
 const (
-	pseudoGenericEndpointName = "caliPseudoGenericEndpoint"
+	// Use an invalid interface name for generic endpoint.
+	pseudoGenericEndpointName = "/cali/PseudoGeneric/Endpoint/"
 )
 
 // Endpoint Mark Mapper (EPM) provides set of functions to manage allocation/free endpoint mark bit

--- a/rules/epmark.go
+++ b/rules/epmark.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	// Use an invalid interface name for generic endpoint.
-	pseudoGenericEndpointName = "/cali/PseudoGeneric/Endpoint/"
+	// Use an invalid interface name for non-cali endpoint.
+	pseudoNonCaliEndpointName = "/cali/Pseudo/NonCali/Endpoint/"
 )
 
 // Endpoint Mark Mapper (EPM) provides set of functions to manage allocation/free endpoint mark bit
@@ -50,11 +50,11 @@ type DefaultEPMarkManager struct {
 	activeMarkToEndpoint     map[uint32]string
 }
 
-func NewEndpointMarkMapper(markMask, genericMark uint32) EndpointMarkMapper {
-	return NewEndpointMarkMapperWithShim(markMask, genericMark, fnv.New32())
+func NewEndpointMarkMapper(markMask, nonCaliMark uint32) EndpointMarkMapper {
+	return NewEndpointMarkMapperWithShim(markMask, nonCaliMark, fnv.New32())
 }
 
-func NewEndpointMarkMapperWithShim(markMask, genericMark uint32, hash32 HashCalculator32) EndpointMarkMapper {
+func NewEndpointMarkMapperWithShim(markMask, nonCaliMark uint32, hash32 HashCalculator32) EndpointMarkMapper {
 	markBitsManager := markbits.NewMarkBitsManager(markMask, "endpoint-iptable-mark")
 
 	epmm := &DefaultEPMarkManager{
@@ -67,14 +67,14 @@ func NewEndpointMarkMapperWithShim(markMask, genericMark uint32, hash32 HashCalc
 		activeMarkToEndpoint:     map[uint32]string{},
 	}
 
-	// Reserve genericMark to pseudoGenericEndpoint. This mark is reserved for any traffic whose
+	// Reserve nonCaliMark to pseudoNonCaliEndpoint. This mark is reserved for any traffic whose
 	// incoming interface is neither a workload nor a host endpoint.
-	err := epmm.SetEndpointMark(pseudoGenericEndpointName, genericMark)
+	err := epmm.SetEndpointMark(pseudoNonCaliEndpointName, nonCaliMark)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"MarkMask":    markMask,
-			"GenericMark": genericMark,
-		}).Panic("Reserve generic endpoint mark failed.")
+			"NonCaliMark": nonCaliMark,
+		}).Panic("Reserve non-cali endpoint mark failed.")
 	}
 
 	return epmm

--- a/rules/epmark_test.go
+++ b/rules/epmark_test.go
@@ -29,13 +29,13 @@ func init() {
 	ErrMark := uint32(0)
 
 	DescribeTable("EndpointMarkMapper initialization",
-		func(mask, genericMark uint32) {
-			epmm := NewEndpointMarkMapperWithShim(mask, genericMark, &mockHash32{})
+		func(mask, nonCaliMark uint32) {
+			epmm := NewEndpointMarkMapperWithShim(mask, nonCaliMark, &mockHash32{})
 			Expect(epmm.GetMask()).To(Equal(mask))
 
-			mark, err := epmm.GetEndpointMark("/cali/PseudoGeneric/Endpoint/")
+			mark, err := epmm.GetEndpointMark("/cali/Pseudo/NonCali/Endpoint/")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(mark).To(Equal(uint32(genericMark)))
+			Expect(mark).To(Equal(uint32(nonCaliMark)))
 		},
 		Entry("should initialise with one bit", uint32(0x10), uint32(0x10)),
 		Entry("should initialise with some bits", uint32(0x123f), uint32(0x01)),

--- a/rules/epmark_test.go
+++ b/rules/epmark_test.go
@@ -29,20 +29,24 @@ func init() {
 	ErrMark := uint32(0)
 
 	DescribeTable("EndpointMarkMapper initialization",
-		func(mask uint32) {
-			epmm := NewEndpointMarkMapperWithShim(mask, &mockHash32{})
+		func(mask, genericMark uint32) {
+			epmm := NewEndpointMarkMapperWithShim(mask, genericMark, &mockHash32{})
 			Expect(epmm.GetMask()).To(Equal(mask))
+
+			mark, err := epmm.GetEndpointMark("/cali/PseudoGeneric/Endpoint/")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(mark).To(Equal(uint32(genericMark)))
 		},
-		Entry("should initialise with one bit", uint32(0x10)),
-		Entry("should initialise with some bits", uint32(0x123f)),
-		Entry("should initialise with max bits", uint32(0xffffffff)),
+		Entry("should initialise with one bit", uint32(0x10), uint32(0x10)),
+		Entry("should initialise with some bits", uint32(0x123f), uint32(0x01)),
+		Entry("should initialise with max bits", uint32(0xffffffff), uint32(0x01)),
 	)
 
 	Describe("EndpointMarkMapper allocation/release", func() {
 
 		var epmm EndpointMarkMapper
 		BeforeEach(func() {
-			epmm = NewEndpointMarkMapperWithShim(0x700, &mockHash32{})
+			epmm = NewEndpointMarkMapperWithShim(0x700, 0x100, &mockHash32{})
 		})
 		DescribeTable("EndpointMarkMapper allocation",
 			func(eps []string, expected []uint32) {
@@ -60,16 +64,16 @@ func init() {
 			},
 			Entry("should allocate sequentially and repeat",
 				[]string{"cali1", "cali2", "cali3", "cali1", "cali2", "cali7"},
-				[]uint32{0x100, 0x200, 0x300, 0x100, 0x200, 0x700}),
+				[]uint32{0x200, 0x300, 0x400, 0x200, 0x300, 0x700}),
 			Entry("should allocate with collision and fail correctly",
 				[]string{"cali1", "cali6", "cali3", "cali11", "cali22", "cali33", "cali8", "cali9"},
-				[]uint32{0x100, 0x600, 0x300, 0x200, 0x400, 0x500, 0x700, ErrMark}),
+				[]uint32{0x200, 0x600, 0x300, 0x400, 0x500, 0x700, ErrMark, ErrMark}),
 			Entry("should allocate/release with collision",
 				[]string{"cali1", "cali6", "cali3", "xcali1", "xcali2", "cali33", "cali11", "cali66"},
-				[]uint32{0x100, 0x600, 0x300, 0x400, 0x100, 0x700}),
+				[]uint32{0x200, 0x600, 0x300, 0x400, 0x200, 0x700}),
 			Entry("should allocate/fail/release/allocate",
 				[]string{"cali1", "cali6", "cali3", "cali11", "cali22", "cali33", "cali8", "cali5", "xcali3", "xcali6", "cali55", "cali66"},
-				[]uint32{0x100, 0x600, 0x300, 0x200, 0x400, 0x500, 0x700, ErrMark, 0x600, 0x300}),
+				[]uint32{0x200, 0x600, 0x300, 0x400, 0x500, 0x700, ErrMark, ErrMark, 0x600, 0x300}),
 		)
 	})
 
@@ -77,7 +81,7 @@ func init() {
 
 		var epmm EndpointMarkMapper
 		BeforeEach(func() {
-			epmm = NewEndpointMarkMapperWithShim(0x700, &mockHash32{})
+			epmm = NewEndpointMarkMapperWithShim(0x700, 0x100, &mockHash32{})
 		})
 		It("should not set mark with wrong value", func() {
 			err := epmm.SetEndpointMark("cali1", uint32(0x210))
@@ -104,13 +108,13 @@ func init() {
 		It("should not set mark with different endpoint", func() {
 			mark, err := epmm.GetEndpointMark("cali1")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(mark).To(Equal(uint32(0x100)))
+			Expect(mark).To(Equal(uint32(0x200)))
 
-			err = epmm.SetEndpointMark("cali3", uint32(0x100))
+			err = epmm.SetEndpointMark("cali3", uint32(0x200))
 			Expect(err).Should(HaveOccurred())
 
 			epmm.ReleaseEndpointMark("cali1")
-			err = epmm.SetEndpointMark("cali3", uint32(0x100))
+			err = epmm.SetEndpointMark("cali3", uint32(0x200))
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("should set mark and allocate", func() {

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ const (
 	ChainDispatchFromHostEndPointForward = ChainNamePrefix + "from-hep-forward"
 	ChainDispatchSetEndPointMark         = ChainNamePrefix + "set-endpoint-mark"
 	ChainDispatchFromEndPointMark        = ChainNamePrefix + "from-endpoint-mark"
+	ChainDispatchClearEndPointMark       = ChainNamePrefix + "clear-endpoint-mark"
 
 	ChainForwardCheck        = ChainNamePrefix + "forward-check"
 	ChainForwardEndpointMark = ChainNamePrefix + "forward-endpoint-mark"
@@ -222,7 +223,7 @@ type Config struct {
 	IptablesMarkScratch0        uint32
 	IptablesMarkScratch1        uint32
 	IptablesMarkEndpoint        uint32
-	IptablesMarkEndpointGeneric uint32 // an endpoint mark which is reserved to mark generic endpoints.
+	IptablesMarkNonCaliEndpoint uint32 // an endpoint mark which is reserved to mark generic endpoints.
 
 	KubeNodePortRanges     []numorstring.Port
 	KubeIPVSSupportEnabled bool
@@ -256,7 +257,7 @@ func (c *Config) validate() {
 	usedBits := uint32(0)
 	for i := 0; i < myValue.NumField(); i++ {
 		fieldName := myType.Field(i).Name
-		if strings.HasPrefix(fieldName, "IptablesMark") && fieldName != "IptablesMarkEndpointGeneric" {
+		if strings.HasPrefix(fieldName, "IptablesMark") && fieldName != "IptablesMarkNonCaliEndpoint" {
 			bits := myValue.Field(i).Interface().(uint32)
 			if bits == 0 {
 				log.WithField("field", fieldName).Panic(

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -16,11 +16,10 @@ package rules
 
 import (
 	"net"
-
-	log "github.com/sirupsen/logrus"
-
 	"reflect"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/felix/config"
 	"github.com/projectcalico/felix/ipsets"
@@ -223,7 +222,9 @@ type Config struct {
 	IptablesMarkScratch0        uint32
 	IptablesMarkScratch1        uint32
 	IptablesMarkEndpoint        uint32
-	IptablesMarkNonCaliEndpoint uint32 // an endpoint mark which is reserved to mark generic endpoints.
+	// IptablesMarkNonCaliEndpoint is an endpoint mark which is reserved
+	// to mark non-calico (workload or host) endpoint.
+	IptablesMarkNonCaliEndpoint uint32
 
 	KubeNodePortRanges     []numorstring.Port
 	KubeIPVSSupportEnabled bool

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -217,11 +217,11 @@ type Config struct {
 
 	WorkloadIfacePrefixes []string
 
-	IptablesMarkAccept          uint32
-	IptablesMarkPass            uint32
-	IptablesMarkScratch0        uint32
-	IptablesMarkScratch1        uint32
-	IptablesMarkEndpoint        uint32
+	IptablesMarkAccept   uint32
+	IptablesMarkPass     uint32
+	IptablesMarkScratch0 uint32
+	IptablesMarkScratch1 uint32
+	IptablesMarkEndpoint uint32
 	// IptablesMarkNonCaliEndpoint is an endpoint mark which is reserved
 	// to mark non-calico (workload or host) endpoint.
 	IptablesMarkNonCaliEndpoint uint32


### PR DESCRIPTION
## Description
Enable host endpoint policy with kube-proxy running in IPVS mode.

## Todos
- [x] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Enable host endpoint policy with kube-proxy running in IPVS mode.
```
