### PR TITLE
Unexpected fix for HEP Policy fix

### DIFF
--- a/fv/host_port_test.go
+++ b/fv/host_port_test.go
@@ -17,8 +17,6 @@
 package fv_test
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
@@ -149,21 +147,7 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 			})
 
 			It("port should be reachable", func() {
-				//Eventually(metricsPortReachable, "10s", "1s").Should(BeTrue())
-				// Switching to the loop below, *seems* to have fixed a flake
-				// that was happening here with the Eventually check above.
-				// The loop is purposefully high vs what is being checked so
-				// if another failure occurs we can see if the timeout is just
-				// a little too low or it is something more.
-				i := 0
-				for i := 0; i < 50; i++ {
-					reachable := metricsPortReachable()
-					if reachable {
-						break
-					}
-					time.Sleep(time.Second)
-				}
-				Expect(i).To(BeNumerically("<", 10))
+				Eventually(metricsPortReachable, "10s", "1s").Should(BeTrue())
 			})
 		})
 	})

--- a/fv/metrics/metrics.go
+++ b/fv/metrics/metrics.go
@@ -36,7 +36,8 @@ func PortString() string {
 
 func GetFelixMetric(felixIP, name string) (metric string, err error) {
 	var resp *http.Response
-	resp, err = http.Get("http://" + felixIP + ":" + PortString() + "/metrics")
+	httpClient := http.Client{Timeout: time.Second}
+	resp, err = httpClient.Get("http://" + felixIP + ":" + PortString() + "/metrics")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
- Ensured that HostEndpoint is blocking traffic before adding policy to
  allow traffic.
- Changed Eventually test to a loop that checks longer than Eventually
  did to try to get a little more information if the flake happens
  again.  Unexplainably the change seemed to fix the flake.

## Description

## Todos

## Release Note

```release-note
None required
```
