### PR TITLE
Sync IPSets over Policy Sync API

### DIFF
--- a/policysync/ipset.go
+++ b/policysync/ipset.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policysync
+
+import (
+	"fmt"
+
+	"github.com/projectcalico/felix/ipsets"
+	"github.com/projectcalico/felix/proto"
+	"github.com/projectcalico/libcalico-go/lib/set"
+)
+
+type ipSetInfo struct {
+	ipsets.IPSetMetadata
+	members set.Set
+}
+
+func newIPSet(update *proto.IPSetUpdate) *ipSetInfo {
+	s := &ipSetInfo{}
+
+	switch update.GetType() {
+	case proto.IPSetUpdate_IP:
+		s.Type = ipsets.IPSetTypeHashIP
+	case proto.IPSetUpdate_IP_AND_PORT:
+		s.Type = ipsets.IPSetTypeHashIPPort
+	case proto.IPSetUpdate_NET:
+		s.Type = ipsets.IPSetTypeHashNet
+	}
+
+	s.SetID = update.GetId()
+
+	// Note: We ignore MaxSize.
+
+	s.replaceMembers(update)
+	return s
+}
+
+func (s *ipSetInfo) replaceMembers(update *proto.IPSetUpdate) {
+	s.members = set.New()
+	for _, ms := range update.GetMembers() {
+		s.members.Add(s.Type.CanonicaliseMember(ms))
+	}
+}
+
+func (s *ipSetInfo) deltaUpdate(update *proto.IPSetDeltaUpdate) {
+	for _, ms := range update.GetAddedMembers() {
+		s.members.Add(s.Type.CanonicaliseMember(ms))
+	}
+	for _, ms := range update.GetRemovedMembers() {
+		s.members.Discard(s.Type.CanonicaliseMember(ms))
+	}
+}
+
+func (s *ipSetInfo) getIPSetUpdate() *proto.IPSetUpdate {
+	u := &proto.IPSetUpdate{Id: s.SetID}
+	s.members.Iter(func(item interface{}) error {
+		m := item.(fmt.Stringer)
+		u.Members = append(u.Members, m.String())
+		return nil
+	})
+	return u
+}
+
+type ruleList interface {
+	GetInboundRules() []*proto.Rule
+	GetOutboundRules() []*proto.Rule
+}
+
+func addIPSetsRuleList(rl ruleList, s map[string]bool) {
+	for _, rule := range rl.GetInboundRules() {
+		addIPSetsRule(rule, s)
+	}
+	for _, rule := range rl.GetOutboundRules() {
+		addIPSetsRule(rule, s)
+	}
+}
+
+func addIPSetsRule(r *proto.Rule, s map[string]bool) {
+	addAll(r.SrcIpSetIds, s)
+	addAll(r.DstIpSetIds, s)
+	addAll(r.SrcNamedPortIpSetIds, s)
+	addAll(r.DstNamedPortIpSetIds, s)
+	addAll(r.NotSrcIpSetIds, s)
+	addAll(r.NotDstIpSetIds, s)
+	addAll(r.NotSrcNamedPortIpSetIds, s)
+	addAll(r.NotDstNamedPortIpSetIds, s)
+}
+
+func addAll(items []string, s map[string]bool) {
+	for _, i := range items {
+		s[i] = true
+	}
+}

--- a/policysync/ipset.go
+++ b/policysync/ipset.go
@@ -37,6 +37,8 @@ func newIPSet(update *proto.IPSetUpdate) *ipSetInfo {
 		s.Type = ipsets.IPSetTypeHashIPPort
 	case proto.IPSetUpdate_NET:
 		s.Type = ipsets.IPSetTypeHashNet
+	default:
+		panic("unknown IPSetType")
 	}
 
 	s.SetID = update.GetId()
