### PR TITLE
Add batching support to fv make target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,14 @@ FELIX_IMAGE_NAME?=calico/felix$(ARCHTAG):latest
 FV_FELIXIMAGE?=$(FELIX_IMAGE_NAME)
 FV_ETCDIMAGE?=quay.io/coreos/etcd:v3.2.5$(ARCHTAG)
 FV_K8SIMAGE?=gcr.io/google_containers/hyperkube$(ARCHTAG):v1.7.5
-FV_GINKGO_NODES?=4
+
+# Total number of ginkgo batches to run.  The CI system sets this according to the number
+# of jobs that it divides the FVs into.
+FV_NUM_BATCHES?=3
+# Space-delimited list of FV batches to run in parallel.  Defaults to running all batches
+# in parallel on this host.  The CI system runs a subset of batches in each parallel job.
+FV_BATCHES_TO_RUN?=$(shell seq $(FV_NUM_BATCHES))
+FV_SLOW_SPEC_THRESH=90
 
 help:
 	@echo "Felix Makefile"
@@ -404,34 +411,28 @@ ut combined.coverprofile: vendor/.up-to-date $(FELIX_GO_FILES)
 	@echo Running Go UTs.
 	$(DOCKER_GO_BUILD) ./utils/run-coverage $(GINKGO_ARGS)
 
-FV_TESTS=$(subst _suite_test.go,.test,$(shell find fv -name "*_suite_test.go"))
-
-$(FV_TESTS): vendor/.up-to-date $(FELIX_GO_FILES)
+fv/fv.test: vendor/.up-to-date $(FELIX_GO_FILES)
 	# We pre-build the FV test binaries so that we can run them
 	# outside a container and allow them to interact with docker.
 	$(DOCKER_GO_BUILD) go test ./$(shell dirname $@) -c --tags fvtests -o $@
 
 .PHONY: fv
-fv fv/latency.log: calico/felix bin/iptables-locker bin/test-workload bin/test-connection $(FV_TESTS)
-	# Copy the ginkgo binary out of the container since we need to run the fv tests directly
-	# on the host (because they need to be able to manipulate docker).  It'd be even nicer
-	# if we could give the build container access to the docker API but we've so-far struggled
-	# to get that working.
-	@echo Running Go FVs.
-	$(DOCKER_GO_BUILD) cp /go/bin/ginkgo bin/ginkgo
-	rm -rf fv/latency.log
-	for t in $(FV_TESTS); do \
-	    cd $(TOPDIR)/`dirname $$t` && \
-	    FV_FELIXIMAGE=$(FV_FELIXIMAGE) \
-	    FV_ETCDIMAGE=$(FV_ETCDIMAGE) \
-	    FV_TYPHAIMAGE=$(FV_TYPHAIMAGE) \
-	    FV_K8SIMAGE=$(FV_K8SIMAGE) \
-	    $(TOPDIR)/bin/ginkgo $(GINKGO_ARGS) -slowSpecThreshold 80 -nodes $(FV_GINKGO_NODES) ./`basename $$t` || exit; \
-	done
-	@echo
-	@echo "Latency results:"
-	@echo
-	-@cat fv/latency.log
+fv fv/latency.log: calico/felix bin/iptables-locker bin/test-workload bin/test-connection fv/fv.test
+	cd fv && \
+	  FV_FELIXIMAGE=$(FV_FELIXIMAGE) \
+	  FV_ETCDIMAGE=$(FV_ETCDIMAGE) \
+	  FV_TYPHAIMAGE=$(FV_TYPHAIMAGE) \
+	  FV_K8SIMAGE=$(FV_K8SIMAGE) \
+	  FV_NUM_BATCHES=$(FV_NUM_BATCHES) \
+	  FV_BATCHES_TO_RUN="$(FV_BATCHES_TO_RUN)" \
+	  GINKGO_ARGS='$(GINKGO_ARGS)' \
+	  ./run-batches
+	@if [ -e fv/latency.log ]; then \
+	   echo; \
+	   echo "Latency results:"; \
+	   echo; \
+	   cat fv/latency.log; \
+	fi
 
 bin/check-licenses: $(FELIX_GO_FILES)
 	$(DOCKER_GO_BUILD) go build -v -i -o $@ "github.com/projectcalico/felix/check-licenses"

--- a/fv/run-batches
+++ b/fv/run-batches
@@ -1,0 +1,39 @@
+#!/bin/bash -ex
+
+# Copyright (c) 2018 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+: ${FV_NUM_BATCHES:=4}
+: ${FV_BATCHES_TO_RUN:=1 2 3 4}
+: ${FV_SLOW_SPEC_THRESH:=90}
+: ${GINKGO_ARGS:=}
+
+for batch in ${FV_BATCHES_TO_RUN}; do
+  (
+     echo "Running FV batch ${batch}"
+     ./fv.test -ginkgo.parallel.node ${batch} \
+               -ginkgo.parallel.total ${FV_NUM_BATCHES} \
+               -ginkgo.seed 1 \
+               -ginkgo.randomizeAllSpecs=true \
+               -ginkgo.slowSpecThreshold ${FV_SLOW_SPEC_THRESH} \
+               ${GINKGO_ARGS}; \
+  ) &
+  pids[${batch}]=$!
+done
+
+for batch in ${FV_BATCHES_TO_RUN}; do
+  echo "Waiting on batch $batch; PID=${pids[$batch]}"
+  wait ${pids[$batch]}
+  echo "Result: $?"
+done


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

I recently reworked the SemaphoreCI job structure to split up the FV tests into multiple Semaphore jobs.  The code in Semaphore was just a proof of concept, which unrolled a lot of Makefile function into a Semaphore job script 👎 .  This PR moves that code into the Makefile and a utility script 👍 .

The general approach is to precompile the fv.test binary and then, via a shell script, invoke it directly.  The script supports running multiple batches in parallel on the same node, which I'm now making use of in Semaphore to run two parallel batches in each Semaphore job.  `make fv` now defaults to running 3 batches in parallel; I believe the previous 4-batch default was causing problems for some team members.

Note: the previous approach of using `ginkgo` to execute the test binary doesn't work for the Semaphore use case because `ginkgo` doesn't support running a subset of the batches.  We need to do that because a single Semaphore box can only handle 1-2 batches in parallel and the tests take too long if we run them sequentially.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
