### PR TITLE
Add retries to iptables commands in fv tests

### DIFF
--- a/fv/etcd_restart_test.go
+++ b/fv/etcd_restart_test.go
@@ -159,12 +159,16 @@ var _ = Context("etcd connection interruption", func() {
 					// Use the raw table to drop the TCP connections (to etcd) that felix is using,
 					// in both directions, based on source and destination port.
 					felix.Exec("iptables",
+						"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
+						"-W", "100000", // How often to probe the lock in microsecs.
 						"-t", "raw", "-I", "PREROUTING",
 						"-p", "tcp",
 						"-s", etcd.IP,
 						"-m", "multiport", "--destination-ports", matches[1],
 						"-j", "DROP")
 					felix.Exec("iptables",
+						"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
+						"-W", "100000", // How often to probe the lock in microsecs.
 						"-t", "raw", "-I", "OUTPUT",
 						"-p", "tcp",
 						"-d", etcd.IP,

--- a/fv/infrastructure/felix.go
+++ b/fv/infrastructure/felix.go
@@ -88,7 +88,10 @@ func RunFelix(infra DatastoreInfra, options TopologyOptions) *Felix {
 	// that packet, not just allow it to pass through cali-FORWARD and assume it will
 	// be accepted by the rest of the chain.  Establishing that setting in this FV
 	// allows us to test that.
-	c.Exec("iptables", "-P", "FORWARD", "DROP")
+	c.Exec("iptables",
+		"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
+		"-W", "100000", // How often to probe the lock in microsecs.
+		"-P", "FORWARD", "DROP")
 
 	return &Felix{
 		Container: c,

--- a/fv/pre_dnat_test.go
+++ b/fv/pre_dnat_test.go
@@ -107,6 +107,8 @@ var _ = infrastructure.DatastoreDescribe("pre-dnat with initialized Felix, 2 wor
 		BeforeEach(func() {
 			felix.Exec(
 				"iptables", "-t", "nat",
+				"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
+				"-W", "100000", // How often to probe the lock in microsecs.
 				"-A", "PREROUTING",
 				"-p", "tcp",
 				"-d", "10.65.0.10", "--dport", "32010",
@@ -114,6 +116,8 @@ var _ = infrastructure.DatastoreDescribe("pre-dnat with initialized Felix, 2 wor
 			)
 			felix.Exec(
 				"iptables", "-t", "nat",
+				"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
+				"-W", "100000", // How often to probe the lock in microsecs.
 				"-A", "PREROUTING",
 				"-p", "tcp",
 				"-d", "10.65.0.11", "--dport", "32011",


### PR DESCRIPTION
## Description
Fix an FV flake where we were hitting: 
"Another app is currently holding the xtables lock. Perhaps you want to use the -w option?"

## Release Note
```release-note
None required
```
