### PR TITLE
Glide: Restore CNI pin and remove libcalico-go pin

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a2f43643238a6915b97b16ddc21db189bed5066282d349bea7c84df144bcc1a8
-updated: 2018-07-12T20:54:38.481336548-07:00
+hash: 900f6e65e88d5d5dff2fd70a769ba38d443304f6c27a39c2a049f954c9f0e888
+updated: 2018-07-17T10:46:51.942051302-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -94,6 +94,13 @@ imports:
   version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
   subpackages:
   - simplelru
+- name: github.com/hpcloud/tail
+  version: a1dbeea552b7c8df4b542c66073e393de198a800
+  subpackages:
+  - ratelimiter
+  - util
+  - watch
+  - winfile
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/ipfs/go-log
@@ -109,7 +116,7 @@ imports:
 - name: github.com/kardianos/osext
   version: ae77be60afb1dcacde03767a8c37337fad28ac14
 - name: github.com/kelseyhightower/envconfig
-  version: f611eb38b3875cc3bd991ca91c51d06446afa14c
+  version: dd1402a4d99de9ac2f396cd6fcb957bc2c695ec1
 - name: github.com/libp2p/go-reuseport
   version: c2c3368efe65c8b85ddff6b278df5bef3ce235e2
   subpackages:
@@ -138,7 +145,7 @@ imports:
 - name: github.com/modern-go/reflect2
   version: 05fbef0ca5da472bbf96c9322b84a53edc03c9fd
 - name: github.com/onsi/ginkgo
-  version: fa5fabab2a1bfbd924faf4c067d07ae414e2aedf
+  version: 3774a09d95489ccaa16032e0770d08ea77ba6184
   subpackages:
   - config
   - extensions/table
@@ -159,7 +166,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: 62bff4df71bdbc266561a0caee19f0594b17c240
+  version: b6ea1ea48f981d0f615a154a45eabb9dd466556d
   subpackages:
   - format
   - internal/assertion
@@ -234,7 +241,7 @@ imports:
   - pkg/syncproto
   - pkg/tlsutils
 - name: github.com/prometheus/client_golang
-  version: 967789050ba94deca04a5e84cce8ad472ce313c1
+  version: bcbbc08eb2ddff3af83bbf11e7ec13b4fd730b6e
   subpackages:
   - prometheus
   - prometheus/promhttp
@@ -244,13 +251,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 7600349dcfe1abd18d72d3a1770870d9800a7801
+  version: e3fb1a1acd7605367a2b378bc2e2f893c05174b7
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: f98634e408857669d61064b283c4cde240622865
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
   subpackages:
   - xfs
 - name: github.com/satori/go.uuid
@@ -335,7 +342,7 @@ imports:
   - internal/urlfetch
   - urlfetch
 - name: google.golang.org/genproto
-  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
+  version: 2731d4fa720b67f9fe38e9051a2a9b38e4609260
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
@@ -358,10 +365,14 @@ imports:
   - status
   - tap
   - transport
+- name: gopkg.in/fsnotify/fsnotify.v1
+  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: gopkg.in/go-playground/validator.v8
   version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+- name: gopkg.in/tomb.v1
+  version: c131134a1947e9afd9cecfe11f4c6dff0732ae58
 - name: gopkg.in/yaml.v2
   version: 670d4cfef0544295bc27a114dbac37980d83185a
 - name: k8s.io/api

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,9 +3,12 @@ homepage: https://projectcalico.org
 license: Apache-2.0
 import:
 - package: github.com/containernetworking/cni
+  version: v0.5.2
   subpackages:
   - pkg/ns
+# Need to pin to an older version as our code uses code that is deprecated in newer versions.
 - package: github.com/docopt/docopt-go
+  version: ^0.6.2
 - package: github.com/go-ini/ini
 - package: github.com/gogo/protobuf
   subpackages:
@@ -26,7 +29,6 @@ import:
   subpackages:
   - types
 - package: github.com/projectcalico/libcalico-go
-  version: 10c63d26035e5cf5124a2a148e4e15365b83c2e1
   subpackages:
   - lib/apiconfig
   - lib/apis/v3


### PR DESCRIPTION
CNI is actually needed - the pkg/ns package is removed from master
Libcalico-go pin isn't needed - the version from Typha should be used

This PR doesn't change the revision in the glide.lock for the CNI or libcalico packages