### PR TITLE
Add option to specify port-range for outgoing NAT.

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -180,7 +180,7 @@ type Config struct {
 	FailsafeOutboundHostPorts []ProtoPort `config:"port-list;udp:53,udp:67,tcp:179,tcp:2379,tcp:2380,tcp:6666,tcp:6667;die-on-fail"`
 
 	KubeNodePortRanges []numorstring.Port `config:"portrange-list;30000:32767"`
-	NatPortRange       string             `config:"portrange;"`
+	NatPortRange       string             `config:"portrange;;local"`
 
 	UsageReportingEnabled          bool          `config:"bool;true"`
 	UsageReportingInitialDelaySecs time.Duration `config:"seconds;300"`

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -180,6 +180,7 @@ type Config struct {
 	FailsafeOutboundHostPorts []ProtoPort `config:"port-list;udp:53,udp:67,tcp:179,tcp:2379,tcp:2380,tcp:6666,tcp:6667;die-on-fail"`
 
 	KubeNodePortRanges []numorstring.Port `config:"portrange-list;30000:32767"`
+	NatPortRange       string             `config:"portrange;"`
 
 	UsageReportingEnabled          bool          `config:"bool;true"`
 	UsageReportingInitialDelaySecs time.Duration `config:"seconds;300"`
@@ -516,6 +517,8 @@ func loadParams() {
 			param = &EndpointListParam{}
 		case "port-list":
 			param = &PortListParam{}
+		case "portrange":
+			param = &PortRangeParam{}
 		case "portrange-list":
 			param = &PortRangeListParam{}
 		case "hostname":

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -180,7 +180,7 @@ type Config struct {
 	FailsafeOutboundHostPorts []ProtoPort `config:"port-list;udp:53,udp:67,tcp:179,tcp:2379,tcp:2380,tcp:6666,tcp:6667;die-on-fail"`
 
 	KubeNodePortRanges []numorstring.Port `config:"portrange-list;30000:32767"`
-	NatPortRange       numorstring.Port   `config:"portrange;;local"`
+	NATPortRange       numorstring.Port   `config:"portrange;"`
 
 	UsageReportingEnabled          bool          `config:"bool;true"`
 	UsageReportingInitialDelaySecs time.Duration `config:"seconds;300"`

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -180,7 +180,7 @@ type Config struct {
 	FailsafeOutboundHostPorts []ProtoPort `config:"port-list;udp:53,udp:67,tcp:179,tcp:2379,tcp:2380,tcp:6666,tcp:6667;die-on-fail"`
 
 	KubeNodePortRanges []numorstring.Port `config:"portrange-list;30000:32767"`
-	NatPortRange       string             `config:"portrange;;local"`
+	NatPortRange       numorstring.Port   `config:"portrange;;local"`
 
 	UsageReportingEnabled          bool          `config:"bool;true"`
 	UsageReportingInitialDelaySecs time.Duration `config:"seconds;300"`

--- a/config/param_types.go
+++ b/config/param_types.go
@@ -281,6 +281,18 @@ func (p *PortListParam) Parse(raw string) (interface{}, error) {
 	return result, nil
 }
 
+type PortRangeParam struct {
+	Metadata
+}
+
+func (p *PortRangeParam) Parse(raw string) (interface{}, error) {
+	portRange, err := numorstring.PortFromString(raw)
+	if err != nil {
+		return nil, p.parseFailed(raw, fmt.Sprintf("%s is not a valid port range", raw))
+	}
+	return portRange.String(), nil
+}
+
 type PortRangeListParam struct {
 	Metadata
 }

--- a/config/param_types.go
+++ b/config/param_types.go
@@ -290,7 +290,10 @@ func (p *PortRangeParam) Parse(raw string) (interface{}, error) {
 	if err != nil {
 		return nil, p.parseFailed(raw, fmt.Sprintf("%s is not a valid port range", raw))
 	}
-	return portRange.String(), nil
+	if len(portRange.PortName) > 0 {
+		return nil, p.parseFailed(raw, fmt.Sprintf("%s has port name set", raw))
+	}
+	return portRange, nil
 }
 
 type PortRangeListParam struct {

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -130,6 +130,8 @@ func StartDataplaneDriver(configParams *config.Config,
 				FailsafeOutboundHostPorts: configParams.FailsafeOutboundHostPorts,
 
 				DisableConntrackInvalid: configParams.DisableConntrackInvalidCheck,
+
+				NATPortRange: configParams.NatPortRange,
 			},
 			IPIPMTU:                        configParams.IpInIpMtu,
 			IptablesRefreshInterval:        configParams.IptablesRefreshInterval,

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -131,7 +131,7 @@ func StartDataplaneDriver(configParams *config.Config,
 
 				DisableConntrackInvalid: configParams.DisableConntrackInvalidCheck,
 
-				NATPortRange: configParams.NatPortRange,
+				NATPortRange: configParams.NATPortRange,
 			},
 			IPIPMTU:                        configParams.IpInIpMtu,
 			IptablesRefreshInterval:        configParams.IptablesRefreshInterval,

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 41ad0474efa259eeb1b352e7fc636c3539d68b61ed4f67d5135fe48a3d975714
-updated: 2018-05-29T16:18:20.167258908Z
+hash: 34a79aa2a9f35f43318d0bc9ee535e0f2cd2b1b45ef1c27e27f645c879637629
+updated: 2018-06-26T10:41:22.2309252Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -116,7 +116,7 @@ imports:
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/ipfs/go-log
-  version: b9df188d0fae32d69c1a519fa81741668a12f55a
+  version: 5dc2060baaf8db344f31dafd852340b93811d03f
   subpackages:
   - tracer
   - tracer/wire
@@ -195,7 +195,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/opentracing/opentracing-go
-  version: 6c572c00d1830223701e155de97408483dfcd14a
+  version: bd9c3193394760d98b2fa6ebb2291f0cd1d06a7d
   subpackages:
   - ext
   - log
@@ -212,7 +212,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: d6aff54dc3527357f016c0cd5c5364f21a15e9b4
+  version: 8bf1e12ff13ecf994ae410efdf7808ed934a53fc
   subpackages:
   - lib
   - lib/apiconfig
@@ -251,7 +251,7 @@ imports:
   - lib/validator/v3
   - lib/watch
 - name: github.com/projectcalico/typha
-  version: 7b5833a1ae2d67d23d1e1930f65d4024ceaf8cb4
+  version: 5ef90ad5dd6d0d6a12ecb736d8f813b4b7020739
   subpackages:
   - pkg/syncclient
   - pkg/syncproto
@@ -295,7 +295,7 @@ imports:
 - name: github.com/whyrusleeping/go-logging
   version: 0457bb6b88fc1973573aaf6b5145d8d3ae972390
 - name: golang.org/x/crypto
-  version: ab813273cd59e1333f7ae7bff5d027d4aadf528c
+  version: a49355c7e3f8fe157a85be2f77e6e269a0f89602
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net

--- a/glide.yaml
+++ b/glide.yaml
@@ -37,7 +37,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: d6aff54dc3527357f016c0cd5c5364f21a15e9b4
+  version: 8bf1e12ff13ecf994ae410efdf7808ed934a53fc
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus
@@ -57,7 +57,7 @@ import:
 - package: k8s.io/client-go
   version: 82aa063804cf055e16e8911250f888bc216e8b61
 - package: github.com/projectcalico/typha
-  version: 7b5833a1ae2d67d23d1e1930f65d4024ceaf8cb4
+  version: 5ef90ad5dd6d0d6a12ecb736d8f813b4b7020739
   subpackages:
   - pkg/syncclient
 - package: github.com/emicklei/go-restful

--- a/iptables/actions.go
+++ b/iptables/actions.go
@@ -127,10 +127,14 @@ func (g SNATAction) String() string {
 }
 
 type MasqAction struct {
+	ToPorts  string
 	TypeMasq struct{}
 }
 
 func (g MasqAction) ToFragment() string {
+	if g.ToPorts != "" {
+		return fmt.Sprintf("--jump MASQUERADE --to-ports %s", g.ToPorts)
+	}
 	return "--jump MASQUERADE"
 }
 

--- a/rules/nat.go
+++ b/rules/nat.go
@@ -26,13 +26,38 @@ func (r *DefaultRuleRenderer) NATOutgoingChain(natOutgoingActive bool, ipVersion
 		ipConf := r.ipSetConfig(ipVersion)
 		allIPsSetName := ipConf.NameForMainIPSet(IPSetIDNATOutgoingAllPools)
 		masqIPsSetName := ipConf.NameForMainIPSet(IPSetIDNATOutgoingMasqPools)
-		rules = []iptables.Rule{
-			{
-				Action: iptables.MasqAction{},
-				Match: iptables.Match().
-					SourceIPSet(masqIPsSetName).
-					NotDestIPSet(allIPsSetName),
-			},
+		if r.Config.NATPortRange != "" {
+			rules = []iptables.Rule{
+				{
+					Action: iptables.MasqAction{ToPorts: r.Config.NATPortRange},
+					Match: iptables.Match().
+						SourceIPSet(masqIPsSetName).
+						NotDestIPSet(allIPsSetName).
+						Protocol("udp"),
+				},
+				{
+					Action: iptables.MasqAction{ToPorts: r.Config.NATPortRange},
+					Match: iptables.Match().
+						SourceIPSet(masqIPsSetName).
+						NotDestIPSet(allIPsSetName).
+						Protocol("tcp"),
+				},
+				{
+					Action: iptables.MasqAction{},
+					Match: iptables.Match().
+						SourceIPSet(masqIPsSetName).
+						NotDestIPSet(allIPsSetName),
+				},
+			}
+		} else {
+			rules = []iptables.Rule{
+				{
+					Action: iptables.MasqAction{},
+					Match: iptables.Match().
+						SourceIPSet(masqIPsSetName).
+						NotDestIPSet(allIPsSetName),
+				},
+			}
 		}
 	}
 	return &iptables.Chain{

--- a/rules/nat.go
+++ b/rules/nat.go
@@ -38,7 +38,21 @@ func (r *DefaultRuleRenderer) NATOutgoingChain(natOutgoingActive bool, ipVersion
 						Protocol("tcp"),
 				},
 				{
+					Action: iptables.ReturnAction{},
+					Match: iptables.Match().
+						SourceIPSet(masqIPsSetName).
+						NotDestIPSet(allIPsSetName).
+						Protocol("tcp"),
+				},
+				{
 					Action: iptables.MasqAction{ToPorts: toPorts},
+					Match: iptables.Match().
+						SourceIPSet(masqIPsSetName).
+						NotDestIPSet(allIPsSetName).
+						Protocol("udp"),
+				},
+				{
+					Action: iptables.ReturnAction{},
 					Match: iptables.Match().
 						SourceIPSet(masqIPsSetName).
 						NotDestIPSet(allIPsSetName).

--- a/rules/nat.go
+++ b/rules/nat.go
@@ -15,6 +15,7 @@
 package rules
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/projectcalico/felix/iptables"
@@ -26,21 +27,22 @@ func (r *DefaultRuleRenderer) NATOutgoingChain(natOutgoingActive bool, ipVersion
 		ipConf := r.ipSetConfig(ipVersion)
 		allIPsSetName := ipConf.NameForMainIPSet(IPSetIDNATOutgoingAllPools)
 		masqIPsSetName := ipConf.NameForMainIPSet(IPSetIDNATOutgoingMasqPools)
-		if r.Config.NATPortRange != "" {
+		if r.Config.NATPortRange.MaxPort > 0 {
+			toPorts := fmt.Sprintf("%d-%d", r.Config.NATPortRange.MinPort, r.Config.NATPortRange.MaxPort)
 			rules = []iptables.Rule{
 				{
-					Action: iptables.MasqAction{ToPorts: r.Config.NATPortRange},
-					Match: iptables.Match().
-						SourceIPSet(masqIPsSetName).
-						NotDestIPSet(allIPsSetName).
-						Protocol("udp"),
-				},
-				{
-					Action: iptables.MasqAction{ToPorts: r.Config.NATPortRange},
+					Action: iptables.MasqAction{ToPorts: toPorts},
 					Match: iptables.Match().
 						SourceIPSet(masqIPsSetName).
 						NotDestIPSet(allIPsSetName).
 						Protocol("tcp"),
+				},
+				{
+					Action: iptables.MasqAction{ToPorts: toPorts},
+					Match: iptables.Match().
+						SourceIPSet(masqIPsSetName).
+						NotDestIPSet(allIPsSetName).
+						Protocol("udp"),
 				},
 				{
 					Action: iptables.MasqAction{},

--- a/rules/nat_test.go
+++ b/rules/nat_test.go
@@ -60,7 +60,7 @@ var _ = Describe("NAT", func() {
 
 		//copy struct
 		localConfig := rrConfigNormal
-		localConfig.NATPortRange = numorstring.Port{99, 100, ""}
+		localConfig.NATPortRange, _ = numorstring.PortFromRange(99, 100)
 		renderer = NewRenderer(localConfig)
 
 		Expect(renderer.NATOutgoingChain(true, 4)).To(Equal(&Chain{

--- a/rules/nat_test.go
+++ b/rules/nat_test.go
@@ -16,6 +16,7 @@ package rules_test
 
 import (
 	. "github.com/projectcalico/felix/rules"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -46,6 +47,37 @@ var _ = Describe("NAT", func() {
 		Expect(renderer.NATOutgoingChain(true, 4)).To(Equal(&Chain{
 			Name: "cali-nat-outgoing",
 			Rules: []Rule{
+				{
+					Action: MasqAction{},
+					Match: Match().
+						SourceIPSet("cali40masq-ipam-pools").
+						NotDestIPSet("cali40all-ipam-pools"),
+				},
+			},
+		}))
+	})
+	It("should render rules when active with explicit port range", func() {
+
+		//copy struct
+		localConfig := rrConfigNormal
+		localConfig.NATPortRange = numorstring.Port{99, 100, ""}
+		renderer = NewRenderer(localConfig)
+
+		Expect(renderer.NATOutgoingChain(true, 4)).To(Equal(&Chain{
+			Name: "cali-nat-outgoing",
+			Rules: []Rule{
+				{
+					Action: MasqAction{ToPorts: "99-100"},
+					Match: Match().
+						SourceIPSet("cali40masq-ipam-pools").
+						NotDestIPSet("cali40all-ipam-pools").Protocol("tcp"),
+				},
+				{
+					Action: MasqAction{ToPorts: "99-100"},
+					Match: Match().
+						SourceIPSet("cali40masq-ipam-pools").
+						NotDestIPSet("cali40all-ipam-pools").Protocol("udp"),
+				},
 				{
 					Action: MasqAction{},
 					Match: Match().

--- a/rules/nat_test.go
+++ b/rules/nat_test.go
@@ -73,7 +73,19 @@ var _ = Describe("NAT", func() {
 						NotDestIPSet("cali40all-ipam-pools").Protocol("tcp"),
 				},
 				{
+					Action: ReturnAction{},
+					Match: Match().
+						SourceIPSet("cali40masq-ipam-pools").
+						NotDestIPSet("cali40all-ipam-pools").Protocol("tcp"),
+				},
+				{
 					Action: MasqAction{ToPorts: "99-100"},
+					Match: Match().
+						SourceIPSet("cali40masq-ipam-pools").
+						NotDestIPSet("cali40all-ipam-pools").Protocol("udp"),
+				},
+				{
+					Action: ReturnAction{},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
 						NotDestIPSet("cali40all-ipam-pools").Protocol("udp"),

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -246,6 +246,8 @@ type Config struct {
 	FailsafeOutboundHostPorts []config.ProtoPort
 
 	DisableConntrackInvalid bool
+
+	NATPortRange string
 }
 
 func (c *Config) validate() {

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -247,7 +247,7 @@ type Config struct {
 
 	DisableConntrackInvalid bool
 
-	NATPortRange string
+	NATPortRange numorstring.Port
 }
 
 func (c *Config) validate() {


### PR DESCRIPTION
This commit allow to optionally specify a port range for the outgoing NAT rules that are created by felix.

## Description
This option allows to specify the port range used by iptables for outgoing NAT (e.g. `MASQUERADE`). We are running calico on a VMware based OpenStack with security groups implemented by a stateless firewall (VMware distributed virtual switch, DVS). This imposes some limitations how `egress` rules are implemented. In fact we need to ensure that outgoing traffic is coming from the default ephemeral port range (32768-65535). This works fine for traffic initiated by processes from the host network but breaks for the default masquerading case. The reason being that iptables picks arbitrary ports to resolve port collisions by default.

I realise that this is a rather exotic issue but the proposed configuration change is rather generic and fully optional.
I'm hoping to get this merged so that we can use upstream calico in our stack.  Would this change be generally acceptable to you?

## Todos
- [x] Unit tests (full coverage)
- [x] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```