### PR TITLE
standard makefile targets and multi-arch push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ junit.xml
 /k8sfv/prometheus/data
 /k8sfv/prometheus/prometheus.yml
 /k8sfv/output/
+

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ your contribution.
 ## How do I build Felix?
 
 Felix mostly uses Docker for builds.  We develop on Ubuntu 16.04 but other
-Linux distributions should work (there are known Makefile that prevent building on OS X).  
+Linux distributions should work (there are known `Makefile` issues that prevent building on OS X).  
 To build Felix, you will need:
 
 - A suitable linux box.
@@ -53,15 +53,37 @@ Then, as a one-off, run
 make update-tools
 ```
 which will install a couple more go tools that we haven't yet containerised.
- 
+
 Then, to build the calico-felix binary:
 ```
-make bin/calico-felix
+make build
 ```
 or, the `calico/felix` docker image:
 ```
-make calico/felix
+make image
 ```
+
+### Other architectures
+When you run `make build` or `make image`, it creates the felix binary or docker image for linux on your architecture. The outputs are as follows:
+
+* Binary: `bin/calico-felix-${ARCH}`, e.g. `bin/calico-felix-amd64` or `bin/calico-felix-arm64`
+* Image: `calico/felix:${TAG}-${ARCH}`, e.g. `calico/felix:3.0.0-amd64` or `calico/felix:latest-ppc64le`
+
+When you are running on `amd64`, you can build the binaries and images for other platforms by setting the `ARCH` variable. For example:
+
+```
+$ make build ARCH=arm64 # OR
+$ make image ARCH=ppc64le
+```
+
+If you wish to make **all** of the binaries or images, use the standard calico project targets `build-all` and `image-all`:
+
+```
+$ make build-all # OR
+$ make image-all
+```
+
+Note that the `image` and `image-all` targets have the `build` targets as a depedency.
 
 ## How can I run Felix's unit tests?
 
@@ -79,7 +101,7 @@ To get coverage stats:
 ```
 make cover-report
 ```
-or 
+or
 ```
 make cover-browser
 ```
@@ -108,7 +130,7 @@ Ginkgo will re-run tests as files are modified and saved.
 
 ### Docker
 
-After building the docker image (see above), you can run Felix and log to screen 
+After building the docker image (see above), you can run Felix and log to screen
 with, for example:
 
 ```


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

* adds calico-project-standard `build` and `image` targets to wrap `bin/calico-felix` and `calico/felix`, respectively
* adds calico-project-standard `build-all` and `image-all` targets to build and image for all supported architectures 
* adds calico-project-standard `push` and `push-all` targets to push images to docker hub and quay.io, pushing arch-less tags as `linux-amd64` until such time as multi-arch manifests are supported
* updates `README.md` to describe the targets

This should make it much easier for our process to simply "build and deploy for all architectures"

As discussed on slack with @fasaxc and @caseydavenport 

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->
Multi-arch image support

```release-note
None required
```