### PR TITLE
Stop healthchecks from listening on all interfaces.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -157,12 +157,13 @@ type Config struct {
 
 	DisableConntrackInvalidCheck bool `config:"bool;false"`
 
-	HealthEnabled                   bool `config:"bool;false"`
-	HealthPort                      int  `config:"int(0,65535);9099"`
-	PrometheusMetricsEnabled        bool `config:"bool;false"`
-	PrometheusMetricsPort           int  `config:"int(0,65535);9091"`
-	PrometheusGoMetricsEnabled      bool `config:"bool;true"`
-	PrometheusProcessMetricsEnabled bool `config:"bool;true"`
+	HealthEnabled                   bool   `config:"bool;false"`
+	HealthPort                      int    `config:"int(0,65535);9099"`
+	HealthHost                      string `config:"string;localhost"`
+	PrometheusMetricsEnabled        bool   `config:"bool;false"`
+	PrometheusMetricsPort           int    `config:"int(0,65535);9091"`
+	PrometheusGoMetricsEnabled      bool   `config:"bool;true"`
+	PrometheusProcessMetricsEnabled bool   `config:"bool;true"`
 
 	FailsafeInboundHostPorts  []ProtoPort `config:"port-list;tcp:22,udp:68,tcp:179,tcp:2379,tcp:2380,tcp:6666,tcp:6667;die-on-fail"`
 	FailsafeOutboundHostPorts []ProtoPort `config:"port-list;udp:53,udp:67,tcp:179,tcp:2379,tcp:2380,tcp:6666,tcp:6667;die-on-fail"`

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -220,6 +220,10 @@ var _ = DescribeTable("Config parsing",
 	Entry("MaxIpsetSize", "MaxIpsetSize", "12345", int(12345)),
 	Entry("IptablesMarkMask", "IptablesMarkMask", "0xf0f0", uint32(0xf0f0)),
 
+	Entry("HealthEnabled", "HealthEnabled", "true", true),
+	Entry("HealthHost", "HealthHost", "127.0.0.1", "127.0.0.1"),
+	Entry("HealthPort", "HealthPort", "1234", int(1234)),
+
 	Entry("PrometheusMetricsEnabled", "PrometheusMetricsEnabled", "true", true),
 	Entry("PrometheusMetricsPort", "PrometheusMetricsPort", "1234", int(1234)),
 	Entry("PrometheusGoMetricsEnabled", "PrometheusGoMetricsEnabled", "false", false),

--- a/felix.go
+++ b/felix.go
@@ -211,7 +211,7 @@ configRetry:
 
 		// Each time round this loop, check that we're serving health reports if we should
 		// be, or cancel any existing server if we should not be serving any more.
-		healthAggregator.ServeHTTP(configParams.HealthEnabled, "", configParams.HealthPort)
+		healthAggregator.ServeHTTP(configParams.HealthEnabled, configParams.HealthHost, configParams.HealthPort)
 
 		// We should now have enough config to connect to the datastore
 		// so we can load the remainder of the config.
@@ -282,7 +282,7 @@ configRetry:
 	healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
 
 	// Enable or disable the health HTTP server according to coalesced config.
-	healthAggregator.ServeHTTP(configParams.HealthEnabled, "", configParams.HealthPort)
+	healthAggregator.ServeHTTP(configParams.HealthEnabled, configParams.HealthHost, configParams.HealthPort)
 
 	// If we get here, we've loaded the configuration successfully.
 	// Update log levels before we do anything else.

--- a/fv/health_test.go
+++ b/fv/health_test.go
@@ -206,13 +206,14 @@ var _ = Describe("health tests", func() {
 		typhaLiveness = getHealthStatus(typhaContainer.IP, "9098", "liveness")
 	}
 
-	startFelix := func(typhaAddr string, getDockerArgs func() []string, calcGraphHangTime string, dataplaneHangTime string) {
+	startFelix := func(typhaAddr string, getDockerArgs func() []string, calcGraphHangTime, dataplaneHangTime, healthHost string) {
 		felixContainer = containers.Run("felix",
 			containers.RunOpts{AutoRemove: true},
 			append(getDockerArgs(),
 				"--privileged",
 				"-e", "FELIX_IPV6SUPPORT=false",
 				"-e", "FELIX_HEALTHENABLED=true",
+				"-e", "FELIX_HEALTHHOST="+healthHost,
 				"-e", "FELIX_LOGSEVERITYSCREEN=info",
 				"-e", "FELIX_PROMETHEUSMETRICSENABLED=true",
 				"-e", "FELIX_USAGEREPORTINGENABLED=false",
@@ -227,9 +228,35 @@ var _ = Describe("health tests", func() {
 		felixLiveness = getHealthStatus(felixContainer.IP, "9099", "liveness")
 	}
 
+	Describe("healthHost not 'all interfaces'", func() {
+		checkHealthInternally := func() error {
+			_, err := felixContainer.ExecOutput("wget", "-S", "-T", "2", "http://127.0.0.1:9099/readiness", "-O", "-")
+			return err
+		}
+
+		It("should run healthchecks on localhost by default", func() {
+			startFelix("", k8sInfra.GetDockerArgs, "", "", "")
+			Eventually(checkHealthInternally, "10s", "100ms").ShouldNot(HaveOccurred())
+		})
+
+		It("should run support running healthchecks on '127.0.0.1'", func() {
+			startFelix("", k8sInfra.GetDockerArgs, "", "", "127.0.0.1")
+			Eventually(checkHealthInternally, "10s", "100ms").ShouldNot(HaveOccurred())
+		})
+
+		It("should support running healthchecks on 'localhost'", func() {
+			startFelix("", k8sInfra.GetDockerArgs, "", "", "localhost")
+			Eventually(checkHealthInternally, "10s", "100ms").ShouldNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			felixContainer.Stop()
+		})
+	})
+
 	Describe("with Felix running (no Typha)", func() {
 		BeforeEach(func() {
-			startFelix("", k8sInfra.GetDockerArgs, "", "")
+			startFelix("", k8sInfra.GetDockerArgs, "", "", "0.0.0.0")
 		})
 
 		AfterEach(func() {
@@ -241,7 +268,7 @@ var _ = Describe("health tests", func() {
 
 	Describe("with Felix (no Typha) and Felix calc graph set to hang", func() {
 		BeforeEach(func() {
-			startFelix("", k8sInfra.GetDockerArgs, "5", "")
+			startFelix("", k8sInfra.GetDockerArgs, "5", "", "0.0.0.0")
 		})
 
 		AfterEach(func() {
@@ -257,7 +284,7 @@ var _ = Describe("health tests", func() {
 
 	Describe("with Felix (no Typha) and Felix dataplane set to hang", func() {
 		BeforeEach(func() {
-			startFelix("", k8sInfra.GetDockerArgs, "", "5")
+			startFelix("", k8sInfra.GetDockerArgs, "", "5", "0.0.0.0")
 		})
 
 		AfterEach(func() {
@@ -274,7 +301,7 @@ var _ = Describe("health tests", func() {
 	Describe("with Felix and Typha running", func() {
 		BeforeEach(func() {
 			startTypha(k8sInfra.GetDockerArgs)
-			startFelix(typhaContainer.IP+":5473", k8sInfra.GetDockerArgs, "", "")
+			startFelix(typhaContainer.IP+":5473", k8sInfra.GetDockerArgs, "", "", "0.0.0.0")
 		})
 
 		AfterEach(func() {
@@ -335,7 +362,7 @@ var _ = Describe("health tests", func() {
 				options.SetOptions{},
 			)
 			Expect(err).NotTo(HaveOccurred())
-			startFelix("", k8sInfra.GetDockerArgs, "", "")
+			startFelix("", k8sInfra.GetDockerArgs, "", "", "0.0.0.0")
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Modify healthchecks so that they listen on `localhost` by default instead of `0.0.0.0`.

Exposed the adress as a Felix config option because in DC/OS, healthchecks come from the scheduler (marathon), not the node process (mesos-slave). So that is one known case where the healthcheck endpoint needs to be accessible beyond localhost.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
HealthCheck default behavior changed from listening on all interfaces to just listening on localhost. This behavior can be controlled by the new HealthHost parameter.
```
