### PR TITLE
Replace FlexVol Management API with binder

### DIFF
--- a/binder/auth.go
+++ b/binder/auth.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binder
+
+import (
+	"golang.org/x/net/context"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+const (
+	authType = "udsuspver"
+)
+
+// TODO relocate to shared location
+type Credentials struct {
+	Uid            string
+	Workload       string
+	Namespace      string
+	ServiceAccount string
+}
+
+func (c Credentials) AuthType() string {
+	return authType
+}
+
+func CallerFromContext(ctx context.Context) (Credentials, bool) {
+	peer, ok := peer.FromContext(ctx)
+	if !ok {
+		return Credentials{}, false
+	}
+	return CallerFromAuthInfo(peer.AuthInfo)
+}
+
+func CallerFromAuthInfo(ainfo credentials.AuthInfo) (Credentials, bool) {
+	if ci, ok := ainfo.(Credentials); ok {
+		return ci, true
+	}
+	return Credentials{}, false
+}

--- a/binder/binder.go
+++ b/binder/binder.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binder
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+
+	"google.golang.org/grpc"
+)
+
+const MountSubdir = "mount"
+const SocketFilename = "socket"
+
+type Binder interface {
+
+	// Returns the gRPC server for this Binder. Used to register the service to be provided to workloads.
+	Server() *grpc.Server
+
+	// The path this Binder is searching for workload mounts on.
+	SearchPath() string
+
+	// Search for pod mounts to bind sockets in.
+	// Send any value over the stop channel to gracefully cancel.
+	SearchAndBind(stop <-chan bool)
+}
+
+type binder struct {
+	server     *grpc.Server
+	searchPath string
+	workloads  *workloadStore
+}
+
+type workload struct {
+	uid      string
+	listener net.Listener
+	creds    Credentials
+}
+
+func NewBinder(searchPath string) Binder {
+	ws := newWorkloadStore()
+	return &binder{
+		searchPath: searchPath,
+		server:     grpc.NewServer(grpc.Creds(ws)),
+		workloads:  ws}
+}
+
+func (b *binder) Server() *grpc.Server {
+	return b.server
+}
+
+func (b *binder) SearchPath() string {
+	return b.searchPath
+}
+
+func (b *binder) SearchAndBind(stop <-chan bool) {
+	w := NewWatcher(b.searchPath)
+	events := w.watch()
+	var event workloadEvent
+	for {
+		select {
+		case event = <-events:
+			b.handleEvent(event)
+		case <-stop:
+			break
+		}
+	}
+	// Got stop signal! Close any open sockets
+	for _, wl := range b.workloads.getAll() {
+		wl.listener.Close()
+	}
+}
+
+func (b *binder) handleEvent(e workloadEvent) {
+	switch e.op {
+	case Added:
+		b.addListener(e.uid)
+	case Removed:
+		b.removeListener(e.uid)
+	default:
+		panic("Unknown workloadEvent op")
+	}
+}
+
+func (b *binder) addListener(uid string) {
+	w := workload{uid: uid}
+	credPath := filepath.Join(b.searchPath, CredentialsSubdir, uid+CredentialsExtension)
+	err := readCredentials(credPath, &w.creds)
+	if err != nil {
+		log.Printf("failed to read credentials at %s %v", credPath, err)
+		return
+	}
+	sockPath := filepath.Join(b.searchPath, MountSubdir, uid, SocketFilename)
+	_, err = os.Stat(sockPath)
+	if !os.IsNotExist(err) {
+		// file exists, try to delete it.
+		err := os.Remove(sockPath)
+		if err != nil {
+			log.Printf("File %s exists and unable to remove.", sockPath)
+			return
+		}
+	}
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		// TODO: consider adding retries
+		log.Printf("failed to listen at %s %v", sockPath, err)
+		return
+	}
+	w.listener = lis
+	b.workloads.store(uid, w)
+
+	// Start listening on a separate goroutine.
+	go func() {
+		if err := b.server.Serve(lis); err != nil {
+			log.Printf("stopped listening on %s %v", sockPath, err)
+		}
+	}()
+
+}
+
+func readCredentials(path string, c *Credentials) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(data, c)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *binder) removeListener(uid string) {
+	w := b.workloads.get(uid)
+	// Closing the listener automatically removes it from the gRPC server.
+	w.listener.Close()
+	b.workloads.delete(uid)
+}

