### PR TITLE
Backport SNAT --random-fully and xtables lock support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,7 +493,7 @@ go-meta-linter: vendor/.up-to-date $(GENERATED_GO_FILES)
 fix go-fmt goimports:
 	$(DOCKER_GO_BUILD) sh -c 'glide nv -x | \
       grep -v -e "^\\.$$" | \
-      xargs goimports -w -local github.com/projectcalico/ *.go'
+      xargs goimports -w -local github.com/projectcalico/'
 
 .PHONY: check-typha-pins
 check-typha-pins: vendor/.up-to-date

--- a/check-licenses/check_licenses.go
+++ b/check-licenses/check_licenses.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -100,6 +100,8 @@ var (
 		// Mozilla Public License.  Note, would prohibit us from ever releasing our code
 		// under a *GPL license (if we wanted to do that).
 		{pkgName: "github.com/projectcalico/felix/vendor/github.com/hashicorp/golang-lru/simplelru",
+			license: "Mozilla Public License 2.0"},
+		{pkgName: "github.com/projectcalico/felix/vendor/github.com/hashicorp/go-version",
 			license: "Mozilla Public License 2.0"},
 		// Not detected properly - But it's apache license - https://github.com/go-yaml/yaml/blob/v2.2.1/LICENSE
 		{pkgName: "github.com/projectcalico/felix/vendor/gopkg.in/yaml.v2",

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -27,9 +27,10 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
-	log "github.com/sirupsen/logrus"
 )
 
 var _ = Describe("FelixConfig vs ConfigParams parity", func() {

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -240,22 +240,31 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		InsertMode:            config.IptablesInsertMode,
 		RefreshInterval:       config.IptablesRefreshInterval,
 		PostWriteInterval:     config.IptablesPostWriteCheckInterval,
+		LockTimeout:           config.IptablesLockTimeout,
+		LockProbeInterval:     config.IptablesLockProbeInterval,
 	}
 
 	// However, the NAT tables need an extra cleanup regex.
 	iptablesNATOptions := iptablesOptions
 	iptablesNATOptions.ExtraCleanupRegexPattern = rules.HistoricInsertedNATRuleRegex
 
+	featureDetector := iptables.NewFeatureDetector()
+	iptablesFeatures := featureDetector.GetFeatures()
+
 	var iptablesLock sync.Locker
-	if config.IptablesLockTimeout <= 0 {
-		log.Info("iptables lock disabled.")
+	if iptablesFeatures.RestoreSupportsLock {
+		log.Debug("Calico implementation of iptables lock disabled (because detected version of " +
+			"iptables-restore will use its own implementation).")
+		iptablesLock = dummyLock{}
+	} else if config.IptablesLockTimeout <= 0 {
+		log.Debug("Calico implementation of iptables lock disabled (by configuration).")
 		iptablesLock = dummyLock{}
 	} else {
 		// Create the shared iptables lock.  This allows us to block other processes from
 		// manipulating iptables while we make our updates.  We use a shared lock because we
 		// actually do multiple updates in parallel (but to different tables), which is safe.
-		log.WithField("timeout", config.IptablesLockTimeout).Info(
-			"iptables lock enabled")
+		log.WithField("timeout", config.IptablesLockTimeout).Debug(
+			"Calico implementation of iptables lock enabled")
 		iptablesLock = iptables.NewSharedLock(
 			config.IptablesLockFilePath,
 			config.IptablesLockTimeout,
@@ -268,12 +277,14 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
+		featureDetector,
 		iptablesOptions)
 	natTableV4 := iptables.NewTable(
 		"nat",
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
+		featureDetector,
 		iptablesNATOptions,
 	)
 	rawTableV4 := iptables.NewTable(
@@ -281,12 +292,14 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
+		featureDetector,
 		iptablesOptions)
 	filterTableV4 := iptables.NewTable(
 		"filter",
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
+		featureDetector,
 		iptablesOptions)
 	ipSetsConfigV4 := config.RulesConfig.IPSetConfigV4
 	ipSetsV4 := ipsets.NewIPSets(ipSetsConfigV4)
@@ -332,6 +345,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,
+			featureDetector,
 			iptablesOptions,
 		)
 		natTableV6 := iptables.NewTable(
@@ -339,6 +353,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,
+			featureDetector,
 			iptablesNATOptions,
 		)
 		rawTableV6 := iptables.NewTable(
@@ -346,6 +361,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,
+			featureDetector,
 			iptablesOptions,
 		)
 		filterTableV6 := iptables.NewTable(
@@ -353,6 +369,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,
+			featureDetector,
 			iptablesOptions,
 		)
 

--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -113,6 +113,15 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 		infra.Stop()
 	})
 
+	It("should use the --random-fully flag in the MASQUERADE rules", func() {
+		for _, felix := range felixes {
+			Eventually(func() string {
+				out, _ := felix.ExecOutput("iptables-save", "-c")
+				return out
+			}, "10s", "100ms").Should(ContainSubstring("--random-fully"))
+		}
+	})
+
 	It("should have workload to workload connectivity", func() {
 		cc.ExpectSome(w[0], w[1])
 		cc.ExpectSome(w[1], w[0])

--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -113,12 +113,13 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 		infra.Stop()
 	})
 
-	It("should use the --random-fully flag in the MASQUERADE rules", func() {
+	It("should succeed in adding MASQUERADE rules (i.e. implies that it detects that "+
+		"--random-fully is not available in Alpine 3.7)", func() {
 		for _, felix := range felixes {
 			Eventually(func() string {
 				out, _ := felix.ExecOutput("iptables-save", "-c")
 				return out
-			}, "10s", "100ms").Should(ContainSubstring("--random-fully"))
+			}, "10s", "100ms").Should(ContainSubstring("MASQUERADE"))
 		}
 	})
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cba0ee8f62c07d05fb47373b19e3504c58f27cbcd8e939b672adc4a3c75c8c9a
-updated: 2018-10-17T08:36:57.711546126Z
+hash: 908101f631c3a18cdc47d9736ae9c0a0f867dc96177af210966886e108522be7
+updated: 2018-10-17T10:25:42.511523121Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -254,10 +254,9 @@ imports:
   - pkg/syncproto
   - pkg/tlsutils
 - name: github.com/prometheus/client_golang
-  version: 1cafe34db7fdec6022e17e00e1c1ea501022f3e4
+  version: 5b23715facdef1452016bae512489c3cdf82458c
   subpackages:
   - prometheus
-  - prometheus/internal
   - prometheus/promhttp
   - prometheus/push
 - name: github.com/prometheus/client_model
@@ -265,7 +264,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: bcb74de08d37a417cb6789eec1d6c810040f0470
+  version: c7de2306084e37d54b8be01f3541a8464345e9a5
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 99e45bce1604b129e07d0cb72db685e78bc681a10ec5c9a43f15443f38df35a9
-updated: 2018-08-10T06:19:12.083235509Z
+hash: cba0ee8f62c07d05fb47373b19e3504c58f27cbcd8e939b672adc4a3c75c8c9a
+updated: 2018-10-17T08:36:57.711546126Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -45,7 +45,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: d58d458bec3cb5adec4b7ddb41131855eac0b33f
+  version: 9c8236e659b76e87bf02044d06fde8683008ff3e
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -90,6 +90,8 @@ imports:
   version: 80a92cca79a8041496ccc9dd773fcb52a57ec6f9
 - name: github.com/gxed/GoEndian
   version: 0f5c6873267e5abf306ffcdfcfa4bf77517ef4a7
+- name: github.com/hashicorp/go-version
+  version: b5a281d3160aa11950a6182bd9a9dc2cb1e02d50
 - name: github.com/hashicorp/golang-lru
   version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
   subpackages:
@@ -110,7 +112,7 @@ imports:
   - tracer/wire
   - writer
 - name: github.com/jbenet/go-reuseport
-  version: 562c3ba3003e80c9829992a6c1a760d51eb0792b
+  version: dd0c37d7767bc38280bd9813145b65f8bd560629
 - name: github.com/json-iterator/go
   version: f2b4162afba35581b6d4a50d3b8f34e33c144682
 - name: github.com/kardianos/osext
@@ -118,18 +120,18 @@ imports:
 - name: github.com/kelseyhightower/envconfig
   version: dd1402a4d99de9ac2f396cd6fcb957bc2c695ec1
 - name: github.com/libp2p/go-reuseport
-  version: 562c3ba3003e80c9829992a6c1a760d51eb0792b
+  version: dd0c37d7767bc38280bd9813145b65f8bd560629
   subpackages:
   - poll
   - singlepoll
 - name: github.com/libp2p/go-sockaddr
-  version: 3c898fbfff40e5933d76362819727708dae6da97
+  version: a7494d4eefeb607c8bc491cf8850a6e8dbd41cab
   subpackages:
   - net
 - name: github.com/mattn/go-colorable
   version: efa589957cd060542a26d2dd7832fd6a6c6c3ade
 - name: github.com/mattn/go-isatty
-  version: 6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
+  version: 3fb116b820352b7f0c281308a4d6250c22d94e27
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
@@ -177,7 +179,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: b6ea1ea48f981d0f615a154a45eabb9dd466556d
+  version: 7615b9433f86a8bdf29709bf288bc4fd0636a369
   subpackages:
   - format
   - internal/assertion
@@ -191,7 +193,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/opentracing/opentracing-go
-  version: bd9c3193394760d98b2fa6ebb2291f0cd1d06a7d
+  version: be550b025b433cdfa2f11efb962afa2ea3c4d967
   subpackages:
   - ext
   - log
@@ -252,9 +254,10 @@ imports:
   - pkg/syncproto
   - pkg/tlsutils
 - name: github.com/prometheus/client_golang
-  version: 5b23715facdef1452016bae512489c3cdf82458c
+  version: 1cafe34db7fdec6022e17e00e1c1ea501022f3e4
   subpackages:
   - prometheus
+  - prometheus/internal
   - prometheus/promhttp
   - prometheus/push
 - name: github.com/prometheus/client_model
@@ -262,7 +265,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: c7de2306084e37d54b8be01f3541a8464345e9a5
+  version: bcb74de08d37a417cb6789eec1d6c810040f0470
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -286,7 +289,7 @@ imports:
 - name: github.com/whyrusleeping/go-logging
   version: 0457bb6b88fc1973573aaf6b5145d8d3ae972390
 - name: golang.org/x/crypto
-  version: de0752318171da717af4ce24d0a2e8626afaeb11
+  version: 0c41d7ab0a0ee717d4590a44bcb987dfd9e183eb
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -341,7 +344,7 @@ imports:
   subpackages:
   - rate
 - name: google.golang.org/appengine
-  version: 4216e58b9158e5f1c906f1aca75162a46a2ec88a
+  version: ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06
   subpackages:
   - internal
   - internal/app_identity
@@ -353,29 +356,38 @@ imports:
   - internal/urlfetch
   - urlfetch
 - name: google.golang.org/genproto
-  version: 383e8b2c3b9e36c4076b235b32537292176bae20
+  version: 94acd270e44e65579b9ee3cdab25034d33fed608
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
   version: 5b3c4e850e90a4cf6a20ebd46c8b32a0a3afcb9e
   subpackages:
   - balancer
+  - balancer/base
+  - balancer/roundrobin
   - codes
   - connectivity
   - credentials
-  - grpclb/grpc_lb_v1/messages
+  - encoding
+  - encoding/proto
   - grpclog
   - health/grpc_health_v1
   - internal
+  - internal/backoff
+  - internal/channelz
+  - internal/envconfig
+  - internal/grpcrand
+  - internal/transport
   - keepalive
   - metadata
   - naming
   - peer
   - resolver
+  - resolver/dns
+  - resolver/passthrough
   - stats
   - status
   - tap
-  - transport
 - name: gopkg.in/fsnotify/fsnotify.v1
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: gopkg.in/go-playground/validator.v8

--- a/glide.yaml
+++ b/glide.yaml
@@ -67,11 +67,16 @@ import:
   subpackages:
   - pkg/syncclient
   - pkg/tlsutils
+# Pinned on release branch (to previously chosen commit) because it floated to a version with breaking API changes.
 - package: github.com/prometheus/client_golang
+  version: 5b23715facdef1452016bae512489c3cdf82458c
   subpackages:
   - prometheus
   - prometheus/promhttp
   - prometheus/push
+# Pinned on release branch (to previously chosen commit) because it floated to a version with breaking API changes.
+- package: github.com/prometheus/common
+  version: c7de2306084e37d54b8be01f3541a8464345e9a5
 - package: github.com/prometheus/procfs
   version: a6e9df898b1336106c743392c48ee0b71f5c4efa
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -118,3 +118,5 @@ import:
 - package: github.com/davecgh/go-spew
   subpackages:
   - spew
+- package: github.com/hashicorp/go-version
+  version: ^1.0.0

--- a/iptables/actions_test.go
+++ b/iptables/actions_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,20 +22,23 @@ import (
 )
 
 var _ = DescribeTable("Actions",
-	func(action Action, expRendering string) {
-		Expect(action.ToFragment()).To(Equal(expRendering))
+	func(features Features, action Action, expRendering string) {
+		Expect(action.ToFragment(&features)).To(Equal(expRendering))
 	},
-	Entry("GotoAction", GotoAction{Target: "cali-abcd"}, "--goto cali-abcd"),
-	Entry("JumpAction", JumpAction{Target: "cali-abcd"}, "--jump cali-abcd"),
-	Entry("ReturnAction", ReturnAction{}, "--jump RETURN"),
-	Entry("DropAction", DropAction{}, "--jump DROP"),
-	Entry("AcceptAction", AcceptAction{}, "--jump ACCEPT"),
-	Entry("LogAction", LogAction{Prefix: "prefix"}, `--jump LOG --log-prefix "prefix: " --log-level 5`),
-	Entry("DNATAction", DNATAction{DestAddr: "10.0.0.1", DestPort: 8081}, "--jump DNAT --to-destination 10.0.0.1:8081"),
-	Entry("MasqAction", MasqAction{}, "--jump MASQUERADE"),
-	Entry("ClearMarkAction", ClearMarkAction{Mark: 0x1000}, "--jump MARK --set-mark 0/0x1000"),
-	Entry("SetMarkAction", SetMarkAction{Mark: 0x1000}, "--jump MARK --set-mark 0x1000/0x1000"),
-	Entry("SetMaskedMarkAction", SetMaskedMarkAction{
+	Entry("GotoAction", Features{}, GotoAction{Target: "cali-abcd"}, "--goto cali-abcd"),
+	Entry("JumpAction", Features{}, JumpAction{Target: "cali-abcd"}, "--jump cali-abcd"),
+	Entry("ReturnAction", Features{}, ReturnAction{}, "--jump RETURN"),
+	Entry("DropAction", Features{}, DropAction{}, "--jump DROP"),
+	Entry("AcceptAction", Features{}, AcceptAction{}, "--jump ACCEPT"),
+	Entry("LogAction", Features{}, LogAction{Prefix: "prefix"}, `--jump LOG --log-prefix "prefix: " --log-level 5`),
+	Entry("DNATAction", Features{}, DNATAction{DestAddr: "10.0.0.1", DestPort: 8081}, "--jump DNAT --to-destination 10.0.0.1:8081"),
+	Entry("SNATAction", Features{}, SNATAction{ToAddr: "10.0.0.1"}, "--jump SNAT --to-source 10.0.0.1"),
+	Entry("SNATAction fully random", Features{SNATFullyRandom: true}, SNATAction{ToAddr: "10.0.0.1"}, "--jump SNAT --to-source 10.0.0.1 --random-fully"),
+	Entry("MasqAction", Features{}, MasqAction{}, "--jump MASQUERADE"),
+	Entry("MasqAction", Features{MASQFullyRandom: true}, MasqAction{}, "--jump MASQUERADE --random-fully"),
+	Entry("ClearMarkAction", Features{}, ClearMarkAction{Mark: 0x1000}, "--jump MARK --set-mark 0/0x1000"),
+	Entry("SetMarkAction", Features{}, SetMarkAction{Mark: 0x1000}, "--jump MARK --set-mark 0x1000/0x1000"),
+	Entry("SetMaskedMarkAction", Features{}, SetMaskedMarkAction{
 		Mark: 0x1000,
 		Mask: 0xf000,
 	}, "--jump MARK --set-mark 0x1000/0xf000"),

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -101,7 +101,11 @@ func (d *FeatureDetector) refreshFeaturesLockHeld() {
 	}
 
 	if d.featureCache == nil || *d.featureCache != features {
-		log.WithField("features", features).Info("Updating detected iptables features")
+		log.WithFields(log.Fields{
+			"features":        features,
+			"kernelVersion":   kerV,
+			"iptablesVersion": iptV,
+		}).Info("Updating detected iptables features")
 		d.featureCache = &features
 	}
 }
@@ -114,6 +118,7 @@ func (d *FeatureDetector) getIptablesVersion() *version.Version {
 		return v1Dot4Dot7
 	}
 	s := string(out)
+	log.WithField("rawVersion", s).Debug("Ran iptables --version")
 	matches := vXDotYDotZRegexp.FindStringSubmatch(s)
 	if len(matches) == 0 {
 		log.WithField("rawVersion", s).Warn(
@@ -126,6 +131,7 @@ func (d *FeatureDetector) getIptablesVersion() *version.Version {
 			"Failed to parse iptables version, assuming old version with no optional features")
 		return v1Dot4Dot7
 	}
+	log.WithField("version", parsedVersion).Debug("Parsed iptables version")
 	return parsedVersion
 }
 
@@ -136,6 +142,7 @@ func (d *FeatureDetector) getKernelVersion() *version.Version {
 		return v3Dot10Dot0
 	}
 	s := string(kernVersion)
+	log.WithField("rawVersion", s).Debug("Raw kernel version")
 	matches := kernelVersionRegexp.FindStringSubmatch(s)
 	if len(matches) == 0 {
 		log.WithField("rawVersion", s).Warn(
@@ -148,6 +155,7 @@ func (d *FeatureDetector) getKernelVersion() *version.Version {
 			"Failed to parse kernel version, assuming old version with no optional features")
 		return v3Dot10Dot0
 	}
+	log.WithField("version", parsedVersion).Debug("Parsed kernel version")
 	return parsedVersion
 }
 

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+
+	"github.com/hashicorp/go-version"
+	"github.com/sirupsen/logrus"
+)
+
+type Features struct {
+	SNATFullyRandom bool
+	MASQFullyRandom bool
+}
+
+func MergeFeatures(a, b *Features) *Features {
+	var merged Features
+	featuresT := reflect.TypeOf(merged)
+	for i := 0; i < featuresT.NumField(); i++ {
+		if reflect.ValueOf(*a).Field(i).Bool() && reflect.ValueOf(*b).Field(i).Bool() {
+			reflect.ValueOf(&merged).Elem().Field(i).SetBool(true)
+		}
+	}
+	return &merged
+}
+
+var (
+	v1Dot6Dot0  = mustParseVersion("1.6.0")
+	v1Dot6Dot2  = mustParseVersion("1.6.2")
+	v3Dot14Dot0 = mustParseVersion("3.14.0")
+)
+
+func mustParseVersion(v string) *version.Version {
+	ver, err := version.NewVersion(v)
+	if err != nil {
+		logrus.WithError(err).Panic("Failed to parse version.")
+	}
+	return ver
+}
+
+// VersionToFeatures converts an iptables version line as returned by iptables --version into a set of feature flags.
+func VersionToFeatures(s string) (*Features, error) {
+	re := regexp.MustCompile(`v(\d+\.\d+\.\d+)`)
+	matches := re.FindStringSubmatch(s)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("iptables returned bad version: %s", s)
+	}
+	iptablesVersion, err := version.NewVersion(matches[1])
+	if err != nil {
+		return nil, err
+	}
+	var features Features
+	if iptablesVersion.Compare(v1Dot6Dot0) >= 0 {
+		features.SNATFullyRandom = true
+	}
+	if iptablesVersion.Compare(v1Dot6Dot2) >= 0 {
+		features.MASQFullyRandom = true
+	}
+	return &features, nil
+}
+
+// KernelVersionToFeatures parses a /proc/version-formatted string and returns the features supported by the kernel.
+func KernelVersionToFeatures(s string) (*Features, error) {
+	re := regexp.MustCompile(`Linux version (\d+\.\d+\.\d+)`)
+	matches := re.FindStringSubmatch(s)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("kernel returned bad version: %s", s)
+	}
+	iptablesVersion, err := version.NewVersion(matches[1])
+	if err != nil {
+		return nil, err
+	}
+	var features Features
+	if iptablesVersion.Compare(v3Dot14Dot0) >= 0 {
+		features.SNATFullyRandom = true
+		features.MASQFullyRandom = true
+	}
+	return &features, nil
+}

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -15,80 +15,146 @@
 package iptables
 
 import (
-	"fmt"
-	"reflect"
+	"io/ioutil"
 	"regexp"
+	"sync"
 
 	"github.com/hashicorp/go-version"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	vXDotYDotZRegexp    = regexp.MustCompile(`v(\d+\.\d+\.\d+)`)
+	kernelVersionRegexp = regexp.MustCompile(`Linux version (\d+\.\d+\.\d+)`)
+
+	// iptables versions:
+	// v1Dot4Dot7 is the oldest version we've ever supported.
+	v1Dot4Dot7 = mustParseVersion("1.4.7")
+	// v1Dot6Dot0 added --random-fully to SNAT.
+	v1Dot6Dot0 = mustParseVersion("1.6.0")
+	// v1Dot6Dot2 added --random-fully to MASQUERADE and the xtables lock to iptables-restore.
+	v1Dot6Dot2 = mustParseVersion("1.6.2")
+
+	// Linux kernel versions:
+	// v3Dot10Dot0 is the oldest version we support at time of writing.
+	v3Dot10Dot0 = mustParseVersion("3.10.0")
+	// v3Dot14Dot0 added the random-fully feature on the iptables interface.
+	v3Dot14Dot0 = mustParseVersion("3.14.0")
 )
 
 type Features struct {
+	// SNATFullyRandom is true if --random-fully is supported by the SNAT action.
 	SNATFullyRandom bool
+	// MASQFullyRandom is true if --random-fully is supported by the MASQUERADE action.
 	MASQFullyRandom bool
+	// RestoreSupportsLock is true if the iptables-restore command supports taking the xtables lock and the
+	// associated -w and -W arguments.
+	RestoreSupportsLock bool
 }
 
-func MergeFeatures(a, b *Features) *Features {
-	var merged Features
-	featuresT := reflect.TypeOf(merged)
-	for i := 0; i < featuresT.NumField(); i++ {
-		if reflect.ValueOf(*a).Field(i).Bool() && reflect.ValueOf(*b).Field(i).Bool() {
-			reflect.ValueOf(&merged).Elem().Field(i).SetBool(true)
-		}
+type FeatureDetector struct {
+	lock         sync.Mutex
+	featureCache *Features
+
+	// Shim for reading ioutil.ReadFile
+	ReadFile func(name string) ([]byte, error)
+	// Factory for making commands, used by UTs to shim exec.Command().
+	NewCmd cmdFactory
+}
+
+func NewFeatureDetector() *FeatureDetector {
+	return &FeatureDetector{
+		ReadFile: ioutil.ReadFile,
+		NewCmd:   newRealCmd,
 	}
-	return &merged
 }
 
-var (
-	v1Dot6Dot0  = mustParseVersion("1.6.0")
-	v1Dot6Dot2  = mustParseVersion("1.6.2")
-	v3Dot14Dot0 = mustParseVersion("3.14.0")
-)
+func (d *FeatureDetector) GetFeatures() *Features {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.featureCache == nil {
+		d.refreshFeaturesLockHeld()
+	}
+
+	return d.featureCache
+}
+
+func (d *FeatureDetector) RefreshFeatures() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	d.refreshFeaturesLockHeld()
+}
+
+func (d *FeatureDetector) refreshFeaturesLockHeld() {
+	// Get the versions.  If we fail to detect a version for some reason, we use a safe default.
+	log.Debug("Refreshing detected iptables features")
+	iptV := d.getIptablesVersion()
+	kerV := d.getKernelVersion()
+
+	// Calculate the features.
+	features := Features{
+		SNATFullyRandom:     iptV.Compare(v1Dot6Dot0) >= 0 && kerV.Compare(v3Dot14Dot0) >= 0,
+		MASQFullyRandom:     iptV.Compare(v1Dot6Dot2) >= 0 && kerV.Compare(v3Dot14Dot0) >= 0,
+		RestoreSupportsLock: iptV.Compare(v1Dot6Dot2) >= 0,
+	}
+
+	if d.featureCache == nil || *d.featureCache != features {
+		log.WithField("features", features).Info("Updating detected iptables features")
+		d.featureCache = &features
+	}
+}
+
+func (d *FeatureDetector) getIptablesVersion() *version.Version {
+	cmd := d.NewCmd("iptables", "--version")
+	out, err := cmd.Output()
+	if err != nil {
+		log.WithError(err).Warn("Failed to get iptables version, assuming old version with no optional features")
+		return v1Dot4Dot7
+	}
+	s := string(out)
+	matches := vXDotYDotZRegexp.FindStringSubmatch(s)
+	if len(matches) == 0 {
+		log.WithField("rawVersion", s).Warn(
+			"Failed to parse iptables version, assuming old version with no optional features")
+		return v1Dot4Dot7
+	}
+	parsedVersion, err := version.NewVersion(matches[1])
+	if err != nil {
+		log.WithField("rawVersion", s).WithError(err).Warn(
+			"Failed to parse iptables version, assuming old version with no optional features")
+		return v1Dot4Dot7
+	}
+	return parsedVersion
+}
+
+func (d *FeatureDetector) getKernelVersion() *version.Version {
+	kernVersion, err := d.ReadFile("/proc/version")
+	if err != nil {
+		log.WithError(err).Warn("Failed to get kernel version, assuming old version with no optional features")
+		return v3Dot10Dot0
+	}
+	s := string(kernVersion)
+	matches := kernelVersionRegexp.FindStringSubmatch(s)
+	if len(matches) == 0 {
+		log.WithField("rawVersion", s).Warn(
+			"Failed to parse kernel version, assuming old version with no optional features")
+		return v3Dot10Dot0
+	}
+	parsedVersion, err := version.NewVersion(matches[1])
+	if err != nil {
+		log.WithField("rawVersion", s).WithError(err).Warn(
+			"Failed to parse kernel version, assuming old version with no optional features")
+		return v3Dot10Dot0
+	}
+	return parsedVersion
+}
 
 func mustParseVersion(v string) *version.Version {
 	ver, err := version.NewVersion(v)
 	if err != nil {
-		logrus.WithError(err).Panic("Failed to parse version.")
+		log.WithError(err).Panic("Failed to parse version.")
 	}
 	return ver
-}
-
-// VersionToFeatures converts an iptables version line as returned by iptables --version into a set of feature flags.
-func VersionToFeatures(s string) (*Features, error) {
-	re := regexp.MustCompile(`v(\d+\.\d+\.\d+)`)
-	matches := re.FindStringSubmatch(s)
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("iptables returned bad version: %s", s)
-	}
-	iptablesVersion, err := version.NewVersion(matches[1])
-	if err != nil {
-		return nil, err
-	}
-	var features Features
-	if iptablesVersion.Compare(v1Dot6Dot0) >= 0 {
-		features.SNATFullyRandom = true
-	}
-	if iptablesVersion.Compare(v1Dot6Dot2) >= 0 {
-		features.MASQFullyRandom = true
-	}
-	return &features, nil
-}
-
-// KernelVersionToFeatures parses a /proc/version-formatted string and returns the features supported by the kernel.
-func KernelVersionToFeatures(s string) (*Features, error) {
-	re := regexp.MustCompile(`Linux version (\d+\.\d+\.\d+)`)
-	matches := re.FindStringSubmatch(s)
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("kernel returned bad version: %s", s)
-	}
-	iptablesVersion, err := version.NewVersion(matches[1])
-	if err != nil {
-		return nil, err
-	}
-	var features Features
-	if iptablesVersion.Compare(v3Dot14Dot0) >= 0 {
-		features.SNATFullyRandom = true
-		features.MASQFullyRandom = true
-	}
-	return &features, nil
 }

