### PR TITLE
processor_test.go timeouts for large IPSet updates

### DIFF
--- a/policysync/processor.go
+++ b/policysync/processor.go
@@ -210,8 +210,7 @@ func (p *Processor) handleDataplane(update interface{}) {
 		p.handleIPSetRemove(update)
 	default:
 		log.WithFields(log.Fields{
-			"update": update,
-			"type":   reflect.TypeOf(update),
+			"type": reflect.TypeOf(update),
 		}).Warn("Unhandled update")
 	}
 }

--- a/policysync/processor_test.go
+++ b/policysync/processor_test.go
@@ -770,76 +770,90 @@ var _ = Describe("Processor", func() {
 						Expect(g).To(HavePayload(wepUpd))
 
 						close(done)
-					})
+					}, 2)
 
 					It("should split large IPSetUpdate", func(done Done) {
 						msg := updateIpSet(IPSetName, 82250)
+						By("sending a large IPSetUpdate")
 						updates <- msg
 
+						By("receiving the first part")
 						out, err := syncStream.Recv()
 						Expect(err).ToNot(HaveOccurred())
 						Expect(out.GetIpsetUpdate().GetMembers()).To(HaveLen(82200))
 
+						By("receiving the second part")
 						out, err = syncStream.Recv()
 						Expect(err).ToNot(HaveOccurred())
 						Expect(out.GetIpsetDeltaUpdate().GetAddedMembers()).To(HaveLen(50))
 						close(done)
-					})
+					}, 5)
 
 					It("should split IpSetDeltaUpdates with both large adds and removes", func(done Done) {
 						msg2 := deltaUpdateIpSet(IPSetName, 82250, 82250)
+						By("sending a large IPSetDeltaUpdate")
 						updates <- msg2
+
+						By("receiving the first part with added members")
 						out, err := syncStream.Recv()
 						Expect(err).ToNot(HaveOccurred())
 						Expect(out.GetIpsetDeltaUpdate().GetAddedMembers()).To(HaveLen(82200))
 						Expect(out.GetIpsetDeltaUpdate().GetRemovedMembers()).To(HaveLen(0))
 
+						By("receiving the second part with added and removed members")
 						out, err = syncStream.Recv()
 						Expect(err).ToNot(HaveOccurred())
 						Expect(out.GetIpsetDeltaUpdate().GetAddedMembers()).To(HaveLen(50))
 						Expect(out.GetIpsetDeltaUpdate().GetRemovedMembers()).To(HaveLen(50))
 
+						By("receiving the third part with removed members")
 						out, err = syncStream.Recv()
 						Expect(err).ToNot(HaveOccurred())
 						Expect(out.GetIpsetDeltaUpdate().GetAddedMembers()).To(HaveLen(0))
 						Expect(out.GetIpsetDeltaUpdate().GetRemovedMembers()).To(HaveLen(82200))
 
 						close(done)
-					})
+					}, 5)
 
 					It("should split IpSetDeltaUpdates with large adds", func(done Done) {
 						msg2 := deltaUpdateIpSet(IPSetName, 82250, 0)
+						By("sending a large IPSetDeltaUpdate")
 						updates <- msg2
 
+						By("receiving the first part")
 						out, err := syncStream.Recv()
 						Expect(err).ToNot(HaveOccurred())
 						Expect(out.GetIpsetDeltaUpdate().GetAddedMembers()).To(HaveLen(82200))
 						Expect(out.GetIpsetDeltaUpdate().GetRemovedMembers()).To(HaveLen(0))
 
+						By("receiving the second part")
 						out, err = syncStream.Recv()
 						Expect(err).ToNot(HaveOccurred())
 						Expect(out.GetIpsetDeltaUpdate().GetAddedMembers()).To(HaveLen(50))
 						Expect(out.GetIpsetDeltaUpdate().GetRemovedMembers()).To(HaveLen(0))
 
 						close(done)
-					})
+					}, 5)
 
 					It("should split IpSetDeltaUpdates with large removes", func(done Done) {
 						msg2 := deltaUpdateIpSet(IPSetName, 0, 82250)
+						By("sending a large IPSetDeltaUpdate")
 						updates <- msg2
 
+						By("receiving the first part")
 						out, err := syncStream.Recv()
 						Expect(err).ToNot(HaveOccurred())
 						Expect(out.GetIpsetDeltaUpdate().GetAddedMembers()).To(HaveLen(0))
 						Expect(out.GetIpsetDeltaUpdate().GetRemovedMembers()).To(HaveLen(50))
 
+						By("receiving the second part")
 						out, err = syncStream.Recv()
 						Expect(err).ToNot(HaveOccurred())
 						Expect(out.GetIpsetDeltaUpdate().GetAddedMembers()).To(HaveLen(0))
 						Expect(out.GetIpsetDeltaUpdate().GetRemovedMembers()).To(HaveLen(82200))
 
 						close(done)
-					})
+					}, 5)
 
 					AfterEach(func() {
 						clientCancel()


### PR DESCRIPTION
## Description
Increase test timeouts for sending large IPSet updates.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
