### PR TITLE
Handle initial Felix restart for IpInIpTunnelAddr config change

### DIFF
--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -201,6 +201,11 @@ func (c *Container) WatchStdoutFor(re *regexp.Regexp) chan struct{} {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
+	log.WithFields(log.Fields{
+		"container": c.Name,
+		"regex":     re,
+	}).Info("Start watching stdout")
+
 	ch := make(chan struct{})
 	c.stdoutWatches = append(c.stdoutWatches, &watch{
 		regexp: re,

--- a/fv/infrastructure/infra_etcd.go
+++ b/fv/infrastructure/infra_etcd.go
@@ -77,16 +77,20 @@ func (eds *EtcdDatastoreInfra) GetCalicoClient() client.Interface {
 	return utils.GetEtcdClient(eds.etcdContainer.IP)
 }
 
+func (eds *EtcdDatastoreInfra) SetExpectedIPIPTunnelAddr(felix *Felix, idx int, needBGP bool) {
+	if needBGP {
+		felix.ExpectedIPIPTunnelAddr = fmt.Sprintf("10.65.%d.1", idx)
+	}
+}
+
 func (eds *EtcdDatastoreInfra) AddNode(felix *Felix, idx int, needBGP bool) {
 	felixNode := api.NewNode()
 	felixNode.Name = felix.Hostname
 	if needBGP {
-		tunnelAddr := fmt.Sprintf("10.65.%d.1", idx)
 		felixNode.Spec.BGP = &api.NodeBGPSpec{
 			IPv4Address:        felix.IP,
-			IPv4IPIPTunnelAddr: tunnelAddr,
+			IPv4IPIPTunnelAddr: felix.ExpectedIPIPTunnelAddr,
 		}
-		felix.ExpectedIPIPTunnelAddr = tunnelAddr
 	}
 	Eventually(func() error {
 		_, err := eds.GetCalicoClient().Nodes().Create(utils.Ctx, felixNode, utils.NoOptions)

--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -316,6 +316,10 @@ func (kds *K8sDatastoreInfra) GetCalicoClient() client.Interface {
 	return kds.calicoClient
 }
 
+func (kds *K8sDatastoreInfra) SetExpectedIPIPTunnelAddr(felix *Felix, idx int, needBGP bool) {
+	felix.ExpectedIPIPTunnelAddr = fmt.Sprintf("10.65.%d.1", idx)
+}
+
 func (kds *K8sDatastoreInfra) AddNode(felix *Felix, idx int, needBGP bool) {
 	node_in := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -332,7 +336,6 @@ func (kds *K8sDatastoreInfra) AddNode(felix *Felix, idx int, needBGP bool) {
 	if err != nil {
 		panic(err)
 	}
-	felix.ExpectedIPIPTunnelAddr = fmt.Sprintf("10.65.%d.0", idx)
 }
 
 func (kds *K8sDatastoreInfra) AddWorkload(wep *api.WorkloadEndpoint) (*api.WorkloadEndpoint, error) {

--- a/fv/infrastructure/infrastructure.go
+++ b/fv/infrastructure/infrastructure.go
@@ -34,6 +34,10 @@ type DatastoreInfra interface {
 	// GetCalicoClient will return a client.Interface configured to access
 	// the datastore.
 	GetCalicoClient() client.Interface
+	// SetExpectedIPIPTunnelAddr will set the Felix object's
+	// ExpectedIPIPTunnelAddr field, if we expect Felix to see that field being
+	// set after it has started up for the first time.
+	SetExpectedIPIPTunnelAddr(felix *Felix, idx int, needBGP bool)
 	// AddNode will take the appropriate steps to add a node to the datastore.
 	// From the passed in felix the Hostname and IPv4 address will be pulled
 	// and added to the Node appropriately.

--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -135,6 +135,7 @@ func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (feli
 	for i := 0; i < n; i++ {
 		// Then start Felix and create a node for it.
 		felix := RunFelix(infra, opts)
+		infra.SetExpectedIPIPTunnelAddr(felix, i, bool(n > 1))
 
 		var w chan struct{}
 		if felix.ExpectedIPIPTunnelAddr != "" {
@@ -147,6 +148,7 @@ func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (feli
 		infra.AddNode(felix, i, bool(n > 1))
 		if w != nil {
 			// Wait for any Felix restart...
+			log.Info("Wait for Felix to restart")
 			Eventually(w, "10s").Should(BeClosed())
 		}
 		felixes = append(felixes, felix)


### PR DESCRIPTION
This change completes the workaround intended in #1813, to avoid the
possibility of Felix restarting _after_ it had seen a HostEndpoint -
which in the KDD case would mean Felix being unable to reconnect to the
datastore after restarting.
