### PR TITLE
Ensure RPM directory exists

### DIFF
--- a/rpm/build-rpms
+++ b/rpm/build-rpms
@@ -56,10 +56,12 @@ rpmbuild --target=$(uname -m) --define '_topdir '`pwd` --define "dist .${EL_VERS
 case "$EL_VERSION" in
   "el7")
     rm -rf /code/dist/rpms
+    mkdir -p /code/dist
     cp -r /tmp/rpmbuild /code/dist/rpms
     ;;
   "el6")
     rm -rf /code/dist/rpms/el6-rpms
+    mkdir -p /code/dist
     cp -r /tmp/rpmbuild /code/dist/el6-rpms
     ;;
 esac


### PR DESCRIPTION
This is another fix following recent multiarch changes - but really the
error was rpm/build-rpms assuming that a directory would exist, so we
fix that here.
