### PR TITLE
Fix accidental nanosecond sleep

### DIFF
--- a/fv/k8sapiserver/k8sapiserver.go
+++ b/fv/k8sapiserver/k8sapiserver.go
@@ -87,7 +87,7 @@ func SetUp() *Server {
 				log.Panic("Persistently failed to create k8s API server")
 			}
 			log.Info("Retrying...")
-			time.Sleep(1)
+			time.Sleep(1 * time.Second)
 		}
 	}
 


### PR DESCRIPTION
Was causing this warning in `make static-checks`:
```
fv/k8sapiserver/k8sapiserver.go:90:15: sleeping for 1 nanoseconds is probably a bug. Be explicit if it isn't: time.Sleep(time.Nanosecond) (SA1004)
```