### PR TITLE
NetworkSet CIDRs in canonical format

### DIFF
--- a/ip/ip_addr.go
+++ b/ip/ip_addr.go
@@ -187,7 +187,7 @@ func CIDRFromCalicoNet(ipNet calinet.IPNet) CIDR {
 func CIDRFromIPNet(ipNet *net.IPNet) CIDR {
 	ones, _ := ipNet.Mask.Size()
 	// Mask the IP before creating the CIDR so that we have it in canonical format.
-	ip := FromNetIP(getMaskedIp(ipNet))
+	ip := FromNetIP(ipNet.IP.Mask(ipNet.Mask))
 	if ip.Version() == 4 {
 		return V4CIDR{
 			addr:   ip.(V4Addr),
@@ -199,14 +199,6 @@ func CIDRFromIPNet(ipNet *net.IPNet) CIDR {
 			prefix: uint8(ones),
 		}
 	}
-}
-
-func getMaskedIp(ipNet *net.IPNet) net.IP {
-	var ip net.IP
-	for i, octet := range ipNet.IP {
-		ip = append(ip, octet&ipNet.Mask[i])
-	}
-	return ip
 }
 
 // CIDRFromNetIP converts the given IP into our CIDR representation as a /32 or /128.

--- a/ip/ip_addr.go
+++ b/ip/ip_addr.go
@@ -186,7 +186,8 @@ func CIDRFromCalicoNet(ipNet calinet.IPNet) CIDR {
 
 func CIDRFromIPNet(ipNet *net.IPNet) CIDR {
 	ones, _ := ipNet.Mask.Size()
-	ip := FromNetIP(ipNet.IP)
+	// Mask the IP before creating the CIDR so that we have it in canonical format.
+	ip := FromNetIP(getMaskedIp(ipNet))
 	if ip.Version() == 4 {
 		return V4CIDR{
 			addr:   ip.(V4Addr),
@@ -198,6 +199,14 @@ func CIDRFromIPNet(ipNet *net.IPNet) CIDR {
 			prefix: uint8(ones),
 		}
 	}
+}
+
+func getMaskedIp(ipNet *net.IPNet) net.IP {
+	var ip net.IP
+	for i, octet := range ipNet.IP {
+		ip = append(ip, octet&ipNet.Mask[i])
+	}
+	return ip
 }
 
 // CIDRFromNetIP converts the given IP into our CIDR representation as a /32 or /128.

--- a/labelindex/named_port_index_test.go
+++ b/labelindex/named_port_index_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labelindex_test
+
+import (
+	. "github.com/projectcalico/felix/labelindex"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"net"
+
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	calinet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/selector"
+)
+
+var _ = Describe("SelectorAndNamedPortIndex", func() {
+	var uut *SelectorAndNamedPortIndex
+	var recorder *testRecorder
+
+	BeforeEach(func() {
+		uut = NewSelectorAndNamedPortIndex()
+		recorder = &testRecorder{ipsets: make(map[string]map[IPSetMember]bool)}
+		uut.OnMemberAdded = recorder.OnMemberAdded
+		uut.OnMemberRemoved = recorder.OnMemberRemoved
+	})
+
+	Describe("NetworkSet CIDRs", func() {
+		It("should include equivalent CIDRs only once", func() {
+			uut.OnUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key: model.NetworkSetKey{Name: "blinky"},
+					Value: &model.NetworkSet{
+						Nets: []calinet.IPNet{
+							{net.IPNet{
+								IP:   net.IP{192, 168, 4, 10},
+								Mask: net.IPMask{255, 255, 0, 0},
+							}},
+						},
+						Labels: map[string]string{"villain": "ghost"},
+					},
+				},
+			})
+			uut.OnUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key: model.NetworkSetKey{Name: "inky"},
+					Value: &model.NetworkSet{
+						Nets: []calinet.IPNet{
+							{net.IPNet{
+								IP:   net.IP{192, 168, 20, 1},
+								Mask: net.IPMask{255, 255, 0, 0},
+							}},
+						},
+						Labels: map[string]string{"villain": "ghost"},
+					},
+				},
+			})
+			s, err := selector.Parse("villain == 'ghost'")
+			Expect(err).ToNot(HaveOccurred())
+			uut.UpdateIPSet("villains", s, ProtocolNone, "")
+			set, ok := recorder.ipsets["villains"]
+			Expect(ok).To(BeTrue())
+			Expect(set).To(HaveLen(1))
+		})
+	})
+})
+
+type testRecorder struct {
+	ipsets map[string]map[IPSetMember]bool
+}
+
+func (t *testRecorder) OnMemberAdded(ipSetID string, member IPSetMember) {
+	s := t.ipsets[ipSetID]
+	if s == nil {
+		s = make(map[IPSetMember]bool)
+		t.ipsets[ipSetID] = s
+	}
+	s[member] = true
+}
+
+func (t *testRecorder) OnMemberRemoved(ipSetID string, member IPSetMember) {
+	s := t.ipsets[ipSetID]
+	delete(s, member)
+	if len(s) == 0 {
+		delete(t.ipsets, ipSetID)
+	}
+}


### PR DESCRIPTION
## Description
Fixes #1735 

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) Not needed
- [ ] Release note

## Release Note
I believe no release note is required because this affects Network Sets, which were not shipped in 3.0.x. @fasaxc please confirm.

```release-note
None required
```
