### PR TITLE
Windows dataplane driver should apply profiles when policies are not …

### DIFF
--- a/dataplane/windows/endpoint_mgr.go
+++ b/dataplane/windows/endpoint_mgr.go
@@ -160,8 +160,8 @@ func (m *endpointManager) ProcessIpSetUpdate(ipSetId string) {
 		profilesApply := true
 
 		if len(workload.Tiers) > 0 {
-			activePolicyNames = append(activePolicyNames, policysets.AppendPrefixToPolicyNames(policysets.PolicyNamePrefix, workload.Tiers[0].IngressPolicies)...)
-			activePolicyNames = append(activePolicyNames, policysets.AppendPrefixToPolicyNames(policysets.PolicyNamePrefix, workload.Tiers[0].EgressPolicies)...)
+			activePolicyNames = append(activePolicyNames, prependAll(policysets.PolicyNamePrefix, workload.Tiers[0].IngressPolicies)...)
+			activePolicyNames = append(activePolicyNames, prependAll(policysets.PolicyNamePrefix, workload.Tiers[0].EgressPolicies)...)
 
 			if len(workload.Tiers[0].IngressPolicies) > 0 && len(workload.Tiers[0].EgressPolicies) > 0 {
 				profilesApply = false
@@ -169,7 +169,7 @@ func (m *endpointManager) ProcessIpSetUpdate(ipSetId string) {
 		}
 
 		if profilesApply && len(workload.ProfileIds) > 0 {
-			activePolicyNames = append(activePolicyNames, policysets.AppendPrefixToPolicyNames(policysets.ProfileNamePrefix, workload.ProfileIds)...)
+			activePolicyNames = append(activePolicyNames, prependAll(policysets.ProfileNamePrefix, workload.ProfileIds)...)
 		}
 
 	Policies:
@@ -223,18 +223,18 @@ func (m *endpointManager) CompleteDeferredWork() error {
 
 			if len(workload.Tiers) > 0 && len(workload.Tiers[0].IngressPolicies) > 0 {
 				logCxt.Debug("Workload Tier Policies will be applied Inbound")
-				inboundPolicyIds = append(inboundPolicyIds, policysets.AppendPrefixToPolicyNames(policysets.PolicyNamePrefix, workload.Tiers[0].IngressPolicies)...)
+				inboundPolicyIds = append(inboundPolicyIds, prependAll(policysets.PolicyNamePrefix, workload.Tiers[0].IngressPolicies)...)
 			} else if len(workload.ProfileIds) > 0 {
 				logCxt.Debug("Profiles will be applied Inbound")
-				inboundPolicyIds = append(inboundPolicyIds, policysets.AppendPrefixToPolicyNames(policysets.ProfileNamePrefix, workload.ProfileIds)...)
+				inboundPolicyIds = append(inboundPolicyIds, prependAll(policysets.ProfileNamePrefix, workload.ProfileIds)...)
 			}
 
 			if len(workload.Tiers) > 0 && len(workload.Tiers[0].EgressPolicies) > 0 {
 				logCxt.Debug("Workload Tier Policies will be applied Outbound")
-				outboundPolicyIds = append(outboundPolicyIds, policysets.AppendPrefixToPolicyNames(policysets.PolicyNamePrefix, workload.Tiers[0].EgressPolicies)...)
+				outboundPolicyIds = append(outboundPolicyIds, prependAll(policysets.PolicyNamePrefix, workload.Tiers[0].EgressPolicies)...)
 			} else if len(workload.ProfileIds) > 0 {
 				logCxt.Debug("Profiles will be applied Outbound")
-				outboundPolicyIds = append(outboundPolicyIds, policysets.AppendPrefixToPolicyNames(policysets.ProfileNamePrefix, workload.ProfileIds)...)
+				outboundPolicyIds = append(outboundPolicyIds, prependAll(policysets.ProfileNamePrefix, workload.ProfileIds)...)
 			}
 
 			err := m.applyRules(id, endpointId, inboundPolicyIds, outboundPolicyIds)
@@ -315,4 +315,12 @@ func (m *endpointManager) getHnsEndpointId(ip string) (string, error) {
 
 	log.WithField("ip", ip).Info("Could not resolve hns endpoint id")
 	return "", ErrorUnknownEndpoint
+}
+
+// prependAll prepends a string to all of the provided input strings
+func prependAll(prefix string, in []string) (out []string) {
+	for _, s := range in {
+		out = append(out, prefix+s)
+	}
+	return
 }

--- a/dataplane/windows/endpoint_mgr.go
+++ b/dataplane/windows/endpoint_mgr.go
@@ -157,13 +157,19 @@ func (m *endpointManager) ProcessIpSetUpdate(ipSetId string) {
 		}
 
 		var activePolicyNames []string
+		profilesApply := true
+
 		if len(workload.Tiers) > 0 {
-			activePolicyNames = append(activePolicyNames, workload.Tiers[0].IngressPolicies...)
-			activePolicyNames = append(activePolicyNames, workload.Tiers[0].EgressPolicies...)
-		} else {
-			if len(workload.ProfileIds) > 0 {
-				activePolicyNames = workload.ProfileIds
+			activePolicyNames = append(activePolicyNames, policysets.AppendPrefixToPolicyNames(policysets.PolicyNamePrefix, workload.Tiers[0].IngressPolicies)...)
+			activePolicyNames = append(activePolicyNames, policysets.AppendPrefixToPolicyNames(policysets.PolicyNamePrefix, workload.Tiers[0].EgressPolicies)...)
+
+			if len(workload.Tiers[0].IngressPolicies) > 0 && len(workload.Tiers[0].EgressPolicies) > 0 {
+				profilesApply = false
 			}
+		}
+
+		if profilesApply && len(workload.ProfileIds) > 0 {
+			activePolicyNames = append(activePolicyNames, policysets.AppendPrefixToPolicyNames(policysets.ProfileNamePrefix, workload.ProfileIds)...)
 		}
 
 	Policies:
@@ -193,7 +199,8 @@ func (m *endpointManager) CompleteDeferredWork() error {
 	for id, workload := range m.pendingWlEpUpdates {
 		logCxt := log.WithField("id", id)
 
-		var policyNames []string
+		var inboundPolicyIds []string
+		var outboundPolicyIds []string
 		var endpointId string
 
 		// A non-nil workload indicates this is a pending add or update operation
@@ -214,18 +221,23 @@ func (m *endpointManager) CompleteDeferredWork() error {
 
 			logCxt.Info("Processing endpoint add/update")
 
-			if len(workload.Tiers) > 0 {
-				logCxt.Debug("Workload tiers are present - Policies will be applied")
-				policyNames = append(policyNames, workload.Tiers[0].IngressPolicies...)
-				policyNames = append(policyNames, workload.Tiers[0].EgressPolicies...)
-			} else {
-				if len(workload.ProfileIds) > 0 {
-					logCxt.Debug("Workload tiers are not present - Profiles will be applied")
-					policyNames = workload.ProfileIds
-				}
+			if len(workload.Tiers) > 0 && len(workload.Tiers[0].IngressPolicies) > 0 {
+				logCxt.Debug("Workload Tier Policies will be applied Inbound")
+				inboundPolicyIds = append(inboundPolicyIds, policysets.AppendPrefixToPolicyNames(policysets.PolicyNamePrefix, workload.Tiers[0].IngressPolicies)...)
+			} else if len(workload.ProfileIds) > 0 {
+				logCxt.Debug("Profiles will be applied Inbound")
+				inboundPolicyIds = append(inboundPolicyIds, policysets.AppendPrefixToPolicyNames(policysets.ProfileNamePrefix, workload.ProfileIds)...)
 			}
 
-			err := m.applyRules(id, endpointId, policyNames)
+			if len(workload.Tiers) > 0 && len(workload.Tiers[0].EgressPolicies) > 0 {
+				logCxt.Debug("Workload Tier Policies will be applied Outbound")
+				outboundPolicyIds = append(outboundPolicyIds, policysets.AppendPrefixToPolicyNames(policysets.PolicyNamePrefix, workload.Tiers[0].EgressPolicies)...)
+			} else if len(workload.ProfileIds) > 0 {
+				logCxt.Debug("Profiles will be applied Outbound")
+				outboundPolicyIds = append(outboundPolicyIds, policysets.AppendPrefixToPolicyNames(policysets.ProfileNamePrefix, workload.ProfileIds)...)
+			}
+
+			err := m.applyRules(id, endpointId, inboundPolicyIds, outboundPolicyIds)
 			if err != nil {
 				// Failed to apply, this will be rescheduled and retried
 				return err
@@ -247,13 +259,15 @@ func (m *endpointManager) CompleteDeferredWork() error {
 
 // applyRules gathers all of the rules for the specified policies and sends them to hns
 // as an endpoint policy update (this actually applies the rules to the dataplane).
-func (m *endpointManager) applyRules(workloadId proto.WorkloadEndpointID, endpointId string, policyNames []string) error {
+func (m *endpointManager) applyRules(workloadId proto.WorkloadEndpointID, endpointId string, inboundPolicyIds []string, outboundPolicyIds []string) error {
 	logCxt := log.WithFields(log.Fields{"id": workloadId, "endpointId": endpointId})
-	logCxt.WithField("policies", policyNames).Info("Applying endpoint rules")
+	logCxt.WithFields(log.Fields{"inboundPolicyIds": inboundPolicyIds, "outboundPolicyIds": outboundPolicyIds}).Info("Applying endpoint rules")
 
 	var rules []*hns.ACLPolicy
-	if len(policyNames) > 0 {
-		rules = m.policysetsDataplane.GetPolicySetRules(policyNames)
+	rules = append(rules, m.policysetsDataplane.GetPolicySetRules(inboundPolicyIds, true)...)
+	rules = append(rules, m.policysetsDataplane.GetPolicySetRules(outboundPolicyIds, false)...)
+
+	if len(rules) > 0 {
 		if log.GetLevel() >= log.DebugLevel {
 			for _, rule := range rules {
 				logCxt.WithField("rule", rule).Debug("Complete set of rules to be applied")

--- a/dataplane/windows/policysets/policyset_defs.go
+++ b/dataplane/windows/policysets/policyset_defs.go
@@ -65,7 +65,7 @@ type PolicySetsDataplane interface {
 	AddOrReplacePolicySet(setId string, policy interface{})
 	RemovePolicySet(setId string)
 	NewRule(isInbound bool, priority uint16) *hns.ACLPolicy
-	GetPolicySetRules(setIds []string) (rules []*hns.ACLPolicy)
+	GetPolicySetRules(setIds []string, isInbound bool) (rules []*hns.ACLPolicy)
 	ProcessIpSetUpdate(ipSetId string) []string
 }
 

--- a/dataplane/windows/policysets/policysets.go
+++ b/dataplane/windows/policysets/policysets.go
@@ -91,18 +91,23 @@ func (s *PolicySets) RemovePolicySet(setId string) {
 }
 
 // GetPolicySetRules receives a list of Policy set ids and it computes the complete
-// set of resultant hns rules which are needed to enforce all of the Policy sets. As
-// the Policy sets are processed, we increment a priority number and assign it to each rule
-// from the current set. By incremening the rule priority for each set, we ensure that all of
-// the sets will be enforced and considered by the dataplane in the order intended by felix.
-// Once all rules are gathered, we add a final pair of rules to default deny any traffic which
-// has not matched any rules from any Policy sets.
-func (s *PolicySets) GetPolicySetRules(setIds []string) (rules []*hns.ACLPolicy) {
+// set of resultant hns rules which are needed to enforce all of the Policy sets for the
+// specified direction. As the Policy sets are processed, we increment a priority number
+// and assign it to each rule from the current set. By incremening the rule priority for
+// each set, we ensure that all of the sets will be enforced and considered by the dataplane
+// in the order intended by felix. Once all rules are gathered, we add a final pair of rules
+// to default deny any traffic which has not matched any rules from any Policy sets.
+func (s *PolicySets) GetPolicySetRules(setIds []string, isInbound bool) (rules []*hns.ACLPolicy) {
 	// Rules from the first set will receive the default rule priority
 	currentPriority := rulePriority
 
+	direction := hns.Out
+	if isInbound {
+		direction = hns.In
+	}
+
 	for _, setId := range setIds {
-		log.WithField("setId", setId).Debug("Gathering rules for policy set")
+		log.WithFields(log.Fields{"setId": setId, "isInbound": isInbound}).Debug("Gathering per-direction rules for policy set")
 
 		policySet := s.policySetIdToPolicySet[setId]
 		if policySet == nil {
@@ -112,8 +117,10 @@ func (s *PolicySets) GetPolicySetRules(setIds []string) (rules []*hns.ACLPolicy)
 
 		policySet.Members.Iter(func(item interface{}) error {
 			member := item.(*hns.ACLPolicy)
-			member.Priority = currentPriority
-			rules = append(rules, member)
+			if member.Direction == direction {
+				member.Priority = currentPriority
+				rules = append(rules, member)
+			}
 			return nil
 		})
 
@@ -122,12 +129,12 @@ func (s *PolicySets) GetPolicySetRules(setIds []string) (rules []*hns.ACLPolicy)
 		currentPriority += 1
 	}
 
-	// Apply a default block rule for each direction at the end of the policy
-	rules = append(rules, s.NewRule(true, currentPriority), s.NewRule(false, currentPriority))
+	// Apply a default block rule for this direction at the end of the policy
+	rules = append(rules, s.NewRule(isInbound, currentPriority))
 
-	// Finally, for RS3 only, add default allow rules with a host-scope to allow traffic through
+	// Finally, for RS3 only, add default allow rule with a host-scope to allow traffic through
 	// the host windows firewall
-	rules = append(rules, s.NewHostRule(true), s.NewHostRule(false))
+	rules = append(rules, s.NewHostRule(isInbound))
 
 	return
 }
@@ -150,7 +157,6 @@ func (s *PolicySets) ProcessIpSetUpdate(ipSetId string) []string {
 			log.WithFields(log.Fields{"IPSetId": ipSetId, "Policy": policyId}).Error("Unable to find Policy set, this set will be skipped")
 			continue
 		}
-
 		s.AddOrReplacePolicySet(policySet.PolicySetMetadata.SetId, policySet.Policy)
 	}
 
@@ -537,7 +543,6 @@ func (s *PolicySets) NewHostRule(isInbound bool) *hns.ACLPolicy {
 		RuleType:  hns.Host,
 		Action:    hns.Allow,
 		Direction: direction,
-		Priority:  100,
 		Protocol:  256, // Any
 	}
 }
@@ -556,6 +561,14 @@ func filterNets(mixedCIDRs []string, ipVersion uint8) (filtered []string, filter
 		}
 		filtered = append(filtered, net)
 		filteredAll = false
+	}
+	return
+}
+
+// AppendPrefixToPolicyNames appends a prefix to each policy name
+func AppendPrefixToPolicyNames(prefix string, policyNames []string) (appendedNames []string) {
+	for _, policyName := range policyNames {
+		appendedNames = append(appendedNames, prefix+policyName)
 	}
 	return
 }

--- a/dataplane/windows/policysets/policysets.go
+++ b/dataplane/windows/policysets/policysets.go
@@ -543,6 +543,7 @@ func (s *PolicySets) NewHostRule(isInbound bool) *hns.ACLPolicy {
 		RuleType:  hns.Host,
 		Action:    hns.Allow,
 		Direction: direction,
+		Priority:  100,
 		Protocol:  256, // Any
 	}
 }
@@ -561,14 +562,6 @@ func filterNets(mixedCIDRs []string, ipVersion uint8) (filtered []string, filter
 		}
 		filtered = append(filtered, net)
 		filteredAll = false
-	}
-	return
-}
-
-// AppendPrefixToPolicyNames appends a prefix to each policy name
-func AppendPrefixToPolicyNames(prefix string, policyNames []string) (appendedNames []string) {
-	for _, policyName := range policyNames {
-		appendedNames = append(appendedNames, prefix+policyName)
 	}
 	return
 }


### PR DESCRIPTION
…applicable for a given direction

## Description
Type of fix: Bug fix

Tested on: Windows RS3 / RS4 pre-release

Components affected: Windows Dataplane driver

Details: When workload tier Policies are not applicable for a direction (e.g. egress) the driver was applying a default block rule for that direction instead of applying any applicable Profiles. In some configurations, this would result in traffic being dropped by default rather than allowed.

## Todos
- [X ] Unit tests (full coverage)
- [X ] Documentation

## Release Note

```release-note
None required
```
