### PR TITLE
Auto detect kube-proxy mode for ipvs.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
-//
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -167,8 +167,7 @@ type Config struct {
 	FailsafeInboundHostPorts  []ProtoPort `config:"port-list;tcp:22,udp:68,tcp:179,tcp:2379,tcp:2380,tcp:6666,tcp:6667;die-on-fail"`
 	FailsafeOutboundHostPorts []ProtoPort `config:"port-list;udp:53,udp:67,tcp:179,tcp:2379,tcp:2380,tcp:6666,tcp:6667;die-on-fail"`
 
-	KubeNodePortRanges     []numorstring.Port `config:"portrange-list;30000:32767"`
-	KubeIPVSSupportEnabled bool               `config:"bool;false"`
+	KubeNodePortRanges []numorstring.Port `config:"portrange-list;30000:32767"`
 
 	UsageReportingEnabled          bool          `config:"bool;true"`
 	UsageReportingInitialDelaySecs time.Duration `config:"seconds;300"`

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -312,10 +312,6 @@ var _ = DescribeTable("Config parsing",
 			{Protocol: "tcp", Port: 6667},
 		},
 	),
-	Entry("KubeIPVSSupportEnabled empty", "KubeIPVSSupportEnabled", "", false),
-	Entry("KubeIPVSSupportEnabled true", "KubeIPVSSupportEnabled", "true", true),
-	Entry("KubeIPVSSupportEnabled false", "KubeIPVSSupportEnabled", "false", false),
-
 	Entry("KubeNodePortRanges empty", "KubeNodePortRanges", "",
 		[]numorstring.Port{
 			{30000, 32767, ""},

--- a/dataplane/driver_windows.go
+++ b/dataplane/driver_windows.go
@@ -24,7 +24,9 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/health"
 )
 
-func StartDataplaneDriver(configParams *config.Config, healthAggregator *health.HealthAggregator) (DataplaneDriver, *exec.Cmd) {
+func StartDataplaneDriver(configParams *config.Config,
+	healthAggregator *health.HealthAggregator,
+	configChangedRestartCallback func()) (DataplaneDriver, *exec.Cmd) {
 	log.Info("Using Windows dataplane driver.")
 
 	dpConfig := windataplane.Config{

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,6 +43,9 @@ const (
 	// channel before we apply the changes.  Higher values allow us to batch up more work on
 	// the channel for greater throughput when we're under load (at cost of higher latency).
 	msgPeekLimit = 100
+
+	// Interface name used by kube-proxy to bind service ips.
+	KubeIPVSInterface = "kube-ipvs0"
 )
 
 var (
@@ -111,6 +114,8 @@ type Config struct {
 	IfaceMonitorConfig ifacemonitor.Config
 
 	StatusReportingInterval time.Duration
+
+	ConfigChangedRestartCallback func()
 
 	PostInSyncCallback func()
 	HealthAggregator   *health.HealthAggregator
@@ -456,6 +461,26 @@ type ifaceUpdate struct {
 	State ifacemonitor.State
 }
 
+// Check if current felix ipvs config is correct when felix gets an kube-ipvs0 interface update.
+// If KubeIPVSInterface is UP and felix ipvs support is disabled (kube-proxy switched from iptables to ipvs mode),
+// or if KubeIPVSInterface is DOWN and felix ipvs support is enabled (kube-proxy switched from ipvs to iptables mode),
+// restart felix to pick up correct ipvs support mode.
+func (d *InternalDataplane) checkIPVSConfigOnIfaceUpdate(update *ifaceUpdate) {
+	if update.Name != KubeIPVSInterface {
+		return
+	}
+
+	if (!d.config.RulesConfig.KubeIPVSSupportEnabled && update.State == ifacemonitor.StateUp) ||
+		(d.config.RulesConfig.KubeIPVSSupportEnabled && update.State == ifacemonitor.StateDown) {
+		log.WithFields(log.Fields{
+			"ifaceName":   update.Name,
+			"ifaceStatus": update.State,
+			"ipvsSupport": d.config.RulesConfig.KubeIPVSSupportEnabled,
+		}).Info("kube-proxy mode changed. Restart felix.")
+		d.config.ConfigChangedRestartCallback()
+	}
+}
+
 // onIfaceAddrsChange is our interface address monitor callback.  It gets called
 // from the monitor's thread.
 func (d *InternalDataplane) onIfaceAddrsChange(ifaceName string, addrs set.Set) {
@@ -604,6 +629,11 @@ func (d *InternalDataplane) loopUpdatingDataplane() {
 
 	processIfaceUpdate := func(ifaceUpdate *ifaceUpdate) {
 		log.WithField("msg", ifaceUpdate).Info("Received interface update")
+		if ifaceUpdate.Name == KubeIPVSInterface {
+			d.checkIPVSConfigOnIfaceUpdate(ifaceUpdate)
+			return
+		}
+
 		for _, mgr := range d.allManagers {
 			mgr.OnUpdate(ifaceUpdate)
 		}

--- a/felix.go
+++ b/felix.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -296,11 +296,14 @@ configRetry:
 	var dpDriver dp.DataplaneDriver
 	var dpDriverCmd *exec.Cmd
 
-	dpDriver, dpDriverCmd = dp.StartDataplaneDriver(configParams, healthAggregator)
+	failureReportChan := make(chan string)
+	configChangedRestartCallback := func() { failureReportChan <- reasonConfigChanged }
+
+	dpDriver, dpDriverCmd = dp.StartDataplaneDriver(configParams, healthAggregator, configChangedRestartCallback)
 
 	// Initialise the glue logic that connects the calculation graph to/from the dataplane driver.
 	log.Info("Connect to the dataplane driver.")
-	failureReportChan := make(chan string)
+
 	var connToUsageRepUpdChan chan map[string]string
 	if configParams.UsageReportingEnabled {
 		// Make a channel for the connector to use to send updates to the usage reporter.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: dccac4dcca4560ddb151295ff9cf33aca844156e7cbeda27162d79f00ac8aa48
-updated: 2018-03-08T13:59:40.483147298Z
+hash: d4772d16edde9ad8a1699afabd772e9aa2c49ee06039e64284b56fee21b30810
+updated: 2018-03-08T15:08:11.486396967Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -201,7 +201,8 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 3be72c2105351f081f6e5c71e1fe036ca71ec343
+  version: 4d968310fc51d299eeb2339293a36dfe990b00d5
+  repo: https://github.com/song-jiang/libcalico-go.git
   subpackages:
   - lib
   - lib/apiconfig

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d4772d16edde9ad8a1699afabd772e9aa2c49ee06039e64284b56fee21b30810
-updated: 2018-03-08T15:08:11.486396967Z
+hash: 7649b13bae7a29285e72dc4fd63014aea9b7c353951295938eb1b0787be6d2f9
+updated: 2018-03-08T16:44:12.291369623Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -201,8 +201,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 4d968310fc51d299eeb2339293a36dfe990b00d5
-  repo: https://github.com/song-jiang/libcalico-go.git
+  version: 5f90a75a16b8c4b94fd045afbfbb545194b451ac
   subpackages:
   - lib
   - lib/apiconfig
@@ -241,7 +240,7 @@ imports:
   - lib/validator/v3
   - lib/watch
 - name: github.com/projectcalico/typha
-  version: ad2633003df694deb8ebaf345c10a53452632258
+  version: 5f958fbfe89745a33cb9e862890195b0d9723be5
   subpackages:
   - pkg/syncclient
   - pkg/syncproto

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,8 +35,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  repo:    https://github.com/song-jiang/libcalico-go.git
-  version: ipvs-auto
+  version: 5f90a75a16b8c4b94fd045afbfbb545194b451ac
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus
@@ -55,7 +54,7 @@ import:
 - package: k8s.io/client-go
   version: 82aa063804cf055e16e8911250f888bc216e8b61
 - package: github.com/projectcalico/typha
-  version: ad2633003df694deb8ebaf345c10a53452632258
+  version: 5f958fbfe89745a33cb9e862890195b0d9723be5
   subpackages:
   - pkg/syncclient
 - package: github.com/emicklei/go-restful

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,7 +35,8 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: 3be72c2105351f081f6e5c71e1fe036ca71ec343
+  repo:    https://github.com/song-jiang/libcalico-go.git
+  version: ipvs-auto
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus


### PR DESCRIPTION
## Description
Felix auto detect kube-proxy mode for ipvs support. If kube-proxy changes its mode from iptables to ipvs or vice versa, felix will restart itself to pick up the correct configuration.

## Todos
- [X] Unit tests (full coverage)
- [X] Integration tests 
- [ ] Documentation

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
