### PR TITLE
Http rule passthru

### DIFF
--- a/calc/rule_convert.go
+++ b/calc/rule_convert.go
@@ -128,6 +128,10 @@ func parsedRuleToProtoRule(in *ParsedRule) *proto.Rule {
 		}
 	}
 
+	if in.HTTPMatch != nil {
+		out.HttpMatch = &proto.HTTPMatch{Methods: in.HTTPMatch.Methods}
+	}
+
 	// Fill in the ICMP fields.  We can't follow the pattern and make a
 	// convertICMP() function because we can't name the return type of the
 	// function (it's private to the protobuf package).

--- a/calc/rule_convert_test.go
+++ b/calc/rule_convert_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/felix/proto"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
@@ -83,6 +84,8 @@ var fullyLoadedParsedRule = ParsedRule{
 
 	OriginalDstServiceAccountSelector: "has(sa-dst)",
 	OriginalDstServiceAccountNames:    []string{"dst-1"},
+
+	HTTPMatch: &model.HTTPMatch{Methods: []string{"GET", "POST"}},
 }
 
 var fullyLoadedProtoRule = proto.Rule{
@@ -143,6 +146,8 @@ var fullyLoadedProtoRule = proto.Rule{
 		Selector: "has(sa-dst)",
 		Names:    []string{"dst-1"},
 	},
+
+	HttpMatch: &proto.HTTPMatch{Methods: []string{"GET", "POST"}},
 }
 
 var _ = DescribeTable("ParsedRulesToProtoRules",

--- a/calc/rule_scanner.go
+++ b/calc/rule_scanner.go
@@ -301,6 +301,10 @@ type ParsedRule struct {
 	OriginalSrcServiceAccountSelector string
 	OriginalDstServiceAccountNames    []string
 	OriginalDstServiceAccountSelector string
+
+	// These fields allow us to pass through the HTTP match criteria from the V3 datamodel. The iptables dataplane
+	// does not implement the match, but other dataplanes such as Dikastes do.
+	HTTPMatch *model.HTTPMatch
 }
 
 func ruleToParsedRule(rule *model.Rule) (parsedRule *ParsedRule, allIPSets []*IPSetData) {
@@ -404,6 +408,7 @@ func ruleToParsedRule(rule *model.Rule) (parsedRule *ParsedRule, allIPSets []*IP
 		OriginalSrcServiceAccountSelector: rule.OriginalSrcServiceAccountSelector,
 		OriginalDstServiceAccountNames:    rule.OriginalDstServiceAccountNames,
 		OriginalDstServiceAccountSelector: rule.OriginalDstServiceAccountSelector,
+		HTTPMatch:                         rule.HTTPMatch,
 	}
 
 	allIPSets = append(allIPSets, srcNamedPortIPSets...)

--- a/calc/rule_scanner_test.go
+++ b/calc/rule_scanner_test.go
@@ -146,6 +146,8 @@ var _ = DescribeTable("RuleScanner rule conversion should generate correct Parse
 	Entry("OriginalSrcServiceAccountSelector", model.Rule{OriginalSrcServiceAccountSelector: "all()"}, ParsedRule{OriginalSrcServiceAccountSelector: "all()"}),
 	Entry("OriginalDstServiceAccountSelector", model.Rule{OriginalDstServiceAccountSelector: "all()"}, ParsedRule{OriginalDstServiceAccountSelector: "all()"}),
 
+	Entry("HTTPMatch", model.Rule{HTTPMatch: &model.HTTPMatch{Methods: []string{"GET", "HEAD"}}}, ParsedRule{HTTPMatch: &model.HTTPMatch{Methods: []string{"GET", "HEAD"}}}),
+
 	// Tags/Selectors.
 	Entry("source tag", model.Rule{SrcTag: "tag1"}, ParsedRule{SrcIPSetIDs: []string{tag1ID}}),
 	Entry("dest tag", model.Rule{DstTag: "tag1"}, ParsedRule{DstIPSetIDs: []string{tag1ID}}),

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 09c709ac5c97939531514c55c3af71fb6dfc82f243f1e0e2af1cf868817f6260
-updated: 2018-03-02T11:05:01.106648595Z
+hash: 2204735473fb1cc0a932f8a235d80af5794e55b51e1fc2afc32395f787ce346e
+updated: 2018-03-07T22:32:10.437123127Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -201,7 +201,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 4b03e4787e79a341d3d830684a5373cc01328cb6
+  version: 3be72c2105351f081f6e5c71e1fe036ca71ec343
   subpackages:
   - lib
   - lib/apiconfig
@@ -240,7 +240,7 @@ imports:
   - lib/validator/v3
   - lib/watch
 - name: github.com/projectcalico/typha
-  version: 44154bc0d49ce6d711e2d8f656898859d7e845c2
+  version: 54687aa752d176a3822463b86fecc0d6eb2975fb
   subpackages:
   - pkg/syncclient
   - pkg/syncproto
@@ -283,7 +283,7 @@ imports:
 - name: github.com/whyrusleeping/go-logging
   version: 0457bb6b88fc1973573aaf6b5145d8d3ae972390
 - name: golang.org/x/crypto
-  version: 91a49db82a88618983a78a06c1cbd4e00ab749ab
+  version: 85f98707c97e11569271e4d9b3d397e079c4f4d0
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -350,7 +350,7 @@ imports:
   - internal/urlfetch
   - urlfetch
 - name: google.golang.org/genproto
-  version: 2c5e7ac708aaa719366570dd82bda44541ca2a63
+  version: df60624c1e9b9d2973e889c7a1cff73155da81c4
   subpackages:
   - googleapis
   - googleapis/rpc/status

--- a/glide.yaml
+++ b/glide.yaml
@@ -30,7 +30,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: feature-policy-api
+  version: 3be72c2105351f081f6e5c71e1fe036ca71ec343
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus
@@ -52,7 +52,7 @@ import:
 - package: k8s.io/client-go
   version: 82aa063804cf055e16e8911250f888bc216e8b61
 - package: github.com/projectcalico/typha
-  version: feature-policy-api
+  version: 54687aa752d176a3822463b86fecc0d6eb2975fb
   subpackages:
   - pkg/syncclient
 - package: github.com/emicklei/go-restful

--- a/policysync/processor_test.go
+++ b/policysync/processor_test.go
@@ -100,11 +100,10 @@ var _ = Describe("Processor", func() {
 
 				Context("on new join", func() {
 					var output chan proto.ToDataplane
-					var joinMeta policysync.JoinMetadata
 					var accounts [3]proto.ServiceAccountID
 
 					BeforeEach(func() {
-						output, joinMeta = join("test")
+						output, _ = join("test")
 						for i := 0; i < 3; i++ {
 							msg := <-output
 							accounts[i] = *msg.GetServiceAccountUpdate().Id
@@ -140,13 +139,12 @@ var _ = Describe("Processor", func() {
 
 			Context("with two joined endpoints", func() {
 				var output [2]chan proto.ToDataplane
-				var joinMeta [2]policysync.JoinMetadata
 
 				BeforeEach(func() {
 					for i := 0; i < 2; i++ {
 						w := fmt.Sprintf("test%d", i)
 						d := testId(w)
-						output[i], joinMeta[i] = join(w)
+						output[i], _ = join(w)
 
 						// Ensure the joins are completed by sending a workload endpoint for each.
 						updates <- &proto.WorkloadEndpointUpdate{
@@ -217,11 +215,10 @@ var _ = Describe("Processor", func() {
 
 				Context("on new join", func() {
 					var output chan proto.ToDataplane
-					var joinMeta policysync.JoinMetadata
 					var accounts [3]proto.NamespaceID
 
 					BeforeEach(func() {
-						output, joinMeta = join("test")
+						output, _ = join("test")
 						for i := 0; i < 3; i++ {
 							msg := <-output
 							accounts[i] = *msg.GetNamespaceUpdate().Id

--- a/proto/felixbackend.proto
+++ b/proto/felixbackend.proto
@@ -254,6 +254,9 @@ message Rule {
   ServiceAccountMatch src_service_account_match = 120;
   ServiceAccountMatch dst_service_account_match = 121;
 
+  // Pass through of the v3 datamodel HTTP match criteria.
+  HTTPMatch http_match = 122;
+
   // Changed to config option.
   reserved 200;
   reserved "log_prefix";
@@ -265,6 +268,10 @@ message Rule {
 message ServiceAccountMatch {
   string selector = 1;
   repeated string names = 2;
+}
+
+message HTTPMatch {
+  repeated string methods = 1;
 }
 
 message IcmpTypeAndCode {


### PR DESCRIPTION
## Description
Pass-thru HTTPMatch from libcalico to the dataplane (including Policy Sync API).

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan
- [x] Documentation in plan as part of App Layer Policy
- [x] Backport not needed
- [x] Release note in plan as part of App Layer Policy

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
