### PR TITLE
Use iptables-restore xtables lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -506,7 +506,7 @@ go-meta-linter: vendor/.up-to-date $(GENERATED_GO_FILES)
 fix go-fmt goimports:
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'glide nv -x | \
       grep -v -e "^\\.$$" | \
-      xargs goimports -w -local github.com/projectcalico/ *.go'
+      xargs goimports -w -local github.com/projectcalico/'
 
 .PHONY: check-typha-pins
 check-typha-pins: vendor/.up-to-date

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -27,9 +27,10 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
-	log "github.com/sirupsen/logrus"
 )
 
 var _ = Describe("FelixConfig vs ConfigParams parity", func() {

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -248,19 +248,23 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	iptablesNATOptions := iptablesOptions
 	iptablesNATOptions.ExtraCleanupRegexPattern = rules.HistoricInsertedNATRuleRegex
 
+	featureDetector := iptables.NewFeatureDetector()
+	iptablesFeatures := featureDetector.GetFeatures()
+
 	var iptablesLock sync.Locker
-	if config.IptablesLockTimeout <= 0 {
+	if iptablesFeatures.RestoreSupportsLock {
+		log.Debug("Calico implementation of iptables lock disabled (because detected version of " +
+			"iptables-restore will use its own implementation).")
+		iptablesLock = dummyLock{}
+	} else if config.IptablesLockTimeout <= 0 {
 		log.Debug("Calico implementation of iptables lock disabled (by configuration).")
 		iptablesLock = dummyLock{}
 	} else {
 		// Create the shared iptables lock.  This allows us to block other processes from
 		// manipulating iptables while we make our updates.  We use a shared lock because we
 		// actually do multiple updates in parallel (but to different tables), which is safe.
-		//
-		// Note: this is only used for iptables < v1.6.2; v1.6.2 added mandatory lock support
-		// to iptables-restore, which we'll detect later on.
 		log.WithField("timeout", config.IptablesLockTimeout).Debug(
-			"Calico implementation of iptables lock will be enabled (if iptables is pre-v1.6.2)")
+			"Calico implementation of iptables lock enabled")
 		iptablesLock = iptables.NewSharedLock(
 			config.IptablesLockFilePath,
 			config.IptablesLockTimeout,
@@ -273,12 +277,14 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
+		featureDetector,
 		iptablesOptions)
 	natTableV4 := iptables.NewTable(
 		"nat",
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
+		featureDetector,
 		iptablesNATOptions,
 	)
 	rawTableV4 := iptables.NewTable(
@@ -286,12 +292,14 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
+		featureDetector,
 		iptablesOptions)
 	filterTableV4 := iptables.NewTable(
 		"filter",
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
+		featureDetector,
 		iptablesOptions)
 	ipSetsConfigV4 := config.RulesConfig.IPSetConfigV4
 	ipSetsV4 := ipsets.NewIPSets(ipSetsConfigV4)
@@ -337,6 +345,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,
+			featureDetector,
 			iptablesOptions,
 		)
 		natTableV6 := iptables.NewTable(
@@ -344,6 +353,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,
+			featureDetector,
 			iptablesNATOptions,
 		)
 		rawTableV6 := iptables.NewTable(
@@ -351,6 +361,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,
+			featureDetector,
 			iptablesOptions,
 		)
 		filterTableV6 := iptables.NewTable(
@@ -358,6 +369,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,
+			featureDetector,
 			iptablesOptions,
 		)
 

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -24,8 +24,13 @@ import (
 )
 
 type Features struct {
+	// SNATFullyRandom is true if --fully-random is supported by the SNAT action.
 	SNATFullyRandom bool
+	// MASQFullyRandom is true if --fully-random is supported by the MASQUERADE action.
 	MASQFullyRandom bool
+	// RestoreSupportsLock is true if the iptables-restore command supports taking the xtables lock and the
+	// associated -w and -W arguments.
+	RestoreSupportsLock bool
 }
 
 func MergeFeatures(a, b *Features) *Features {
@@ -70,6 +75,7 @@ func VersionToFeatures(s string) (*Features, error) {
 	}
 	if iptablesVersion.Compare(v1Dot6Dot2) >= 0 {
 		features.MASQFullyRandom = true
+		features.RestoreSupportsLock = true
 	}
 	return &features, nil
 }
@@ -86,6 +92,7 @@ func KernelVersionToFeatures(s string) (*Features, error) {
 		return nil, err
 	}
 	var features Features
+	features.RestoreSupportsLock = true // Not kernel dependent.
 	if iptablesVersion.Compare(v3Dot14Dot0) >= 0 {
 		features.SNATFullyRandom = true
 		features.MASQFullyRandom = true

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -32,7 +32,7 @@ var (
 	v1Dot4Dot7 = mustParseVersion("1.4.7")
 	// v1Dot6Dot0 added --random-fully to SNAT.
 	v1Dot6Dot0 = mustParseVersion("1.6.0")
-	// v1Dot6Dot2 added --random-fully to MASQUERADE
+	// v1Dot6Dot2 added --random-fully to MASQUERADE and the xtables lock to iptables-restore.
 	v1Dot6Dot2 = mustParseVersion("1.6.2")
 
 	// Linux kernel versions:
@@ -43,9 +43,9 @@ var (
 )
 
 type Features struct {
-	// SNATFullyRandom is true if --fully-random is supported by the SNAT action.
+	// SNATFullyRandom is true if --random-fully is supported by the SNAT action.
 	SNATFullyRandom bool
-	// MASQFullyRandom is true if --fully-random is supported by the MASQUERADE action.
+	// MASQFullyRandom is true if --random-fully is supported by the MASQUERADE action.
 	MASQFullyRandom bool
 	// RestoreSupportsLock is true if the iptables-restore command supports taking the xtables lock and the
 	// associated -w and -W arguments.

--- a/iptables/features_detect_test.go
+++ b/iptables/features_detect_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	. "github.com/projectcalico/felix/iptables"
+)
+
+func TestFeatureDetection(t *testing.T) {
+	RegisterTestingT(t)
+
+	type test struct {
+		iptablesVersion, kernelVersion string
+		features                       Features
+	}
+	for _, tst := range []test{
+		{
+			"iptables v1.6.2",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: true,
+				SNATFullyRandom:     true,
+				MASQFullyRandom:     true,
+			},
+		},
+		{
+			"iptables v1.6.1",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: false,
+				SNATFullyRandom:     true,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"iptables v1.5.0",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: false,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"iptables v1.6.2",
+			"Linux version 3.13.0",
+			Features{
+				RestoreSupportsLock: true,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"garbage",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: false,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"iptables v1.6.2",
+			"garbage",
+			Features{
+				RestoreSupportsLock: true,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"error",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: false,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"iptables v1.6.2",
+			"error",
+			Features{
+				RestoreSupportsLock: true,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+	} {
+		tst := tst
+		t.Run("iptables version "+tst.iptablesVersion+" kernel "+tst.kernelVersion, func(t *testing.T) {
+			RegisterTestingT(t)
+			dataplane := newMockDataplane("filter", map[string][]string{})
+			featureDetector := NewFeatureDetector()
+			featureDetector.NewCmd = dataplane.newCmd
+			featureDetector.ReadFile = dataplane.readFile
+
+			if tst.iptablesVersion == "error" {
+				dataplane.FailNextVersion = true
+			} else {
+				dataplane.Version = tst.iptablesVersion
+			}
+
+			if tst.kernelVersion == "error" {
+				dataplane.FailNextReadFile = true
+			} else {
+				dataplane.KernelVersion = tst.kernelVersion
+			}
+
+			Expect(featureDetector.GetFeatures()).To(Equal(&tst.features))
+		})
+	}
+}

--- a/iptables/rules_test.go
+++ b/iptables/rules_test.go
@@ -16,6 +16,7 @@ package iptables
 
 import (
 	"bytes"
+	"errors"
 
 	"sync"
 
@@ -68,11 +69,19 @@ var _ = Describe("Hash extraction tests", func() {
 	var table *Table
 
 	BeforeEach(func() {
+		fd := NewFeatureDetector()
+		fd.ReadFile = func(name string) ([]byte, error) {
+			return nil, errors.New("not implemented")
+		}
+		fd.NewCmd = func(name string, arg ...string) CmdIface {
+			return newRealCmd("echo", "iptables v1.4.7")
+		}
 		table = NewTable(
 			"filter",
 			4,
 			"cali:",
 			&sync.Mutex{},
+			fd,
 			TableOptions{
 				HistoricChainPrefixes:    []string{"felix-", "cali"},
 				ExtraCleanupRegexPattern: "an-old-rule",

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"reflect"
 	"regexp"
@@ -183,8 +182,8 @@ type Table struct {
 	Name      string
 	IPVersion uint8
 
-	// Detected features of the iptables tools. Populated on the first resync.
-	Features *Features
+	// featureDetector detects the features of the dataplane.
+	featureDetector *FeatureDetector
 
 	// chainToInsertedRules maps from chain name to a list of rules to be inserted at the start
 	// of that chain.  Rules are written with rule hash comments.  The Table cleans up inserted
@@ -231,7 +230,14 @@ type Table struct {
 	postWriteInterval        time.Duration
 	refreshInterval          time.Duration
 
+	// calicoXtablesLock, if enabled, our implementation of the xtables lock.
 	calicoXtablesLock sync.Locker
+
+	// lockTimeout is the timeout used for iptables-restore's native xtables lock implementation.
+	lockTimeout time.Duration
+	// lockTimeout is the lock probe interval used for iptables-restore's native xtables lock
+	// implementation.
+	lockProbeInterval time.Duration
 
 	logCxt *log.Entry
 
@@ -241,13 +247,9 @@ type Table struct {
 
 	// Factory for making commands, used by UTs to shim exec.Command().
 	newCmd cmdFactory
-	// Shim for reading ioutil.ReadFile
-	readFile func(name string) ([]byte, error)
 	// Shims for time.XXX functions:
-	timeSleep         func(d time.Duration)
-	timeNow           func() time.Time
-	lockTimeout       time.Duration
-	lockProbeInterval time.Duration
+	timeSleep func(d time.Duration)
+	timeNow   func() time.Time
 }
 
 type TableOptions struct {
@@ -257,17 +259,17 @@ type TableOptions struct {
 	RefreshInterval          time.Duration
 	PostWriteInterval        time.Duration
 
+	// LockTimeout is the timeout to use for iptables-restore's native xtables lock.
+	LockTimeout time.Duration
+	// LockProbeInterval is the probe interval to use for iptables-restore's native xtables lock.
+	LockProbeInterval time.Duration
+
 	// NewCmdOverride for tests, if non-nil, factory to use instead of the real exec.Command()
 	NewCmdOverride cmdFactory
-	// ReadFileOverride for tests, if non-nil, alternative to ioutil.ReadFile().
-	ReadFileOverride func(name string) ([]byte, error)
 	// SleepOverride for tests, if non-nil, replacement for time.Sleep()
 	SleepOverride func(d time.Duration)
 	// NowOverride for tests, if non-nil, replacement for time.Now()
 	NowOverride func() time.Time
-
-	LockTimeout       time.Duration
-	LockProbeInterval time.Duration
 }
 
 func NewTable(
@@ -275,6 +277,7 @@ func NewTable(
 	ipVersion uint8,
 	hashPrefix string,
 	iptablesWriteLock sync.Locker,
+	detector *FeatureDetector,
 	options TableOptions,
 ) *Table {
 	// Calculate the regex used to match the hash comment.  The comment looks like this:
@@ -327,10 +330,6 @@ func NewTable(
 	if options.NewCmdOverride != nil {
 		newCmd = options.NewCmdOverride
 	}
-	readFile := ioutil.ReadFile
-	if options.ReadFileOverride != nil {
-		readFile = options.ReadFileOverride
-	}
 	sleep := time.Sleep
 	if options.SleepOverride != nil {
 		sleep = options.SleepOverride
@@ -343,6 +342,7 @@ func NewTable(
 	table := &Table{
 		Name:                   name,
 		IPVersion:              ipVersion,
+		featureDetector:        detector,
 		chainToInsertedRules:   inserts,
 		dirtyInserts:           dirtyInserts,
 		chainNameToChain:       map[string]*Chain{},
@@ -374,7 +374,6 @@ func NewTable(
 		lockProbeInterval: options.LockProbeInterval,
 
 		newCmd:    newCmd,
-		readFile:  readFile,
 		timeSleep: sleep,
 		timeNow:   now,
 
@@ -453,50 +452,13 @@ func (t *Table) RemoveChainByName(name string) {
 	t.InvalidateDataplaneCache("chain removal")
 }
 
-func (t *Table) refreshFeatures() error {
-	cmd := t.newCmd("iptables", "--version")
-	out, err := cmd.Output()
-	if err != nil {
-		return err
-	}
-
-	s := string(out)
-	features, err := VersionToFeatures(s)
-	if err != nil {
-		return err
-	}
-
-	kernVersion, err := t.readFile("/proc/version")
-	if err != nil {
-		return err
-	}
-	log.WithField("version", string(kernVersion)).Debug("Loaded kernel version")
-	kernFeatures, err := KernelVersionToFeatures(string(kernVersion))
-	if err != nil {
-		return err
-	}
-
-	merged := MergeFeatures(features, kernFeatures)
-
-	if t.Features == nil || *t.Features != *merged {
-		log.WithFields(log.Fields{
-			"iptables": features,
-			"kernel":   kernFeatures,
-			"merged":   merged,
-		}).Info("Detected iptables features")
-		t.Features = merged
-	}
-	return nil
-}
-
 func (t *Table) loadDataplaneState() {
+	// Refresh the cache of feature data.
+	t.featureDetector.RefreshFeatures()
+
 	// Load the hashes from the dataplane.
 	t.logCxt.Info("Loading current iptables state and checking it is correct.")
 	t.lastReadTime = t.timeNow()
-	err := t.refreshFeatures()
-	if err != nil {
-		log.WithError(err).Panic("Failed to parse iptables version information")
-	}
 	dataplaneHashes := t.getHashesFromDataplane()
 
 	// Check that the rules we think we've programmed are still there and mark any inconsistent
@@ -603,7 +565,8 @@ func (t *Table) expectedHashesForInsertChain(
 ) (allHashes, ourHashes []string) {
 	insertedRules := t.chainToInsertedRules[chainName]
 	allHashes = make([]string, len(insertedRules)+numNonCalicoRules)
-	ourHashes = calculateRuleInsertHashes(chainName, insertedRules, t.Features)
+	features := t.featureDetector.GetFeatures()
+	ourHashes = calculateRuleInsertHashes(chainName, insertedRules, features)
 	offset := 0
 	if t.insertMode == "append" {
 		log.Debug("In append mode, returning our hashes at end.")
@@ -874,6 +837,9 @@ func (t *Table) Apply() (rescheduleAfter time.Duration) {
 
 func (t *Table) applyUpdates() error {
 	var inputBuf bytes.Buffer
+	// If needed, detect the dataplane features.
+	features := t.featureDetector.GetFeatures()
+
 	// iptables-restore input starts with a line indicating the table name.
 	tableNameLine := fmt.Sprintf("*%s\n", t.Name)
 	inputBuf.WriteString(tableNameLine)
@@ -905,7 +871,7 @@ func (t *Table) applyUpdates() error {
 			// Chain update or creation.  Scan the chain against its previous hashes
 			// and replace/append/delete as appropriate.
 			previousHashes := t.chainToDataplaneHashes[chainName]
-			currentHashes := chain.RuleHashes(t.Features)
+			currentHashes := chain.RuleHashes(features)
 			newHashes[chainName] = currentHashes
 			for i := 0; i < len(previousHashes) || i < len(currentHashes); i++ {
 				var line string
@@ -916,7 +882,7 @@ func (t *Table) applyUpdates() error {
 					// Hash doesn't match, replace the rule.
 					ruleNum := i + 1 // 1-indexed.
 					prefixFrag := t.commentFrag(currentHashes[i])
-					line = chain.Rules[i].RenderReplace(chainName, ruleNum, prefixFrag, t.Features)
+					line = chain.Rules[i].RenderReplace(chainName, ruleNum, prefixFrag, features)
 				} else if i < len(previousHashes) {
 					// previousHashes was longer, remove the old rules from the end.
 					ruleNum := len(currentHashes) + 1 // 1-indexed
@@ -924,7 +890,7 @@ func (t *Table) applyUpdates() error {
 				} else {
 					// currentHashes was longer.  Append.
 					prefixFrag := t.commentFrag(currentHashes[i])
-					line = chain.Rules[i].RenderAppend(chainName, prefixFrag, t.Features)
+					line = chain.Rules[i].RenderAppend(chainName, prefixFrag, features)
 				}
 				inputBuf.WriteString(line)
 				inputBuf.WriteString("\n")
@@ -972,7 +938,7 @@ func (t *Table) applyUpdates() error {
 			// state of the chain.
 			for i := len(rules) - 1; i >= 0; i-- {
 				prefixFrag := t.commentFrag(newRuleHashes[i])
-				line := rules[i].RenderInsert(chainName, prefixFrag, t.Features)
+				line := rules[i].RenderInsert(chainName, prefixFrag, features)
 				inputBuf.WriteString(line)
 				inputBuf.WriteString("\n")
 				t.countNumLinesExecuted.Inc()
@@ -981,7 +947,7 @@ func (t *Table) applyUpdates() error {
 			t.logCxt.Debug("Rendering append rules.")
 			for i := 0; i < len(rules); i++ {
 				prefixFrag := t.commentFrag(newRuleHashes[i])
-				line := rules[i].RenderAppend(chainName, prefixFrag, t.Features)
+				line := rules[i].RenderAppend(chainName, prefixFrag, features)
 				inputBuf.WriteString(line)
 				inputBuf.WriteString("\n")
 				t.countNumLinesExecuted.Inc()
@@ -1022,10 +988,9 @@ func (t *Table) applyUpdates() error {
 
 		var outputBuf, errBuf bytes.Buffer
 		args := []string{"--noflush", "--verbose"}
-		if t.Features.RestoreSupportsLock {
-			// Versions of iptables-restore that support the xtables lock _always_ take the xtables lock.  Make sure
-			// that we configure it to retry and configure for a short retry interval (the default is to wait 1s
-			// between lock probes).
+		if features.RestoreSupportsLock {
+			// Versions of iptables-restore that support the xtables lock also make it mandatory.  Make sure
+			// that we configure it to retry and configure for a short retry interval (the default is not to retry).
 			lockTimeout := t.lockTimeout.Seconds()
 			if lockTimeout <= 0 {
 				// Before iptables-restore added lock support, we were able to disable the lock completely, which
@@ -1050,14 +1015,9 @@ func (t *Table) applyUpdates() error {
 		cmd.SetStdout(&outputBuf)
 		cmd.SetStderr(&errBuf)
 		countNumRestoreCalls.Inc()
-		if !t.Features.RestoreSupportsLock {
-			// Use our xtables lock implementation (if enabled) if iptables-restore doesn't support it.
-			t.calicoXtablesLock.Lock()
-		}
+		t.calicoXtablesLock.Lock() // Will be a dummy lock if our xtables lock is disabled.
 		err := cmd.Run()
-		if !t.Features.RestoreSupportsLock {
-			t.calicoXtablesLock.Unlock()
-		}
+		t.calicoXtablesLock.Unlock()
 		if err != nil {
 			t.logCxt.WithFields(log.Fields{
 				"output":      outputBuf.String(),

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -76,12 +76,13 @@ var _ = Describe("Table with an empty dataplane", func() {
 		}))
 	})
 
-	It("should detect MASQ fully random for version 1.6.2", func() {
+	It("should detect MASQ fully random, RestoreSupportsLock for version 1.6.2", func() {
 		dataplane.Version = "iptables v1.6.2\n"
 		table.Apply()
 		Expect(table.Features).To(Equal(&Features{
-			SNATFullyRandom: true,
-			MASQFullyRandom: true,
+			SNATFullyRandom:     true,
+			MASQFullyRandom:     true,
+			RestoreSupportsLock: true,
 		}))
 	})
 

--- a/iptables/utils_for_test.go
+++ b/iptables/utils_for_test.go
@@ -68,6 +68,7 @@ type mockDataplane struct {
 	FailAllSaves           bool
 	FailNextPipeClose      bool
 	FailNextStart          bool
+	FailNextReadFile       bool
 	PipeBuffers            []*closableBuffer
 	CumulativeSleep        time.Duration
 	Time                   time.Time
@@ -124,6 +125,10 @@ func (d *mockDataplane) newCmd(name string, arg ...string) CmdIface {
 }
 
 func (d *mockDataplane) readFile(name string) ([]byte, error) {
+	if d.FailNextReadFile {
+		d.FailNextReadFile = false
+		return nil, errors.New("dummy error")
+	}
 	if name == "/proc/version" {
 		return []byte(d.KernelVersion), nil
 	}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Based on feature-detection work added in #1901 

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Need to update manifests to map in the xtables lock file. cf https://github.com/kubernetes-incubator/kubespray/pull/3191/files: https://github.com/projectcalico/calico/pull/2224
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
If deployed with iptables v1.6.2 or above (as included in the calico/felix and calico/node images), all iptables write operations are protected by the xtables global lock.  Previously, the lock was disabled by default but iptables v1.6.2 made the lock mandatory.
```
