### PR TITLE
v2.6 Whitelist failsafe port response traffic in the raw table only

### DIFF
--- a/fv/donottrack_test.go
+++ b/fv/donottrack_test.go
@@ -1,0 +1,279 @@
+// +build fvtests
+
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/fv/containers"
+	"github.com/projectcalico/felix/fv/workload"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+)
+
+var _ = Context("do-not-track policy tests; with 2 nodes", func() {
+
+	var (
+		etcd        *containers.Container
+		felixes     []*containers.Felix
+		hostW       [2]*workload.Workload
+		client      client.Interface
+		cc          *workload.ConnectivityChecker
+		dumpedDiags bool
+	)
+
+	BeforeEach(func() {
+		dumpedDiags = false
+		options := containers.DefaultTopologyOptions()
+		felixes, etcd, client = containers.StartNNodeEtcdTopology(2, options)
+		cc = &workload.ConnectivityChecker{}
+
+		// Start a host networked workload on each host for connectivity checks.
+		for ii := range felixes {
+			// We tell each workload to open:
+			// - its normal (uninteresting) port, 8055
+			// - port 2379, which is both an inbound and an outbound failsafe port
+			// - port 22, which is an inbound failsafe port.
+			// This allows us to test the interaction between do-not-track policy and failsafe
+			// ports.
+			const portsToOpen = "8055,2379,22"
+			hostW[ii] = workload.Run(
+				felixes[ii],
+				fmt.Sprintf("host%d", ii),
+				"", // No interface name means "run in the host's namespace"
+				felixes[ii].IP,
+				portsToOpen,
+				"tcp")
+		}
+	})
+
+	// Utility function to dump diags if the test failed.  Should be called in the inner-most
+	// AfterEach() to dump diags before the test is torn down.  Only the first call for a given
+	// test has any effect.
+	dumpDiags := func() {
+		if !CurrentGinkgoTestDescription().Failed || dumpedDiags {
+			return
+		}
+		for ii := range felixes {
+			iptSave, err := felixes[ii].ExecOutput("iptables-save", "-c")
+			if err == nil {
+				log.WithField("felix", ii).Info("iptables-save:\n" + iptSave)
+			}
+			ipR, err := felixes[ii].ExecOutput("ip", "r")
+			if err == nil {
+				log.WithField("felix", ii).Info("ip route:\n" + ipR)
+			}
+		}
+		etcd.Exec("etcdctl", "ls", "--recursive", "/")
+
+	}
+
+	AfterEach(func() {
+		dumpDiags()
+		for _, f := range felixes {
+			f.Stop()
+		}
+		etcd.Stop()
+	})
+
+	expectFullConnectivity := func() {
+		cc.ResetExpectations()
+		cc.ExpectSome(felixes[0], hostW[1].Port(8055))
+		cc.ExpectSome(felixes[1], hostW[0].Port(8055))
+		cc.ExpectSome(felixes[0], hostW[1].Port(2379))
+		cc.ExpectSome(felixes[1], hostW[0].Port(2379))
+		cc.ExpectSome(felixes[0], hostW[1].Port(22))
+		cc.ExpectSome(felixes[1], hostW[0].Port(22))
+		cc.ExpectSome(etcd, hostW[1].Port(22))
+		cc.ExpectSome(etcd, hostW[0].Port(22))
+		cc.CheckConnectivityOffset(1)
+	}
+
+	It("before adding policy, should have connectivity between hosts", func() {
+		expectFullConnectivity()
+	})
+
+	Context("after adding host endpoints", func() {
+		var (
+			ctx    context.Context
+			cancel context.CancelFunc
+		)
+
+		BeforeEach(func() {
+			ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+
+			for _, f := range felixes {
+				hep := api.NewHostEndpoint()
+				hep.Name = "eth0-" + f.Name
+				hep.Labels = map[string]string{
+					"name": hep.Name,
+				}
+				hep.Spec.Node = f.Hostname
+				hep.Spec.ExpectedIPs = []string{f.IP}
+				_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		AfterEach(func() {
+			dumpDiags()
+			cancel()
+		})
+
+		It("should implement untracked policy correctly", func() {
+			// This test covers both normal connectivity and failsafe connectivity.  We combine the
+			// tests because we rely on the changes of normal connectivity at each step to make sure
+			// that the policy has actually flowed through to the dataplane.
+
+			By("having only failsafe connectivity to start with")
+			cc.ExpectNone(felixes[0], hostW[1].Port(8055))
+			cc.ExpectNone(felixes[1], hostW[0].Port(8055))
+			cc.ExpectSome(felixes[0], hostW[1].Port(2379))
+			cc.ExpectSome(felixes[1], hostW[0].Port(2379))
+			// Port 22 is inbound-only so it'll be blocked by the (lack of egress policy).
+			cc.ExpectNone(felixes[0], hostW[1].Port(22))
+			cc.ExpectNone(felixes[1], hostW[0].Port(22))
+			// But etcd should still be able to access it...
+			cc.ExpectSome(etcd, hostW[1].Port(22))
+			cc.ExpectSome(etcd, hostW[0].Port(22))
+			cc.CheckConnectivity()
+
+			host0Selector := fmt.Sprintf("name == 'eth0-%s'", felixes[0].Name)
+			host1Selector := fmt.Sprintf("name == 'eth0-%s'", felixes[1].Name)
+
+			By("Having connectivity after installing bidirectional policies")
+			host0Pol := api.NewGlobalNetworkPolicy()
+			host0Pol.Name = "host-0-pol"
+			host0Pol.Spec.Selector = host0Selector
+			host0Pol.Spec.DoNotTrack = true
+			host0Pol.Spec.ApplyOnForward = true
+			host0Pol.Spec.Ingress = []api.Rule{
+				{
+					Action: api.Allow,
+					Source: api.EntityRule{
+						Selector: host1Selector,
+					},
+				},
+			}
+			host0Pol.Spec.Egress = []api.Rule{
+				{
+					Action: api.Allow,
+					Destination: api.EntityRule{
+						Selector: host1Selector,
+					},
+				},
+			}
+			host0Pol, err := client.GlobalNetworkPolicies().Create(ctx, host0Pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			host1Pol := api.NewGlobalNetworkPolicy()
+			host1Pol.Name = "host-1-pol"
+			host1Pol.Spec.Selector = host1Selector
+			host1Pol.Spec.DoNotTrack = true
+			host1Pol.Spec.ApplyOnForward = true
+			host1Pol.Spec.Ingress = []api.Rule{
+				{
+					Action: api.Allow,
+					Source: api.EntityRule{
+						Selector: host0Selector,
+					},
+				},
+			}
+			host1Pol.Spec.Egress = []api.Rule{
+				{
+					Action: api.Allow,
+					Destination: api.EntityRule{
+						Selector: host0Selector,
+					},
+				},
+			}
+			host1Pol, err = client.GlobalNetworkPolicies().Create(ctx, host1Pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			expectFullConnectivity()
+
+			By("Having only failsafe connectivity after replacing host-0's egress rules with Deny")
+			// Since there's no conntrack, removing rules in one direction is enough to prevent
+			// connectivity in either direction.
+			host0Pol.Spec.Egress = []api.Rule{
+				{
+					Action: api.Deny,
+					Destination: api.EntityRule{
+						Selector: host0Selector,
+					},
+				},
+			}
+			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			cc.ResetExpectations()
+			cc.ExpectNone(felixes[0], hostW[1].Port(8055))
+			cc.ExpectNone(felixes[1], hostW[0].Port(8055))
+			cc.ExpectSome(felixes[0], hostW[1].Port(2379))
+			cc.ExpectSome(felixes[1], hostW[0].Port(2379))
+			cc.ExpectNone(felixes[0], hostW[1].Port(22)) // Now blocked (lack of egress).
+			cc.ExpectSome(felixes[1], hostW[0].Port(22)) // Still open due to failsafe.
+			cc.ExpectSome(etcd, hostW[1].Port(22))       // Allowed by failsafe
+			cc.ExpectSome(etcd, hostW[0].Port(22))       // Allowed by failsafe
+			cc.CheckConnectivity()
+
+			By("Having full connectivity after putting them back")
+			host0Pol.Spec.Egress = []api.Rule{
+				{
+					Action: api.Allow,
+					Destination: api.EntityRule{
+						Selector: host1Selector,
+					},
+				},
+			}
+			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			expectFullConnectivity()
+
+			By("Having only failsafe connectivity after replacing host-0's ingress rules with Deny")
+			host0Pol.Spec.Ingress = []api.Rule{
+				{
+					Action: api.Deny,
+					Destination: api.EntityRule{
+						Selector: host0Selector,
+					},
+				},
+			}
+			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			cc.ResetExpectations()
+			cc.ExpectNone(felixes[0], hostW[1].Port(8055))
+			cc.ExpectNone(felixes[1], hostW[0].Port(8055))
+			cc.ExpectSome(felixes[0], hostW[1].Port(2379))
+			cc.ExpectSome(felixes[1], hostW[0].Port(2379))
+			cc.ExpectNone(felixes[0], hostW[1].Port(22)) // Response traffic blocked by policy
+			cc.ExpectSome(felixes[1], hostW[0].Port(22)) // Allowed by failsafe
+			cc.ExpectSome(etcd, hostW[1].Port(22))       // Allowed by failsafe
+			cc.ExpectSome(etcd, hostW[0].Port(22))       // Allowed by failsafe
+			cc.CheckConnectivity()
+		})
+	})
+})

--- a/fv/donottrack_test.go
+++ b/fv/donottrack_test.go
@@ -21,36 +21,50 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/projectcalico/libcalico-go/lib/net"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/projectcalico/felix/fv/utils"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/felix/fv/containers"
 	"github.com/projectcalico/felix/fv/workload"
-	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
-	client "github.com/projectcalico/libcalico-go/lib/clientv3"
-	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/client"
 )
 
 var _ = Context("do-not-track policy tests; with 2 nodes", func() {
 
 	var (
 		etcd        *containers.Container
-		felixes     []*containers.Felix
+		felixes     []*containers.Container
 		hostW       [2]*workload.Workload
-		client      client.Interface
+		client      *client.Client
 		cc          *workload.ConnectivityChecker
 		dumpedDiags bool
 	)
 
 	BeforeEach(func() {
 		dumpedDiags = false
-		options := containers.DefaultTopologyOptions()
-		felixes, etcd, client = containers.StartNNodeEtcdTopology(2, options)
+
+		etcd = containers.RunEtcd()
+
+		client = utils.GetEtcdClient(etcd.IP)
+		Eventually(client.EnsureInitialized, "10s", "1s").ShouldNot(HaveOccurred())
+
 		cc = &workload.ConnectivityChecker{}
 
 		// Start a host networked workload on each host for connectivity checks.
-		for ii := range felixes {
+		for ii := 0; ii < 2; ii++ {
+			felix := containers.RunFelix(etcd.IP)
+
+			felixNode := api.NewNode()
+			felixNode.Metadata.Name = felix.Hostname
+			_, err := client.Nodes().Create(felixNode)
+			Expect(err).NotTo(HaveOccurred())
+			felixes = append(felixes, felix)
+
 			// We tell each workload to open:
 			// - its normal (uninteresting) port, 8055
 			// - port 2379, which is both an inbound and an outbound failsafe port
@@ -59,12 +73,12 @@ var _ = Context("do-not-track policy tests; with 2 nodes", func() {
 			// ports.
 			const portsToOpen = "8055,2379,22"
 			hostW[ii] = workload.Run(
-				felixes[ii],
+				felix,
 				fmt.Sprintf("host%d", ii),
 				"", // No interface name means "run in the host's namespace"
 				felixes[ii].IP,
 				portsToOpen,
-				"tcp")
+			)
 		}
 	})
 
@@ -125,13 +139,13 @@ var _ = Context("do-not-track policy tests; with 2 nodes", func() {
 
 			for _, f := range felixes {
 				hep := api.NewHostEndpoint()
-				hep.Name = "eth0-" + f.Name
-				hep.Labels = map[string]string{
-					"name": hep.Name,
+				hep.Metadata.Name = "eth0-" + f.Name
+				hep.Metadata.Labels = map[string]string{
+					"name": hep.Metadata.Name,
 				}
-				hep.Spec.Node = f.Hostname
-				hep.Spec.ExpectedIPs = []string{f.IP}
-				_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
+				hep.Metadata.Node = f.Hostname
+				hep.Spec.ExpectedIPs = []net.IP{net.MustParseIP(f.IP)}
+				_, err := client.HostEndpoints().Create(hep)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})
@@ -149,9 +163,10 @@ var _ = Context("do-not-track policy tests; with 2 nodes", func() {
 			By("having only failsafe connectivity to start with")
 			cc.ExpectNone(felixes[0], hostW[1].Port(8055))
 			cc.ExpectNone(felixes[1], hostW[0].Port(8055))
-			cc.ExpectSome(felixes[0], hostW[1].Port(2379))
-			cc.ExpectSome(felixes[1], hostW[0].Port(2379))
-			// Port 22 is inbound-only so it'll be blocked by the (lack of egress policy).
+			// 2379 is outbound only.
+			cc.ExpectNone(felixes[0], hostW[1].Port(2379))
+			cc.ExpectNone(felixes[1], hostW[0].Port(2379))
+			// Port 22 is inbound-only so it'll be blocked by the (lack of) egress policy.
 			cc.ExpectNone(felixes[0], hostW[1].Port(22))
 			cc.ExpectNone(felixes[1], hostW[0].Port(22))
 			// But etcd should still be able to access it...
@@ -163,116 +178,114 @@ var _ = Context("do-not-track policy tests; with 2 nodes", func() {
 			host1Selector := fmt.Sprintf("name == 'eth0-%s'", felixes[1].Name)
 
 			By("Having connectivity after installing bidirectional policies")
-			host0Pol := api.NewGlobalNetworkPolicy()
-			host0Pol.Name = "host-0-pol"
+			host0Pol := api.NewPolicy()
+			host0Pol.Metadata.Name = "host-0-pol"
 			host0Pol.Spec.Selector = host0Selector
 			host0Pol.Spec.DoNotTrack = true
-			host0Pol.Spec.ApplyOnForward = true
-			host0Pol.Spec.Ingress = []api.Rule{
+			host0Pol.Spec.IngressRules = []api.Rule{
 				{
-					Action: api.Allow,
+					Action: "allow",
 					Source: api.EntityRule{
 						Selector: host1Selector,
 					},
 				},
 			}
-			host0Pol.Spec.Egress = []api.Rule{
+			host0Pol.Spec.EgressRules = []api.Rule{
 				{
-					Action: api.Allow,
+					Action: "allow",
 					Destination: api.EntityRule{
 						Selector: host1Selector,
 					},
 				},
 			}
-			host0Pol, err := client.GlobalNetworkPolicies().Create(ctx, host0Pol, options.SetOptions{})
+			host0Pol, err := client.Policies().Create(host0Pol)
 			Expect(err).NotTo(HaveOccurred())
 
-			host1Pol := api.NewGlobalNetworkPolicy()
-			host1Pol.Name = "host-1-pol"
+			host1Pol := api.NewPolicy()
+			host1Pol.Metadata.Name = "host-1-pol"
 			host1Pol.Spec.Selector = host1Selector
 			host1Pol.Spec.DoNotTrack = true
-			host1Pol.Spec.ApplyOnForward = true
-			host1Pol.Spec.Ingress = []api.Rule{
+			host1Pol.Spec.IngressRules = []api.Rule{
 				{
-					Action: api.Allow,
+					Action: "allow",
 					Source: api.EntityRule{
 						Selector: host0Selector,
 					},
 				},
 			}
-			host1Pol.Spec.Egress = []api.Rule{
+			host1Pol.Spec.EgressRules = []api.Rule{
 				{
-					Action: api.Allow,
+					Action: "allow",
 					Destination: api.EntityRule{
 						Selector: host0Selector,
 					},
 				},
 			}
-			host1Pol, err = client.GlobalNetworkPolicies().Create(ctx, host1Pol, options.SetOptions{})
+			host1Pol, err = client.Policies().Create(host1Pol)
 			Expect(err).NotTo(HaveOccurred())
 
 			expectFullConnectivity()
 
-			By("Having only failsafe connectivity after replacing host-0's egress rules with Deny")
+			By("Having only failsafe connectivity after replacing host-0's egress rules with deny")
 			// Since there's no conntrack, removing rules in one direction is enough to prevent
 			// connectivity in either direction.
-			host0Pol.Spec.Egress = []api.Rule{
+			host0Pol.Spec.EgressRules = []api.Rule{
 				{
-					Action: api.Deny,
+					Action: "deny",
 					Destination: api.EntityRule{
 						Selector: host0Selector,
 					},
 				},
 			}
-			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+			host0Pol, err = client.Policies().Update(host0Pol)
 			Expect(err).NotTo(HaveOccurred())
 
 			cc.ResetExpectations()
 			cc.ExpectNone(felixes[0], hostW[1].Port(8055))
 			cc.ExpectNone(felixes[1], hostW[0].Port(8055))
-			cc.ExpectSome(felixes[0], hostW[1].Port(2379))
-			cc.ExpectSome(felixes[1], hostW[0].Port(2379))
+			cc.ExpectSome(felixes[0], hostW[1].Port(2379)) // Allowed by host[0]'s egress failsafe + host[1]'s ingress
+			cc.ExpectNone(felixes[1], hostW[0].Port(2379))
 			cc.ExpectNone(felixes[0], hostW[1].Port(22)) // Now blocked (lack of egress).
 			cc.ExpectSome(felixes[1], hostW[0].Port(22)) // Still open due to failsafe.
-			cc.ExpectSome(etcd, hostW[1].Port(22))       // Allowed by failsafe
-			cc.ExpectSome(etcd, hostW[0].Port(22))       // Allowed by failsafe
+			cc.ExpectSome(etcd, hostW[1].Port(22))       // allowed by failsafe
+			cc.ExpectSome(etcd, hostW[0].Port(22))       // allowed by failsafe
 			cc.CheckConnectivity()
 
 			By("Having full connectivity after putting them back")
-			host0Pol.Spec.Egress = []api.Rule{
+			host0Pol.Spec.EgressRules = []api.Rule{
 				{
-					Action: api.Allow,
+					Action: "allow",
 					Destination: api.EntityRule{
 						Selector: host1Selector,
 					},
 				},
 			}
-			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+			host0Pol, err = client.Policies().Update(host0Pol)
 			Expect(err).NotTo(HaveOccurred())
 
 			expectFullConnectivity()
 
-			By("Having only failsafe connectivity after replacing host-0's ingress rules with Deny")
-			host0Pol.Spec.Ingress = []api.Rule{
+			By("Having only failsafe connectivity after replacing host-0's ingress rules with deny")
+			host0Pol.Spec.IngressRules = []api.Rule{
 				{
-					Action: api.Deny,
+					Action: "deny",
 					Destination: api.EntityRule{
 						Selector: host0Selector,
 					},
 				},
 			}
-			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+			host0Pol, err = client.Policies().Update(host0Pol)
 			Expect(err).NotTo(HaveOccurred())
 
 			cc.ResetExpectations()
 			cc.ExpectNone(felixes[0], hostW[1].Port(8055))
 			cc.ExpectNone(felixes[1], hostW[0].Port(8055))
-			cc.ExpectSome(felixes[0], hostW[1].Port(2379))
-			cc.ExpectSome(felixes[1], hostW[0].Port(2379))
+			cc.ExpectSome(felixes[0], hostW[1].Port(2379)) // allowed by host[0]'s egress failsafe + host[1]'s ingress
+			cc.ExpectNone(felixes[1], hostW[0].Port(2379))
 			cc.ExpectNone(felixes[0], hostW[1].Port(22)) // Response traffic blocked by policy
-			cc.ExpectSome(felixes[1], hostW[0].Port(22)) // Allowed by failsafe
-			cc.ExpectSome(etcd, hostW[1].Port(22))       // Allowed by failsafe
-			cc.ExpectSome(etcd, hostW[0].Port(22))       // Allowed by failsafe
+			cc.ExpectSome(felixes[1], hostW[0].Port(22)) // allowed by failsafe
+			cc.ExpectSome(etcd, hostW[1].Port(22))       // allowed by failsafe
+			cc.ExpectSome(etcd, hostW[0].Port(22))       // allowed by failsafe
 			cc.CheckConnectivity()
 		})
 	})

--- a/fv/test-connection/test-connection.go
+++ b/fv/test-connection/test-connection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,10 @@ import (
 
 	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/docopt/docopt-go"
+	reuse "github.com/jbenet/go-reuseport"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/satori/go.uuid"
 
 	"github.com/projectcalico/felix/fv/utils"
 )
@@ -32,7 +35,11 @@ import (
 const usage = `test-connection: test connection to some target, for Felix FV testing.
 
 Usage:
-  test-connection <namespace-path> <ip-address> <port>
+  test-connection <namespace-path> <ip-address> <port> [--source-port=<source>] [--protocol=<protocol>]
+
+Options:
+  --source-port=<source>  Source port to use for the connection [default: 0].
+  --protocol=<protocol>  Protocol to test [default: tcp].
 
 If connection is successful, test-connection exits successfully.
 
@@ -46,14 +53,24 @@ func main() {
 		println(usage)
 		log.WithError(err).Fatal("Failed to parse usage")
 	}
+	log.WithField("args", arguments).Info("Parsed arguments")
 	namespacePath := arguments["<namespace-path>"].(string)
 	ipAddress := arguments["<ip-address>"].(string)
 	port := arguments["<port>"].(string)
-	log.Infof("Test connection from %v to IP %v port %v", namespacePath, ipAddress, port)
+	sourcePort := arguments["--source-port"].(string)
+	log.Infof("Test connection from %v:%v to IP %v port %v", namespacePath, sourcePort, ipAddress, port)
+	protocol := arguments["--protocol"].(string)
+
+	// I found that configuring the timeouts on all the network calls was a bit fiddly.  Since
+	// it leaves the process hung if one of them is missed, use a global timeout instead.
+	go func() {
+		time.Sleep(2 * time.Second)
+		panic("Timed out")
+	}()
 
 	if namespacePath == "-" {
 		// Test connection from wherever we are already running.
-		err = tryConnect(ipAddress, port)
+		err = tryConnect(ipAddress, port, sourcePort, protocol)
 	} else {
 		// Get the specified network namespace (representing a workload).
 		var namespace ns.NetNS
@@ -65,7 +82,7 @@ func main() {
 
 		// Now, in that namespace, try connecting to the target.
 		err = namespace.Do(func(_ ns.NetNS) error {
-			return tryConnect(ipAddress, port)
+			return tryConnect(ipAddress, port, sourcePort, protocol)
 		})
 	}
 
@@ -74,29 +91,66 @@ func main() {
 	}
 }
 
-func tryConnect(ipAddress, port string) error {
+func tryConnect(ipAddress, port string, sourcePort string, protocol string) error {
 
 	err := utils.RunCommand("ip", "r")
 	if err != nil {
 		return err
 	}
 
-	const testMessage = "hello"
+	uid := uuid.NewV4().String()
+	testMessage := "hello," + uid
 
-	conn, err := net.DialTimeout("tcp", ipAddress+":"+port, 5*time.Second)
-	if err != nil {
-		return err
+	// The reuse library implements a version of net.Dialer that can reuse UDP/TCP ports, which we
+	// need in order to make connection retries work.
+	var d reuse.Dialer
+	var localAddr string
+	var remoteAddr string
+	if strings.Contains(ipAddress, ":") {
+		localAddr = "[::]:" + sourcePort
+		remoteAddr = "[" + ipAddress + "]:" + port
+	} else {
+		localAddr = "0.0.0.0:" + sourcePort
+		remoteAddr = ipAddress + ":" + port
 	}
-	defer conn.Close()
+	if protocol == "udp" {
+		log.Infof("Connecting from %v to %v", localAddr, remoteAddr)
+		d.D.LocalAddr, _ = net.ResolveUDPAddr("udp", localAddr)
+		conn, err := d.Dial("udp", remoteAddr)
+		if err != nil {
+			panic(err)
+		}
+		defer conn.Close()
 
-	fmt.Fprintf(conn, testMessage+"\n")
-	reply, err := bufio.NewReader(conn).ReadString('\n')
-	if err != nil {
-		return err
-	}
-	reply = strings.TrimSpace(reply)
-	if reply != testMessage {
-		return errors.New("Unexpected reply: " + reply)
+		fmt.Fprintf(conn, testMessage+"\n")
+		reply, err := bufio.NewReader(conn).ReadString('\n')
+		if err != nil {
+			panic(err)
+		}
+		reply = strings.TrimSpace(reply)
+		if reply != testMessage {
+			panic(errors.New("Unexpected reply: " + reply))
+		}
+	} else {
+		d.D.LocalAddr, err = net.ResolveTCPAddr("tcp", localAddr)
+		if err != nil {
+			return err
+		}
+		conn, err := d.Dial("tcp", remoteAddr)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		fmt.Fprintf(conn, testMessage+"\n")
+		reply, err := bufio.NewReader(conn).ReadString('\n')
+		if err != nil {
+			return err
+		}
+		reply = strings.TrimSpace(reply)
+		if reply != testMessage {
+			return errors.New("Unexpected reply: " + reply)
+		}
 	}
 
 	return nil

--- a/fv/test-workload/test-workload.go
+++ b/fv/test-workload/test-workload.go
@@ -74,9 +74,13 @@ func main() {
 		log.WithField("namespace", namespace).Debug("Created namespace")
 
 		// Create a veth pair.
+		peerName := "w" + interfaceName
+		if len(peerName) > 11 {
+			peerName = peerName[:11]
+		}
 		veth := &netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{Name: interfaceName},
-			PeerName:  string([]byte("w" + interfaceName)[:11]),
+			PeerName:  peerName,
 		}
 		err = netlink.LinkAdd(veth)
 		panicIfError(err)

--- a/fv/test-workload/test-workload.go
+++ b/fv/test-workload/test-workload.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"net"
+	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -30,8 +33,10 @@ import (
 
 const usage = `test-workload, test workload for Felix FV testing.
 
+If <interface-name> is "", the workload will start in the current namespace.
+
 Usage:
-  test-workload <interface-name> <ip-address> <ports>
+  test-workload [--udp] <interface-name> <ip-address> <ports>
 `
 
 func main() {
@@ -45,58 +50,145 @@ func main() {
 	interfaceName := arguments["<interface-name>"].(string)
 	ipAddress := arguments["<ip-address>"].(string)
 	portsStr := arguments["<ports>"].(string)
+	udp := arguments["--udp"].(bool)
 	panicIfError(err)
 
 	ports := strings.Split(portsStr, ",")
 
-	// Create a new network namespace for the workload.
-	namespace, err := ns.NewNS()
-	panicIfError(err)
-	log.WithField("namespace", namespace).Debug("Created namespace")
+	var namespace ns.NetNS
+	if interfaceName != "" {
+		// Create a new network namespace for the workload.
+		attempts := 0
+		for {
+			namespace, err = ns.NewNS()
+			if err == nil {
+				break
+			}
+			log.WithError(err).Error("Failed to create namespace")
+			attempts++
+			time.Sleep(1 * time.Second)
+			if attempts > 30 {
+				log.WithError(err).Panic("Giving up after multiple retries")
+			}
+		}
+		log.WithField("namespace", namespace).Debug("Created namespace")
 
-	// Create a veth pair.
-	veth := &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{Name: interfaceName},
-		PeerName:  "w" + interfaceName,
+		// Create a veth pair.
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: interfaceName},
+			PeerName:  string([]byte("w" + interfaceName)[:11]),
+		}
+		err = netlink.LinkAdd(veth)
+		panicIfError(err)
+		log.WithField("veth", veth).Debug("Created veth pair")
+
+		err := netlink.LinkSetUp(veth)
+		panicIfError(err)
+
+		peerVeth, err := netlink.LinkByName(veth.PeerName)
+		panicIfError(err)
+
+		// Need to set the peer up in order to get an IPv6 address.
+		err = netlink.LinkSetUp(peerVeth)
+		panicIfError(err)
+
+		var hostIPv6Addr net.IP
+		if strings.Contains(ipAddress, ":") {
+			attempts := 0
+			for {
+				// No need to add a dummy next hop route as the host veth device will already have an IPv6
+				// link local address that can be used as a next hop.
+				// Just fetch the address of the host end of the veth and use it as the next hop.
+				addresses, err := netlink.AddrList(veth, netlink.FAMILY_V6)
+				if err != nil {
+					log.WithError(err).Panic("Error listing IPv6 addresses for the host side of the veth pair")
+				}
+
+				if len(addresses) < 1 {
+					attempts++
+					if attempts > 30 {
+						log.WithError(err).Panic("Giving up waiting for IPv6 addresses after multiple retries")
+					}
+
+					time.Sleep(100 * time.Millisecond)
+					continue
+				}
+
+				hostIPv6Addr = addresses[0].IP
+				break
+			}
+		}
+
+		// Move the workload end of the pair into the namespace, and set it up.
+		workloadIf, err := netlink.LinkByName(veth.PeerName)
+		log.WithField("workloadIf", workloadIf).Debug("Workload end")
+		panicIfError(err)
+		err = netlink.LinkSetNsFd(workloadIf, int(namespace.Fd()))
+		panicIfError(err)
+		err = namespace.Do(func(_ ns.NetNS) (err error) {
+			err = utils.RunCommand("ip", "link", "set", veth.PeerName, "name", "eth0")
+			if err != nil {
+				return
+			}
+			err = utils.RunCommand("ip", "link", "set", "eth0", "up")
+			if err != nil {
+				return
+			}
+
+			if strings.Contains(ipAddress, ":") {
+				// Make sure ipv6 is enabled in the container/pod network namespace.
+				// Without these sysctls enabled, interfaces will come up but they won't get a link local IPv6 address,
+				// which is required to add the default IPv6 route.
+				if err = writeProcSys("/proc/sys/net/ipv6/conf/all/disable_ipv6", "0"); err != nil {
+					return
+				}
+
+				if err = writeProcSys("/proc/sys/net/ipv6/conf/default/disable_ipv6", "0"); err != nil {
+					return
+				}
+
+				if err = writeProcSys("/proc/sys/net/ipv6/conf/lo/disable_ipv6", "0"); err != nil {
+					return
+				}
+
+				err = utils.RunCommand("ip", "-6", "addr", "add", ipAddress+"/128", "dev", "eth0")
+				if err != nil {
+					return
+				}
+				err = utils.RunCommand("ip", "-6", "route", "add", "default", "via", hostIPv6Addr.String(), "dev", "eth0")
+
+				// Output the routing table to the log for diagnostic purposes.
+				utils.RunCommand("ip", "-6", "route")
+				utils.RunCommand("ip", "-6", "addr")
+			} else {
+				err = utils.RunCommand("ip", "addr", "add", ipAddress+"/32", "dev", "eth0")
+				if err != nil {
+					return
+				}
+				err = utils.RunCommand("ip", "route", "add", "169.254.169.254/32", "dev", "eth0")
+				if err != nil {
+					return
+				}
+				err = utils.RunCommand("ip", "route", "add", "default", "via", "169.254.169.254", "dev", "eth0")
+
+				// Output the routing table to the log for diagnostic purposes.
+				utils.RunCommand("ip", "route")
+				utils.RunCommand("ip", "addr")
+			}
+			return
+		})
+		panicIfError(err)
+
+		// Set the host end up too.
+		hostIf, err := netlink.LinkByName(veth.LinkAttrs.Name)
+		log.WithField("hostIf", hostIf).Debug("Host end")
+		panicIfError(err)
+		err = netlink.LinkSetUp(hostIf)
+		panicIfError(err)
+	} else {
+		namespace, err = ns.GetCurrentNS()
+		panicIfError(err)
 	}
-	err = netlink.LinkAdd(veth)
-	panicIfError(err)
-	log.WithField("veth", veth).Debug("Created veth pair")
-
-	// Move the workload end of the pair into the namespace, and set it up.
-	workloadIf, err := netlink.LinkByName(veth.PeerName)
-	log.WithField("workloadIf", workloadIf).Debug("Workload end")
-	panicIfError(err)
-	err = netlink.LinkSetNsFd(workloadIf, int(namespace.Fd()))
-	panicIfError(err)
-	err = namespace.Do(func(_ ns.NetNS) (err error) {
-		err = utils.RunCommand("ip", "link", "set", veth.PeerName, "name", "eth0")
-		if err != nil {
-			return
-		}
-		err = utils.RunCommand("ip", "link", "set", "eth0", "up")
-		if err != nil {
-			return
-		}
-		err = utils.RunCommand("ip", "addr", "add", ipAddress+"/32", "dev", "eth0")
-		if err != nil {
-			return
-		}
-		err = utils.RunCommand("ip", "route", "add", "169.254.169.254/32", "dev", "eth0")
-		if err != nil {
-			return
-		}
-		err = utils.RunCommand("ip", "route", "add", "default", "via", "169.254.169.254", "dev", "eth0")
-		return
-	})
-	panicIfError(err)
-
-	// Set the host end up too.
-	hostIf, err := netlink.LinkByName(veth.LinkAttrs.Name)
-	log.WithField("hostIf", hostIf).Debug("Host end")
-	panicIfError(err)
-	err = netlink.LinkSetUp(hostIf)
-	panicIfError(err)
 
 	// Print out the namespace path, so that test code can pick it up and execute subsequent
 	// operations in the same namespace - which (in the context of this FV framework)
@@ -105,6 +197,22 @@ func main() {
 
 	// Now listen on the specified ports in the workload namespace.
 	err = namespace.Do(func(_ ns.NetNS) error {
+		if strings.Contains(ipAddress, ":") {
+			attempts := 0
+			for {
+				out, err := exec.Command("ip", "-6", "addr").CombinedOutput()
+				panicIfError(err)
+				if strings.Contains(string(out), "tentative") {
+					attempts++
+					if attempts > 30 {
+						log.Panic("IPv6 address still tentative after 30s")
+					}
+					time.Sleep(1 * time.Second)
+					continue
+				}
+				break
+			}
+		}
 
 		handleRequest := func(conn net.Conn) {
 			log.WithFields(log.Fields{
@@ -128,23 +236,51 @@ func main() {
 			}
 		}
 
-		// Listen on each port.
+		// Listen on each port for either TCP or UDP.
 		for _, port := range ports {
-			log.WithField("port", port).Info("About to listen for connections")
-			l, err := net.Listen("tcp", ipAddress+":"+port)
-			panicIfError(err)
-			log.WithField("port", port).Info("Listening for connections")
+			var myAddr string
+			if strings.Contains(ipAddress, ":") {
+				myAddr = "[" + ipAddress + "]:" + port
+			} else {
+				myAddr = ipAddress + ":" + port
+			}
+			logCxt := log.WithFields(log.Fields{
+				"udp":    udp,
+				"myAddr": myAddr,
+			})
+			if udp {
+				// Since UDP is connectionless, we can't use Listen() as we do for TCP.  Instead,
+				// we use ListenPacket so that we can directly send/receive individual packets.
+				logCxt.Info("About to listen for UDP packets")
+				p, err := net.ListenPacket("udp", myAddr)
+				panicIfError(err)
+				logCxt.Info("Listening for UDP connections")
 
-			go func() {
-				defer l.Close()
-				for {
-					conn, err := l.Accept()
-					panicIfError(err)
-					go handleRequest(conn)
-				}
-			}()
+				go func() {
+					defer p.Close()
+					for {
+						buffer := make([]byte, 1024)
+						n, addr, err := p.ReadFrom(buffer)
+						panicIfError(err)
+						_, err = p.WriteTo(buffer[:n], addr)
+						logCxt.WithError(err).WithField("remoteAddr", addr).Info("Responded")
+					}
+				}()
+			} else {
+				logCxt.Info("About to listen for TCP connections")
+				l, err := net.Listen("tcp", myAddr)
+				panicIfError(err)
+				logCxt.Info("Listening for TCP connections")
+				go func() {
+					defer l.Close()
+					for {
+						conn, err := l.Accept()
+						panicIfError(err)
+						go handleRequest(conn)
+					}
+				}()
+			}
 		}
-
 		for {
 			time.Sleep(10 * time.Second)
 		}
@@ -159,4 +295,20 @@ func panicIfError(err error) {
 		panic(err)
 	}
 	return
+}
+
+// writeProcSys takes the sysctl path and a string value to set i.e. "0" or "1" and sets the sysctl.
+func writeProcSys(path, value string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write([]byte(value))
+	if err == nil && n < len(value) {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 7d603735922f8b63940ee09226865770abc48ae902648375d1eb2d3400610b7c
-updated: 2018-04-03T10:39:23.277073227Z
+updated: 2018-04-03T13:37:47.785445273Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -212,7 +212,7 @@ imports:
   - lib/testutils
   - lib/validator
 - name: github.com/projectcalico/typha
-  version: f05b0beb3a2bb80a331ac91d3927d0b71ca1126b
+  version: 2d2086ef926660cd6b96e8def7d5b29ecc1c2dff
   subpackages:
   - pkg/syncclient
   - pkg/syncproto
@@ -333,7 +333,7 @@ imports:
   subpackages:
   - patricia
 - name: gopkg.in/yaml.v2
-  version: 670d4cfef0544295bc27a114dbac37980d83185a
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/apimachinery
   version: b317fa7ec8e0e7d1f77ac63bf8c3ec7b29a2a215
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cfd2a15b2af62e2cc3e7db913c77f1cc971594da148dfc214523bffd6da11e32
-updated: 2018-01-29T15:35:35.524185972-08:00
+hash: 7d603735922f8b63940ee09226865770abc48ae902648375d1eb2d3400610b7c
+updated: 2018-04-03T10:39:23.277073227Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -7,7 +7,7 @@ imports:
   - compute/metadata
   - internal
 - name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/containernetworking/cni
@@ -45,7 +45,7 @@ imports:
   - httputil
   - timeutil
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
   subpackages:
   - spew
 - name: github.com/docker/distribution
@@ -65,7 +65,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-ini/ini
-  version: 32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a
+  version: 5e9692864e22d02ac79e2fa499cffb00520b4fea
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -82,15 +82,31 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
+  version: e09c5db296004fbe3f74490e84dcd62c3c5ddb1b
   subpackages:
   - proto
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+- name: github.com/gxed/eventfd
+  version: 80a92cca79a8041496ccc9dd773fcb52a57ec6f9
+- name: github.com/gxed/GoEndian
+  version: 0f5c6873267e5abf306ffcdfcfa4bf77517ef4a7
 - name: github.com/howeyc/gopass
   version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
+- name: github.com/ipfs/go-log
+  version: 4b54e7d2460df21c1c2d345af2337f91bfc938ca
+- name: github.com/jbenet/go-reuseport
+  version: 7eed93a5b50b20c209baefe9fafa53c3d965a33c
+  repo: https://github.com/fasaxc/go-reuseport.git
+  subpackages:
+  - poll
+  - singlepoll
+- name: github.com/jbenet/go-sockaddr
+  version: 2e7ea655c10e4d4d73365f0f073b81b39cb08ee1
+  subpackages:
+  - net
 - name: github.com/jonboulle/clockwork
   version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/juju/ratelimit
@@ -105,6 +121,10 @@ imports:
   - buffer
   - jlexer
   - jwriter
+- name: github.com/mattn/go-colorable
+  version: efa589957cd060542a26d2dd7832fd6a6c6c3ade
+- name: github.com/mattn/go-isatty
+  version: 6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
@@ -146,6 +166,11 @@ imports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
   - types
+- name: github.com/opentracing/opentracing-go
+  version: 328fceb7548c744337cd010914152b74eaf4c4ab
+  subpackages:
+  - ext
+  - log
 - name: github.com/projectcalico/go-json
   version: 6219dc7339ba20ee4c57df0a8baac62317d19cb1
   subpackages:
@@ -155,7 +180,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: edcbcf64348004bfeb0dc3882cd2790743ec7728
+  version: 118b53104e93cd9f56bc93e93191e78be04b4ab1
   subpackages:
   - lib
   - lib/api
@@ -192,7 +217,7 @@ imports:
   - pkg/syncclient
   - pkg/syncproto
 - name: github.com/prometheus/client_golang
-  version: 967789050ba94deca04a5e84cce8ad472ce313c1
+  version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
   - prometheus
   - prometheus/promhttp
@@ -202,13 +227,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 89604d197083d4781071d3c65855d24ecfb0a563
+  version: 38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: cb4147076ac75738c9a7d279075a253c0cc5acbd
+  version: 780932d4fbbe0e69b84c34c20f5c8d0981e109ea
   subpackages:
   - internal/util
   - nfs
@@ -222,7 +247,7 @@ imports:
 - name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
@@ -233,6 +258,8 @@ imports:
   - nl
 - name: github.com/vishvananda/netns
   version: 8ba1072b58e0c2a240eb5f6120165c7776c3e7b8
+- name: github.com/whyrusleeping/go-logging
+  version: 0457bb6b88fc1973573aaf6b5145d8d3ae972390
 - name: golang.org/x/crypto
   version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:
@@ -257,7 +284,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 378d26f46672a356c46195c28f61bdb4c0a781dd
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -306,7 +333,7 @@ imports:
   subpackages:
   - patricia
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: 670d4cfef0544295bc27a114dbac37980d83185a
 - name: k8s.io/apimachinery
   version: b317fa7ec8e0e7d1f77ac63bf8c3ec7b29a2a215
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -60,3 +60,6 @@ import:
   - net
 - package: github.com/onsi/gomega
   version: ^1.1.0
+- name: gopkg.in/yaml.v2
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+

--- a/glide.yaml
+++ b/glide.yaml
@@ -51,5 +51,12 @@ import:
   version: v1.2
 - package: github.com/containernetworking/cni
   version: v0.5.2
+- package: github.com/jbenet/go-reuseport
+  repo: https://github.com/fasaxc/go-reuseport.git
+  version: disable-dial-check
+- package: github.com/jbenet/go-sockaddr
+  version: 2e7ea655c10e4d4d73365f0f073b81b39cb08ee1
+  subpackages:
+  - net
 - package: github.com/onsi/gomega
   version: ^1.1.0

--- a/rules/static.go
+++ b/rules/static.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ func (r *DefaultRuleRenderer) StaticFilterInputChains(ipVersion uint8) []*Chain 
 	return []*Chain{
 		r.filterInputChain(ipVersion),
 		r.filterWorkloadToHostChain(ipVersion),
-		r.failsafeInChain(),
+		r.failsafeInChain("filter"),
 	}
 }
 
@@ -201,7 +201,7 @@ func (r *DefaultRuleRenderer) filterWorkloadToHostChain(ipVersion uint8) *Chain 
 	}
 }
 
-func (r *DefaultRuleRenderer) failsafeInChain() *Chain {
+func (r *DefaultRuleRenderer) failsafeInChain(table string) *Chain {
 	rules := []Rule{}
 
 	for _, protoPort := range r.Config.FailsafeInboundHostPorts {
@@ -213,13 +213,28 @@ func (r *DefaultRuleRenderer) failsafeInChain() *Chain {
 		})
 	}
 
+	if table == "raw" {
+		// We're in the raw table, before conntrack, so we need to whitelist response traffic.
+		// Otherwise, it could fall through to some doNotTrack policy and half of the connection
+		// would get untracked.  If we ACCEPT here then the traffic falls through to the filter
+		// table, where it'll only be accepted if there's a conntrack entry.
+		for _, protoPort := range r.Config.FailsafeOutboundHostPorts {
+			rules = append(rules, Rule{
+				Match: Match().
+					Protocol(protoPort.Protocol).
+					SourcePorts(protoPort.Port),
+				Action: AcceptAction{},
+			})
+		}
+	}
+
 	return &Chain{
 		Name:  ChainFailsafeIn,
 		Rules: rules,
 	}
 }
 
-func (r *DefaultRuleRenderer) failsafeOutChain() *Chain {
+func (r *DefaultRuleRenderer) failsafeOutChain(table string) *Chain {
 	rules := []Rule{}
 
 	for _, protoPort := range r.Config.FailsafeOutboundHostPorts {
@@ -229,6 +244,21 @@ func (r *DefaultRuleRenderer) failsafeOutChain() *Chain {
 				DestPorts(protoPort.Port),
 			Action: AcceptAction{},
 		})
+	}
+
+	if table == "raw" {
+		// We're in the raw table, before conntrack, so we need to whitelist response traffic.
+		// Otherwise, it could fall through to some doNotTrack policy and half of the connection
+		// would get untracked.  If we ACCEPT here then the traffic falls through to the filter
+		// table, where it'll only be accepted if there's a conntrack entry.
+		for _, protoPort := range r.Config.FailsafeInboundHostPorts {
+			rules = append(rules, Rule{
+				Match: Match().
+					Protocol(protoPort.Protocol).
+					SourcePorts(protoPort.Port),
+				Action: AcceptAction{},
+			})
+		}
 	}
 
 	return &Chain{
@@ -321,7 +351,7 @@ func (r *DefaultRuleRenderer) StaticFilterForwardChains() []*Chain {
 func (r *DefaultRuleRenderer) StaticFilterOutputChains(ipVersion uint8) []*Chain {
 	return []*Chain{
 		r.filterOutputChain(ipVersion),
-		r.failsafeOutChain(),
+		r.failsafeOutChain("filter"),
 	}
 }
 
@@ -482,7 +512,7 @@ func (r *DefaultRuleRenderer) StaticNATOutputChains(ipVersion uint8) []*Chain {
 
 func (r *DefaultRuleRenderer) StaticMangleTableChains(ipVersion uint8) (chains []*Chain) {
 	return []*Chain{
-		r.failsafeInChain(),
+		r.failsafeInChain("mangle"),
 		r.StaticManglePreroutingChain(ipVersion),
 	}
 }
@@ -551,8 +581,8 @@ func (r *DefaultRuleRenderer) StaticManglePreroutingChain(ipVersion uint8) *Chai
 
 func (r *DefaultRuleRenderer) StaticRawTableChains(ipVersion uint8) []*Chain {
 	return []*Chain{
-		r.failsafeInChain(),
-		r.failsafeOutChain(),
+		r.failsafeInChain("raw"),
+		r.failsafeOutChain("raw"),
 		r.StaticRawPreroutingChain(ipVersion),
 		r.StaticRawOutputChain(),
 	}

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,6 +59,26 @@ var _ = Describe("Static", func() {
 			Describe(fmt.Sprintf("IPv%d", ipVersion), func() {
 				// Capture current value of ipVersion.
 				ipVersion := ipVersion
+
+				expRawFailsafeIn := &Chain{
+					Name: "cali-failsafe-in",
+					Rules: []Rule{
+						{Match: Match().Protocol("tcp").DestPorts(22), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").DestPorts(1022), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").SourcePorts(23), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").SourcePorts(1023), Action: AcceptAction{}},
+					},
+				}
+
+				expRawFailsafeOut := &Chain{
+					Name: "cali-failsafe-out",
+					Rules: []Rule{
+						{Match: Match().Protocol("tcp").DestPorts(23), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").DestPorts(1023), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").SourcePorts(22), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").SourcePorts(1022), Action: AcceptAction{}},
+					},
+				}
 
 				expFailsafeIn := &Chain{
 					Name: "cali-failsafe-in",
@@ -179,10 +199,10 @@ var _ = Describe("Static", func() {
 					}))
 				})
 				It("Should return expected raw failsafe in chain", func() {
-					Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-in")).To(Equal(expFailsafeIn))
+					Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-in")).To(Equal(expRawFailsafeIn))
 				})
 				It("Should return expected raw failsafe out chain", func() {
-					Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-out")).To(Equal(expFailsafeOut))
+					Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-out")).To(Equal(expRawFailsafeOut))
 				})
 				It("should return only the expected raw chains", func() {
 					Expect(len(rr.StaticRawTableChains(ipVersion))).To(Equal(4))


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Backport #1718 to v2.6

Whitelist failsafe port response traffic in the raw table only

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [x] Backport
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes an interaction between failsafe inbound/outbound ports and do-not-track policy that resulted in failsafe ports being blocked if do-not-track policy was added.
```
