### PR TITLE
[release-v3.0] cherry-pick: Allow hep-forwarded traffic by default

### DIFF
--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -207,7 +207,7 @@ func chainsForIfaces(ifaceMetadata []string, host bool, tableKind string) []*ipt
 				Action:  iptables.ReturnAction{},
 				Comment: "Return if policy accepted",
 			})
-			if tableKind == "normal" || tableKind == "applyOnForward" {
+			if tableKind == "normal" {
 				// Only end with a drop rule in the filter chain.  In the raw chain,
 				// we consider the policy as unfinished, because some of the
 				// policy may live in the filter chain.
@@ -224,6 +224,18 @@ func chainsForIfaces(ifaceMetadata []string, host bool, tableKind string) []*ipt
 				Match:   iptables.Match(),
 				Action:  iptables.DropAction{},
 				Comment: "Drop if no profiles matched",
+			})
+		}
+
+		if tableKind == "applyOnForward" {
+			// Expect forwarded traffic to be allowed by default.
+			outRules = append(outRules, iptables.Rule{
+				Action:  iptables.SetMarkAction{Mark: 8},
+				Comment: "Allow forwarded traffic by default",
+			})
+			outRules = append(outRules, iptables.Rule{
+				Action:  iptables.ReturnAction{},
+				Comment: "Return for accepted forward traffic",
 			})
 		}
 
@@ -274,7 +286,7 @@ func chainsForIfaces(ifaceMetadata []string, host bool, tableKind string) []*ipt
 				Action:  iptables.ReturnAction{},
 				Comment: "Return if policy accepted",
 			})
-			if tableKind == "normal" || tableKind == "applyOnForward" {
+			if tableKind == "normal" {
 				// Only end with a drop rule in the filter chain.  In the raw chain,
 				// we consider the policy as unfinished, because some of the
 				// policy may live in the filter chain.
@@ -292,6 +304,19 @@ func chainsForIfaces(ifaceMetadata []string, host bool, tableKind string) []*ipt
 				Comment: "Drop if no profiles matched",
 			})
 		}
+
+		if tableKind == "applyOnForward" {
+			// Expect forwarded traffic to be allowed by default.
+			inRules = append(inRules, iptables.Rule{
+				Action:  iptables.SetMarkAction{Mark: 8},
+				Comment: "Allow forwarded traffic by default",
+			})
+			inRules = append(inRules, iptables.Rule{
+				Action:  iptables.ReturnAction{},
+				Comment: "Return for accepted forward traffic",
+			})
+		}
+
 		if tableKind == "preDNAT" {
 			chains = append(chains,
 				&iptables.Chain{

--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -207,7 +207,7 @@ func chainsForIfaces(ifaceMetadata []string, host bool, tableKind string) []*ipt
 				Action:  iptables.ReturnAction{},
 				Comment: "Return if policy accepted",
 			})
-			if tableKind == "normal" {
+			if tableKind == "normal" || tableKind == "applyOnForward" {
 				// Only end with a drop rule in the filter chain.  In the raw chain,
 				// we consider the policy as unfinished, because some of the
 				// policy may live in the filter chain.
@@ -217,18 +217,10 @@ func chainsForIfaces(ifaceMetadata []string, host bool, tableKind string) []*ipt
 					Comment: "Drop if no policies passed packet",
 				})
 			}
-		}
 
-		if tableKind == "normal" {
-			outRules = append(outRules, iptables.Rule{
-				Match:   iptables.Match(),
-				Action:  iptables.DropAction{},
-				Comment: "Drop if no profiles matched",
-			})
-		}
-
-		if tableKind == "applyOnForward" {
-			// Expect forwarded traffic to be allowed by default.
+		} else if tableKind == "applyOnForward" {
+			// Expect forwarded traffic to be allowed when there are no
+			// applicable policies.
 			outRules = append(outRules, iptables.Rule{
 				Action:  iptables.SetMarkAction{Mark: 8},
 				Comment: "Allow forwarded traffic by default",
@@ -236,6 +228,14 @@ func chainsForIfaces(ifaceMetadata []string, host bool, tableKind string) []*ipt
 			outRules = append(outRules, iptables.Rule{
 				Action:  iptables.ReturnAction{},
 				Comment: "Return for accepted forward traffic",
+			})
+		}
+
+		if tableKind == "normal" {
+			outRules = append(outRules, iptables.Rule{
+				Match:   iptables.Match(),
+				Action:  iptables.DropAction{},
+				Comment: "Drop if no profiles matched",
 			})
 		}
 
@@ -286,7 +286,7 @@ func chainsForIfaces(ifaceMetadata []string, host bool, tableKind string) []*ipt
 				Action:  iptables.ReturnAction{},
 				Comment: "Return if policy accepted",
 			})
