### PR TITLE
Break binder event loop on stop

### DIFF
--- a/binder/binder.go
+++ b/binder/binder.go
@@ -73,12 +73,13 @@ func (b *binder) SearchAndBind(stop <-chan bool) {
 	w := NewWatcher(b.searchPath)
 	events := w.watch()
 	var event workloadEvent
+EventLoop:
 	for {
 		select {
 		case event = <-events:
 			b.handleEvent(event)
 		case <-stop:
-			break
+			break EventLoop
 		}
 	}
 	// Got stop signal! Close any open sockets


### PR DESCRIPTION
Fix bug in code that had binder break out of its event loop.
