### PR TITLE
Fix go-meta-linter errors

### DIFF
--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -25,7 +25,6 @@ import (
 	"regexp"
 
 	"github.com/projectcalico/felix/fv/containers"
-	"github.com/projectcalico/felix/fv/utils"
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	client "github.com/projectcalico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/libcalico-go/lib/options"
@@ -74,12 +73,11 @@ func StartNNodeEtcdTopology(n int, opts TopologyOptions) (felixes []*Felix, etcd
 
 	eds, err := GetEtcdDatastoreInfra()
 	Expect(err).ToNot(HaveOccurred())
+	etcd = eds.etcdContainer
 
-	felixes, _ = StartNNodeTopology(n, opts, eds)
+	felixes, client = StartNNodeTopology(n, opts, eds)
 
-	client = utils.GetEtcdClient(eds.etcdContainer.IP)
-
-	return felixes, eds.etcdContainer, client
+	return
 }
 
 // StartSingleNodeEtcdTopology starts an etcd container and a single Felix container; it initialises


### PR DESCRIPTION
/go/src/github.com/projectcalico/felix/calc/calc_graph_test.go:231:6: lastStats declared but not used
couldn't load packages due to errors: github.com/projectcalico/felix/calc_test
fv/infrastructure/infra_k8s.go:273:2: this value of info is never used (SA4006)
fv/infrastructure/topology.go:78:11: this value of client is never used (SA4006)
