### PR TITLE
Sync service accounts

### DIFF
--- a/calc/calc_graph.go
+++ b/calc/calc_graph.go
@@ -72,6 +72,8 @@ type passthruCallbacks interface {
 	OnHostIPRemove(hostname string)
 	OnIPPoolUpdate(model.IPPoolKey, *model.IPPool)
 	OnIPPoolRemove(model.IPPoolKey)
+	OnServiceAccountUpdate(*proto.ServiceAccountUpdate)
+	OnServiceAccountRemove(proto.ServiceAccountID)
 }
 
 type PipelineCallbacks interface {
@@ -287,6 +289,23 @@ func NewCalculationGraph(callbacks PipelineCallbacks, hostname string) (allUpdDi
 	//
 	configBatcher := NewConfigBatcher(hostname, callbacks)
 	configBatcher.RegisterWith(allUpdDispatcher)
+
+	// The profile decoder identifies objects with special dataplane significance which have
+	// been encoded as profiles by libcalico-go. At present this includes Kubernetes Service
+	// Accounts, but will also include Kubernetes Namespaces in the future.
+	//        ...
+	//     Dispatcher (all updates)
+	//         |
+	//         | Profiles
+	//         |
+	//       profile decoder
+	//         |
+	//         |
+	//         |
+	//      <dataplane>
+	//
+	profileDecoder := NewProfileDecoder(callbacks)
+	profileDecoder.RegisterWith(allUpdDispatcher)
 
 	return allUpdDispatcher
 }

--- a/calc/profile_decoder.go
+++ b/calc/profile_decoder.go
@@ -33,21 +33,21 @@ const (
 	KindServiceAccount
 )
 
-// profileDecoder takes updates from a dispatcher, determines if the profile is a Kubernetes Service Account, and
+// ProfileDecoder takes updates from a dispatcher, determines if the profile is a Kubernetes Service Account, and
 // if it is, generates a dataplane update or remove for it.
-type profileDecoder struct {
+type ProfileDecoder struct {
 	callbacks passthruCallbacks
 }
 
-func NewProfileDecoder(callbacks passthruCallbacks) *profileDecoder {
-	return &profileDecoder{callbacks}
+func NewProfileDecoder(callbacks passthruCallbacks) *ProfileDecoder {
+	return &ProfileDecoder{callbacks}
 }
 
-func (p *profileDecoder) RegisterWith(d *dispatcher.Dispatcher) {
+func (p *ProfileDecoder) RegisterWith(d *dispatcher.Dispatcher) {
 	d.Register(model.ProfileKey{}, p.OnUpdate)
 }
 
-func (p *profileDecoder) OnUpdate(update api.Update) (filterOut bool) {
+func (p *ProfileDecoder) OnUpdate(update api.Update) (filterOut bool) {
 	// This type assertion is safe because we only registered for Profile updates.
 	key := update.Key.(model.ProfileKey)
 	id, kind := classifyProfile(key)
@@ -66,7 +66,7 @@ func (p *profileDecoder) OnUpdate(update api.Update) (filterOut bool) {
 }
 
 func classifyProfile(key model.ProfileKey) (proto.ServiceAccountID, kind) {
-	if strings.HasPrefix(conversion.ServiceAccountProfileNamePrefix, key.Name) {
+	if strings.HasPrefix(key.Name, conversion.ServiceAccountProfileNamePrefix) {
 		c := strings.Split(key.Name, ".")
 		if len(c) == 3 {
 			return proto.ServiceAccountID{Name: c[2], Namespace: c[1]}, KindServiceAccount

--- a/calc/profile_decoder.go
+++ b/calc/profile_decoder.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calc
+
+import (
+	"strings"
+
+	"github.com/projectcalico/felix/dispatcher"
+	"github.com/projectcalico/felix/proto"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type kind int
+
+const (
+	KindUnknown kind = iota
+	KindServiceAccount
+)
+
+// profileDecoder takes updates from a dispatcher, determines if the profile is a Kubernetes Service Account, and
+// if it is, generates a dataplane update or remove for it.
+type profileDecoder struct {
+	callbacks passthruCallbacks
+}
+
+func NewProfileDecoder(callbacks passthruCallbacks) *profileDecoder {
+	return &profileDecoder{callbacks}
+}
+
+func (p *profileDecoder) RegisterWith(d *dispatcher.Dispatcher) {
+	d.Register(model.ProfileKey{}, p.OnUpdate)
+}
+
+func (p *profileDecoder) OnUpdate(update api.Update) (filterOut bool) {
+	// This type assertion is safe because we only registered for Profile updates.
+	key := update.Key.(model.ProfileKey)
+	id, kind := classifyProfile(key)
+	if kind == KindUnknown {
+		// We only care about Profiles that are service accounts.
+		return false
+	}
+	if update.Value == nil {
+		p.callbacks.OnServiceAccountRemove(id)
+	} else {
+		profile := update.Value.(*model.Profile)
+		msg := proto.ServiceAccountUpdate{Id: &id, Labels: decodeServiceAccountLabels(profile.Labels)}
+		p.callbacks.OnServiceAccountUpdate(&msg)
+	}
+	return false
+}
+
+func classifyProfile(key model.ProfileKey) (proto.ServiceAccountID, kind) {
+	if strings.HasPrefix(conversion.ServiceAccountProfileNamePrefix, key.Name) {
+		c := strings.Split(key.Name, ".")
+		if len(c) == 3 {
+			return proto.ServiceAccountID{Name: c[2], Namespace: c[1]}, KindServiceAccount
+		} else {
+			log.WithField("name", key.Name).Warn("Profile with SA prefix could not be parsed.")
+			return proto.ServiceAccountID{}, KindUnknown
+		}
+	} else {
+		return proto.ServiceAccountID{}, KindUnknown
+	}
+}
+
+func decodeServiceAccountLabels(in map[string]string) map[string]string {
+	out := make(map[string]string)
+	for k, v := range in {
+		k = strings.TrimPrefix(k, conversion.ServiceAccountLabelPrefix)
+		out[k] = v
+	}
+	return out
+}

--- a/calc/profile_decoder.go
+++ b/calc/profile_decoder.go
@@ -80,6 +80,8 @@ func classifyProfile(key model.ProfileLabelsKey) (proto.ServiceAccountID, kind) 
 	}
 }
 
+// decodeServiceAccountLabels strips the special prefix we add to Service Account labels when converting it to a
+// Profile. This gives us the original labels on the ServiceAccount object.
 func decodeServiceAccountLabels(in map[string]string) map[string]string {
 	out := make(map[string]string)
 	for k, v := range in {

--- a/calc/profile_decoder_test.go
+++ b/calc/profile_decoder_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calc_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/calc"
+	"github.com/projectcalico/felix/dispatcher"
+	"github.com/projectcalico/felix/proto"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/net"
+)
+
+var _ = Describe("profileDecoder", func() {
+	var uut *calc.ProfileDecoder
+	var callbacks *passthruCallbackRecorder
+
+	BeforeEach(func() {
+		callbacks = &passthruCallbackRecorder{}
+		uut = calc.NewProfileDecoder(callbacks)
+	})
+
+	Describe("RegisterWith", func() {
+		var disp *dispatcher.Dispatcher
+
+		BeforeEach(func() {
+			disp = dispatcher.NewDispatcher()
+			uut.RegisterWith(disp)
+		})
+
+		It("should Register for Profiles only", func() {
+			disp.OnUpdate(api.Update{
+				KVPair:     model.KVPair{Key: model.HostEndpointKey{}},
+				UpdateType: api.UpdateTypeKVNew,
+			})
+		})
+	})
+
+	Describe("OnUpdate", func() {
+
+		It("should pass k8s service account update", func() {
+			update := api.Update{
+				KVPair: model.KVPair{
+					Key: model.ProfileKey{
+						Name: conversion.ServiceAccountProfileNamePrefix +
+							"test_namespace.test_serviceaccount"},
+					Value: &model.Profile{
+						Labels: map[string]string{
+							conversion.ServiceAccountLabelPrefix + "k1": "v1",
+							conversion.ServiceAccountLabelPrefix + "k2": "v2",
+						},
+					},
+				},
+				UpdateType: api.UpdateTypeKVNew,
+			}
+			uut.OnUpdate(update)
+			Expect(callbacks.updates).To(Equal([]*proto.ServiceAccountUpdate{
+				{
+					Id: &proto.ServiceAccountID{
+						Namespace: "test_namespace",
+						Name:      "test_serviceaccount",
+					},
+					Labels: map[string]string{"k1": "v1", "k2": "v2"},
+				},
+			}))
+		})
+
+		It("should not pass non service account profile updates", func() {
+			update := api.Update{
+				KVPair: model.KVPair{
+					Key:   model.ProfileKey{Name: "test_profile"},
+					Value: &model.Profile{Labels: map[string]string{"k1": "v1", "k2": "v2"}},
+				},
+				UpdateType: api.UpdateTypeKVNew,
+			}
+			uut.OnUpdate(update)
+			Expect(callbacks.updates).To(BeNil())
+		})
+
+		It("should send k8s service account profile remove", func() {
+			update := api.Update{
+				KVPair: model.KVPair{
+					Key: model.ProfileKey{
+						Name: conversion.ServiceAccountProfileNamePrefix +
+							"test_namespace.test_serviceaccount"},
+				},
+				UpdateType: api.UpdateTypeKVDeleted,
+			}
+			uut.OnUpdate(update)
+			Expect(callbacks.removes).To(Equal([]proto.ServiceAccountID{
+				{Name: "test_serviceaccount", Namespace: "test_namespace"},
+			}))
+		})
+
+		It("should not send non-service account profile remove", func() {
+			update := api.Update{
+				KVPair:     model.KVPair{Key: model.ProfileKey{Name: "test_profile"}},
+				UpdateType: api.UpdateTypeKVDeleted,
+			}
+			uut.OnUpdate(update)
+			Expect(callbacks.removes).To(BeNil())
+		})
+
+		It("should not send malformed k8s service account profile update", func() {
+			update := api.Update{
+				KVPair: model.KVPair{
+					Key: model.ProfileKey{
+						Name: conversion.ServiceAccountProfileNamePrefix +
+							"test_namespace-test_serviceaccount"},
+					Value: &model.Profile{
+						Labels: map[string]string{
+							conversion.ServiceAccountLabelPrefix + "k1": "v1",
+							conversion.ServiceAccountLabelPrefix + "k2": "v2",
+						},
+					},
+				},
+				UpdateType: api.UpdateTypeKVNew,
+			}
+			uut.OnUpdate(update)
+			Expect(callbacks.updates).To(BeNil())
+		})
+	})
+})
+
+type passthruCallbackRecorder struct {
+	updates []*proto.ServiceAccountUpdate
+	removes []proto.ServiceAccountID
+}
+
+func (p *passthruCallbackRecorder) OnHostIPUpdate(hostname string, ip *net.IP) {
+	Fail("HostIPUpdate received")
+}
+
+func (p *passthruCallbackRecorder) OnHostIPRemove(hostname string) {
+	Fail("HostIPRemove received")
+}
+
+func (p *passthruCallbackRecorder) OnIPPoolUpdate(model.IPPoolKey, *model.IPPool) {
+	Fail("IPPoolUpdate received")
+}
+
+func (p *passthruCallbackRecorder) OnIPPoolRemove(model.IPPoolKey) {
+	Fail("IPPoolRemove received")
+}
+
+func (p *passthruCallbackRecorder) OnServiceAccountUpdate(update *proto.ServiceAccountUpdate) {
+	p.updates = append(p.updates, update)
+}
+
+func (p *passthruCallbackRecorder) OnServiceAccountRemove(id proto.ServiceAccountID) {
+	p.removes = append(p.removes, id)
+}

--- a/dataplane/external/ext_dataplane.go
+++ b/dataplane/external/ext_dataplane.go
@@ -165,6 +165,10 @@ func (fc *extDataplaneConn) SendMessage(msg interface{}) error {
 		envelope.Payload = &proto.ToDataplane_IpamPoolUpdate{msg}
 	case *proto.IPAMPoolRemove:
 		envelope.Payload = &proto.ToDataplane_IpamPoolRemove{msg}
+	case *proto.ServiceAccountUpdate:
+		envelope.Payload = &proto.ToDataplane_ServiceAccountUpdate{msg}
+	case *proto.ServiceAccountRemove:
+		envelope.Payload = &proto.ToDataplane_ServiceAccountRemove{msg}
 	default:
 		log.WithField("msg", msg).Panic("Unknown message type")
 	}

--- a/dataplane/mock/mock_dataplane.go
+++ b/dataplane/mock/mock_dataplane.go
@@ -41,6 +41,7 @@ type MockDataplane struct {
 	endpointToPreDNATPolicyOrder   map[string][]TierInfo
 	endpointToAllPolicyIDs         map[string][]proto.PolicyID
 	endpointToProfiles             map[string][]string
+	serviceAccounts                map[proto.ServiceAccountID]*proto.ServiceAccountUpdate
 	config                         map[string]string
 }
 
@@ -129,6 +130,16 @@ func (d *MockDataplane) EndpointToPreDNATPolicyOrder() map[string][]TierInfo {
 
 	return copyPolOrder(d.endpointToPreDNATPolicyOrder)
 }
+func (d *MockDataplane) ServiceAccounts() map[proto.ServiceAccountID]*proto.ServiceAccountUpdate {
+	d.Lock()
+	defer d.Unlock()
+
+	copy := make(map[proto.ServiceAccountID]*proto.ServiceAccountUpdate)
+	for k, v := range d.serviceAccounts {
+		copy[k] = v
+	}
+	return copy
+}
 
 func copyPolOrder(in map[string][]TierInfo) map[string][]TierInfo {
 	copy := map[string][]TierInfo{}
@@ -171,6 +182,7 @@ func NewMockDataplane() *MockDataplane {
 		endpointToPreDNATPolicyOrder:   make(map[string][]TierInfo),
 		endpointToProfiles:             make(map[string][]string),
 		endpointToAllPolicyIDs:         make(map[string][]proto.PolicyID),
+		serviceAccounts:                make(map[proto.ServiceAccountID]*proto.ServiceAccountUpdate),
 	}
 	return s
 }
@@ -330,6 +342,10 @@ func (d *MockDataplane) OnEvent(event interface{}) {
 		delete(d.endpointToPolicyOrder, id.String())
 		delete(d.endpointToUntrackedPolicyOrder, id.String())
 		delete(d.endpointToPreDNATPolicyOrder, id.String())
+	case *proto.ServiceAccountUpdate:
+		d.serviceAccounts[*event.Id] = event
+	case *proto.ServiceAccountRemove:
+		delete(d.serviceAccounts, *event.Id)
 	}
 }
 

--- a/dataplane/mock/mock_dataplane.go
+++ b/dataplane/mock/mock_dataplane.go
@@ -134,11 +134,11 @@ func (d *MockDataplane) ServiceAccounts() map[proto.ServiceAccountID]*proto.Serv
 	d.Lock()
 	defer d.Unlock()
 
-	copy := make(map[proto.ServiceAccountID]*proto.ServiceAccountUpdate)
+	cpy := make(map[proto.ServiceAccountID]*proto.ServiceAccountUpdate)
 	for k, v := range d.serviceAccounts {
-		copy[k] = v
+		cpy[k] = v
 	}
-	return copy
+	return cpy
 }
 
 func copyPolOrder(in map[string][]TierInfo) map[string][]TierInfo {

--- a/dataplane/mock/mock_dataplane.go
+++ b/dataplane/mock/mock_dataplane.go
@@ -345,7 +345,9 @@ func (d *MockDataplane) OnEvent(event interface{}) {
 	case *proto.ServiceAccountUpdate:
 		d.serviceAccounts[*event.Id] = event
 	case *proto.ServiceAccountRemove:
-		delete(d.serviceAccounts, *event.Id)
+		id := *event.Id
+		Expect(d.serviceAccounts).To(HaveKey(id))
+		delete(d.serviceAccounts, id)
 	}
 }
 

--- a/policysync/policysync_suite_test.go
+++ b/policysync/policysync_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policysync_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPolicysync(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Policysync Suite")
+}

--- a/policysync/processor.go
+++ b/policysync/processor.go
@@ -276,7 +276,7 @@ func (p *Processor) handleActiveProfileUpdate(update *proto.ActiveProfileUpdate)
 
 func (p *Processor) handleActiveProfileRemove(update *proto.ActiveProfileRemove) {
 	pId := *update.Id
-	log.WithFields(log.Fields{"ProfileID": pId.String()}).Debug("Processing ActiveProfileRemove")
+	log.WithFields(log.Fields{"ProfileID": pId}).Debug("Processing ActiveProfileRemove")
 
 	// Push the update to any endpoints it was synced to
 	for _, ei := range p.updateableEndpoints() {
@@ -290,7 +290,7 @@ func (p *Processor) handleActiveProfileRemove(update *proto.ActiveProfileRemove)
 
 func (p *Processor) handleActivePolicyUpdate(update *proto.ActivePolicyUpdate) {
 	pId := *update.Id
-	log.WithFields(log.Fields{"PolicyID": pId.String()}).Debug("Processing ActivePolicyUpdate")
+	log.WithFields(log.Fields{"PolicyID": pId}).Debug("Processing ActivePolicyUpdate")
 	policy := update.GetPolicy()
 	p.policyByID[pId] = policy
 
@@ -311,7 +311,7 @@ func (p *Processor) handleActivePolicyUpdate(update *proto.ActivePolicyUpdate) {
 
 func (p *Processor) handleActivePolicyRemove(update *proto.ActivePolicyRemove) {
 	pId := *update.Id
-	log.WithFields(log.Fields{"PolicyID": pId.String()}).Debug("Processing ActivePolicyRemove")
+	log.WithFields(log.Fields{"PolicyID": pId}).Debug("Processing ActivePolicyRemove")
 
 	// Push the update to any endpoints it was synced to
 	for _, ei := range p.updateableEndpoints() {
@@ -325,7 +325,7 @@ func (p *Processor) handleActivePolicyRemove(update *proto.ActivePolicyRemove) {
 
 func (p *Processor) handleServiceAccountUpdate(update *proto.ServiceAccountUpdate) {
 	id := *update.Id
-	log.WithField("ServiceAccountID", id.String()).Debug("Processing ServiceAccountUpdate")
+	log.WithField("ServiceAccountID", id).Debug("Processing ServiceAccountUpdate")
 
 	for _, ei := range p.updateableEndpoints() {
 		ei.output <- proto.ToDataplane{Payload: &proto.ToDataplane_ServiceAccountUpdate{update}}
@@ -336,7 +336,7 @@ func (p *Processor) handleServiceAccountUpdate(update *proto.ServiceAccountUpdat
 
 func (p *Processor) handleServiceAccountRemove(update *proto.ServiceAccountRemove) {
 	id := *update.Id
-	log.WithField("ServiceAccountID", id.String()).Debug("Processing ServiceAccountRemove")
+	log.WithField("ServiceAccountID", id).Debug("Processing ServiceAccountRemove")
 
 	for _, ei := range p.updateableEndpoints() {
 		ei.output <- proto.ToDataplane{Payload: &proto.ToDataplane_ServiceAccountRemove{update}}
@@ -432,8 +432,8 @@ func (p *Processor) syncRemovedProfiles(ei *EndpointInfo) {
 func (p *Processor) sendServiceAccounts(ei *EndpointInfo) {
 	for _, update := range p.serviceAccountByID {
 		log.WithFields(log.Fields{
-			"serviceAccount": update.Id.String(),
-			"endpoint":       ei.endpointUpd.GetEndpoint().String(),
+			"serviceAccount": update.Id,
+			"endpoint":       ei.endpointUpd.GetEndpoint(),
 		}).Debug("sending ServiceAccountUpdate")
 		ei.output <- proto.ToDataplane{Payload: &proto.ToDataplane_ServiceAccountUpdate{update}}
 	}

--- a/policysync/processor_test.go
+++ b/policysync/processor_test.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policysync_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/policysync"
+	"github.com/projectcalico/felix/proto"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var _ = Describe("Processor", func() {
+	var uut *policysync.Processor
+	var updates chan interface{}
+	var updateServiceAccount func(name, namespace string)
+	var removeServiceAccount func(name, namespace string)
+	var join func(w string) (chan proto.ToDataplane, policysync.JoinMetadata)
+
+	BeforeEach(func() {
+		updates = make(chan interface{})
+		uut = policysync.NewProcessor(updates)
+
+		updateServiceAccount = func(name, namespace string) {
+			msg := &proto.ServiceAccountUpdate{
+				Id: &proto.ServiceAccountID{Name: name, Namespace: namespace},
+			}
+			updates <- msg
+		}
+		removeServiceAccount = func(name, namespace string) {
+			msg := &proto.ServiceAccountRemove{
+				Id: &proto.ServiceAccountID{Name: name, Namespace: namespace},
+			}
+			log.Info("sending remove")
+			updates <- msg
+			log.Info("Sent remove")
+		}
+		join = func(w string) (chan proto.ToDataplane, policysync.JoinMetadata) {
+			// Buffer outputs so that Processor won't block.
+			output := make(chan proto.ToDataplane, 100)
+			joinMeta := policysync.JoinMetadata{
+				EndpointID: testId(w),
+			}
+			jr := policysync.JoinRequest{JoinMetadata: joinMeta, C: output}
+			uut.JoinUpdates <- jr
+			return output, joinMeta
+		}
+	})
+
+	Context("with Processor started", func() {
+
+		BeforeEach(func() {
+			uut.Start()
+		})
+
+		Describe("ServiceAccount update/remove", func() {
+
+			Context("updates before any join", func() {
+
+				BeforeEach(func() {
+					// Add, delete, re-add
+					updateServiceAccount("test_serviceaccount0", "test_namespace0")
+					removeServiceAccount("test_serviceaccount0", "test_namespace0")
+					updateServiceAccount("test_serviceaccount0", "test_namespace0")
+
+					// Some simple adds
+					updateServiceAccount("test_serviceaccount0", "test_namespace1")
+					updateServiceAccount("test_serviceaccount1", "test_namespace0")
+
+					// Add, delete
+					updateServiceAccount("removed", "removed")
+					removeServiceAccount("removed", "removed")
+				})
+
+				Context("on new join", func() {
+					var output chan proto.ToDataplane
+					var joinMeta policysync.JoinMetadata
+					var accounts [3]proto.ServiceAccountID
+
+					BeforeEach(func() {
+						output, joinMeta = join("test")
+						for i := 0; i < 3; i++ {
+							msg := <-output
+							accounts[i] = *msg.GetServiceAccountUpdate().Id
+						}
+					})
+
+					It("should get 3 updates", func() {
+						Expect(accounts).To(ContainElement(proto.ServiceAccountID{
+							Name: "test_serviceaccount0", Namespace: "test_namespace0"}))
+						Expect(accounts).To(ContainElement(proto.ServiceAccountID{
+							Name: "test_serviceaccount0", Namespace: "test_namespace1"}))
+						Expect(accounts).To(ContainElement(proto.ServiceAccountID{
+							Name: "test_serviceaccount1", Namespace: "test_namespace0"}))
+					})
+
+					It("should pass updates", func() {
+						updateServiceAccount("t0", "t5")
+						msg := <-output
+						Expect(msg.GetServiceAccountUpdate().GetId()).To(Equal(
+							&proto.ServiceAccountID{Name: "t0", Namespace: "t5"},
+						))
+					})
+
+					It("should pass removes", func() {
+						removeServiceAccount("test_serviceaccount0", "test_namespace0")
+						msg := <-output
+						Expect(msg.GetServiceAccountRemove().GetId()).To(Equal(&proto.ServiceAccountID{
+							Name: "test_serviceaccount0", Namespace: "test_namespace0"},
+						))
+					})
+				})
+			})
+
+			Context("with two joined endpoints", func() {
+				var output [2]chan proto.ToDataplane
+				var joinMeta [2]policysync.JoinMetadata
+
+				BeforeEach(func() {
+					for i := 0; i < 2; i++ {
+						w := fmt.Sprintf("test%d", i)
+						d := testId(w)
+						output[i], joinMeta[i] = join(w)
+
+						// Ensure the joins are completed by sending a workload endpoint for each.
+						updates <- &proto.WorkloadEndpointUpdate{
+							Id:       &d,
+							Endpoint: &proto.WorkloadEndpoint{},
+						}
+						<-output[i]
+					}
+				})
+
+				It("should forward updates to both endpoints", func() {
+					updateServiceAccount("t23", "t2")
+					Eventually(output[0]).Should(Receive(&proto.ToDataplane{
+						Payload: &proto.ToDataplane_ServiceAccountUpdate{
+							&proto.ServiceAccountUpdate{
+								Id: &proto.ServiceAccountID{Name: "t23", Namespace: "t2"},
+							},
+						},
+					}))
+					Eventually(output[1]).Should(Receive(&proto.ToDataplane{
+						Payload: &proto.ToDataplane_ServiceAccountUpdate{
+							&proto.ServiceAccountUpdate{
+								Id: &proto.ServiceAccountID{Name: "t23", Namespace: "t2"},
+							},
+						},
+					}))
+				})
+
+				It("should forward removes to both endpoints", func() {
+					removeServiceAccount("t23", "t2")
+					Eventually(output[0]).Should(Receive(&proto.ToDataplane{
+						Payload: &proto.ToDataplane_ServiceAccountRemove{
+							&proto.ServiceAccountRemove{
+								Id: &proto.ServiceAccountID{Name: "t23", Namespace: "t2"},
+							},
+						},
+					}))
+					Eventually(output[1]).Should(Receive(&proto.ToDataplane{
+						Payload: &proto.ToDataplane_ServiceAccountRemove{
+							&proto.ServiceAccountRemove{
+								Id: &proto.ServiceAccountID{Name: "t23", Namespace: "t2"},
+							},
+						},
+					}))
+				})
+
+			})
+		})
+	})
+})
+
+func testId(w string) proto.WorkloadEndpointID {
+	return proto.WorkloadEndpointID{
+		OrchestratorId: "test",
+		WorkloadId:     w,
+		EndpointId:     "test",
+	}
+}

--- a/proto/felixbackend.proto
+++ b/proto/felixbackend.proto
@@ -14,6 +14,8 @@ service PolicySync {
   //  - ActivePolicyRemove
   //  - WorkloadEndpointUpdate
   //  - WorkloadEndpointRemove
+  //  - ServiceAccountUpdate
+  //  - ServiceAccountRemove
   rpc Sync(SyncRequest) returns (stream ToDataplane);
 }
 
@@ -83,6 +85,11 @@ message ToDataplane {
     IPAMPoolUpdate ipam_pool_update = 16;
     // IPAMPoolRemove is sent when an IPAM pool is removed.
     IPAMPoolRemove ipam_pool_remove = 17;
+
+    // ServiceAccountUpdate is sent when a ServiceAccount is added/updated.
+    ServiceAccountUpdate service_account_update = 19;
+    // ServiceAccountRemove is sent when a ServiceAccount is removed.
+    ServiceAccountRemove service_account_remove = 20;
   }
 }
 
@@ -388,4 +395,18 @@ message IPAMPoolRemove {
 message IPAMPool {
   string cidr = 1;
   bool masquerade = 2;
+}
+
+message ServiceAccountUpdate {
+  ServiceAccountID id = 1;
+  map<string, string> labels = 2;
+}
+
+message ServiceAccountRemove {
+  ServiceAccountID id = 1;
+}
+
+message ServiceAccountID {
+  string namespace = 1;
+  string name = 2;
 }


### PR DESCRIPTION
## Description
Felix finds profiles that are K8s Service Accounts and passes them to the dataplane.
PolicySync API fans these out to all connected workloads.

## Todos
- [X] Unit tests (full coverage)
- [X] Integration tests (delete as appropriate) In plan

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
