### PR TITLE
Configure model FV hosts to drop forwarded traffic by default

### DIFF
--- a/fv/infrastructure/felix.go
+++ b/fv/infrastructure/felix.go
@@ -82,6 +82,14 @@ func RunFelix(infra DatastoreInfra, options TopologyOptions) *Felix {
 		c.Exec("sysctl", "-w", "net.ipv6.conf.all.forwarding=0")
 	}
 
+	// Configure our model host to drop forwarded traffic by default.  Modern
+	// Kubernetes/Docker hosts now have this setting, and the consequence is that
+	// whenever Calico policy intends to allow a packet, it must explicitly ACCEPT
+	// that packet, not just allow it to pass through cali-FORWARD and assume it will
+	// be accepted by the rest of the chain.  Establishing that setting in this FV
+	// allows us to test that.
+	c.Exec("iptables", "-P", "FORWARD", "DROP")
+
 	return &Felix{
 		Container: c,
 	}


### PR DESCRIPTION
Configure our model hosts to drop forwarded traffic by default.  Modern
Kubernetes/Docker hosts now have this setting, and the consequence is
that whenever Calico policy intends to allow a packet, it must
explicitly ACCEPT that packet, not just allow it to pass through
cali-FORWARD and assume it will be accepted by the rest of the chain.
Establishing that setting in this FV allows us to test that.
