### PR TITLE
Allow others to import and run Felix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -492,7 +492,7 @@ bin/calico-felix-$(ARCH): $(FELIX_GO_FILES) vendor/.up-to-date
 	@echo Building felix for $(ARCH) on $(BUILDARCH)
 	mkdir -p bin
 	$(DOCKER_GO_BUILD) \
-	   sh -c 'go build -v -i -o $@ -v $(LDFLAGS) "github.com/projectcalico/felix" && \
+	   sh -c 'go build -v -i -o $@ -v $(LDFLAGS) "github.com/projectcalico/felix/cmd/calico-felix" && \
 		( ldd $@ 2>&1 | grep -q -e "Not a valid dynamic program" \
 		-e "not a dynamic executable" || \
 		( echo "Error: $@ was not statically linked"; false ) )'
@@ -532,7 +532,7 @@ bin/calico-felix.exe: $(FELIX_GO_FILES) vendor/.up-to-date
 	@echo Building felix for Windows...
 	mkdir -p bin
 	$(DOCKER_GO_BUILD) \
-           sh -c 'GOOS=windows go build -v -o $@ -v $(LDFLAGS) "github.com/projectcalico/felix" && \
+           sh -c 'GOOS=windows go build -v -o $@ -v $(LDFLAGS) "github.com/projectcalico/felix/cmd/calico-felix" && \
 		( ldd $@ 2>&1 | grep -q "Not a valid dynamic program" || \
 		( echo "Error: $@ was not statically linked"; false ) )'
 
@@ -550,7 +550,7 @@ go-fmt goimports:
 	                          xargs goimports -w -local github.com/projectcalico/ *.go'
 
 check-licenses/dependency-licenses.txt: vendor/.up-to-date
-	$(DOCKER_GO_BUILD) sh -c 'licenses . > check-licenses/dependency-licenses.txt'
+	$(DOCKER_GO_BUILD) sh -c 'licenses ./cmd/calico-felix > check-licenses/dependency-licenses.txt'
 
 .PHONY: ut
 ut combined.coverprofile: vendor/.up-to-date $(FELIX_GO_FILES)

--- a/cmd/calico-felix/calico-felix.go
+++ b/cmd/calico-felix/calico-felix.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	docopt "github.com/docopt/docopt-go"
+
+	"github.com/projectcalico/felix/buildinfo"
+	"github.com/projectcalico/felix/daemon"
+)
+
+const usage = `Felix, the Calico per-host daemon.
+
+Usage:
+  calico-felix [options]
+
+Options:
+  -c --config-file=<filename>  Config file to load [default: /etc/calico/felix.cfg].
+  --version                    Print the version and exit.
+`
+
+// main is the entry point to the calico-felix binary.
+//
+func main() {
+	// Parse command-line args.
+	version := "Version:            " + buildinfo.GitVersion + "\n" +
+		"Full git commit ID: " + buildinfo.GitRevision + "\n" +
+		"Build date:         " + buildinfo.BuildDate + "\n"
+	arguments, err := docopt.Parse(usage, nil, true, version, false)
+	if err != nil {
+		println(usage)
+		log.Fatalf("Failed to parse usage, exiting: %v", err)
+	}
+	configFile := arguments["--config-file"].(string)
+
+	// Execute felix.
+	daemon.Run(configFile)
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Minor refactor - lets others import "github.com/projectcalico/felix/felix" and call `felix.Run("")`.

Not perfect, since Felix calls exit a bunch so with just this PR you couldn't, say, run felix as one goroutine amongst many, but might be a neat place to end up at.

With this PR though it can be compiled in with other packages that share the same code in order to reduce binary size by sharing dependencies. 

WDYT?

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
