### PR TITLE
[WIP] HTTP Path rule convert over to protobuf.

### DIFF
--- a/calc/rule_convert_test.go
+++ b/calc/rule_convert_test.go
@@ -85,7 +85,7 @@ var fullyLoadedParsedRule = ParsedRule{
 	OriginalDstServiceAccountSelector: "has(sa-dst)",
 	OriginalDstServiceAccountNames:    []string{"dst-1"},
 
-	HTTPMatch: &model.HTTPMatch{Methods: []string{"GET", "POST"}},
+	HTTPMatch: &model.HTTPMatch{Methods: []string{"GET", "POST"}, Paths: []map[string]string{{"exact": "/foo"}, {"prefix": "/bar"}}},
 }
 
 var fullyLoadedProtoRule = proto.Rule{
@@ -147,7 +147,11 @@ var fullyLoadedProtoRule = proto.Rule{
 		Names:    []string{"dst-1"},
 	},
 
-	HttpMatch: &proto.HTTPMatch{Methods: []string{"GET", "POST"}},
+	HttpMatch: &proto.HTTPMatch{Methods: []string{"GET", "POST"},
+		Paths: []*proto.HTTPMatchPathMatchTypes{
+			{&proto.HTTPMatchPathMatchTypes_Exact{Exact: "/foo"}},
+			{&proto.HTTPMatchPathMatchTypes_Prefix{Prefix: "/bar"}},
+		}},
 }
 
 var _ = DescribeTable("ParsedRulesToProtoRules",

--- a/calc/rule_scanner_test.go
+++ b/calc/rule_scanner_test.go
@@ -146,7 +146,7 @@ var _ = DescribeTable("RuleScanner rule conversion should generate correct Parse
 	Entry("OriginalSrcServiceAccountSelector", model.Rule{OriginalSrcServiceAccountSelector: "all()"}, ParsedRule{OriginalSrcServiceAccountSelector: "all()"}),
 	Entry("OriginalDstServiceAccountSelector", model.Rule{OriginalDstServiceAccountSelector: "all()"}, ParsedRule{OriginalDstServiceAccountSelector: "all()"}),
 
-	Entry("HTTPMatch", model.Rule{HTTPMatch: &model.HTTPMatch{Methods: []string{"GET", "HEAD"}}}, ParsedRule{HTTPMatch: &model.HTTPMatch{Methods: []string{"GET", "HEAD"}}}),
+	Entry("HTTPMatch", model.Rule{HTTPMatch: &model.HTTPMatch{Methods: []string{"GET", "HEAD"}, Paths: []map[string]string{{"exact": "/foo"}, {"prefix": "/bar"}}}}, ParsedRule{HTTPMatch: &model.HTTPMatch{Methods: []string{"GET", "HEAD"}, Paths: []map[string]string{{"exact": "/foo"}, {"prefix": "/bar"}}}}),
 
 	// Tags/Selectors.
 	Entry("source tag", model.Rule{SrcTag: "tag1"}, ParsedRule{SrcIPSetIDs: []string{tag1ID}}),

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 41208200ad15c2eb5a3d87968925276d8c24fa389555baba054d1f7d21284c37
-updated: 2018-04-23T13:35:53.294152256Z
+hash: 0e2b4da9ffb43bf5ea2a9d9ddb7ac1ef5e58f23a3e0d57859b4694b47edb95df
+updated: 2018-04-26T22:23:11.139100454Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -116,7 +116,11 @@ imports:
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/ipfs/go-log
-  version: 7ecd3df29a4a648fd3ecd1e78d19d1bfcaacee0f
+  version: 5e734014d0311263d09aa50625882643965cfb35
+  subpackages:
+  - tracer
+  - tracer/wire
+  - writer
 - name: github.com/jbenet/go-reuseport
   version: 7eed93a5b50b20c209baefe9fafa53c3d965a33c
   repo: https://github.com/fasaxc/go-reuseport.git
@@ -208,7 +212,8 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: e3351395c934cee118999b9d29508e9280fa75ec
+  version: 588c41c694780095835bf1183a9f169730dacae4
+  repo: https://github.com/colabsaumoh/libcalico-go
   subpackages:
   - lib
   - lib/apiconfig
@@ -263,7 +268,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: d0f7cd64bda49e08b22ae8a730aa57aa0db125d6
+  version: d811d2e9bf898806ecfb6ef6296774b13ffc314c
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -287,11 +292,11 @@ imports:
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: be1fbeda19366dea804f00efff2dd73a1642fdcc
+  version: 8ba1072b58e0c2a240eb5f6120165c7776c3e7b8
 - name: github.com/whyrusleeping/go-logging
   version: 0457bb6b88fc1973573aaf6b5145d8d3ae972390
 - name: golang.org/x/crypto
-  version: 2b6c08872f4b66da917bb4ce98df4f0307330f78
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net

--- a/glide.yaml
+++ b/glide.yaml
@@ -37,7 +37,8 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: e3351395c934cee118999b9d29508e9280fa75ec
+  version: 588c41c694780095835bf1183a9f169730dacae4
+  repo: https://github.com/colabsaumoh/libcalico-go
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus

--- a/proto/felixbackend.proto
+++ b/proto/felixbackend.proto
@@ -272,6 +272,13 @@ message ServiceAccountMatch {
 
 message HTTPMatch {
   repeated string methods = 1;
+  message path_match_types{
+    oneof path_match {
+      string exact = 2;
+      string prefix = 3;
+    }
+  }
+  repeated path_match_types paths = 4;
 }
 
 message IcmpTypeAndCode {


### PR DESCRIPTION
## Description
As the PR for `libcalico-go` is under review (https://github.com/projectcalico/libcalico-go/pull/858) I though it best to get the changes in Felix under review sooner than later.
The key change is the protobuf definition and the rest is glue to covert from model to protobuf.

Assuming that `libcalico-go` model isn't changed during review the Felix side should be stable enough for a preliminary review.