### PR TITLE
[v3.0] Whitelist failsafe port response traffic in the raw table only

### DIFF
--- a/fv/donottrack_test.go
+++ b/fv/donottrack_test.go
@@ -1,0 +1,278 @@
+// +build fvtests
+
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/fv/containers"
+	"github.com/projectcalico/felix/fv/workload"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+)
+
+var _ = Context("do-not-track policy tests; with 2 nodes", func() {
+
+	var (
+		etcd        *containers.Container
+		felixes     []*containers.Container
+		hostW       [2]*workload.Workload
+		client      client.Interface
+		cc          *workload.ConnectivityChecker
+		dumpedDiags bool
+	)
+
+	BeforeEach(func() {
+		dumpedDiags = false
+		felixes, etcd, client = containers.StartNNodeEtcdTopology(2)
+		cc = &workload.ConnectivityChecker{}
+
+		// Start a host networked workload on each host for connectivity checks.
+		for ii := range felixes {
+			// We tell each workload to open:
+			// - its normal (uninteresting) port, 8055
+			// - port 2379, which is both an inbound and an outbound failsafe port
+			// - port 22, which is an inbound failsafe port.
+			// This allows us to test the interaction between do-not-track policy and failsafe
+			// ports.
+			const portsToOpen = "8055,2379,22"
+			hostW[ii] = workload.Run(
+				felixes[ii],
+				fmt.Sprintf("host%d", ii),
+				"", // No interface name means "run in the host's namespace"
+				felixes[ii].IP,
+				portsToOpen,
+				"tcp")
+		}
+	})
+
+	// Utility function to dump diags if the test failed.  Should be called in the inner-most
+	// AfterEach() to dump diags before the test is torn down.  Only the first call for a given
+	// test has any effect.
+	dumpDiags := func() {
+		if !CurrentGinkgoTestDescription().Failed || dumpedDiags {
+			return
+		}
+		for ii := range felixes {
+			iptSave, err := felixes[ii].ExecOutput("iptables-save", "-c")
+			if err == nil {
+				log.WithField("felix", ii).Info("iptables-save:\n" + iptSave)
+			}
+			ipR, err := felixes[ii].ExecOutput("ip", "r")
+			if err == nil {
+				log.WithField("felix", ii).Info("ip route:\n" + ipR)
+			}
+		}
+		etcd.Exec("etcdctl", "ls", "--recursive", "/")
+
+	}
+
+	AfterEach(func() {
+		dumpDiags()
+		for _, f := range felixes {
+			f.Stop()
+		}
+		etcd.Stop()
+	})
+
+	expectFullConnectivity := func() {
+		cc.ResetExpectations()
+		cc.ExpectSome(felixes[0], hostW[1].Port(8055))
+		cc.ExpectSome(felixes[1], hostW[0].Port(8055))
+		cc.ExpectSome(felixes[0], hostW[1].Port(2379))
+		cc.ExpectSome(felixes[1], hostW[0].Port(2379))
+		cc.ExpectSome(felixes[0], hostW[1].Port(22))
+		cc.ExpectSome(felixes[1], hostW[0].Port(22))
+		cc.ExpectSome(etcd, hostW[1].Port(22))
+		cc.ExpectSome(etcd, hostW[0].Port(22))
+		cc.CheckConnectivityOffset(1)
+	}
+
+	It("before adding policy, should have connectivity between hosts", func() {
+		expectFullConnectivity()
+	})
+
+	Context("after adding host endpoints", func() {
+		var (
+			ctx    context.Context
+			cancel context.CancelFunc
+		)
+
+		BeforeEach(func() {
+			ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+
+			for _, f := range felixes {
+				hep := api.NewHostEndpoint()
+				hep.Name = "eth0-" + f.Name
+				hep.Labels = map[string]string{
+					"name": hep.Name,
+				}
+				hep.Spec.Node = f.Hostname
+				hep.Spec.ExpectedIPs = []string{f.IP}
+				_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		AfterEach(func() {
+			dumpDiags()
+			cancel()
+		})
+
+		It("should implement untracked policy correctly", func() {
+			// This test covers both normal connectivity and failsafe connectivity.  We combine the
+			// tests because we rely on the changes of normal connectivity at each step to make sure
+			// that the policy has actually flowed through to the dataplane.
+
+			By("having only failsafe connectivity to start with")
+			cc.ExpectNone(felixes[0], hostW[1].Port(8055))
+			cc.ExpectNone(felixes[1], hostW[0].Port(8055))
+			cc.ExpectSome(felixes[0], hostW[1].Port(2379))
+			cc.ExpectSome(felixes[1], hostW[0].Port(2379))
+			// Port 22 is inbound-only so it'll be blocked by the (lack of egress policy).
+			cc.ExpectNone(felixes[0], hostW[1].Port(22))
+			cc.ExpectNone(felixes[1], hostW[0].Port(22))
+			// But etcd should still be able to access it...
+			cc.ExpectSome(etcd, hostW[1].Port(22))
+			cc.ExpectSome(etcd, hostW[0].Port(22))
+			cc.CheckConnectivity()
+
+			host0Selector := fmt.Sprintf("name == 'eth0-%s'", felixes[0].Name)
+			host1Selector := fmt.Sprintf("name == 'eth0-%s'", felixes[1].Name)
+
+			By("Having connectivity after installing bidirectional policies")
+			host0Pol := api.NewGlobalNetworkPolicy()
+			host0Pol.Name = "host-0-pol"
+			host0Pol.Spec.Selector = host0Selector
+			host0Pol.Spec.DoNotTrack = true
+			host0Pol.Spec.ApplyOnForward = true
+			host0Pol.Spec.Ingress = []api.Rule{
+				{
+					Action: api.Allow,
+					Source: api.EntityRule{
+						Selector: host1Selector,
+					},
+				},
+			}
+			host0Pol.Spec.Egress = []api.Rule{
+				{
+					Action: api.Allow,
+					Destination: api.EntityRule{
+						Selector: host1Selector,
+					},
+				},
+			}
+			host0Pol, err := client.GlobalNetworkPolicies().Create(ctx, host0Pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			host1Pol := api.NewGlobalNetworkPolicy()
+			host1Pol.Name = "host-1-pol"
+			host1Pol.Spec.Selector = host1Selector
+			host1Pol.Spec.DoNotTrack = true
+			host1Pol.Spec.ApplyOnForward = true
+			host1Pol.Spec.Ingress = []api.Rule{
+				{
+					Action: api.Allow,
+					Source: api.EntityRule{
+						Selector: host0Selector,
+					},
+				},
+			}
+			host1Pol.Spec.Egress = []api.Rule{
+				{
+					Action: api.Allow,
+					Destination: api.EntityRule{
+						Selector: host0Selector,
+					},
+				},
+			}
+			host1Pol, err = client.GlobalNetworkPolicies().Create(ctx, host1Pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			expectFullConnectivity()
+
+			By("Having only failsafe connectivity after replacing host-0's egress rules with Deny")
+			// Since there's no conntrack, removing rules in one direction is enough to prevent
+			// connectivity in either direction.
+			host0Pol.Spec.Egress = []api.Rule{
+				{
+					Action: api.Deny,
+					Destination: api.EntityRule{
+						Selector: host0Selector,
+					},
+				},
+			}
+			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			cc.ResetExpectations()
+			cc.ExpectNone(felixes[0], hostW[1].Port(8055))
+			cc.ExpectNone(felixes[1], hostW[0].Port(8055))
+			cc.ExpectSome(felixes[0], hostW[1].Port(2379))
+			cc.ExpectSome(felixes[1], hostW[0].Port(2379))
+			cc.ExpectNone(felixes[0], hostW[1].Port(22)) // Now blocked (lack of egress).
+			cc.ExpectSome(felixes[1], hostW[0].Port(22)) // Still open due to failsafe.
+			cc.ExpectSome(etcd, hostW[1].Port(22))       // Allowed by failsafe
+			cc.ExpectSome(etcd, hostW[0].Port(22))       // Allowed by failsafe
+			cc.CheckConnectivity()
+
+			By("Having full connectivity after putting them back")
+			host0Pol.Spec.Egress = []api.Rule{
+				{
+					Action: api.Allow,
+					Destination: api.EntityRule{
+						Selector: host1Selector,
+					},
+				},
+			}
+			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			expectFullConnectivity()
+
+			By("Having only failsafe connectivity after replacing host-0's ingress rules with Deny")
+			host0Pol.Spec.Ingress = []api.Rule{
+				{
+					Action: api.Deny,
+					Destination: api.EntityRule{
+						Selector: host0Selector,
+					},
+				},
+			}
+			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			cc.ResetExpectations()
+			cc.ExpectNone(felixes[0], hostW[1].Port(8055))
+			cc.ExpectNone(felixes[1], hostW[0].Port(8055))
+			cc.ExpectSome(felixes[0], hostW[1].Port(2379))
+			cc.ExpectSome(felixes[1], hostW[0].Port(2379))
+			cc.ExpectNone(felixes[0], hostW[1].Port(22)) // Response traffic blocked by policy
+			cc.ExpectSome(felixes[1], hostW[0].Port(22)) // Allowed by failsafe
+			cc.ExpectSome(etcd, hostW[1].Port(22))       // Allowed by failsafe
+			cc.ExpectSome(etcd, hostW[0].Port(22))       // Allowed by failsafe
+			cc.CheckConnectivity()
+		})
+	})
+})

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -402,11 +402,19 @@ func (c *ConnectivityChecker) ExpectedConnectivity() []string {
 	return result
 }
 
+func (c *ConnectivityChecker) CheckConnectivityOffset(offset int, optionalDescription ...interface{}) {
+	c.CheckConnectivityWithTimeoutOffset(offset+2, 10*time.Second, optionalDescription...)
+}
+
 func (c *ConnectivityChecker) CheckConnectivity(optionalDescription ...interface{}) {
-	c.CheckConnectivityWithTimeout(10*time.Second, optionalDescription...)
+	c.CheckConnectivityWithTimeoutOffset(2, 10*time.Second, optionalDescription...)
 }
 
 func (c *ConnectivityChecker) CheckConnectivityWithTimeout(timeout time.Duration, optionalDescription ...interface{}) {
+	c.CheckConnectivityWithTimeoutOffset(2, timeout, optionalDescription...)
+}
+
+func (c *ConnectivityChecker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout time.Duration, optionalDescription ...interface{}) {
 	expConnectivity := c.ExpectedConnectivity()
 	start := time.Now()
 
@@ -436,5 +444,5 @@ func (c *ConnectivityChecker) CheckConnectivityWithTimeout(timeout time.Duration
 		strings.Join(actualConn, "\n    "),
 		strings.Join(expConnectivity, "\n    "),
 	)
-	Fail(message, 1)
+	Fail(message, callerSkip)
 }

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,6 +59,26 @@ var _ = Describe("Static", func() {
 			Describe(fmt.Sprintf("IPv%d", ipVersion), func() {
 				// Capture current value of ipVersion.
 				ipVersion := ipVersion
+
+				expRawFailsafeIn := &Chain{
+					Name: "cali-failsafe-in",
+					Rules: []Rule{
+						{Match: Match().Protocol("tcp").DestPorts(22), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").DestPorts(1022), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").SourcePorts(23), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").SourcePorts(1023), Action: AcceptAction{}},
+					},
+				}
+
+				expRawFailsafeOut := &Chain{
+					Name: "cali-failsafe-out",
+					Rules: []Rule{
+						{Match: Match().Protocol("tcp").DestPorts(23), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").DestPorts(1023), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").SourcePorts(22), Action: AcceptAction{}},
+						{Match: Match().Protocol("tcp").SourcePorts(1022), Action: AcceptAction{}},
+					},
+				}
 
 				expFailsafeIn := &Chain{
 					Name: "cali-failsafe-in",
@@ -173,10 +193,10 @@ var _ = Describe("Static", func() {
 					}))
 				})
 				It("Should return expected raw failsafe in chain", func() {
-					Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-in")).To(Equal(expFailsafeIn))
+					Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-in")).To(Equal(expRawFailsafeIn))
 				})
 				It("Should return expected raw failsafe out chain", func() {
-					Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-out")).To(Equal(expFailsafeOut))
+					Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-out")).To(Equal(expRawFailsafeOut))
 				})
 				It("should return only the expected raw chains", func() {
 					Expect(len(rr.StaticRawTableChains(ipVersion))).To(Equal(4))


### PR DESCRIPTION
This fixes a nasty interaction between do-not-track policy and
failsafe ports. Previously, adding do-not-track policy to a host
endpoint resulted in failsafe port traffic being blocked because
one leg of the connection would get conntracked, but the return
leg would hit the do-not-track policy, which would either drop
it (thus breaking the failsafe port) or mark it as NOTRACK,
which results in future outbound packets failing the
--ctstate INVALID test (because conntrack has only seen an
outbound SYN, it isn't expecting the outbound to move past the
SYN stage of the handshake).

This change whitelists the response traffic in the raw table
only so that failsafe ports are now forced to be conntracked,
bypassing any do-not-track policy in both directions. Since
the change is made only in the raw table (and we don't mark
failsafe port traffic with the accepted mark), the response
traffic still has to pass the --ctstate ESTABLISHED test in
the filter table.

Merge pull request #1718 from fasaxc/failsafe-donottrack

(cherry picked from commit da11a06dbab7caa33cee45789b9f5d298e95fa0f)

Whitelist failsafe port response traffic in the raw table only

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes an interaction between failsafe inbound/outbound ports and do-not-track policy that resulted in failsafe ports being blocked if do-not-track policy was added.
```