@@ -80,14 +82,14 @@ type ruleList interface {
 
 func addIPSetsRuleList(rl ruleList, s map[string]bool) {
 	for _, rule := range rl.GetInboundRules() {
-		addIPSetsRule(rule, s)
+		AddIPSetsRule(rule, s)
 	}
 	for _, rule := range rl.GetOutboundRules() {
-		addIPSetsRule(rule, s)
+		AddIPSetsRule(rule, s)
 	}
 }
 
-func addIPSetsRule(r *proto.Rule, s map[string]bool) {
+func AddIPSetsRule(r *proto.Rule, s map[string]bool) {
 	addAll(r.SrcIpSetIds, s)
 	addAll(r.DstIpSetIds, s)
 	addAll(r.SrcNamedPortIpSetIds, s)

--- a/policysync/ipset.go
+++ b/policysync/ipset.go
@@ -20,6 +20,8 @@ import (
 	"github.com/projectcalico/felix/ipsets"
 	"github.com/projectcalico/felix/proto"
 	"github.com/projectcalico/libcalico-go/lib/set"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type ipSetInfo struct {
@@ -38,7 +40,7 @@ func newIPSet(update *proto.IPSetUpdate) *ipSetInfo {
 	case proto.IPSetUpdate_NET:
 		s.Type = ipsets.IPSetTypeHashNet
 	default:
-		panic("unknown IPSetType")
+		log.WithField("IPSetType", update.GetType()).Panic("unknown IPSetType")
 	}
 
 	s.SetID = update.GetId()

--- a/policysync/ipset_test.go
+++ b/policysync/ipset_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policysync_test
+
+import (
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/policysync"
+	"github.com/projectcalico/felix/proto"
+
+	"strings"
+)
+
+var _ = Describe("AddIPSetsRule", func() {
+
+	It("should add all fields that end in IpSetIds", func() {
+		r := proto.Rule{}
+		var fields []string
+		rt := reflect.TypeOf(r)
+		rv := reflect.ValueOf(&r)
+		for i := 0; i < rt.NumField(); i++ {
+			fn := rt.Field(i).Name
+			if strings.HasSuffix(fn, "IpSetIds") {
+				fields = append(fields, fn)
+				fv := rv.Elem().Field(i)
+				fv.Set(reflect.ValueOf([]string{fn}))
+			}
+		}
+		result := make(map[string]bool)
+		policysync.AddIPSetsRule(&r, result)
+		for _, fn := range fields {
+			Expect(result[fn]).To(BeTrue())
+		}
+	})
+})

--- a/policysync/policy.go
+++ b/policysync/policy.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policysync
+
+import (
+	"github.com/projectcalico/felix/proto"
+)
+
+type policyInfo struct {
+	p    *proto.Policy
+	refs map[string]bool
+}
+
+func newPolicyInfo(p *proto.Policy) *policyInfo {
+	i := &policyInfo{p: p}
+	i.computeRefs()
+	return i
+}
+
+func (pi *policyInfo) referencesIPSet(id string) bool {
+	return pi.refs[id]
+}
+
+func (pi *policyInfo) computeRefs() {
+	pi.refs = make(map[string]bool)
+	addIPSetsRuleList(pi.p, pi.refs)
+}

--- a/policysync/processor_test.go
+++ b/policysync/processor_test.go
@@ -16,6 +16,8 @@ package policysync_test
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -23,6 +25,9 @@ import (
 	"github.com/projectcalico/felix/policysync"
 	"github.com/projectcalico/felix/proto"
 )
+
+const IPSetName = "testset"
+const ProfileName = "testpro"
 
 var _ = Describe("Processor", func() {
 	var uut *policysync.Processor
@@ -293,6 +298,314 @@ var _ = Describe("Processor", func() {
 
 			})
 		})
+
+		Describe("IP Set updates", func() {
+
+			Context("with two joined endpoints, one with active profile", func() {
+				var refdOutput chan proto.ToDataplane
+				var unrefdOutput chan proto.ToDataplane
+				var refdId proto.WorkloadEndpointID
+				var unrefdId proto.WorkloadEndpointID
+				var assertInactiveNoUpdate func()
+
+				BeforeEach(func(done Done) {
+					refdId = testId("refd")
+					refdOutput, _ = join("refd")
+					unrefdId = testId("unrefd")
+					unrefdOutput, _ = join("unrefd")
+
+					// Ensure the joins are completed by sending a workload endpoint for each.
+					updates <- &proto.WorkloadEndpointUpdate{
+						Id:       &refdId,
+						Endpoint: &proto.WorkloadEndpoint{},
+					}
+					<-refdOutput
+					updates <- &proto.WorkloadEndpointUpdate{
+						Id:       &unrefdId,
+						Endpoint: &proto.WorkloadEndpoint{},
+					}
+					<-unrefdOutput
+
+					// Send the IPSet, a Profile referring to it, and a WEP update referring to the
+					// Profile. This "activates" the WEP relative to the IPSet
+					updates <- updateIpSet(IPSetName, 0)
+					updates <- &proto.ActiveProfileUpdate{
+						Id: &proto.ProfileID{Name: ProfileName},
+						Profile: &proto.Profile{InboundRules: []*proto.Rule{
+							{
+								Action:      "allow",
+								SrcIpSetIds: []string{IPSetName},
+							},
+						}},
+					}
+					updates <- &proto.WorkloadEndpointUpdate{
+						Id:       &refdId,
+						Endpoint: &proto.WorkloadEndpoint{ProfileIds: []string{ProfileName}},
+					}
+					// All three updates get pushed to the active endpoint (1)
+					<-refdOutput
+					<-refdOutput
+					<-refdOutput
+
+					assertInactiveNoUpdate = func() {
+						// Send a WEP update for the inactive and check we get it from the output
+						// channel. This ensures that the inactive endpoint didn't get the IPSetUpdate
+						// without having to wait for a timeout.
+						updates <- &proto.WorkloadEndpointUpdate{
+							Id:       &unrefdId,
+							Endpoint: &proto.WorkloadEndpoint{},
+						}
+						wep := <-unrefdOutput
+						Expect(wep.GetWorkloadEndpointUpdate().GetId()).To(Equal(&unrefdId))
+					}
+
+					close(done)
+				})
+
+				It("should send IPSetUpdate to only to ref'd endpoint", func(done Done) {
+					msg := updateIpSet(IPSetName, 2)
+					updates <- msg
+					g := <-refdOutput
+					Expect(g).To(Equal(proto.ToDataplane{Payload: &proto.ToDataplane_IpsetUpdate{msg}}))
+
+					assertInactiveNoUpdate()
+					close(done)
+				})
+
+				It("should split large IPSetUpdate", func(done Done) {
+					msg := updateIpSet(IPSetName, 82250)
+					updates <- msg
+
+					out := <-refdOutput
+					Expect(len(out.GetIpsetUpdate().GetMembers())).To(Equal(82200))
+					out = <-refdOutput
+					Expect(len(out.GetIpsetDeltaUpdate().GetAddedMembers())).To(Equal(50))
+					close(done)
+				})
+
+				It("should send IPSetDeltaUpdate to ref'd endpoint", func(done Done) {
+
+					// Try combinations of adds, removes, and both to ensure the splitting logic
+					// doesn't split these up strangely.
+
+					msg2 := deltaUpdateIpSet(IPSetName, 2, 2)
+					updates <- msg2
+					g := <-refdOutput
+					Expect(g).To(Equal(proto.ToDataplane{
+						Payload: &proto.ToDataplane_IpsetDeltaUpdate{msg2}}))
+
+					msg2 = deltaUpdateIpSet(IPSetName, 2, 0)
+					updates <- msg2
+					g = <-refdOutput
+					// Split these tests to separate expects for add and delete so that
+					// we don't distinguish nil vs [] for empty lists.
+					Expect(g.GetIpsetDeltaUpdate().GetAddedMembers()).To(Equal(msg2.AddedMembers))
+					Expect(len(g.GetIpsetDeltaUpdate().GetRemovedMembers())).To(Equal(0))
+
+					msg2 = deltaUpdateIpSet(IPSetName, 0, 2)
+					updates <- msg2
+					g = <-refdOutput
+					// Split these tests to separate expects for add and delete so that
+					// we don't distinguish nil vs [] for empty lists.
+					Expect(len(g.GetIpsetDeltaUpdate().GetAddedMembers())).To(Equal(0))
+					Expect(g.GetIpsetDeltaUpdate().GetRemovedMembers()).To(Equal(msg2.RemovedMembers))
+
+					assertInactiveNoUpdate()
+
+					close(done)
+				})
+
+				It("should split IpSetDeltaUpdates with large adds", func(done Done) {
+					msg2 := deltaUpdateIpSet(IPSetName, 82250, 0)
+					updates <- msg2
+					out := <-refdOutput
+					Expect(len(out.GetIpsetDeltaUpdate().GetAddedMembers())).To(Equal(82200))
+					Expect(len(out.GetIpsetDeltaUpdate().GetRemovedMembers())).To(Equal(0))
+					out = <-refdOutput
+					Expect(len(out.GetIpsetDeltaUpdate().GetAddedMembers())).To(Equal(50))
+					Expect(len(out.GetIpsetDeltaUpdate().GetRemovedMembers())).To(Equal(0))
+
+					close(done)
+				})
+
+				It("should split IpSetDeltaUpdates with large removes", func(done Done) {
+					msg2 := deltaUpdateIpSet(IPSetName, 0, 82250)
+					updates <- msg2
+					out := <-refdOutput
+					Expect(len(out.GetIpsetDeltaUpdate().GetAddedMembers())).To(Equal(0))
+					Expect(len(out.GetIpsetDeltaUpdate().GetRemovedMembers())).To(Equal(50))
+					out = <-refdOutput
+					Expect(len(out.GetIpsetDeltaUpdate().GetAddedMembers())).To(Equal(0))
+					Expect(len(out.GetIpsetDeltaUpdate().GetRemovedMembers())).To(Equal(82200))
+
+					close(done)
+				})
+
+				It("should split IpSetDeltaUpdates with both large adds and removes", func(done Done) {
+					msg2 := deltaUpdateIpSet(IPSetName, 82250, 82250)
+					updates <- msg2
+					out := <-refdOutput
+					Expect(len(out.GetIpsetDeltaUpdate().GetAddedMembers())).To(Equal(82200))
+					Expect(len(out.GetIpsetDeltaUpdate().GetRemovedMembers())).To(Equal(0))
+					out = <-refdOutput
+					Expect(len(out.GetIpsetDeltaUpdate().GetAddedMembers())).To(Equal(50))
+					Expect(len(out.GetIpsetDeltaUpdate().GetRemovedMembers())).To(Equal(50))
+					out = <-refdOutput
+					Expect(len(out.GetIpsetDeltaUpdate().GetAddedMembers())).To(Equal(0))
+					Expect(len(out.GetIpsetDeltaUpdate().GetRemovedMembers())).To(Equal(82200))
+
+					close(done)
+				})
+
+				It("should send IPSetUpdate when endpoint newly refs wep update", func(done Done) {
+					updates <- &proto.WorkloadEndpointUpdate{
+						Id:       &unrefdId,
+						Endpoint: &proto.WorkloadEndpoint{ProfileIds: []string{ProfileName}},
+					}
+					g := <-unrefdOutput
+					Expect(g.GetIpsetUpdate().GetId()).To(Equal(IPSetName))
+					Expect(len(g.GetIpsetUpdate().GetMembers())).To(Equal(0))
+					<-unrefdOutput // should also send WEP Update
+
+					close(done)
+				})
+
+				It("should send IPSetRemove when endpoint stops ref wep update", func(done Done) {
+					updates <- &proto.WorkloadEndpointUpdate{
+						Id:       &refdId,
+						Endpoint: &proto.WorkloadEndpoint{ProfileIds: []string{}},
+					}
+					g := <-refdOutput
+					Expect(g.GetWorkloadEndpointUpdate().GetId()).To(Equal(&refdId))
+					g = <-refdOutput
+					Expect(g.GetActiveProfileRemove().GetId().GetName()).To(Equal(ProfileName))
+					g = <-refdOutput
+					Expect(g.GetIpsetRemove().GetId()).To(Equal(IPSetName))
+
+					// Remove the IPSet since nothing references it.
+					updates <- removeIpSet(IPSetName)
+
+					// Send & receive a repeat WEPUpdate to ensure we didn't get a second remove.
+					updates <- &proto.WorkloadEndpointUpdate{
+						Id:       &refdId,
+						Endpoint: &proto.WorkloadEndpoint{ProfileIds: []string{}},
+					}
+					g = <-refdOutput
+					Expect(g.GetWorkloadEndpointUpdate().GetId()).To(Equal(&refdId))
+
+					assertInactiveNoUpdate()
+					close(done)
+				})
+
+				It("should send IPSetUpdate when endpoint newly refs profile update", func(done Done) {
+					newSetName := "new-set"
+					updates <- updateIpSet(newSetName, 6)
+					updates <- &proto.ActiveProfileUpdate{
+						Id: &proto.ProfileID{Name: ProfileName},
+						Profile: &proto.Profile{
+							InboundRules: []*proto.Rule{
+								{Action: "allow", SrcIpSetIds: []string{IPSetName, newSetName}},
+							},
+						},
+					}
+
+					// We should get the IPSetUpdate first, then the Profile that newly references it.
+					g := <-refdOutput
+					Expect(g.GetIpsetUpdate().GetId()).To(Equal(newSetName))
+					Expect(len(g.GetIpsetUpdate().GetMembers())).To(Equal(6))
+
+					g = <-refdOutput
+					Expect(g.GetActiveProfileUpdate().GetId().GetName()).To(Equal(ProfileName))
+
+					assertInactiveNoUpdate()
+
+					close(done)
+				})
+
+				It("should send IPSetRemove when endpoint stops ref profile update", func(done Done) {
+					updates <- &proto.ActiveProfileUpdate{
+						Id: &proto.ProfileID{Name: ProfileName},
+						Profile: &proto.Profile{
+							InboundRules: []*proto.Rule{
+								{Action: "allow", SrcIpSetIds: []string{}},
+							},
+						},
+					}
+
+					// We should get ActiveProfileUpdate first, then IPSetRemove.
+					g := <-refdOutput
+					Expect(g.GetActiveProfileUpdate().GetId().GetName()).To(Equal(ProfileName))
+					g = <-refdOutput
+					Expect(g.GetIpsetRemove().GetId()).To(Equal(IPSetName))
+
+					assertInactiveNoUpdate()
+
+					close(done)
+				})
+
+				It("should send IPSetUpdate/Remove when endpoint newly refs policy update", func(done Done) {
+					// Create the policy without the ref, and link it to the unref'd WEP.
+					policyID := &proto.PolicyID{Tier: "tier0", Name: "testpolicy"}
+					updates <- &proto.ActivePolicyUpdate{
+						Id: policyID,
+						Policy: &proto.Policy{
+							OutboundRules: []*proto.Rule{
+								{Action: "allow", SrcIpSetIds: []string{}},
+							},
+						},
+					}
+					updates <- &proto.WorkloadEndpointUpdate{
+						Id: &unrefdId,
+						Endpoint: &proto.WorkloadEndpoint{
+							Tiers: []*proto.TierInfo{
+								{
+									Name:            policyID.Tier,
+									IngressPolicies: []string{policyID.Name},
+								},
+							},
+						},
+					}
+					g := <-unrefdOutput
+					Expect(g.GetActivePolicyUpdate().GetId()).To(Equal(policyID))
+					g = <-unrefdOutput
+					Expect(g.GetWorkloadEndpointUpdate()).ToNot(BeNil())
+
+					// Now the WEP has an active policy that doesn't reference the IPSet. Send in
+					// a Policy update that references the IPSet.
+					updates <- &proto.ActivePolicyUpdate{
+						Id: policyID,
+						Policy: &proto.Policy{
+							OutboundRules: []*proto.Rule{
+								{Action: "allow", SrcIpSetIds: []string{IPSetName}},
+							},
+						},
+					}
+
+					// Should get IPSetUpdate, followed by Policy update
+					g = <-unrefdOutput
+					Expect(g.GetIpsetUpdate().GetId()).To(Equal(IPSetName))
+					g = <-unrefdOutput
+					Expect(g.GetActivePolicyUpdate().GetId()).To(Equal(policyID))
+
+					// Now, remove the ref and get an IPSetRemove
+					updates <- &proto.ActivePolicyUpdate{
+						Id: policyID,
+						Policy: &proto.Policy{
+							OutboundRules: []*proto.Rule{
+								{Action: "allow", SrcIpSetIds: []string{}},
+							},
+						},
+					}
+
+					g = <-unrefdOutput
+					Expect(g.GetActivePolicyUpdate().GetId()).To(Equal(policyID))
+					g = <-unrefdOutput
+					Expect(g.GetIpsetRemove().GetId()).To(Equal(IPSetName))
+					close(done)
+				})
+
+			})
+		})
 	})
 })
 
@@ -302,4 +615,44 @@ func testId(w string) proto.WorkloadEndpointID {
 		WorkloadId:     w,
 		EndpointId:     "test",
 	}
+}
+
+func updateIpSet(id string, num int) *proto.IPSetUpdate {
+	msg := &proto.IPSetUpdate{
+		Id:   id,
+		Type: proto.IPSetUpdate_IP,
+	}
+	for i := 0; i < num; i++ {
+		msg.Members = append(msg.Members, makeIP(i))
+	}
+	return msg
+}
+
+func removeIpSet(id string) *proto.IPSetRemove {
+	msg := &proto.IPSetRemove{
+		Id: id,
+	}
+	return msg
+}
+
+func deltaUpdateIpSet(id string, add, del int) *proto.IPSetDeltaUpdate {
+	msg := &proto.IPSetDeltaUpdate{
+		Id: id,
+	}
+	for i := 0; i < add; i++ {
+		msg.AddedMembers = append(msg.AddedMembers, makeIP(i))
+	}
+	for i := add; i < add+del; i++ {
+		msg.RemovedMembers = append(msg.RemovedMembers, makeIP(i))
+	}
+	return msg
+}
+
+func makeIP(i int) string {
+	o := make([]string, 4)
+	o[0] = strconv.Itoa(i & 0xff000000 >> 24)
+	o[1] = strconv.Itoa(i & 0x00ff0000 >> 16)
+	o[2] = strconv.Itoa(i & 0x0000ff00 >> 8)
+	o[3] = strconv.Itoa(i & 0x000000ff)
+	return strings.Join(o, ".")
 }

--- a/policysync/profile.go
+++ b/policysync/profile.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policysync
+
+import (
+	"github.com/projectcalico/felix/proto"
+)
+
+type profileInfo struct {
+	p    *proto.Profile
+	refs map[string]bool
+}
+
+func newProfileInfo(p *proto.Profile) *profileInfo {
+	i := &profileInfo{p: p}
+	i.computeRefs()
+	return i
+}
+
+func (pi *profileInfo) referencesIPSet(id string) bool {
+	return pi.refs[id]
+}
+
+func (pi *profileInfo) computeRefs() {
+	pi.refs = make(map[string]bool)
+	addIPSetsRuleList(pi.p, pi.refs)
+}


### PR DESCRIPTION
## Description
Sync IPSets over the Policy Sync API

Handles splitting up large sets into multiple messages.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan
- [x] Documentation in plan

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
