### PR TITLE
[v3.1] Add stats for policy and profile counts.

### DIFF
--- a/calc/calc_graph_test.go
+++ b/calc/calc_graph_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ var _ = DescribeTable("Calculation graph pass-through tests",
 			logrus.WithField("message", message).Info("Received message")
 			messageReceived = message
 		}
-		cg := NewCalculationGraph(eb, "hostname")
+		cg := NewCalculationGraph(eb, "hostname").AllUpdDispatcher
 
 		// Send in the update and flush the buffer.  It should deposit the message
 		// via our callback.
@@ -129,7 +129,7 @@ var _ = Describe("Host IP duplicate squashing test", func() {
 			logrus.WithField("message", message).Info("Received message")
 			messagesReceived = append(messagesReceived, message)
 		}
-		cg = NewCalculationGraph(eb, "hostname")
+		cg = NewCalculationGraph(eb, "hostname").AllUpdDispatcher
 	})
 
 	It("should coalesce duplicate updates", func() {

--- a/calc/stats_collector_test.go
+++ b/calc/stats_collector_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,6 +59,10 @@ var _ = Describe("Stats collector", func() {
 			})
 			Expect(lastStatsUpdate).To(BeNil())
 		})
+		It("should do nothing on policy count update", func() {
+			sc.UpdatePolicyCounts(10, 10)
+			Expect(lastStatsUpdate).To(BeNil())
+		})
 	})
 
 	Describe("after in-sync", func() {
@@ -87,6 +91,18 @@ var _ = Describe("Stats collector", func() {
 			sc.OnUpdate(api.Update{KVPair{Key: HostConfigKey{localHostname, "foo"}}, api.UpdateTypeKVNew})
 			Expect(*lastStatsUpdate).To(Equal(StatsUpdate{
 				NumHosts: 1,
+			}))
+		})
+		It("should count a policy", func() {
+			sc.UpdatePolicyCounts(1, 0)
+			Expect(*lastStatsUpdate).To(Equal(StatsUpdate{
+				NumPolicies: 1,
+			}))
+		})
+		It("should count a profile", func() {
+			sc.UpdatePolicyCounts(0, 1)
+			Expect(*lastStatsUpdate).To(Equal(StatsUpdate{
+				NumProfiles: 1,
 			}))
 		})
 

--- a/felix.go
+++ b/felix.go
@@ -390,7 +390,7 @@ configRetry:
 			statsChanIn <- stats
 			return nil
 		})
-		statsCollector.RegisterWith(asyncCalcGraph.Dispatcher)
+		statsCollector.RegisterWith(asyncCalcGraph.CalcGraph)
 
 		// Rather than sending the updates directly to the usage reporting thread, we
 		// decouple with an extra goroutine.  This prevents blocking the calculation graph
@@ -429,7 +429,7 @@ configRetry:
 		statsCollector := calc.NewStatsCollector(func(stats calc.StatsUpdate) error {
 			return nil
 		})
-		statsCollector.RegisterWith(asyncCalcGraph.Dispatcher)
+		statsCollector.RegisterWith(asyncCalcGraph.CalcGraph)
 	}
 
 	// Create the validator, which sits between the syncer and the

--- a/fv/infrastructure/datastore_describe.go
+++ b/fv/infrastructure/datastore_describe.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
+
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 )
 

--- a/usagerep/usagerep.go
+++ b/usagerep/usagerep.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -182,14 +182,16 @@ func (u *UsageReporter) calculateURL(clusterGUID, clusterType, calicoVersion str
 		"gitRevision":   buildinfo.GitRevision,
 	}).Info("Reporting cluster usage/checking for deprecation warnings.")
 	queryParams := url.Values{
-		"guid":    {clusterGUID},
-		"type":    {clusterType},
-		"cal_ver": {calicoVersion},
-		"size":    {fmt.Sprintf("%v", stats.NumHosts)},
-		"weps":    {fmt.Sprintf("%v", stats.NumWorkloadEndpoints)},
-		"heps":    {fmt.Sprintf("%v", stats.NumHostEndpoints)},
-		"version": {buildinfo.GitVersion},
-		"rev":     {buildinfo.GitRevision},
+		"guid":     {clusterGUID},
+		"type":     {clusterType},
+		"cal_ver":  {calicoVersion},
+		"size":     {fmt.Sprint(stats.NumHosts)},
+		"weps":     {fmt.Sprint(stats.NumWorkloadEndpoints)},
+		"heps":     {fmt.Sprint(stats.NumHostEndpoints)},
+		"version":  {buildinfo.GitVersion},
+		"rev":      {buildinfo.GitRevision},
+		"policies": {fmt.Sprint(stats.NumPolicies)},
+		"profiles": {fmt.Sprint(stats.NumProfiles)},
 	}
 	fullURL := u.BaseURL + queryParams.Encode()
 	log.WithField("url", fullURL).Debug("Calculated URL.")