-			if tableKind == "normal" {
+			if tableKind == "normal" || tableKind == "applyOnForward" {
 				// Only end with a drop rule in the filter chain.  In the raw chain,
 				// we consider the policy as unfinished, because some of the
 				// policy may live in the filter chain.
@@ -296,17 +296,10 @@ func chainsForIfaces(ifaceMetadata []string, host bool, tableKind string) []*ipt
 					Comment: "Drop if no policies passed packet",
 				})
 			}
-		}
-		if tableKind == "normal" {
-			inRules = append(inRules, iptables.Rule{
-				Match:   iptables.Match(),
-				Action:  iptables.DropAction{},
-				Comment: "Drop if no profiles matched",
-			})
-		}
 
-		if tableKind == "applyOnForward" {
-			// Expect forwarded traffic to be allowed by default.
+		} else if tableKind == "applyOnForward" {
+			// Expect forwarded traffic to be allowed when there are no
+			// applicable policies.
 			inRules = append(inRules, iptables.Rule{
 				Action:  iptables.SetMarkAction{Mark: 8},
 				Comment: "Allow forwarded traffic by default",
@@ -314,6 +307,14 @@ func chainsForIfaces(ifaceMetadata []string, host bool, tableKind string) []*ipt
 			inRules = append(inRules, iptables.Rule{
 				Action:  iptables.ReturnAction{},
 				Comment: "Return for accepted forward traffic",
+			})
+		}
+
+		if tableKind == "normal" {
+			inRules = append(inRules, iptables.Rule{
+				Match:   iptables.Match(),
+				Action:  iptables.DropAction{},
+				Comment: "Drop if no profiles matched",
 			})
 		}
 

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -280,25 +280,22 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 			})
 		}
 
-		if chainType == chainTypeNormal {
-			// When rendering normal rules, if no policy marked the packet as "pass",
-			// drop the packet.
+		if chainType == chainTypeNormal || chainType == chainTypeForward {
+			// When rendering normal and forward rules, if no policy marked the packet as "pass", drop the
+			// packet.
 			//
 			// For untracked and pre-DNAT rules, we don't do that because there may be
 			// normal rules still to be applied to the packet in the filter table.
-			//
-			// For applyOnForward rules, we don't do that because we document that
-			// forwarded traffic is allowed by default.
 			rules = append(rules, Rule{
 				Match:   Match().MarkClear(r.IptablesMarkPass),
 				Action:  DropAction{},
 				Comment: "Drop if no policies passed packet",
 			})
 		}
-	}
 
-	if chainType == chainTypeForward {
-		// Forwarded traffic is allowed by default.
+	} else if chainType == chainTypeForward {
+		// Forwarded traffic is allowed when there are no policies with
+		// applyOnForward that apply to this endpoint (and in this direction).
 		rules = append(rules, Rule{
 			Action:  SetMarkAction{Mark: r.IptablesMarkAccept},
 			Comment: "Allow forwarded traffic by default",

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -280,18 +280,33 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 			})
 		}
 
-		if chainType == chainTypeNormal || chainType == chainTypeForward {
-			// When rendering normal and forward rules, if no policy marked the packet as "pass", drop the
-			// packet.
+		if chainType == chainTypeNormal {
+			// When rendering normal rules, if no policy marked the packet as "pass",
+			// drop the packet.
 			//
 			// For untracked and pre-DNAT rules, we don't do that because there may be
 			// normal rules still to be applied to the packet in the filter table.
+			//
+			// For applyOnForward rules, we don't do that because we document that
+			// forwarded traffic is allowed by default.
 			rules = append(rules, Rule{
 				Match:   Match().MarkClear(r.IptablesMarkPass),
 				Action:  DropAction{},
 				Comment: "Drop if no policies passed packet",
 			})
 		}
+	}
+
+	if chainType == chainTypeForward {
+		// Forwarded traffic is allowed by default.
+		rules = append(rules, Rule{
+			Action:  SetMarkAction{Mark: r.IptablesMarkAccept},
+			Comment: "Allow forwarded traffic by default",
+		})
+		rules = append(rules, Rule{
+			Action:  ReturnAction{},
+			Comment: "Return for accepted forward traffic",
+		})
 	}
 
 	if chainType == chainTypeNormal {


### PR DESCRIPTION
Cherry picks the closely related PRs #1841, #1842 and #1844 to release-v3.0.

For this cherry pick, I haven't back-applied the new FV test that is on master and in the v3.1 cherry-pick, because there is too much required FV infrastructure that isn't yet in the release-v3.0 branch.

## Release Note

```release-note
The iptables rules for forwarded traffic passing through a HostEndpoint have been improved so that that traffic is allowed by default (when there is no relevant ApplyOnForward policy) even if the host has `iptables -P FORWARD DROP`.  (For the full intended semantics for forwarded traffic through HostEndpoints, which have not changed, see https://docs.projectcalico.org/master/getting-started/bare-metal/policy/forwarded.)```