### PR TITLE
Update iptables_lock_test and health_test to use FV_FELIXIMAGE.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ k8sfv-test: calico/felix k8sfv-test-existing-felix
 # container image.  To use some existing Felix version other than
 # 'latest', do 'FELIX_VERSION=<...> make k8sfv-test-existing-felix'.
 k8sfv-test-existing-felix: bin/k8sfv.test
+	FV_FELIXIMAGE=$(FV_FELIXIMAGE) \
 	FV_ETCDIMAGE=$(FV_ETCDIMAGE) \
 	FV_TYPHAIMAGE=$(FV_TYPHAIMAGE) \
 	FV_K8SIMAGE=$(FV_K8SIMAGE) \

--- a/fv/health_test.go
+++ b/fv/health_test.go
@@ -221,7 +221,7 @@ var _ = Describe("health tests", func() {
 			"-e", "K8S_INSECURE_SKIP_TLS_VERIFY=true",
 			"-e", "FELIX_TYPHAADDR="+typhaAddr,
 			"-v", k8sAPIServer.CertFileName+":/tmp/apiserver.crt",
-			"calico/felix:latest",
+			utils.Config.FelixImage,
 		)
 		Expect(felixContainer).NotTo(BeNil())
 

--- a/fv/iptables_lock_test.go
+++ b/fv/iptables_lock_test.go
@@ -61,7 +61,7 @@ var _ = Describe("with running container", func() {
 			"--name", containerName,
 			"-v", fmt.Sprintf("%s/..:/codebase", myDir),
 			"--privileged",
-			"calico/felix")
+			utils.Config.FelixImage)
 		err = felixCmd.Start()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -4,11 +4,17 @@
 # running with the Kubernetes datastore driver, driven by CRUD
 # operations through the k8s API server.
 
-# Config.
-#
-# What version of Felix (container image) to use.
-: ${FELIX_VERSION:=latest}
-#
+# Config check.
+if ! test -n "${FV_FELIXIMAGE}"; then
+    echo FV_FELIXIMAGE must be set to indicate the felix image to use.
+    exit -1
+fi
+
+if ! test -n "${FV_ETCDIMAGE}"; then
+    echo FV_ETCDIMAGE must be set to indicate the etcd image to use.
+    exit -1
+fi
+
 if ! test -n "${FV_K8SIMAGE}"; then
     echo FV_K8SIMAGE must be set to indicate the hyperkube image to use.
     exit -1
@@ -195,7 +201,7 @@ docker run --detach --privileged --name ${prefix}-felix \
        -e K8SFV_LOG_LEVEL=${K8SFV_LOG_LEVEL} \
        -v ${PWD}:/testcode \
        -w /testcode/k8sfv/output \
-       calico/felix:${FELIX_VERSION}
+       $FV_FELIXIMAGE
 felix_ip=$(get_container_ip ${prefix}-felix)
 felix_hostname=$(get_container_hostname ${prefix}-felix)
 


### PR DESCRIPTION
## Description
Update iptables_lock_test and health_test to use FV_FELIXIMAGE.

Remove the hard coded felix image name in these tests, the default
image name will not change if FV_FELIXIMAGE is unset.

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Release Note

```release-note
None required
```
