### PR TITLE
Fix missing iptables after a HostEndpoint-protected interface is deleted and re-added

### DIFF
--- a/ifacemonitor/iface_monitor.go
+++ b/ifacemonitor/iface_monitor.go
@@ -52,7 +52,7 @@ type InterfaceMonitor struct {
 
 	netlinkStub  netlinkStub
 	resyncC      <-chan time.Time
-	upIfaces     set.Set
+	upIfaces     map[string]int
 	Callback     InterfaceStateCallback
 	AddrCallback AddrStateCallback
 	ifaceName    map[int]string
@@ -70,7 +70,7 @@ func NewWithStubs(config Config, netlinkStub netlinkStub, resyncC <-chan time.Ti
 		Config:      config,
 		netlinkStub: netlinkStub,
 		resyncC:     resyncC,
-		upIfaces:    set.New(),
+		upIfaces:    map[string]int{},
 		ifaceName:   map[int]string{},
 		ifaceAddrs:  map[int]set.Set{},
 	}
@@ -268,15 +268,15 @@ func (m *InterfaceMonitor) storeAndNotifyLinkInner(ifaceExists bool, ifaceName s
 	// etc.
 	rawFlags := attrs.RawFlags
 	ifaceIsUp := ifaceExists && rawFlags&syscall.IFF_RUNNING != 0
-	ifaceWasUp := m.upIfaces.Contains(ifaceName)
+	_, ifaceWasUp := m.upIfaces[ifaceName]
 	logCxt := log.WithField("ifaceName", ifaceName)
 	if ifaceIsUp && !ifaceWasUp {
 		logCxt.Debug("Interface now up")
-		m.upIfaces.Add(ifaceName)
+		m.upIfaces[ifaceName] = ifIndex
 		m.Callback(ifaceName, StateUp)
 	} else if ifaceWasUp && !ifaceIsUp {
 		logCxt.Debug("Interface now down")
-		m.upIfaces.Discard(ifaceName)
+		delete(m.upIfaces, ifaceName)
 		m.Callback(ifaceName, StateDown)
 	} else {
 		logCxt.WithField("ifaceIsUp", ifaceIsUp).Debug("Nothing to notify")
@@ -326,15 +326,17 @@ func (m *InterfaceMonitor) resync() error {
 		currentIfaces.Add(attrs.Name)
 		m.storeAndNotifyLink(true, link)
 	}
-	m.upIfaces.Iter(func(name interface{}) error {
+	for name, ifIndex := range m.upIfaces {
 		if currentIfaces.Contains(name) {
-			return nil
+			continue
 		}
 		log.WithField("ifaceName", name).Info("Spotted interface removal on resync.")
-		m.Callback(name.(string), StateDown)
-		m.AddrCallback(name.(string), nil)
-		return set.RemoveItem
-	})
+		m.Callback(name, StateDown)
+		m.AddrCallback(name, nil)
+		delete(m.upIfaces, name)
+		delete(m.ifaceAddrs, ifIndex)
+		delete(m.ifaceName, ifIndex)
+	}
 	log.Debug("Resync complete")
 	return nil
 }

--- a/ifacemonitor/ifacemonitor_test.go
+++ b/ifacemonitor/ifacemonitor_test.go
@@ -69,6 +69,7 @@ type mockDataplane struct {
 }
 
 func (nl *netlinkTest) addLink(name string) {
+	log.WithFields(log.Fields{"name": name}).Info("ADDLINK")
 	nl.linksMutex.Lock()
 	if nl.links == nil {
 		nl.links = map[string]linkModel{}
@@ -85,6 +86,7 @@ func (nl *netlinkTest) addLink(name string) {
 }
 
 func (nl *netlinkTest) renameLink(oldName, newName string) {
+	log.WithFields(log.Fields{"oldName": oldName, "newName": newName}).Info("RENAMELINK")
 	nl.linksMutex.Lock()
 	link := nl.links[oldName]
 	delete(nl.links, oldName)
@@ -94,6 +96,7 @@ func (nl *netlinkTest) renameLink(oldName, newName string) {
 }
 
 func (nl *netlinkTest) changeLinkState(name string, state string) {
+	log.WithFields(log.Fields{"name": name, "state": state}).Info("CHANGELINKSTATE")
 	nl.linksMutex.Lock()
 	link := nl.links[name]
 	link.state = state
@@ -103,6 +106,7 @@ func (nl *netlinkTest) changeLinkState(name string, state string) {
 }
 
 func (nl *netlinkTest) delLink(name string) {
+	log.WithFields(log.Fields{"name": name}).Info("DELLINK")
 	var oldIndex int
 	nl.linksMutex.Lock()
 	link, prs := nl.links[name]
@@ -155,6 +159,7 @@ func (nl *netlinkTest) signalLink(name string, oldIndex int) {
 }
 
 func (nl *netlinkTest) addAddr(name string, addr string) {
+	log.WithFields(log.Fields{"name": name, "addr": addr}).Info("ADDADDR")
 	nl.linksMutex.Lock()
 	link := nl.links[name]
 	link.addrs.Add(addr)
@@ -164,6 +169,7 @@ func (nl *netlinkTest) addAddr(name string, addr string) {
 }
 
 func (nl *netlinkTest) delAddr(name string, addr string) {
+	log.WithFields(log.Fields{"name": name, "addr": addr}).Info("DELADDR")
 	nl.linksMutex.Lock()
 	link := nl.links[name]
 	link.addrs.Discard(addr)
@@ -255,8 +261,7 @@ func (nl *netlinkTest) AddrList(link netlink.Link, family int) ([]netlink.Addr, 
 }
 
 func (dp *mockDataplane) linkStateCallback(ifaceName string, ifaceState ifacemonitor.State) {
-	log.Info("linkStateCallback: ifaceName=", ifaceName)
-	log.Info("linkStateCallback: ifaceState=", ifaceState)
+	log.WithFields(log.Fields{"name": ifaceName, "state": ifaceState}).Info("CALLBACK LINK")
 	dp.linkC <- linkUpdate{
 		name:  ifaceName,
 		state: ifaceState,
@@ -281,7 +286,7 @@ func (dp *mockDataplane) addrStateCallback(ifaceName string, addrs set.Set) {
 	log.WithFields(log.Fields{
 		"ifaceName": ifaceName,
 		"addrs":     addrs,
-	}).Info("Address state updated")
+	}).Info("CALLBACK ADDR")
 	dp.addrC <- addrState{ifaceName: ifaceName, addrs: addrs}
 	log.Info("mock dataplane reported address callback")
 }


### PR DESCRIPTION
## Description
A customer reported a calico/node having got into a state where expected
iptables programming for a HostEndpoint was missing.  They created a
bridge device, and a HostEndpoint to protect that, and initially the
expected iptables programming was present.  However, after some period
of churn, which we believe included

- deleting and re-adding the bridge device
- setting the state of the bridge device down and later up again
- creating and deleting many real or simulated pods/containers on that
  node,

it was observed that the HostEndpoint iptables were missing, and that
setting the bridge device down and up made no difference to this.  The
missing iptables could only be recreated by restarting the calico/node.

We identified a bug that would account for this if all of the following
points are also true:

1. One time when the bridge device is deleted, the Netlink event for
that is lost (or delayed for a long time), and the removal of the device
is then detected by a period resync that the Felix code does.  The bug
is that the exact handling here is different than when processing an
individual Netlink event.

2. When the bridge device is added again, it has the same addresses and
interface index as before it was deleted, and either there is no Netlink
event reporting the addresses, or Felix sees that event before it sees
the event about the device reappearing.

3. Later, when the bridge device is set down and up again, either there
are no address changes that ensue from that (which is unusual, because
Linux devices normally do IPv6 autoconfiguration, which means that an
IPv6 address is added when the device goes up, and taken away when the
device goes down), or there is some other reason why Netlink address
events are not generated, or don't reach Felix.

This change adds a UT case to repro that scenario, and demonstrates the
result that we are missing a non-nil address callback when the bridge
device is added again.  In Felix as a whole, the absence of that
callback means that HostEndpoint iptables are not reprogrammed.

The fix - also in this PR - is to clear ifacemonitor's caches at the point in
that scenario when resync spots that an interface has disappeared.

## Todos
- [x] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [x] Release note

## Release Note
```release-note
Fix missing iptables after a HostEndpoint-protected interface is deleted and re-added.
```
