### PR TITLE
Changes to allow libcalico-go upgrade for Felix.

### DIFF
--- a/calc/profile_decoder.go
+++ b/calc/profile_decoder.go
@@ -34,7 +34,7 @@ type ProfileDecoder struct {
 }
 
 func NewProfileDecoder(callbacks passthruCallbacks) *ProfileDecoder {
-	return &ProfileDecoder{callbacks: callbacks, converter: conversion.Converter{true}}
+	return &ProfileDecoder{callbacks: callbacks, converter: conversion.Converter{}}
 }
 
 func (p *ProfileDecoder) RegisterWith(d *dispatcher.Dispatcher) {

--- a/fv/infrastructure/infra_etcd.go
+++ b/fv/infrastructure/infra_etcd.go
@@ -70,7 +70,7 @@ func (eds *EtcdDatastoreInfra) GetBadEndpointDockerArgs() []string {
 }
 
 func (eds *EtcdDatastoreInfra) GetCalicoClient() client.Interface {
-	return utils.GetEtcdClient(eds.etcdContainer.IP, "")
+	return utils.GetEtcdClient(eds.etcdContainer.IP)
 }
 
 func (eds *EtcdDatastoreInfra) AddNode(felix *Felix, idx int, needBGP bool) {

--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -30,11 +30,10 @@ import (
 )
 
 type TopologyOptions struct {
-	FelixLogSeverity      string
-	EnableIPv6            bool
-	ExtraEnvVars          map[string]string
-	ExtraVolumes          map[string]string
-	AlphaFeaturesToEnable string
+	FelixLogSeverity string
+	EnableIPv6       bool
+	ExtraEnvVars     map[string]string
+	ExtraVolumes     map[string]string
 }
 
 func DefaultTopologyOptions() TopologyOptions {
@@ -70,7 +69,7 @@ func StartNNodeEtcdTopology(n int, opts TopologyOptions) (felixes []*Felix, etcd
 
 	felixes, client = StartNNodeTopology(n, opts, eds)
 
-	client = utils.GetEtcdClient(eds.etcdContainer.IP, opts.AlphaFeaturesToEnable)
+	client = utils.GetEtcdClient(eds.etcdContainer.IP)
 
 	return felixes, eds.etcdContainer, client
 }

--- a/fv/policysync_test.go
+++ b/fv/policysync_test.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/projectcalico/felix/binder"
-	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
 	"github.com/projectcalico/libcalico-go/lib/options"
 
@@ -77,7 +76,6 @@ var _ = Context("policy sync API tests", func() {
 		// options.ExtraEnvVars["FELIX_DebugDisableLogDropping"] = "true"
 		// options.FelixLogSeverity = "debug"
 		options.ExtraVolumes[tempDir] = "/var/run/calico"
-		options.AlphaFeaturesToEnable = apiconfig.AlphaFeatureSA + "," + apiconfig.AlphaFeatureHTTP
 		felix, etcd, calicoClient = infrastructure.StartSingleNodeEtcdTopology(options)
 
 		// Install a default profile that allows workloads with this profile to talk to each
@@ -403,7 +401,9 @@ var _ = Context("policy sync API tests", func() {
 											Action:              "allow",
 											OriginalSrcSelector: "all()",
 											SrcIpSetIds: []string{
-												utils.IPSetIDForSelector("all()"),
+												// Copy over the SrcIpSetIds from the Policy.
+												// as it is not a mix of src selector and src ServiceAccountMatch
+												policy.InboundRules[0].SrcIpSetIds[0],
 											},
 											SrcServiceAccountMatch: &proto.ServiceAccountMatch{
 												Selector: "foo == 'bar'",

--- a/fv/utils/utils.go
+++ b/fv/utils/utils.go
@@ -121,14 +121,13 @@ func Command(name string, args ...string) *exec.Cmd {
 	return exec.Command(name, args...)
 }
 
-func GetEtcdClient(etcdIP string, alphaFeatures string) client.Interface {
+func GetEtcdClient(etcdIP string) client.Interface {
 	client, err := client.New(apiconfig.CalicoAPIConfig{
 		Spec: apiconfig.CalicoAPIConfigSpec{
 			DatastoreType: apiconfig.EtcdV3,
 			EtcdConfig: apiconfig.EtcdConfig{
 				EtcdEndpoints: "http://" + etcdIP + ":2379",
 			},
-			AlphaFeatures: alphaFeatures,
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1c56a150fe70632c3f836f4fcebaabc0a9ab54dd2ed16a47fd1c35ab0276776f
-updated: 2018-03-29T19:02:29.041099798Z
+hash: eb7b0d95bae1c15be9ce080ea04c7512734ab9fd3a9f7dcb8148583cb9d2e6b8
+updated: 2018-04-16T19:09:07.30351097Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -51,7 +51,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-ini/ini
-  version: 6333e38ac20b8949a8dd68baa3650f4dee8f39f0
+  version: ace140f73450505f33e8b8418216792275ae82a7
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -113,7 +113,7 @@ imports:
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/ipfs/go-log
-  version: 4b54e7d2460df21c1c2d345af2337f91bfc938ca
+  version: 7ecd3df29a4a648fd3ecd1e78d19d1bfcaacee0f
 - name: github.com/jbenet/go-reuseport
   version: 7eed93a5b50b20c209baefe9fafa53c3d965a33c
   repo: https://github.com/fasaxc/go-reuseport.git
@@ -188,7 +188,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/opentracing/opentracing-go
-  version: 328fceb7548c744337cd010914152b74eaf4c4ab
+  version: 6c572c00d1830223701e155de97408483dfcd14a
   subpackages:
   - ext
   - log
@@ -205,7 +205,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 88291609bbefd0fe22982a7a78ec51d63583a651
+  version: 3c080a2cf53e8bf21b78d33eb5f681d97daad102
   subpackages:
   - lib
   - lib/apiconfig
@@ -259,7 +259,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a
+  version: d0f7cd64bda49e08b22ae8a730aa57aa0db125d6
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -283,11 +283,11 @@ imports:
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: be1fbeda19366dea804f00efff2dd73a1642fdcc
+  version: 8ba1072b58e0c2a240eb5f6120165c7776c3e7b8
 - name: github.com/whyrusleeping/go-logging
   version: 0457bb6b88fc1973573aaf6b5145d8d3ae972390
 - name: golang.org/x/crypto
-  version: 88942b9c40a4c9d203b82b3731787b672d6e809b
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -342,7 +342,7 @@ imports:
   - unicode/norm
   - width
 - name: google.golang.org/appengine
-  version: ad39d7fab7c60b2493fdc318c3d2cdb2128f92a4
+  version: 0a24098c0ec68416ec050f567f75df563d6b231e
   subpackages:
   - internal
   - internal/app_identity
@@ -354,7 +354,7 @@ imports:
   - internal/urlfetch
   - urlfetch
 - name: google.golang.org/genproto
-  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
+  version: 7fd901a49ba6a7f87732eb344f6e3c5b19d1b200
   subpackages:
   - googleapis
   - googleapis/rpc/status

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,7 +35,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: 88291609bbefd0fe22982a7a78ec51d63583a651
+  version: 3c080a2cf53e8bf21b78d33eb5f681d97daad102
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus


### PR DESCRIPTION
## Description
Upgrade the `libcalico-go` pin's in Felix. Made changes to ensure that the ft's work.

NOTE: I had a hard time figuring out what the IPSet's sha244 mac should be now that ServiceAccount Labels are part of the selector. So I ended up copying the `SrcIpSetIds`! But if there is a alternate then please do suggest.