--- a/binder/creds.go
+++ b/binder/creds.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binder
+
+import (
+	"errors"
+	"net"
+	"sync"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/credentials"
+)
+
+type workloadStore struct {
+	mu    sync.RWMutex
+	creds map[string]workload
+}
+
+func newWorkloadStore() *workloadStore {
+	return &workloadStore{creds: make(map[string]workload)}
+}
+
+func (s *workloadStore) ClientHandshake(_ context.Context, _ string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return conn, Credentials{}, errors.New("client handshake unsupported")
+}
+
+func (s *workloadStore) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// TODO: maybe index this for faster lookup?
+	addr := conn.LocalAddr()
+	for _, w := range s.creds {
+		if addrEqual(addr, w.listener.Addr()) {
+			return conn, w.creds, nil
+		}
+	}
+
+	return conn, Credentials{}, errors.New("unknown listener")
+}
+
+func (s *workloadStore) Info() credentials.ProtocolInfo {
+	return credentials.ProtocolInfo{
+		SecurityProtocol: authType,
+		SecurityVersion:  "0.1",
+		ServerName:       "workloadhandler",
+	}
+}
+
+func (s *workloadStore) Clone() credentials.TransportCredentials {
+	other := make(map[string]workload)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for k, v := range s.creds {
+		other[k] = v
+	}
+	return &workloadStore{creds: other}
+}
+
+func (s *workloadStore) OverrideServerName(_ string) error {
+	return nil
+}
+
+// Internal methods for concurrent access to store data.
+
+func (s *workloadStore) getAll() []workload {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ws := make([]workload, 0, len(s.creds))
+	for _, w := range s.creds {
+		ws = append(ws, w)
+	}
+	return ws
+}
+
+func (s *workloadStore) get(uid string) workload {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.creds[uid]
+}
+
+func (s *workloadStore) delete(uid string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.creds, uid)
+	return
+}
+
+func (s *workloadStore) store(uid string, w workload) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.creds[uid] = w
+}
+
+func addrEqual(this, that net.Addr) bool {
+	return this.Network() == that.Network() && this.String() == that.String()
+}

