### PR TITLE
[WIP] Tweaks to get info on flake

### DIFF
--- a/fv/host_port_test.go
+++ b/fv/host_port_test.go
@@ -17,8 +17,6 @@
 package fv_test
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
@@ -148,21 +146,7 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 			})
 
 			It("port should be reachable", func() {
-				//Eventually(metricsPortReachable, "10s", "1s").Should(BeTrue())
-				// Switching to the loop below, *seems* to have fixed a flake
-				// that was happening here with the Eventually check above.
-				// The loop is purposefully high vs what is being checked so
-				// if another failure occurs we can see if the timeout is just
-				// a little too low or it is something more.
-				i := 0
-				for i := 0; i < 50; i++ {
-					reachable := metricsPortReachable()
-					if reachable {
-						break
-					}
-					time.Sleep(time.Second)
-				}
-				Expect(i).To(BeNumerically("<", 10))
+				Eventually(metricsPortReachable, "10s", "1s").Should(BeTrue())
 			})
 		})
 	})

--- a/fv/host_port_test.go
+++ b/fv/host_port_test.go
@@ -17,6 +17,8 @@
 package fv_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
@@ -125,6 +127,8 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 		Context("with pre-DNAT policy defined", func() {
 
 			BeforeEach(func() {
+				// Ensure the HostEndpoint has taken effect and is blocking traffic
+				Eventually(metricsPortReachable, "10s", "1s").Should(BeFalse())
 				policy := api.NewGlobalNetworkPolicy()
 				policy.Name = "pre-dnat-policy-1"
 				policy.Spec.PreDNAT = true
@@ -144,7 +148,21 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 			})
 
 			It("port should be reachable", func() {
-				Eventually(metricsPortReachable, "10s", "1s").Should(BeTrue())
+				//Eventually(metricsPortReachable, "10s", "1s").Should(BeTrue())
+				// Switching to the loop below, *seems* to have fixed a flake
+				// that was happening here with the Eventually check above.
+				// The loop is purposefully high vs what is being checked so
+				// if another failure occurs we can see if the timeout is just
+				// a little too low or it is something more.
+				i := 0
+				for i := 0; i < 50; i++ {
+					reachable := metricsPortReachable()
+					if reachable {
+						break
+					}
+					time.Sleep(time.Second)
+				}
+				Expect(i).To(BeNumerically("<", 10))
 			})
 		})
 	})

--- a/fv/metrics/metrics.go
+++ b/fv/metrics/metrics.go
@@ -36,7 +36,8 @@ func PortString() string {
 
 func GetFelixMetric(felixIP, name string) (metric string, err error) {
 	var resp *http.Response
-	resp, err = http.Get("http://" + felixIP + ":" + PortString() + "/metrics")
+	httpClient := http.Client{Timeout: time.Second}
+	resp, err = httpClient.Get("http://" + felixIP + ":" + PortString() + "/metrics")
 	if err != nil {
 		return
 	}

--- a/fv/run-batches
+++ b/fv/run-batches
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -x
 
 # Copyright (c) 2018 Tigera, Inc. All rights reserved.
 #
@@ -21,21 +21,19 @@
 : ${GINKGO_FOCUS:=.*}
 
 for batch in ${FV_BATCHES_TO_RUN}; do
-  (
-     echo "Running FV batch ${batch}"
-     ./fv.test -ginkgo.parallel.node ${batch} \
-               -ginkgo.parallel.total ${FV_NUM_BATCHES} \
-               -ginkgo.seed 1 \
-               -ginkgo.randomizeAllSpecs=true \
-               -ginkgo.slowSpecThreshold ${FV_SLOW_SPEC_THRESH} \
-               -ginkgo.focus="${GINKGO_FOCUS}" \
-               ${GINKGO_ARGS}; \
-  ) &
-  pids[${batch}]=$!
+  echo "Running FV batch ${batch}"
+  ./fv.test -ginkgo.parallel.node ${batch} \
+            -ginkgo.parallel.total ${FV_NUM_BATCHES} \
+            -ginkgo.seed 1 \
+            -ginkgo.randomizeAllSpecs=true \
+            -ginkgo.slowSpecThreshold ${FV_SLOW_SPEC_THRESH} \
+            -ginkgo.focus="${GINKGO_FOCUS}" \
+            ${GINKGO_ARGS}; \
+  result=$?
+  echo "Result: $result"
+  if [ $result -ne 0 ]; then
+      echo "Batch $result failed with rc $result"
+      exit $result
+  fi
 done
 
-for batch in ${FV_BATCHES_TO_RUN}; do
-  echo "Waiting on batch $batch; PID=${pids[$batch]}"
-  wait ${pids[$batch]}
-  echo "Result: $?"
-done


### PR DESCRIPTION
## Description
Several commits here that were done while trying to fix/get info on some flakes:
- Changed check that was causing a flake in host_port_test.go checking the metrics port for reachablity
- Added to clean up HostEndpoints with KDD after tests.
- Added dumping the HostEndpoints when dumping out KDD when the DumpErrorData is used.
- Added specific GINKGO_FOCUS for fv tests because I was having trouble creating a proper focus with just GINKGO_ARGS
- Removed the parallelism of the batch tests. There was a flake that seemed to just stop mid test and I thought I'd remove any complexity around there. (See https://semaphoreci.com/calico/felix-2/branches/master/builds/950)
  - Looking at the current felix fv batches I did not see any use of the previous parallelism so thought this would be ok.

## Todos

## Release Note

```release-note
None required
```
