### PR TITLE
ci and cd push all arches; ability to exclude specific

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,13 @@ register:
 ifneq ($(BUILDARCH),$(ARCH))
 	docker run --rm --privileged multiarch/qemu-user-static:register || true
 endif
+
+
+# list of arches *not* to build when doing *-all
+#    until s390x works correctly
+EXCLUDEARCH ?= s390x
+VALIDARCHES = $(filter-out $(EXCLUDEARCH),$(ARCHES))
+
 ###############################################################################
 CONTAINER_NAME=calico/felix
 PACKAGE_NAME?=github.com/projectcalico/felix
@@ -207,7 +214,7 @@ clean:
 # Building the binary
 ###############################################################################
 build: bin/calico-felix
-build-all: $(addprefix sub-build-,$(ARCHES))
+build-all: $(addprefix sub-build-,$(VALIDARCHES))
 sub-build-%:
 	$(MAKE) build ARCH=$*
 
@@ -271,7 +278,7 @@ protobuf proto/felixbackend.pb.go: proto/felixbackend.proto
 
 # by default, build the image for the target architecture
 .PHONY: image-all
-image-all: $(addprefix sub-image-,$(ARCHES))
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
 	$(MAKE) image ARCH=$*
 
@@ -281,7 +288,7 @@ calico/felix-$(ARCH): bin/calico-felix-$(ARCH) register
 	rm -rf docker-image/bin
 	mkdir -p docker-image/bin
 	cp bin/calico-felix-$(ARCH) docker-image/bin/
-	docker build --pull -t calico/felix:latest-$(ARCH) --file ./docker-image/Dockerfile.$(ARCH) docker-image
+	docker build --pull -t calico/felix:latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --file ./docker-image/Dockerfile.$(ARCH) docker-image
 ifeq ($(ARCH),amd64)
 	docker tag calico/felix:latest-$(ARCH) calico/felix:latest
 endif
@@ -292,7 +299,7 @@ ifndef IMAGETAG
 endif
 
 ## push all arches
-push-all: imagetag $(addprefix sub-push-,$(ARCHES))
+push-all: imagetag $(addprefix sub-push-,$(VALIDARCHES))
 sub-push-%:
 	$(MAKE) push ARCH=$* IMAGETAG=$(IMAGETAG)
 
@@ -315,7 +322,7 @@ ifeq ($(ARCH),amd64)
 endif
 
 ## tag images of all archs
-tag-images-all: imagetag $(addprefix sub-tag-images-,$(ARCHES))
+tag-images-all: imagetag $(addprefix sub-tag-images-,$(VALIDARCHES))
 sub-tag-images-%:
 	$(MAKE) tag-images ARCH=$* IMAGETAG=$(IMAGETAG)
 
@@ -597,7 +604,7 @@ bin/test-connection: $(SRC_FILES) vendor/.up-to-date
 .PHONY: ci cd
 
 ## run CI cycle - build, test, etc.
-ci: image bin/calico-felix.exe ut upload-to-coveralls static-checks
+ci: image-all bin/calico-felix.exe ut upload-to-coveralls static-checks
 ifeq (,$(filter fv, $(EXCEPT)))
 	@$(MAKE) fv
 endif
@@ -614,8 +621,8 @@ endif
 ifndef BRANCH_NAME
 	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
 endif
-	$(MAKE) tag-images push IMAGETAG=$(BRANCH_NAME)
-	$(MAKE) tag-images push IMAGETAG=$(shell git describe --tags --dirty --always --long)
+	$(MAKE) tag-images-all push-all IMAGETAG=$(BRANCH_NAME) EXCLUDEARCH="$(EXCLUDEARCH)"
+	$(MAKE) tag-images-all push-all IMAGETAG=$(shell git describe --tags --dirty --always --long) EXCLUDEARCH="$(EXCLUDEARCH)"
 
 
 ###############################################################################

