### PR TITLE
Support a custom host for health server

### DIFF
--- a/calc/profile_decoder.go
+++ b/calc/profile_decoder.go
@@ -34,7 +34,7 @@ type ProfileDecoder struct {
 }
 
 func NewProfileDecoder(callbacks passthruCallbacks) *ProfileDecoder {
-	return &ProfileDecoder{callbacks: callbacks, converter: conversion.Converter{true}}
+	return &ProfileDecoder{callbacks: callbacks, converter: conversion.Converter{}}
 }
 
 func (p *ProfileDecoder) RegisterWith(d *dispatcher.Dispatcher) {

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -157,8 +157,10 @@ type Config struct {
 
 	DisableConntrackInvalidCheck bool `config:"bool;false"`
 
-	HealthEnabled                   bool `config:"bool;false"`
-	HealthPort                      int  `config:"int(0,65535);9099"`
+	HealthEnabled                   bool   `config:"bool;false"`
+	HealthHost                      string `config:"string;"`
+	HealthPort                      int    `config:"int(0,65535);9099"`
+
 	PrometheusMetricsEnabled        bool `config:"bool;false"`
 	PrometheusMetricsPort           int  `config:"int(0,65535);9091"`
 	PrometheusGoMetricsEnabled      bool `config:"bool;true"`

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -220,6 +220,10 @@ var _ = DescribeTable("Config parsing",
 	Entry("MaxIpsetSize", "MaxIpsetSize", "12345", int(12345)),
 	Entry("IptablesMarkMask", "IptablesMarkMask", "0xf0f0", uint32(0xf0f0)),
 
+	Entry("HealthEnabled", "HealthEnabled", "true", true),
+	Entry("HealthHost", "HealthHost", "127.0.0.1", "127.0.0.1"),
+	Entry("HealthPort", "HealthPort", "1234", int(1234)),
+
 	Entry("PrometheusMetricsEnabled", "PrometheusMetricsEnabled", "true", true),
 	Entry("PrometheusMetricsPort", "PrometheusMetricsPort", "1234", int(1234)),
 	Entry("PrometheusGoMetricsEnabled", "PrometheusGoMetricsEnabled", "false", false),

--- a/felix.go
+++ b/felix.go
@@ -211,7 +211,7 @@ configRetry:
 
 		// Each time round this loop, check that we're serving health reports if we should
 		// be, or cancel any existing server if we should not be serving any more.
-		healthAggregator.ServeHTTP(configParams.HealthEnabled, "", configParams.HealthPort)
+		healthAggregator.ServeHTTP(configParams.HealthEnabled, configParams.HealthHost, configParams.HealthPort)
 
 		// We should now have enough config to connect to the datastore
 		// so we can load the remainder of the config.
@@ -282,7 +282,7 @@ configRetry:
 	healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
 
 	// Enable or disable the health HTTP server according to coalesced config.
-	healthAggregator.ServeHTTP(configParams.HealthEnabled, "", configParams.HealthPort)
+	healthAggregator.ServeHTTP(configParams.HealthEnabled, configParams.HealthHost, configParams.HealthPort)
 
 	// If we get here, we've loaded the configuration successfully.
 	// Update log levels before we do anything else.

--- a/fv/infrastructure/infra_etcd.go
+++ b/fv/infrastructure/infra_etcd.go
@@ -70,7 +70,7 @@ func (eds *EtcdDatastoreInfra) GetBadEndpointDockerArgs() []string {
 }
 
 func (eds *EtcdDatastoreInfra) GetCalicoClient() client.Interface {
-	return utils.GetEtcdClient(eds.etcdContainer.IP, "")
+	return utils.GetEtcdClient(eds.etcdContainer.IP)
 }
 
 func (eds *EtcdDatastoreInfra) AddNode(felix *Felix, idx int, needBGP bool) {

--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -34,7 +34,6 @@ type TopologyOptions struct {
 	EnableIPv6            bool
 	ExtraEnvVars          map[string]string
 	ExtraVolumes          map[string]string
-	AlphaFeaturesToEnable string
 }
 
 func DefaultTopologyOptions() TopologyOptions {
@@ -70,7 +69,7 @@ func StartNNodeEtcdTopology(n int, opts TopologyOptions) (felixes []*Felix, etcd
 
 	felixes, client = StartNNodeTopology(n, opts, eds)
 
-	client = utils.GetEtcdClient(eds.etcdContainer.IP, opts.AlphaFeaturesToEnable)
+	client = utils.GetEtcdClient(eds.etcdContainer.IP)
 
 	return felixes, eds.etcdContainer, client
 }

--- a/fv/policysync_test.go
+++ b/fv/policysync_test.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/projectcalico/felix/binder"
-	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
 	"github.com/projectcalico/libcalico-go/lib/options"
 
@@ -77,7 +76,6 @@ var _ = Context("policy sync API tests", func() {
 		// options.ExtraEnvVars["FELIX_DebugDisableLogDropping"] = "true"
 		// options.FelixLogSeverity = "debug"
 		options.ExtraVolumes[tempDir] = "/var/run/calico"
-		options.AlphaFeaturesToEnable = apiconfig.AlphaFeatureSA + "," + apiconfig.AlphaFeatureHTTP
 		felix, etcd, calicoClient = infrastructure.StartSingleNodeEtcdTopology(options)
 
 		// Install a default profile that allows workloads with this profile to talk to each

--- a/fv/utils/utils.go
+++ b/fv/utils/utils.go
@@ -121,14 +121,13 @@ func Command(name string, args ...string) *exec.Cmd {
 	return exec.Command(name, args...)
 }
 
-func GetEtcdClient(etcdIP string, alphaFeatures string) client.Interface {
+func GetEtcdClient(etcdIP string) client.Interface {
 	client, err := client.New(apiconfig.CalicoAPIConfig{
 		Spec: apiconfig.CalicoAPIConfigSpec{
 			DatastoreType: apiconfig.EtcdV3,
 			EtcdConfig: apiconfig.EtcdConfig{
 				EtcdEndpoints: "http://" + etcdIP + ":2379",
 			},
-			AlphaFeatures: alphaFeatures,
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1c56a150fe70632c3f836f4fcebaabc0a9ab54dd2ed16a47fd1c35ab0276776f
-updated: 2018-03-29T19:02:29.041099798Z
+hash: 9c4d5d9828dba75f85cf0761e09abe7d4133d62366a078f9c3e753b0410fb6c7
+updated: 2018-04-12T15:03:51.810884+02:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -51,7 +51,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-ini/ini
-  version: 6333e38ac20b8949a8dd68baa3650f4dee8f39f0
+  version: 5e9692864e22d02ac79e2fa499cffb00520b4fea
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -205,7 +205,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 88291609bbefd0fe22982a7a78ec51d63583a651
+  version: 65d364d12c37bdb63e3660df5387826ed4068e40
   subpackages:
   - lib
   - lib/apiconfig

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,7 +35,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: 88291609bbefd0fe22982a7a78ec51d63583a651
+  version: 65d364d12c37bdb63e3660df5387826ed4068e40
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus


### PR DESCRIPTION
Instead of forcing to listen on all interfaces we should give the possibility for the user to make the health server listen on a specific host/IP.

### TODO

- [ ] Wait for https://github.com/projectcalico/typha/pull/140, then update the dependency