### PR TITLE
Handle async client cancel

### DIFF
--- a/fv/policysync_test.go
+++ b/fv/policysync_test.go
@@ -529,8 +529,11 @@ var _ = Context("policy sync API tests", func() {
 					_, err := syncClient.Recv()
 					Expect(err).NotTo(HaveOccurred())
 					clientCancel()
-					_, err = syncClient.Recv()
-					Expect(err).To(HaveOccurred())
+
+					Eventually(func() error {
+						_, err = syncClient.Recv()
+						return err
+					}).Should(HaveOccurred())
 
 					// Then create a new mock client with a new connection.
 					newWlConn, newWlClient := createWorkloadConn(0)


### PR DESCRIPTION
Fixes up FV test failures due to race condition when cancelling