--- a/iptables/features_detect_test.go
+++ b/iptables/features_detect_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	. "github.com/projectcalico/felix/iptables"
+)
+
+func TestFeatureDetection(t *testing.T) {
+	RegisterTestingT(t)
+
+	type test struct {
+		iptablesVersion, kernelVersion string
+		features                       Features
+	}
+	for _, tst := range []test{
+		{
+			"iptables v1.6.2",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: true,
+				SNATFullyRandom:     true,
+				MASQFullyRandom:     true,
+			},
+		},
+		{
+			"iptables v1.6.1",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: false,
+				SNATFullyRandom:     true,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"iptables v1.5.0",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: false,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"iptables v1.6.2",
+			"Linux version 3.13.0",
+			Features{
+				RestoreSupportsLock: true,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"garbage",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: false,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"iptables v1.6.2",
+			"garbage",
+			Features{
+				RestoreSupportsLock: true,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"error",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: false,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+		{
+			"iptables v1.6.2",
+			"error",
+			Features{
+				RestoreSupportsLock: true,
+				SNATFullyRandom:     false,
+				MASQFullyRandom:     false,
+			},
+		},
+	} {
+		tst := tst
+		t.Run("iptables version "+tst.iptablesVersion+" kernel "+tst.kernelVersion, func(t *testing.T) {
+			RegisterTestingT(t)
+			dataplane := newMockDataplane("filter", map[string][]string{})
+			featureDetector := NewFeatureDetector()
+			featureDetector.NewCmd = dataplane.newCmd
+			featureDetector.ReadFile = dataplane.readFile
+
+			if tst.iptablesVersion == "error" {
+				dataplane.FailNextVersion = true
+			} else {
+				dataplane.Version = tst.iptablesVersion
+			}
+
+			if tst.kernelVersion == "error" {
+				dataplane.FailNextReadFile = true
+			} else {
+				dataplane.KernelVersion = tst.kernelVersion
+			}
+
+			Expect(featureDetector.GetFeatures()).To(Equal(&tst.features))
+		})
+	}
+}

--- a/iptables/rules_test.go
+++ b/iptables/rules_test.go
@@ -16,6 +16,7 @@ package iptables
 
 import (
 	"bytes"
+	"errors"
 
 	"sync"
 
@@ -68,11 +69,19 @@ var _ = Describe("Hash extraction tests", func() {
 	var table *Table
 
 	BeforeEach(func() {
+		fd := NewFeatureDetector()
+		fd.ReadFile = func(name string) ([]byte, error) {
+			return nil, errors.New("not implemented")
+		}
+		fd.NewCmd = func(name string, arg ...string) CmdIface {
+			return newRealCmd("echo", "iptables v1.4.7")
+		}
 		table = NewTable(
 			"filter",
 			4,
 			"cali:",
 			&sync.Mutex{},
+			fd,
 			TableOptions{
 				HistoricChainPrefixes:    []string{"felix-", "cali"},
 				ExtraCleanupRegexPattern: "an-old-rule",

--- a/iptables/rules_test.go
+++ b/iptables/rules_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -163,5 +163,5 @@ func calculateHashes(chainName string, rules []Rule) []string {
 		Name:  chainName,
 		Rules: rules,
 	}
-	return chain.RuleHashes()
+	return chain.RuleHashes(&Features{})
 }

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ var _ = Describe("Table with an empty dataplane", func() {
 			TableOptions{
 				HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 				NewCmdOverride:        dataplane.newCmd,
+				ReadFileOverride:      dataplane.readFile,
 				SleepOverride:         dataplane.sleep,
 				NowOverride:           dataplane.now,
 			},
@@ -57,10 +58,40 @@ var _ = Describe("Table with an empty dataplane", func() {
 		table.Apply()
 		// Should only load, since there's nothing to so.
 		Expect(dataplane.CmdNames).To(Equal([]string{
+			"iptables",
 			"iptables-save",
 		}))
 		Expect(iptLock.Held).To(BeFalse())
 		Expect(iptLock.WasTaken).To(BeFalse())
+		Expect(table.Features).To(Equal(&Features{
+			SNATFullyRandom: false,
+		}))
+	})
+
+	It("should detect SNAT fully random for version 1.6.0", func() {
+		dataplane.Version = "iptables v1.6.0\n"
+		table.Apply()
+		Expect(table.Features).To(Equal(&Features{
+			SNATFullyRandom: true,
+		}))
+	})
+
+	It("should detect MASQ fully random for version 1.6.2", func() {
+		dataplane.Version = "iptables v1.6.2\n"
+		table.Apply()
+		Expect(table.Features).To(Equal(&Features{
+			SNATFullyRandom: true,
+			MASQFullyRandom: true,
+		}))
+	})
+
+	It("should detect no SNAT fully random for kernel version 3.13", func() {
+		dataplane.Version = "iptables v1.6.1\n"
+		dataplane.KernelVersion = "Linux version 3.13.0-generic-1234"
+		table.Apply()
+		Expect(table.Features).To(Equal(&Features{
+			SNATFullyRandom: false,
+		}))
 	})
 
 	It("should have a refresh scheduled at start-of-day", func() {
@@ -77,6 +108,7 @@ var _ = Describe("Table with an empty dataplane", func() {
 		Expect(dataplane.CmdNames).To(BeEmpty())
 		table.Apply()
 		Expect(dataplane.CmdNames).To(Equal([]string{
+			"iptables",
 			"iptables-save",
 			"iptables-restore",
 		}))
@@ -139,7 +171,7 @@ var _ = Describe("Table with an empty dataplane", func() {
 				"OUTPUT":  {},
 			}))
 			// Should do a save but then figure out that there's nothing to do
-			Expect(dataplane.CmdNames).To(ConsistOf("iptables-save"))
+			Expect(dataplane.CmdNames).To(ConsistOf("iptables", "iptables-save"))
 		})
 
 		Describe("after inserting a rule then updating the insertions", func() {
@@ -304,7 +336,7 @@ var _ = Describe("Table with an empty dataplane", func() {
 				dataplane.ResetCmds()
 				table.Apply()
 				// Should do a save but then figure out that there's nothing to do
-				Expect(dataplane.CmdNames).To(ConsistOf("iptables-save"))
+				Expect(dataplane.CmdNames).To(ConsistOf("iptables", "iptables-save"))
 			})
 		})
 		Describe("then extending the chain", func() {
@@ -454,7 +486,7 @@ func describePostUpdateCheckTests(enableRefresh bool) {
 		}
 	}
 	assertRecheck := func() {
-		Expect(dataplane.CmdNames).To(ConsistOf("iptables-save"))
+		Expect(dataplane.CmdNames).To(ConsistOf("iptables", "iptables-save"))
 	}
 	assertDelayMillis := func(delay int64) func() {
 		return func() {
@@ -731,7 +763,7 @@ func describeDirtyDataplaneTests(appendMode bool) {
 		It("with no errors, it should get to correct final state", func() {
 			table.Apply()
 			checkFinalState()
-			Expect(len(dataplane.Cmds)).To(Equal(2)) // a save and a restore
+			Expect(dataplane.Cmds).To(HaveLen(3)) // a version, save and a restore
 		})
 		It("with no errors, it shouldn't sleep", func() {
 			table.Apply()
@@ -742,7 +774,7 @@ func describeDirtyDataplaneTests(appendMode bool) {
 				checkFinalState()
 			})
 			It("it should retry once", func() {
-				Expect(len(dataplane.Cmds)).To(Equal(3)) // 2 saves and a restore
+				Expect(dataplane.Cmds).To(HaveLen(4)) // a version, 2 saves and a restore
 			})
 			It("it should sleep", func() {
 				Expect(dataplane.CumulativeSleep).To(Equal(100 * time.Millisecond))
@@ -819,7 +851,7 @@ func describeDirtyDataplaneTests(appendMode bool) {
 				Expect(func() {
 					table.Apply()
 				}).To(Panic())
-				Expect(len(dataplane.Cmds)).To(Equal(4))
+				Expect(dataplane.Cmds).To(HaveLen(5))
 			}, 1)
 		})
 

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -31,6 +31,7 @@ var _ = Describe("Table with an empty dataplane", func() {
 	var dataplane *mockDataplane
 	var table *Table
 	var iptLock *mockMutex
+	var featureDetector *FeatureDetector
 	BeforeEach(func() {
 		dataplane = newMockDataplane("filter", map[string][]string{
 			"FORWARD": {},
@@ -38,15 +39,18 @@ var _ = Describe("Table with an empty dataplane", func() {
 			"OUTPUT":  {},
 		})
 		iptLock = &mockMutex{}
+		featureDetector = NewFeatureDetector()
+		featureDetector.NewCmd = dataplane.newCmd
+		featureDetector.ReadFile = dataplane.readFile
 		table = NewTable(
 			"filter",
 			4,
 			rules.RuleHashPrefix,
 			iptLock,
+			featureDetector,
 			TableOptions{
 				HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 				NewCmdOverride:        dataplane.newCmd,
-				ReadFileOverride:      dataplane.readFile,
 				SleepOverride:         dataplane.sleep,
 				NowOverride:           dataplane.now,
 			},
@@ -63,35 +67,6 @@ var _ = Describe("Table with an empty dataplane", func() {
 		}))
 		Expect(iptLock.Held).To(BeFalse())
 		Expect(iptLock.WasTaken).To(BeFalse())
-		Expect(table.Features).To(Equal(&Features{
-			SNATFullyRandom: false,
-		}))
-	})
-
-	It("should detect SNAT fully random for version 1.6.0", func() {
-		dataplane.Version = "iptables v1.6.0\n"
-		table.Apply()
-		Expect(table.Features).To(Equal(&Features{
-			SNATFullyRandom: true,
-		}))
-	})
-
-	It("should detect MASQ fully random for version 1.6.2", func() {
-		dataplane.Version = "iptables v1.6.2\n"
-		table.Apply()
-		Expect(table.Features).To(Equal(&Features{
-			SNATFullyRandom: true,
-			MASQFullyRandom: true,
-		}))
-	})
-
-	It("should detect no SNAT fully random for kernel version 3.13", func() {
-		dataplane.Version = "iptables v1.6.1\n"
-		dataplane.KernelVersion = "Linux version 3.13.0-generic-1234"
-		table.Apply()
-		Expect(table.Features).To(Equal(&Features{
-			SNATFullyRandom: false,
-		}))
 	})
 
 	It("should have a refresh scheduled at start-of-day", func() {
@@ -129,6 +104,7 @@ var _ = Describe("Table with an empty dataplane", func() {
 				4,
 				rules.RuleHashPrefix,
 				&mockMutex{},
+				featureDetector,
 				TableOptions{
 					HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 					NewCmdOverride:        dataplane.newCmd,
@@ -465,11 +441,15 @@ func describePostUpdateCheckTests(enableRefresh bool) {
 		if enableRefresh {
 			options.RefreshInterval = 30 * time.Second
 		}
+		featureDetector := NewFeatureDetector()
+		featureDetector.NewCmd = dataplane.newCmd
+		featureDetector.ReadFile = dataplane.readFile
 		table = NewTable(
 			"filter",
 			4,
 			rules.RuleHashPrefix,
 			&mockMutex{},
+			featureDetector,
 			options,
 		)
 		table.SetRuleInsertions("FORWARD", []Rule{
@@ -654,11 +634,15 @@ func describeDirtyDataplaneTests(appendMode bool) {
 		if appendMode {
 			insertMode = "append"
 		}
+		featureDetector := NewFeatureDetector()
+		featureDetector.NewCmd = dataplane.newCmd
+		featureDetector.ReadFile = dataplane.readFile
 		table = NewTable(
 			"filter",
 			4,
 			rules.RuleHashPrefix,
 			&mockMutex{},
+			featureDetector,
 			TableOptions{
 				HistoricChainPrefixes:    rules.AllHistoricChainNamePrefixes,
 				ExtraCleanupRegexPattern: "sneaky-rule",
@@ -1026,11 +1010,15 @@ var _ = Describe("Table with inserts and a non-Calico chain", func() {
 			"non-calico": {"-m comment \"foo\""},
 		})
 		iptLock = &mockMutex{}
+		featureDetector := NewFeatureDetector()
+		featureDetector.NewCmd = dataplane.newCmd
+		featureDetector.ReadFile = dataplane.readFile
 		table = NewTable(
 			"filter",
 			6,
 			rules.RuleHashPrefix,
 			iptLock,
+			featureDetector,
 			TableOptions{
 				HistoricChainPrefixes: rules.AllHistoricChainNamePrefixes,
 				NewCmdOverride:        dataplane.newCmd,

--- a/iptables/utils_for_test.go
+++ b/iptables/utils_for_test.go
@@ -68,6 +68,7 @@ type mockDataplane struct {
 	FailAllSaves           bool
 	FailNextPipeClose      bool
 	FailNextStart          bool
+	FailNextReadFile       bool
 	PipeBuffers            []*closableBuffer
 	CumulativeSleep        time.Duration
 	Time                   time.Time
@@ -124,6 +125,10 @@ func (d *mockDataplane) newCmd(name string, arg ...string) CmdIface {
 }
 
 func (d *mockDataplane) readFile(name string) ([]byte, error) {
+	if d.FailNextReadFile {
+		d.FailNextReadFile = false
+		return nil, errors.New("dummy error")
+	}
 	if name == "/proc/version" {
 		return []byte(d.KernelVersion), nil
 	}

--- a/rules/policy_test.go
+++ b/rules/policy_test.go
@@ -315,7 +315,7 @@ var _ = Describe("Protobuf rule to iptables rule conversion", func() {
 			iptRules := renderer.ProtoRuleToIptablesRules(&pRule, 4)
 			rendered := []string{}
 			for _, ir := range iptRules {
-				s := ir.RenderAppend("test", "")
+				s := ir.RenderAppend("test", "", &iptables.Features{})
 				rendered = append(rendered, s)
 			}
 			Expect(rendered).To(Equal(expected))
@@ -431,7 +431,7 @@ var _ = Describe("Protobuf rule to iptables rule conversion", func() {
 			iptRules := renderer.ProtoRuleToIptablesRules(&pRule, 4)
 			rendered := []string{}
 			for _, ir := range iptRules {
-				s := ir.RenderAppend("test", "")
+				s := ir.RenderAppend("test", "", &iptables.Features{})
 				rendered = append(rendered, s)
 			}
 			Expect(rendered).To(Equal(expected))


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Backport of #1905 and #1901.  Main aim was to backport the xtables-lock fix but it was easier to do both.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
For iptables versions that force use of the xtables lock, Felix now tells iptables-restore to wait for the lock.  This prevents errors and Felix restarts caused by failing to acquire the lock on the first try.  

For iptables versions that support it, Felix enables the --random-fully flag on SNAT and MASQUERADE rules.  This works around a race in conntrack set-up that causes occasional DNS timeouts for DNS packets that are NATted.
```
