### PR TITLE
Whitelist failsafe port response traffic in the raw table only

### DIFF
--- a/fv/donottrack_test.go
+++ b/fv/donottrack_test.go
@@ -1,0 +1,138 @@
+// +build fvtests
+
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/fv/containers"
+	"github.com/projectcalico/felix/fv/workload"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+)
+
+var _ = Context("do-not-track policy tests; with 2 nodes", func() {
+
+	var (
+		etcd    *containers.Container
+		felixes []*containers.Felix
+		hostW   [2]*workload.Workload
+		client  client.Interface
+		cc      *workload.ConnectivityChecker
+	)
+
+	BeforeEach(func() {
+		options := containers.DefaultTopologyOptions()
+		felixes, etcd, client = containers.StartNNodeEtcdTopology(2, options)
+		cc = &workload.ConnectivityChecker{}
+
+		// Start a host networked workload on each host for connectivity checks.
+		for ii := range felixes {
+			hostW[ii] = workload.Run(
+				felixes[ii],
+				fmt.Sprintf("host%d", ii),
+				"", // No interface name means "run in the host's namespace"
+				felixes[ii].IP,
+				"8055",
+				"tcp")
+		}
+	})
+
+	AfterEach(func() {
+
+		if CurrentGinkgoTestDescription().Failed {
+			felixes[0].Exec("iptables-save", "-c")
+			felixes[0].Exec("ip", "r")
+		}
+
+		for ii := range felixes {
+			felixes[ii].Stop()
+		}
+
+		if CurrentGinkgoTestDescription().Failed {
+			etcd.Exec("etcdctl", "ls", "--recursive", "/")
+		}
+		etcd.Stop()
+	})
+
+	It("before adding policy, should have connectivity between hosts", func() {
+		cc.ExpectSome(felixes[0], hostW[1])
+		cc.ExpectSome(felixes[1], hostW[0])
+		cc.CheckConnectivity()
+	})
+
+	Context("after adding host endpoints", func() {
+		BeforeEach(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			for _, f := range felixes {
+				hep := api.NewHostEndpoint()
+				hep.Name = "eth0-" + f.Name
+				hep.Spec.Node = f.Hostname
+				hep.Spec.ExpectedIPs = []string{f.IP}
+				_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		It("have no connectivity between hosts", func() {
+			cc.ExpectNone(felixes[0], hostW[1])
+			cc.ExpectNone(felixes[1], hostW[0])
+			cc.CheckConnectivity()
+		})
+	})
+
+	//
+	//Context("with pre-DNAT policy to prevent access from outside", func() {
+	//	BeforeEach(func() {
+	//		policy := api.NewGlobalNetworkPolicy()
+	//		policy.Name = "deny-ingress"
+	//		order := float64(20)
+	//		policy.Spec.Order = &order
+	//		policy.Spec.PreDNAT = true
+	//		policy.Spec.ApplyOnForward = true
+	//		policy.Spec.Ingress = []api.Rule{{Action: api.Deny}}
+	//		policy.Spec.Selector = "has(host-endpoint)"
+	//		_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+	//		Expect(err).NotTo(HaveOccurred())
+	//
+	//		hostEp := api.NewHostEndpoint()
+	//		hostEp.Name = "felix-eth0"
+	//		hostEp.Spec.Node = felix.Hostname
+	//		hostEp.Labels = map[string]string{"host-endpoint": "true"}
+	//		hostEp.Spec.InterfaceName = "eth0"
+	//		_, err = client.HostEndpoints().Create(utils.Ctx, hostEp, utils.NoOptions)
+	//		Expect(err).NotTo(HaveOccurred())
+	//	})
+	//
+	//	It("etcd cannot connect", func() {
+	//		cc := &workload.ConnectivityChecker{}
+	//		cc.ExpectSome(w[0], w[1], 32011)
+	//		cc.ExpectSome(w[1], w[0], 32010)
+	//		cc.ExpectNone(etcd, w[1], 32011)
+	//		cc.ExpectNone(etcd, w[0], 32010)
+	//		cc.CheckConnectivity()
+	//	})
+	//})
+})

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -458,11 +458,19 @@ func (c *ConnectivityChecker) ExpectedConnectivity() []string {
 	return result
 }
 
+func (c *ConnectivityChecker) CheckConnectivityOffset(offset int, optionalDescription ...interface{}) {
+	c.CheckConnectivityWithTimeoutOffset(offset+2, 10*time.Second, optionalDescription...)
+}
+
 func (c *ConnectivityChecker) CheckConnectivity(optionalDescription ...interface{}) {
-	c.CheckConnectivityWithTimeout(10*time.Second, optionalDescription...)
+	c.CheckConnectivityWithTimeoutOffset(2, 10*time.Second, optionalDescription...)
 }
 
 func (c *ConnectivityChecker) CheckConnectivityWithTimeout(timeout time.Duration, optionalDescription ...interface{}) {
+	c.CheckConnectivityWithTimeoutOffset(2, timeout, optionalDescription...)
+}
+
+func (c *ConnectivityChecker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout time.Duration, optionalDescription ...interface{}) {
 	expConnectivity := c.ExpectedConnectivity()
 	start := time.Now()
 
@@ -492,5 +500,5 @@ func (c *ConnectivityChecker) CheckConnectivityWithTimeout(timeout time.Duration
 		strings.Join(actualConn, "\n    "),
 		strings.Join(expConnectivity, "\n    "),
 	)
-	Fail(message, 1)
+	Fail(message, callerSkip)
 }

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -78,6 +78,26 @@ var _ = Describe("Static", func() {
 					}
 					portRanges = append(portRanges, portRange)
 
+					expRawFailsafeIn := &Chain{
+						Name: "cali-failsafe-in",
+						Rules: []Rule{
+							{Match: Match().Protocol("tcp").DestPorts(22), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(1022), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").SourcePorts(23), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").SourcePorts(1023), Action: AcceptAction{}},
+						},
+					}
+
+					expRawFailsafeOut := &Chain{
+						Name: "cali-failsafe-out",
+						Rules: []Rule{
+							{Match: Match().Protocol("tcp").DestPorts(23), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(1023), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").SourcePorts(22), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").SourcePorts(1022), Action: AcceptAction{}},
+						},
+					}
+
 					expFailsafeIn := &Chain{
 						Name: "cali-failsafe-in",
 						Rules: []Rule{
@@ -340,10 +360,10 @@ var _ = Describe("Static", func() {
 						}))
 					})
 					It("Should return expected raw failsafe in chain", func() {
-						Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-in")).To(Equal(expFailsafeIn))
+						Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-in")).To(Equal(expRawFailsafeIn))
 					})
 					It("Should return expected raw failsafe out chain", func() {
-						Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-out")).To(Equal(expFailsafeOut))
+						Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-out")).To(Equal(expRawFailsafeOut))
 					})
 					It("should return only the expected raw chains", func() {
 						Expect(len(rr.StaticRawTableChains(ipVersion))).To(Equal(4))


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

This fixes a nasty interaction between do-not-track policy and failsafe ports.  Previously, adding do-not-track policy to a host endpoint resulted in failsafe port traffic being blocked because one leg of the connection would get conntracked, but the return leg would hit the do-not-track policy, which would either drop it (thus breaking the failsafe port) or mark it as NOTRACK, which results in future outbound packets failing the `--ctstate INVALID` test (because conntrack has only seen an outbound SYN, it isn't expecting the outbound to move past the SYN stage of the handshake).

This change whitelists the response traffic in the raw table only so that failsafe ports are now forced to be conntracked, bypassing any do-not-track policy in both directions.  Since the change is made only in the raw table (and we don't mark failsafe port traffic with the accepted mark), the response traffic still has to pass the `--ctstate ESTABLISHED` test in the filter table.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [ ] Backport
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes an interaction between failsafe inbound/outbound ports and do-not-track policy that resulted in failsafe ports being blocked if do-not-track policy was added.
```