--- a/binder/watcher.go
+++ b/binder/watcher.go
@@ -17,6 +17,7 @@ package binder
 import (
 	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -61,7 +62,15 @@ func (p *pollWatcher) watch() <-chan workloadEvent {
 func (p *pollWatcher) poll(events chan<- workloadEvent) {
 	// The workloads we know about.
 	known := make(map[string]bool)
-	credPath := filepath.Join(p.path + CredentialsSubdir)
+	credPath := filepath.Join(p.path, CredentialsSubdir)
+	for {
+		if _, err := os.Stat(credPath); err != nil {
+			time.Sleep(PollSleepTime)
+		} else {
+			break
+		}
+	}
+	log.Println("Ready to parse credential directory")
 	for {
 		// list the contents of the directory
 		files, err := ioutil.ReadDir(credPath)

--- a/binder/watcher.go
+++ b/binder/watcher.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binder
+
+import (
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type watcher interface {
+	// Returns a channel that sends events whenever workload mounts are created or removed
+	watch() <-chan workloadEvent
+}
+
+type Operation int
+
+const (
+	Added Operation = iota
+	Removed
+)
+
+const CredentialsSubdir = "creds"
+const CredentialsExtension = ".json"
+const PollSleepTime = 100 * time.Millisecond
+
+type workloadEvent struct {
+	// What happended to the workload mount?
+	op  Operation
+	uid string
+}
+
+func NewWatcher(path string) watcher {
+	return &pollWatcher{path}
+}
+
+type pollWatcher struct {
+	path string
+}
+
+func (p *pollWatcher) watch() <-chan workloadEvent {
+	c := make(chan workloadEvent)
+	go p.poll(c)
+	return c
+}
+
+func (p *pollWatcher) poll(events chan<- workloadEvent) {
+	// The workloads we know about.
+	known := make(map[string]bool)
+	credPath := filepath.Join(p.path + CredentialsSubdir)
+	for {
+		// list the contents of the directory
+		files, err := ioutil.ReadDir(credPath)
+		if err != nil {
+			log.Printf("error reading %s: %v", p.path, err)
+			close(events)
+			return
+		}
+		// This set will contain all previously known UIDs that are now absent.
+		removed := copyStringSet(known)
+		for _, file := range files {
+			isCred, uid := parseFilename(file.Name())
+			if isCred {
+				if !known[uid] {
+					events <- workloadEvent{op: Added, uid: uid}
+					known[uid] = true
+				}
+				delete(removed, uid)
+			}
+		}
+		// Send updates for UIDs we no longer know about.
+		for uid := range removed {
+			events <- workloadEvent{op: Removed, uid: uid}
+			delete(known, uid)
+		}
+		time.Sleep(PollSleepTime)
+	}
+}
+
+func parseFilename(name string) (isCred bool, uid string) {
+	if strings.HasSuffix(name, CredentialsExtension) {
+		return true, strings.TrimSuffix(name, CredentialsExtension)
+	} else {
+		return false, ""
+	}
+}
+
+func copyStringSet(original map[string]bool) map[string]bool {
+	n := make(map[string]bool)
+	for k, v := range original {
+		n[k] = v
+	}
+	return n
+}

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -121,8 +121,7 @@ type Config struct {
 	IpsetsRefreshInterval              time.Duration `config:"seconds;10"`
 	MaxIpsetSize                       int           `config:"int;1048576;non-zero"`
 
-	PolicySyncManagementSocketPath     string `config:"file;;"`
-	PolicySyncWorkloadSocketPathPrefix string `config:"file;;"`
+	PolicySyncPathPrefix string `config:"file;;"`
 
 	NetlinkTimeoutSecs time.Duration `config:"seconds;10"`
 

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -49,8 +49,7 @@ var _ = Describe("FelixConfig vs ConfigParams parity", func() {
 		"IpInIpTunnelAddr",
 
 		// FIXME Remove this once libcalico-go supports policy-sync API!
-		"PolicySyncManagementSocketPath",
-		"PolicySyncWorkloadSocketPathPrefix",
+		"PolicySyncPathPrefix",
 	}
 	cpFieldNameToFC := map[string]string{
 		"IpInIpEnabled":                      "IPIPEnabled",

--- a/felix.go
+++ b/felix.go
@@ -315,8 +315,8 @@ configRetry:
 	var policySyncProcessor *policysync.Processor
 	var policySyncAPIBinder binder.Binder
 	calcGraphClientChannels := []chan<- interface{}{dpConnector.ToDataplane}
-	if configParams.PolicySyncManagementSocketPath != "" {
-		log.WithField("managementSocket", configParams.PolicySyncManagementSocketPath).Info(
+	if configParams.PolicySyncPathPrefix != "" {
+		log.WithField("policySyncPathPrefix", configParams.PolicySyncPathPrefix).Info(
 			"Policy sync API enabled.  Creating the policy sync server.")
 		toPolicySync := make(chan interface{})
 		policySyncUIDAllocator := policysync.NewUIDAllocator()
@@ -325,7 +325,7 @@ configRetry:
 			policySyncProcessor.JoinUpdates,
 			policySyncUIDAllocator.NextUID,
 		)
-		policySyncAPIBinder = binder.NewBinder(configParams.PolicySyncManagementSocketPath)
+		policySyncAPIBinder = binder.NewBinder(configParams.PolicySyncPathPrefix)
 		policySyncServer.RegisterGrpc(policySyncAPIBinder.Server())
 		calcGraphClientChannels = append(calcGraphClientChannels, toPolicySync)
 	}
@@ -470,7 +470,7 @@ configRetry:
 	dpConnector.Start()
 
 	if policySyncProcessor != nil {
-		log.WithField("managementSocket", configParams.PolicySyncManagementSocketPath).Info(
+		log.WithField("policySyncPathPrefix", configParams.PolicySyncPathPrefix).Info(
 			"Policy sync API enabled.  Starting the policy sync server.")
 		policySyncProcessor.Start()
 		sc := make(chan bool)

--- a/glide.lock
+++ b/glide.lock
@@ -17,13 +17,6 @@ imports:
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
-- name: github.com/colabsaumoh/proto-udsuspver
-  version: 81f7a4460994018fd0529c31df1ba43a26f7ee4f
-  subpackages:
-  - mgmtwlhintf
-  - nodeagentmgmt
-  - protos/mgmtintf_v1
-  - workloadhandler
 - name: github.com/containernetworking/cni
   version: 137b4975ecab6e1f0c24c1e3c228a50a3cfba75e
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -67,8 +67,6 @@ import:
   version: 78439966b38d69bf38227fbf57ac8a6fee70f69a
 - package: github.com/Microsoft/hcsshim
   version: 34a629f78a5d50f7de07727e41a948685c45e026
-- package: github.com/colabsaumoh/proto-udsuspver
-  version: 81f7a4460994018fd0529c31df1ba43a26f7ee4f
 - package: google.golang.org/genproto
   subpackages:
   - googleapis


### PR DESCRIPTION
## Description
Replaces Flex Volume driver management API, which handles creating per-pod domain sockets for the
Policy Sync API, with a `Binder` object that watches the file system and binds the Policy Sync API server
to per-pod domain sockets.

Depends on https://github.com/istio/istio/tree/master/security/cmd/flexvolume as the Flex Volume Driver.

## Todos
- [ ] Unit tests (full coverage)
- [X] Integration tests (delete as appropriate) In plan
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note

```release-note
None required
```
