### PR TITLE
Squash no-op updates to policy.

### DIFF
--- a/calc/active_rules_calculator.go
+++ b/calc/active_rules_calculator.go
@@ -145,6 +145,10 @@ func (arc *ActiveRulesCalculator) OnUpdate(update api.Update) (_ bool) {
 	case model.ProfileRulesKey:
 		if update.Value != nil {
 			rules := update.Value.(*model.ProfileRules)
+			if reflect.DeepEqual(arc.allProfileRules[key.Name], rules) {
+				log.WithField("key", update.Key).Debug("No-op profile change; ignoring.")
+				return
+			}
 			arc.allProfileRules[key.Name] = rules
 			if arc.profileIDToEndpointKeys.ContainsKey(key.Name) {
 				log.Debugf("Profile rules updated while active: %v", key.Name)
@@ -167,6 +171,10 @@ func (arc *ActiveRulesCalculator) OnUpdate(update api.Update) (_ bool) {
 		if update.Value != nil {
 			log.Debugf("Updating ARC for policy %v", key)
 			policy := update.Value.(*model.Policy)
+			if reflect.DeepEqual(arc.allPolicies[key], policy) {
+				log.WithField("key", update.Key).Debug("No-op policy change; ignoring.")
+				return
+			}
 			arc.allPolicies[key] = policy
 			// Update the index, which will call us back if the selector no
 			// longer matches.

--- a/calc/policy_resolver.go
+++ b/calc/policy_resolver.go
@@ -97,7 +97,9 @@ func (pr *PolicyResolver) OnUpdate(update api.Update) (filterOut bool) {
 	case model.PolicyKey:
 		log.Debugf("Policy update: %v", key)
 		policiesDirty = pr.policySorter.OnUpdate(update)
-		pr.markEndpointsMatchingPolicyDirty(key)
+		if policiesDirty {
+			pr.markEndpointsMatchingPolicyDirty(key)
+		}
 	}
 	pr.sortRequired = pr.sortRequired || policiesDirty
 	pr.maybeFlush()

--- a/calc/states_for_test.go
+++ b/calc/states_for_test.go
@@ -41,8 +41,9 @@ var initialisedStore = empty.withKVUpdates(
 ).withName("<initialised>")
 
 // withPolicy adds a tier and policy containing selectors for all and b=="b"
+var pol1KVPair = KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policy1_order20}
 var withPolicy = initialisedStore.withKVUpdates(
-	KVPair{Key: PolicyKey{Name: "pol-1"}, Value: &policy1_order20},
+	pol1KVPair,
 ).withName("with policy")
 
 // withPolicyIngressOnly adds a tier and ingress policy containing selectors for all

--- a/dataplane/mock/mock_dataplane.go
+++ b/dataplane/mock/mock_dataplane.go
@@ -44,6 +44,7 @@ type MockDataplane struct {
 	serviceAccounts                map[proto.ServiceAccountID]*proto.ServiceAccountUpdate
 	namespaces                     map[proto.NamespaceID]*proto.NamespaceUpdate
 	config                         map[string]string
+	numEvents                      int
 }
 
 func (d *MockDataplane) InSync() bool {
@@ -154,6 +155,13 @@ func (d *MockDataplane) Namespaces() map[proto.NamespaceID]*proto.NamespaceUpdat
 	return cpy
 }
 
+func (d *MockDataplane) NumEventsRecorded() int {
+	d.Lock()
+	defer d.Unlock()
+
+	return d.numEvents
+}
+
 func copyPolOrder(in map[string][]TierInfo) map[string][]TierInfo {
 	copy := map[string][]TierInfo{}
 	for k, v := range in {
@@ -204,6 +212,8 @@ func NewMockDataplane() *MockDataplane {
 func (d *MockDataplane) OnEvent(event interface{}) {
 	d.Lock()
 	defer d.Unlock()
+
+	d.numEvents++
 
 	evType := reflect.TypeOf(event).String()
 	fmt.Fprintf(GinkgoWriter, "       <- Event: %v %v\n", evType, event)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

This works around the OpenStack plugin's propensity to send lots of no-op policy updates.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix now handles no-op policy updates more efficiently, this can significantly reduce CPU usage where policy is frequently rewritten with no changes.
```