--- a/docker-image/Dockerfile.arm64
+++ b/docker-image/Dockerfile.arm64
@@ -1,13 +1,5 @@
-FROM alpine:3.7 as qemu
-
-ARG QEMU_VERSION=2.9.1-1
-ARG CROSS_ARCHS="aarch64 ppc64le"
-
-RUN apk --update add curl
-
-# Enable non-native runs on amd64 architecture hosts
-RUN for i in ${CROSS_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
-RUN chmod +x /usr/bin/qemu-*
+ARG QEMU_IMAGE=calico/go-build:latest
+FROM ${QEMU_IMAGE} as qemu
 
 FROM arm64v8/alpine:3.6 as base
 MAINTAINER Shaun Crampton <shaun@tigera.io>
@@ -15,7 +7,8 @@ MAINTAINER Shaun Crampton <shaun@tigera.io>
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
 # we only need this for the intermediate "base" image, so we can run all the apk and other commands
-COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
+# when running on a kernel >= 4.8, this will become less relevant
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/
 
 RUN apk --no-cache add --update tini
 # Install Felix's dependencies.
@@ -29,12 +22,6 @@ ADD calico-felix-wrapper usr/bin
 RUN mkdir /code
 ADD bin/calico-felix-arm64 /code/calico-felix
 RUN ln -s /code/calico-felix /usr/bin
-
-# final image just copies everything over
-# do NOT do any RUN commands in the final image
-FROM scratch
-
-COPY --from=base / /
 
 WORKDIR /code
 

--- a/docker-image/Dockerfile.ppc64le
+++ b/docker-image/Dockerfile.ppc64le
@@ -1,13 +1,5 @@
-FROM alpine:3.7 as qemu
-
-ARG QEMU_VERSION=2.9.1-1
-ARG CROSS_ARCHS="aarch64 ppc64le"
-
-RUN apk --update add curl
-
-# Enable non-native runs on amd64 architecture hosts
-RUN for i in ${CROSS_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
-RUN chmod +x /usr/bin/qemu-*
+ARG QEMU_IMAGE=calico/go-build:latest
+FROM ${QEMU_IMAGE} as qemu
 
 FROM ppc64le/alpine:3.6 as base
 MAINTAINER Shaun Crampton <shaun@tigera.io>
@@ -15,7 +7,8 @@ MAINTAINER Shaun Crampton <shaun@tigera.io>
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
 # we only need this for the intermediate "base" image, so we can run all the apk and other commands
-COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
+# when running on a kernel >= 4.8, this will become less relevant
+COPY --from=qemu /usr/bin/qemu-ppc64le-static /usr/bin/
 
 RUN apk --no-cache add --update tini
 # Install Felix's dependencies.

--- a/docker-image/Dockerfile.s390x
+++ b/docker-image/Dockerfile.s390x
@@ -1,5 +1,15 @@
+ARG QEMU_IMAGE=calico/go-build:latest
+FROM ${QEMU_IMAGE} as qemu
+
 FROM s390x/alpine:3.6
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+# we only need this for the intermediate "base" image, so we can run all the apk and other commands
+# when running on a kernel >= 4.8, this will become less relevant
+COPY --from=qemu /usr/bin/qemu-s390x-static /usr/bin/
+
 
 # Since our binary isn't designed to run as PID 1, run it via the tini init daemon.
 RUN apk --no-cache add --update tini


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

#### Build and push by default for all supported arches
Before this PR, `ci` and `cd` targets build the binary and the image and push to registry _only_ for `amd64` unless explicitly choosing to add, e.g `make cd ARCH=arm64`. 

This PR makes `ci` and `cd` call the `*-all` targets, thus building binaries and images and pushing to registries for _all_ known arches.

#### Escape hatch to exclude arches
For example:

* `make cd` - push all known arches
* `make cd EXCLUDEARCH=arm64` - push all known arches except `arm64`
* `make cd EXCLUDEARCH="arm64 s390x"` - push all known arches except `arm64` and `s390x`

Same for `make ci`

#### Pull qemu from go-build instead of downloading every time
We have had the `qemu` binaries in `calico/go-build` since v0.15. Why redownload them? Just install them using multistage

#### Install only relevant qemu
Install only the relevant qemu binaries for the given arch, rather than all

#### Exclude s390x
Until such time as we can get `calico/go-build` to work with qemu (or any other interpreter), there is no point in trying to build here.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Build binaries and images, and push images, for all known arches.
```

cc @fasaxc @tomdee @caseydavenport 