--- a/usagerep/usagerep_test.go
+++ b/usagerep/usagerep_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ import (
 	"github.com/projectcalico/felix/buildinfo"
 	"github.com/projectcalico/felix/calc"
 )
+
+const expectedNumberOfURLParams = 10
 
 // These tests start a local HTTP server on a random port and tell the usage reporter to
 // connect to it.  Then we can check that it correctly makes HTTP requests at the right times.
@@ -98,6 +100,8 @@ var _ = Describe("UsageReporter with mocked URL and short interval", func() {
 					NumHosts:             1,
 					NumHostEndpoints:     2,
 					NumWorkloadEndpoints: 3,
+					NumPolicies:          4,
+					NumProfiles:          5,
 				}
 			}
 
@@ -118,13 +122,15 @@ var _ = Describe("UsageReporter with mocked URL and short interval", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(url.Path).To(Equal("/UsageCheck/calicoVersionCheck"))
 				q := url.Query()
-				Expect(len(q)).To(Equal(8))
+				Expect(q).To(HaveLen(expectedNumberOfURLParams), "unexpected number of URL parameters")
 				Expect(q.Get("guid")).To(Equal("someguid"))
 				Expect(q.Get("type")).To(Equal("openstack,k8s,kdd"))
 				Expect(q.Get("cal_ver")).To(Equal("v2.6.3"))
 				Expect(q.Get("size")).To(Equal("1"))
 				Expect(q.Get("heps")).To(Equal("2"))
 				Expect(q.Get("weps")).To(Equal("3"))
+				Expect(q.Get("policies")).To(Equal("4"))
+				Expect(q.Get("profiles")).To(Equal("5"))
 
 				By("checking in again")
 				Eventually(httpHandler.GetRequestURIs, "2s", "100ms").Should(HaveLen(2))
@@ -152,6 +158,8 @@ var _ = Describe("UsageReporter with mocked URL and short interval", func() {
 						NumHosts:             10,
 						NumHostEndpoints:     20,
 						NumWorkloadEndpoints: 30,
+						NumPolicies:          40,
+						NumProfiles:          50,
 					}
 					configUpdateC <- map[string]string{
 						"ClusterGUID":   "someguid2",
@@ -169,13 +177,15 @@ var _ = Describe("UsageReporter with mocked URL and short interval", func() {
 					url, err := url.Parse(uri)
 					Expect(err).NotTo(HaveOccurred())
 					q := url.Query()
-					Expect(len(q)).To(Equal(8))
+					Expect(q).To(HaveLen(expectedNumberOfURLParams), "unexpected number of URL parameters")
 					Expect(q.Get("guid")).To(Equal("someguid2"))
 					Expect(q.Get("type")).To(Equal("openstack,k8s,kdd,typha"))
 					Expect(q.Get("cal_ver")).To(Equal("v3.0.0"))
 					Expect(q.Get("size")).To(Equal("10"))
 					Expect(q.Get("heps")).To(Equal("20"))
 					Expect(q.Get("weps")).To(Equal("30"))
+					Expect(q.Get("policies")).To(Equal("40"))
+					Expect(q.Get("profiles")).To(Equal("50"))
 				})
 			})
 		})
@@ -223,7 +233,7 @@ var _ = Describe("UsageReporter with default URL", func() {
 		url, err := url.Parse(rawURL)
 		Expect(err).NotTo(HaveOccurred())
 		q := url.Query()
-		Expect(len(q)).To(Equal(8))
+		Expect(q).To(HaveLen(expectedNumberOfURLParams), "unexpected number of URL parameters")
 		Expect(q.Get("guid")).To(Equal("theguid"))
 		Expect(q.Get("type")).To(Equal("atype"))
 		Expect(q.Get("cal_ver")).To(Equal("testVer"))
@@ -246,7 +256,7 @@ var _ = Describe("UsageReporter with default URL", func() {
 		url, err := url.Parse(rawURL)
 		Expect(err).NotTo(HaveOccurred())
 		q := url.Query()
-		Expect(len(q)).To(Equal(8))
+		Expect(q).To(HaveLen(expectedNumberOfURLParams), "unexpected number of URL parameters")
 		Expect(q.Get("guid")).To(Equal("baddecaf"))
 		Expect(q.Get("type")).To(Equal("unknown"))
 		Expect(q.Get("cal_ver")).To(Equal("unknown"))


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Backport of #1769 

(cherry picked from commit 09057f7ad4458decd258af676d771f10e7da08cd)

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [x] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Prometheus stats now include number of total policies and profiles.
```
