### PR TITLE
Sync namespace labels

### DIFF
--- a/calc/calc_graph.go
+++ b/calc/calc_graph.go
@@ -74,6 +74,8 @@ type passthruCallbacks interface {
 	OnIPPoolRemove(model.IPPoolKey)
 	OnServiceAccountUpdate(*proto.ServiceAccountUpdate)
 	OnServiceAccountRemove(proto.ServiceAccountID)
+	OnNamespaceUpdate(*proto.NamespaceUpdate)
+	OnNamespaceRemove(proto.NamespaceID)
 }
 
 type PipelineCallbacks interface {
@@ -292,7 +294,7 @@ func NewCalculationGraph(callbacks PipelineCallbacks, hostname string) (allUpdDi
 
 	// The profile decoder identifies objects with special dataplane significance which have
 	// been encoded as profiles by libcalico-go. At present this includes Kubernetes Service
-	// Accounts, but will also include Kubernetes Namespaces in the future.
+	// Accounts and Kubernetes Namespaces.
 	//        ...
 	//     Dispatcher (all updates)
 	//         |

--- a/calc/profile_decoder.go
+++ b/calc/profile_decoder.go
@@ -26,14 +26,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type kind int
-
-const (
-	KindUnknown kind = iota
-	KindServiceAccount
-	KindNamespace
-)
-
 // ProfileDecoder takes updates from a dispatcher, determines if the profile is a Kubernetes Service Account or
 // Kubernetes Namespace, and if it is, generates a dataplane update or remove for it.
 type ProfileDecoder struct {
@@ -53,53 +45,47 @@ func (p *ProfileDecoder) OnUpdate(update api.Update) (filterOut bool) {
 	// This type assertion is safe because we only registered for ProfileLabels updates.
 	key := update.Key.(model.ProfileLabelsKey)
 	log.WithField("key", key.String()).Debug("Decoding ProfileLabels")
-	id, knd := p.classifyProfile(key)
-	switch knd {
-	case KindUnknown:
+	idInterface := p.classifyProfile(key)
+	switch id := idInterface.(type) {
+	case nil:
 		log.WithField("key", key.String()).Debug("Ignoring ProfileLabels")
-	case KindServiceAccount:
-		id := id.(proto.ServiceAccountID)
+	case proto.ServiceAccountID:
 		if update.Value == nil {
 			p.callbacks.OnServiceAccountRemove(id)
 		} else {
 			labels := update.Value.(map[string]string)
-			msg := proto.ServiceAccountUpdate{Id: &id, Labels: decodeLabels(knd, labels)}
+			msg := proto.ServiceAccountUpdate{
+				Id: &id, Labels: decodeLabels(conversion.ServiceAccountLabelPrefix, labels)}
 			p.callbacks.OnServiceAccountUpdate(&msg)
 		}
-	case KindNamespace:
-		id := id.(proto.NamespaceID)
+	case proto.NamespaceID:
 		if update.Value == nil {
 			p.callbacks.OnNamespaceRemove(id)
 		} else {
 			labels := update.Value.(map[string]string)
-			msg := proto.NamespaceUpdate{Id: &id, Labels: decodeLabels(knd, labels)}
+			msg := proto.NamespaceUpdate{
+				Id: &id, Labels: decodeLabels(conversion.NamespaceLabelPrefix, labels)}
 			p.callbacks.OnNamespaceUpdate(&msg)
 		}
 	}
 	return false
 }
 
-func (p *ProfileDecoder) classifyProfile(key model.ProfileLabelsKey) (interface{}, kind) {
+func (p *ProfileDecoder) classifyProfile(key model.ProfileLabelsKey) interface{} {
 	namespace, name, err := p.converter.ProfileNameToServiceAccount(key.Name)
 	if err == nil {
-		return proto.ServiceAccountID{Name: name, Namespace: namespace}, KindServiceAccount
+		return proto.ServiceAccountID{Name: name, Namespace: namespace}
 	}
 	name, err = p.converter.ProfileNameToNamespace(key.Name)
 	if err == nil {
-		return proto.NamespaceID{Name: name}, KindNamespace
+		return proto.NamespaceID{Name: name}
 	}
-	return nil, KindUnknown
+	return nil
 }
 
 // decodeLabels strips the special prefix we add to Profile labels when converting. This gives us the original labels on
 // the ServiceAccount or Namespace object.
-func decodeLabels(k kind, in map[string]string) map[string]string {
-	var prefix string
-	if k == KindServiceAccount {
-		prefix = conversion.ServiceAccountLabelPrefix
-	} else if k == KindNamespace {
-		prefix = conversion.NamespaceLabelPrefix
-	}
+func decodeLabels(prefix string, in map[string]string) map[string]string {
 	out := make(map[string]string)
 	for k, v := range in {
 		k = strings.TrimPrefix(k, prefix)

--- a/dataplane/external/ext_dataplane.go
+++ b/dataplane/external/ext_dataplane.go
@@ -169,6 +169,10 @@ func (fc *extDataplaneConn) SendMessage(msg interface{}) error {
 		envelope.Payload = &proto.ToDataplane_ServiceAccountUpdate{msg}
 	case *proto.ServiceAccountRemove:
 		envelope.Payload = &proto.ToDataplane_ServiceAccountRemove{msg}
+	case *proto.NamespaceUpdate:
+		envelope.Payload = &proto.ToDataplane_NamespaceUpdate{msg}
+	case *proto.NamespaceRemove:
+		envelope.Payload = &proto.ToDataplane_NamespaceRemove{msg}
 	default:
 		log.WithField("msg", msg).Panic("Unknown message type")
 	}

--- a/dataplane/mock/mock_dataplane.go
+++ b/dataplane/mock/mock_dataplane.go
@@ -42,6 +42,7 @@ type MockDataplane struct {
 	endpointToAllPolicyIDs         map[string][]proto.PolicyID
 	endpointToProfiles             map[string][]string
 	serviceAccounts                map[proto.ServiceAccountID]*proto.ServiceAccountUpdate
+	namespaces                     map[proto.NamespaceID]*proto.NamespaceUpdate
 	config                         map[string]string
 }
 
@@ -130,12 +131,24 @@ func (d *MockDataplane) EndpointToPreDNATPolicyOrder() map[string][]TierInfo {
 
 	return copyPolOrder(d.endpointToPreDNATPolicyOrder)
 }
+
 func (d *MockDataplane) ServiceAccounts() map[proto.ServiceAccountID]*proto.ServiceAccountUpdate {
 	d.Lock()
 	defer d.Unlock()
 
 	cpy := make(map[proto.ServiceAccountID]*proto.ServiceAccountUpdate)
 	for k, v := range d.serviceAccounts {
+		cpy[k] = v
+	}
+	return cpy
+}
+
+func (d *MockDataplane) Namespaces() map[proto.NamespaceID]*proto.NamespaceUpdate {
+	d.Lock()
+	defer d.Unlock()
+
+	cpy := make(map[proto.NamespaceID]*proto.NamespaceUpdate)
+	for k, v := range d.namespaces {
 		cpy[k] = v
 	}
 	return cpy
@@ -183,6 +196,7 @@ func NewMockDataplane() *MockDataplane {
 		endpointToProfiles:             make(map[string][]string),
 		endpointToAllPolicyIDs:         make(map[string][]proto.PolicyID),
 		serviceAccounts:                make(map[proto.ServiceAccountID]*proto.ServiceAccountUpdate),
+		namespaces:                     make(map[proto.NamespaceID]*proto.NamespaceUpdate),
 	}
 	return s
 }
@@ -348,6 +362,12 @@ func (d *MockDataplane) OnEvent(event interface{}) {
 		id := *event.Id
 		Expect(d.serviceAccounts).To(HaveKey(id))
 		delete(d.serviceAccounts, id)
+	case *proto.NamespaceUpdate:
+		d.namespaces[*event.Id] = event
+	case *proto.NamespaceRemove:
+		id := *event.Id
+		Expect(d.namespaces).To(HaveKey(id))
+		delete(d.namespaces, id)
 	}
 }
 

--- a/proto/felixbackend.proto
+++ b/proto/felixbackend.proto
@@ -90,6 +90,11 @@ message ToDataplane {
     ServiceAccountUpdate service_account_update = 19;
     // ServiceAccountRemove is sent when a ServiceAccount is removed.
     ServiceAccountRemove service_account_remove = 20;
+
+    // NamespaceUpdate is sent when a Namespace is added/updated.
+    NamespaceUpdate namespace_update = 21;
+    // NamespaceRemove is sent when a Namespace is removed.
+    NamespaceRemove namespace_remove = 22;
   }
 }
 

--- a/proto/felixbackend.proto
+++ b/proto/felixbackend.proto
@@ -16,6 +16,8 @@ service PolicySync {
   //  - WorkloadEndpointRemove
   //  - ServiceAccountUpdate
   //  - ServiceAccountRemove
+  //  - NamespaceUpdate
+  //  - NamespaceRemove
   rpc Sync(SyncRequest) returns (stream ToDataplane);
 }
 

--- a/proto/felixbackend.proto
+++ b/proto/felixbackend.proto
@@ -410,3 +410,16 @@ message ServiceAccountID {
   string namespace = 1;
   string name = 2;
 }
+
+message NamespaceUpdate {
+  NamespaceID id = 1;
+  map<string, string> labels = 2;
+}
+
+message NamespaceRemove {
+  NamespaceID id = 1;
+}
+
+message NamespaceID {
+  string name = 1;
+}


### PR DESCRIPTION
## Description
Decode Calico Profiles which represent K8s Namespaces and pass them over the Policy Sync API.

## Todos
- [X] Unit tests (full coverage)
- [X] Integration tests (delete as appropriate) In plan

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
