### PR TITLE
Strip the `v` from the version number when building debs

### DIFF
--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -40,6 +40,10 @@ function git_commit_id {
     git rev-parse HEAD | cut -c-7
 }
 
+function strip_v {
+	echo $1 | cut -d "v" -f 2
+}
+
 # Convert PEP 440 version to Debian.
 function git_version_to_deb {
     echo $1 | sed 's/\([0-9]\)-\?\(a\|b\|rc\|pre\)/\1~\2/'

--- a/utils/make-packages.sh
+++ b/utils/make-packages.sh
@@ -39,6 +39,7 @@ for package_type in "$@"; do
 	deb )
 	    # The Debian version that we are about to generate.
 	    debver=`git_version_to_deb ${version}`
+	    debver=`strip_v ${debver}`
 
 	    # The last Git tag that was packaged, according to the
 	    # debian/changelog file.
@@ -95,6 +96,7 @@ EOF
 
 	rpm )
 	    debver=`git_version_to_rpm ${version}`
+	    debver=`strip_v ${debver}`
 	    rpm_spec=rpm/felix.spec
 
 	    # The last Git tag that was packaged, according to the RPM


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Allows us to use a `v` like other calico components in the `calico/felix` release, but when building the debs they seem to need to start with a number. 

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
