### PR TITLE
Work around temporary IP set deletion failure

### DIFF
--- a/ipsets/ipset_defs.go
+++ b/ipsets/ipset_defs.go
@@ -215,7 +215,6 @@ type ipSet struct {
 	IPSetMetadata
 
 	MainIPSetName string
-	TempIPSetName string
 
 	// members either contains the members that we've programmed or is nil, indicating that
 	// we're out of sync.
@@ -295,14 +294,8 @@ func NewIPVersionConfig(
 	}
 }
 
-// NameForTempIPSet converts the given IP set ID (example: "qMt7iLlGDhvLnCjM0l9nzxbabcd"), to
-// a name for use in the dataplane.  The return value will have the configured prefix and is
-// guaranteed to be short enough to use as an ipset name (example:
-// "cali6ts:qMt7iLlGDhvLnCjM0l9nzxb").
-func (c IPVersionConfig) NameForTempIPSet(setID string) string {
-	// Since IP set IDs are chosen with a secure hash already, we can simply truncate them
-	// to length to get maximum entropy.
-	return combineAndTrunc(c.tempSetNamePrefix, setID, MaxIPSetNameLength)
+func (c IPVersionConfig) NameForTempIPSet(n uint) string {
+	return fmt.Sprint(c.tempSetNamePrefix, n)
 }
 
 // NameForMainIPSet converts the given IP set ID (example: "qMt7iLlGDhvLnCjM0l9nzxbabcd"), to
@@ -319,6 +312,10 @@ func (c IPVersionConfig) NameForMainIPSet(setID string) string {
 // starts with an expected prefix.
 func (c IPVersionConfig) OwnsIPSet(setName string) bool {
 	return c.ourNamePrefixesRegexp.MatchString(setName)
+}
+
+func (c IPVersionConfig) IsTempIPSetName(setName string) bool {
+	return strings.HasPrefix(setName, c.tempSetNamePrefix)
 }
 
 // combineAndTrunc concatenates the given prefix and suffix and truncates the result to maxLength.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
- Use unique temporary IP set names.
- Wait for next resync to retry deletions to avoid tight loop.

Fixes #1745 

## Todos
- [x] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix now uses unique temporary IP set names; this works around transient deletion failures and failures caused by other apps incorrectly referencing Calico IP sets.
```
