### PR TITLE
Allow build from local libcalico-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,15 @@ ifeq ($(ARCH),x86_64)
     override ARCH=amd64
 endif
 
+# Build mounts for running in "local build" mode. Mount in libcalico, but null out
+# the vendor directory. This allows an easy build using local development code,
+# assuming that there is a local checkout of libcalico in the same directory as this repo.
+LOCAL_BUILD_MOUNTS ?=
+ifeq ($(LOCAL_BUILD),true)
+LOCAL_BUILD_MOUNTS = -v $(CURDIR)/../libcalico-go:/go/src/$(PACKAGE_NAME)/vendor/github.com/projectcalico/libcalico-go:ro \
+	-v $(CURDIR)/.empty:/go/src/$(PACKAGE_NAME)/vendor/github.com/projectcalico/libcalico-go/vendor:ro
+endif
+
 # we want to be able to run the same recipe on multiple targets keyed on the image name
 # to do that, we would use the entire image name, e.g. calico/node:abcdefg, as the stem, or '%', in the target
 # however, make does **not** allow the usage of invalid filename characters - like / and : - in a stem, and thus errors out
@@ -170,7 +179,10 @@ FV_SLOW_SPEC_THRESH=90
 # <unknown> if this isn't a git checkout.
 GIT_COMMIT:=$(shell git rev-parse HEAD || echo '<unknown>')
 BUILD_ID:=$(shell git rev-parse HEAD || uuidgen | sed 's/-//g')
-GIT_DESCRIPTION:=$(shell git describe --tags || echo '<unknown>')
+GIT_DESCRIPTION:=$(shell git describe --tags --dirty --always || echo '<unknown>')
+ifeq ($(LOCAL_BUILD),true)
+	GIT_DESCRIPTION = $(shell git describe --tags --dirty --always || echo '<unknown>')-dev-build
+endif
 
 # Calculate a timestamp for any build artefacts.
 DATE:=$(shell date -u +'%FT%T%z')
@@ -208,7 +220,7 @@ endif
 ifdef SSH_AUTH_SOCK
   EXTRA_DOCKER_ARGS += -v $(SSH_AUTH_SOCK):/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent
 endif
-DOCKER_GO_BUILD := mkdir -p .go-pkg-cache && \
+DOCKER_RUN := mkdir -p .go-pkg-cache && \
                    docker run --rm \
                               --net=host \
                               $(EXTRA_DOCKER_ARGS) \
@@ -217,8 +229,7 @@ DOCKER_GO_BUILD := mkdir -p .go-pkg-cache && \
                               -v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \
                               -v $(CURDIR)/.go-pkg-cache:/gocache:rw \
                               -w /go/src/$(PACKAGE_NAME) \
-                              -e GOARCH=$(ARCH) \
-                              $(CALICO_BUILD)
+                              -e GOARCH=$(ARCH)
 
 .PHONY: clean
 clean:
@@ -256,7 +267,7 @@ VENDOR_REMADE := false
 .PHONY: update-vendor
 update-vendor glide.lock:
 	mkdir -p $$HOME/.glide
-	$(DOCKER_GO_BUILD) glide up --strip-vendor
+	$(DOCKER_RUN) $(CALICO_BUILD) glide up --strip-vendor
 	touch vendor/.up-to-date
 	# Optimization: since glide up does the job of glide install, flag to the
 	# vendor target that it doesn't need to do anything.
@@ -267,7 +278,7 @@ update-vendor glide.lock:
 vendor vendor/.up-to-date: glide.lock
 	if ! $(VENDOR_REMADE); then \
 	  mkdir -p $$HOME/.glide && \
-	  $(DOCKER_GO_BUILD) glide install --strip-vendor && \
+	  $(DOCKER_RUN) $(CALICO_BUILD) glide install --strip-vendor && \
 	  touch vendor/.up-to-date; \
 	fi
 
