### PR TITLE
FV: fix interfaceName trimming in test-workload

### DIFF
--- a/fv/test-workload/test-workload.go
+++ b/fv/test-workload/test-workload.go
@@ -73,10 +73,14 @@ func main() {
 		}
 		log.WithField("namespace", namespace).Debug("Created namespace")
 
+		peerName := "w" + interfaceName
+		if len(peerName) > 11 {
+			peerName = peerName[:11]
+		}
 		// Create a veth pair.
 		veth := &netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{Name: interfaceName},
-			PeerName:  string([]byte("w" + interfaceName)[:11]),
+			PeerName:  peerName,
 		}
 		err = netlink.LinkAdd(veth)
 		panicIfError(err)


### PR DESCRIPTION
## Description
@fasaxc pointed out that the trimming I added in the test-workload caused problems if the passed in interfaceName was too short.  Do the trimming only if necessary and the string is long enough.

## Todos

## Release Note

```release-note
None required
```
