### PR TITLE
FV: Understand if there are silent failures

### DIFF
--- a/fv/run-batches
+++ b/fv/run-batches
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -x
 
 # Copyright (c) 2018 Tigera, Inc. All rights reserved.
 #
@@ -29,13 +29,28 @@ for batch in ${FV_BATCHES_TO_RUN}; do
                -ginkgo.randomizeAllSpecs=true \
                -ginkgo.slowSpecThreshold ${FV_SLOW_SPEC_THRESH} \
                -ginkgo.focus="${GINKGO_FOCUS}" \
-               ${GINKGO_ARGS}; \
+               ${GINKGO_ARGS}
+     status=$?
+     echo "Test batch $batch completed with status $status"
+     exit $status
   ) &
   pids[${batch}]=$!
 done
 
+result=0
 for batch in ${FV_BATCHES_TO_RUN}; do
   echo "Waiting on batch $batch; PID=${pids[$batch]}"
   wait ${pids[$batch]}
-  echo "Result: $?"
+  st=$?
+  echo "Result: $st"
+  if [ $st -ne 0 ]; then
+    result=1
+  fi
 done
+
+if [ $result -eq 0 ]; then
+  echo "All tests passed"
+else
+  echo "Tests failed"
+  exit 1
+fi


### PR DESCRIPTION
## Description
There are Semaphore test failures of the FVs where the tests look to be passing and then there is no additional output.  This change is trying to ensure there is output after any possible test failure (silent or otherwise) so that we can tell if Semaphore is stopping this mid-run or there is a silent failure of the test run.

## Todos

## Release Note

```release-note
None required
```