@@ -277,7 +288,7 @@ TYPHA_VERSION?=$(shell git ls-remote git@github.com:projectcalico/typha master 2
 
 ## Update typha pin in glide.yaml
 update-typha:
-	    $(DOCKER_GO_BUILD) sh -c '\
+	    $(DOCKER_RUN) $(CALICO_BUILD) sh -c '\
         echo "Updating typha to $(TYPHA_VERSION) from $(TYPHA_REPO)"; \
         export OLD_VER=$$(grep --after 50 typha glide.yaml |grep --max-count=1 --only-matching --perl-regexp "version:\s*\K[^\s]+") ;\
         echo "Old version: $$OLD_VER";\
@@ -294,7 +305,7 @@ bin/calico-felix: bin/calico-felix-$(ARCH)
 bin/calico-felix-$(ARCH): $(SRC_FILES) vendor/.up-to-date
 	@echo Building felix for $(ARCH) on $(BUILDARCH)
 	mkdir -p bin
-	$(DOCKER_GO_BUILD) \
+	$(DOCKER_RUN) $(LOCAL_BUILD_MOUNTS) $(CALICO_BUILD) \
 	   sh -c 'go build -v -i -o $@ -v $(LDFLAGS) "$(PACKAGE_NAME)/cmd/calico-felix" && \
 		( ldd $@ 2>&1 | grep -q -e "Not a valid dynamic program" \
 		-e "not a dynamic executable" || \
@@ -304,7 +315,7 @@ bin/calico-felix-$(ARCH): $(SRC_FILES) vendor/.up-to-date
 bin/calico-felix.exe: $(SRC_FILES) vendor/.up-to-date
 	@echo Building felix for Windows...
 	mkdir -p bin
-	$(DOCKER_GO_BUILD) \
+	$(DOCKER_RUN) $(LOCAL_BUILD_MOUNTS) $(CALICO_BUILD) \
            sh -c 'GOOS=windows go build -v -o $@ -v $(LDFLAGS) "$(PACKAGE_NAME)/cmd/calico-felix" && \
 		( ldd $@ 2>&1 | grep -q "Not a valid dynamic program" || \
 		( echo "Error: $@ was not statically linked"; false ) )'
@@ -468,22 +479,22 @@ static-checks:
 	$(MAKE) check-typha-pins go-meta-linter check-licenses
 
 bin/check-licenses: $(SRC_FILES)
-	$(DOCKER_GO_BUILD) go build -v -i -o $@ "$(PACKAGE_NAME)/check-licenses"
+	$(DOCKER_RUN) $(LOCAL_BUILD_MOUNTS) $(CALICO_BUILD) go build -v -i -o $@ "$(PACKAGE_NAME)/check-licenses"
 
 .PHONY: check-licenses
 check-licenses: check-licenses/dependency-licenses.txt bin/check-licenses
 	@echo Checking dependency licenses
-	$(DOCKER_GO_BUILD) bin/check-licenses
+	$(DOCKER_RUN) $(CALICO_BUILD) bin/check-licenses
 
 check-licenses/dependency-licenses.txt: vendor/.up-to-date
-	$(DOCKER_GO_BUILD) sh -c 'licenses ./cmd/calico-felix > check-licenses/dependency-licenses.txt'
+	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'licenses ./cmd/calico-felix > check-licenses/dependency-licenses.txt'
 
 .PHONY: go-meta-linter
 go-meta-linter: vendor/.up-to-date $(GENERATED_GO_FILES)
 	# Run staticcheck stand-alone since gometalinter runs concurrent copies, which
 	# uses a lot of RAM.
-	$(DOCKER_GO_BUILD) sh -c 'glide nv | xargs -n 3 staticcheck'
-	$(DOCKER_GO_BUILD) gometalinter --deadline=300s \
+	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'glide nv | xargs -n 3 staticcheck'
+	$(DOCKER_RUN) $(CALICO_BUILD) gometalinter --deadline=300s \
 	                                --disable-all \
 	                                --enable=goimports \
 	                                --vendor ./...
@@ -491,7 +502,7 @@ go-meta-linter: vendor/.up-to-date $(GENERATED_GO_FILES)
 # Run go fmt on all our go files.
 .PHONY: go-fmt goimports fix
 fix go-fmt goimports:
-	$(DOCKER_GO_BUILD) sh -c 'glide nv -x | \
+	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'glide nv -x | \
       grep -v -e "^\\.$$" | \
       xargs goimports -w -local github.com/projectcalico/ *.go'
 
@@ -512,7 +523,7 @@ check-typha-pins: vendor/.up-to-date
 
 .PHONY: pre-commit
 pre-commit:
-	$(DOCKER_GO_BUILD) git-hooks/pre-commit-in-container
+	$(DOCKER_RUN) $(CALICO_BUILD) git-hooks/pre-commit-in-container
 
 .PHONY: install-git-hooks
 ## Install Git hooks
@@ -525,7 +536,7 @@ install-git-hooks:
 .PHONY: ut
 ut combined.coverprofile: vendor/.up-to-date $(SRC_FILES)
 	@echo Running Go UTs.
-	$(DOCKER_GO_BUILD) ./utils/run-coverage $(GINKGO_ARGS)
+	$(DOCKER_RUN) $(LOCAL_BUILD_MOUNTS) $(CALICO_BUILD) ./utils/run-coverage $(GINKGO_ARGS)
 
 ###############################################################################
 # FV Tests
@@ -533,7 +544,7 @@ ut combined.coverprofile: vendor/.up-to-date $(SRC_FILES)
 fv/fv.test: vendor/.up-to-date $(SRC_FILES)
 	# We pre-build the FV test binaries so that we can run them
 	# outside a container and allow them to interact with docker.
-	$(DOCKER_GO_BUILD) go test ./$(shell dirname $@) -c --tags fvtests -o $@
+	$(DOCKER_RUN) $(LOCAL_BUILD_MOUNTS) $(CALICO_BUILD) go test ./$(shell dirname $@) -c --tags fvtests -o $@
 
 .PHONY: fv
 # runs all of the fv tests
@@ -607,7 +618,7 @@ k8sfv-test-existing-felix: bin/k8sfv.test
 
 bin/k8sfv.test: $(K8SFV_GO_FILES) vendor/.up-to-date
 	@echo Building $@...
-	$(DOCKER_GO_BUILD) \
+	$(DOCKER_RUN) $(LOCAL_BUILD_MOUNTS) $(CALICO_BUILD) \
 	    sh -c 'go test -c -o $@ ./k8sfv && \
 		( ldd $@ 2>&1 | grep -q -e "Not a valid dynamic program" \
 		-e "not a dynamic executable" || \
@@ -648,19 +659,19 @@ stop-grafana:
 bin/iptables-locker: $(SRC_FILES) vendor/.up-to-date
 	@echo Building iptables-locker...
 	mkdir -p bin
-	$(DOCKER_GO_BUILD) \
+	$(DOCKER_RUN) $(LOCAL_BUILD_MOUNTS) $(CALICO_BUILD) \
 	    sh -c 'go build -v -i -o $@ -v $(LDFLAGS) "$(PACKAGE_NAME)/fv/iptables-locker"'
 
 bin/test-workload: $(SRC_FILES) vendor/.up-to-date
 	@echo Building test-workload...
 	mkdir -p bin
-	$(DOCKER_GO_BUILD) \
+	$(DOCKER_RUN) $(LOCAL_BUILD_MOUNTS) $(CALICO_BUILD) \
 	    sh -c 'go build -v -i -o $@ -v $(LDFLAGS) "$(PACKAGE_NAME)/fv/test-workload"'
 
 bin/test-connection: $(SRC_FILES) vendor/.up-to-date
 	@echo Building test-connection...
 	mkdir -p bin
-	$(DOCKER_GO_BUILD) \
+	$(DOCKER_RUN) $(LOCAL_BUILD_MOUNTS) $(CALICO_BUILD) \
 	    sh -c 'go build -v -i -o $@ -v $(LDFLAGS) "$(PACKAGE_NAME)/fv/test-connection"'
 
 ###############################################################################
@@ -790,6 +801,9 @@ release-prereqs:
 ifndef VERSION
 	$(error VERSION is undefined - run using make release VERSION=vX.Y.Z)
 endif
+ifdef LOCAL_BUILD
+	$(error LOCAL_BUILD must not be set for a release)
+endif
 
 ###############################################################################
 # Developer helper scripts (not used by build or test)
@@ -797,12 +811,12 @@ endif
 .PHONY: ut-no-cover
 ut-no-cover: vendor/.up-to-date $(SRC_FILES)
 	@echo Running Go UTs without coverage.
-	$(DOCKER_GO_BUILD) ginkgo -r -skipPackage fv,k8sfv,windows $(GINKGO_ARGS)
+	$(DOCKER_RUN) $(CALICO_BUILD) ginkgo -r -skipPackage fv,k8sfv,windows $(GINKGO_ARGS)
 
 .PHONY: ut-watch
 ut-watch: vendor/.up-to-date $(SRC_FILES)
 	@echo Watching go UTs for changes...
-	$(DOCKER_GO_BUILD) ginkgo watch -r -skipPackage fv,k8sfv,windows $(GINKGO_ARGS)
+	$(DOCKER_RUN) $(CALICO_BUILD) ginkgo watch -r -skipPackage fv,k8sfv,windows $(GINKGO_ARGS)
 
 # Launch a browser with Go coverage stats for the whole project.
 .PHONY: cover-browser
@@ -816,23 +830,23 @@ cover-report: combined.coverprofile
 	@echo
 	@echo ======== All coverage =========
 	@echo
-	@$(DOCKER_GO_BUILD) sh -c 'go tool cover -func combined.coverprofile | \
+	@$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'go tool cover -func combined.coverprofile | \
 	                           sed 's=$(PACKAGE_NAME)/==' | \
 	                           column -t'
 	@echo
 	@echo ======== Missing coverage only =========
 	@echo
-	@$(DOCKER_GO_BUILD) sh -c "go tool cover -func combined.coverprofile | \
+	@$(DOCKER_RUN) $(CALICO_BUILD) sh -c "go tool cover -func combined.coverprofile | \
 	                           sed 's=$(PACKAGE_NAME)/==' | \
 	                           column -t | \
 	                           grep -v '100\.0%'"
 
 bin/calico-felix.transfer-url: bin/calico-felix
-	$(DOCKER_GO_BUILD) sh -c 'curl --upload-file bin/calico-felix https://transfer.sh/calico-felix > $@'
+	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'curl --upload-file bin/calico-felix https://transfer.sh/calico-felix > $@'
 
 .PHONY: patch-script
 patch-script: bin/calico-felix.transfer-url
-	$(DOCKER_GO_BUILD) bash -c 'utils/make-patch-script.sh $$(cat bin/calico-felix.transfer-url)'
+	$(DOCKER_RUN) $(CALICO_BUILD) bash -c 'utils/make-patch-script.sh $$(cat bin/calico-felix.transfer-url)'
 
 # Generate a diagram of Felix's internal calculation graph.
 docs/calc.pdf: docs/calc.dot


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Looking for feedback on the approach with this one - it was a bit more involved due to the nature of the the way the build container command was defined.

We don't want to mount the local build directories when updating vendor, etc. So, I split the DOCKER_GO_BUILD command into three parts:
- DOCKER_RUN - the base docker run command.
- LOCAL_BUILD_MOUNTS - optional mounts, used in build targets only.
- CALICO_BUILD - the image to run

This gave the flexibility required to add the mounts only to the targets that actually run `go build`.

WDYT? 

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
