### PR TITLE
 Fix time allowed for step of k8s infrastructure set up

### DIFF
--- a/fv/apply_on_forward_test.go
+++ b/fv/apply_on_forward_test.go
@@ -46,7 +46,6 @@ var _ = infrastructure.DatastoreDescribe("apply on forward tests; with 2 nodes",
 	)
 
 	BeforeEach(func() {
-		var err error
 		infra = getInfra()
 
 		options := infrastructure.DefaultTopologyOptions()
@@ -54,8 +53,7 @@ var _ = infrastructure.DatastoreDescribe("apply on forward tests; with 2 nodes",
 		felixes, client = infrastructure.StartNNodeTopology(2, options, infra)
 
 		// Install a default profile that allows all ingress and egress, in the absence of any Policy.
-		err = infra.AddDefaultAllow()
-		Expect(err).NotTo(HaveOccurred())
+		infra.AddDefaultAllow()
 
 		// Create workloads, using that profile.  One on each "host".
 		for ii := range w {

--- a/fv/apply_on_forward_test.go
+++ b/fv/apply_on_forward_test.go
@@ -47,8 +47,7 @@ var _ = infrastructure.DatastoreDescribe("apply on forward tests; with 2 nodes",
 
 	BeforeEach(func() {
 		var err error
-		infra, err = getInfra()
-		Expect(err).NotTo(HaveOccurred())
+		infra = getInfra()
 
 		options := infrastructure.DefaultTopologyOptions()
 		options.IPIPEnabled = false

--- a/fv/donottrack_test.go
+++ b/fv/donottrack_test.go
@@ -49,8 +49,7 @@ var _ = infrastructure.DatastoreDescribe("do-not-track policy tests; with 2 node
 
 	BeforeEach(func() {
 		var err error
-		infra, err = getInfra()
-		Expect(err).NotTo(HaveOccurred())
+		infra = getInfra()
 
 		dumpedDiags = false
 		options := infrastructure.DefaultTopologyOptions()

--- a/fv/host_port_test.go
+++ b/fv/host_port_test.go
@@ -71,7 +71,6 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 	)
 
 	BeforeEach(func() {
-		var err error
 		infra = getInfra()
 
 		felix, client = infrastructure.StartSingleNodeTopology(infrastructure.DefaultTopologyOptions(), infra)

--- a/fv/host_port_test.go
+++ b/fv/host_port_test.go
@@ -72,8 +72,7 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 
 	BeforeEach(func() {
 		var err error
-		infra, err = getInfra()
-		Expect(err).NotTo(HaveOccurred())
+		infra = getInfra()
 
 		felix, client = infrastructure.StartSingleNodeTopology(infrastructure.DefaultTopologyOptions(), infra)
 

--- a/fv/infrastructure/datastore_describe.go
+++ b/fv/infrastructure/datastore_describe.go
@@ -22,7 +22,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 )
 
-type InfraFactory func() (DatastoreInfra, error)
+type InfraFactory func() DatastoreInfra
 
 // DatastoreDescribe is a replacement for ginkgo.Describe which invokes Describe
 // multiple times for one or more different datastore drivers - passing in the

--- a/fv/infrastructure/infra_etcd.go
+++ b/fv/infrastructure/infra_etcd.go
@@ -34,8 +34,10 @@ type EtcdDatastoreInfra struct {
 	BadEndpoint string
 }
 
-func createEtcdDatastoreInfra() (DatastoreInfra, error) {
-	return GetEtcdDatastoreInfra()
+func createEtcdDatastoreInfra() DatastoreInfra {
+	infra, err := GetEtcdDatastoreInfra()
+	Expect(err).NotTo(HaveOccurred())
+	return infra
 }
 
 func GetEtcdDatastoreInfra() (*EtcdDatastoreInfra, error) {

--- a/fv/infrastructure/infra_etcd.go
+++ b/fv/infrastructure/infra_etcd.go
@@ -123,14 +123,15 @@ func (eds *EtcdDatastoreInfra) AddAllowToDatastore(selector string) error {
 	return err
 }
 
-func (eds *EtcdDatastoreInfra) AddDefaultAllow() error {
+func (eds *EtcdDatastoreInfra) AddDefaultAllow() {
 	defaultProfile := api.NewProfile()
 	defaultProfile.Name = "default"
 	defaultProfile.Spec.LabelsToApply = map[string]string{"default": ""}
 	defaultProfile.Spec.Egress = []api.Rule{{Action: api.Allow}}
 	defaultProfile.Spec.Ingress = []api.Rule{{Action: api.Allow}}
 	_, err := eds.GetCalicoClient().Profiles().Create(utils.Ctx, defaultProfile, utils.NoOptions)
-	return err
+	Expect(err).NotTo(HaveOccurred())
+	return
 }
 
 func (eds *EtcdDatastoreInfra) AddDefaultDeny() error {

--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -505,8 +506,8 @@ func (kds *K8sDatastoreInfra) AddAllowToDatastore(selector string) error {
 	return err
 }
 
-func (kds *K8sDatastoreInfra) AddDefaultAllow() error {
-	return nil
+func (kds *K8sDatastoreInfra) AddDefaultAllow() {
+	return
 }
 
 func (kds *K8sDatastoreInfra) AddDefaultDeny() error {

--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -209,6 +209,7 @@ func setupK8sDatastoreInfra() (*K8sDatastoreInfra, error) {
 	}
 	log.Info("Added role binding.")
 
+	start = time.Now()
 	for {
 		_, err := kds.K8sClient.CoreV1().Namespaces().List(metav1.ListOptions{})
 		if err == nil {

--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -91,8 +91,10 @@ func TearDownK8sInfra(kds *K8sDatastoreInfra) {
 	}
 }
 
-func createK8sDatastoreInfra() (DatastoreInfra, error) {
-	return GetK8sDatastoreInfra()
+func createK8sDatastoreInfra() DatastoreInfra {
+	infra, err := GetK8sDatastoreInfra()
+	Expect(err).NotTo(HaveOccurred())
+	return infra
 }
 
 func GetK8sDatastoreInfra() (*K8sDatastoreInfra, error) {

--- a/fv/infrastructure/infrastructure.go
+++ b/fv/infrastructure/infrastructure.go
@@ -52,7 +52,7 @@ type DatastoreInfra interface {
 	AddWorkload(wep *api.WorkloadEndpoint) (*api.WorkloadEndpoint, error)
 	// AddDefaultAllow will ensure that the datastore is configured so that
 	// the default profile/namespace will allow traffic.
-	AddDefaultAllow() error
+	AddDefaultAllow()
 	// AddDefaultDeny will ensure that the datastore is configured so that
 	// the default profile/namespace will deny ingress traffic.
 	AddDefaultDeny() error

--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -50,13 +50,11 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 	)
 
 	BeforeEach(func() {
-		var err error
 		infra = getInfra()
 		felixes, client = infrastructure.StartNNodeTopology(2, infrastructure.DefaultTopologyOptions(), infra)
 
 		// Install a default profile that allows all ingress and egress, in the absence of any Policy.
-		err = infra.AddDefaultAllow()
-		Expect(err).NotTo(HaveOccurred())
+		infra.AddDefaultAllow()
 
 		// Wait until the tunl0 device appears; it is created when felix inserts the ipip module
 		// into the kernel.

--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -51,8 +51,7 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 
 	BeforeEach(func() {
 		var err error
-		infra, err = getInfra()
-		Expect(err).NotTo(HaveOccurred())
+		infra = getInfra()
 		felixes, client = infrastructure.StartNNodeTopology(2, infrastructure.DefaultTopologyOptions(), infra)
 
 		// Install a default profile that allows all ingress and egress, in the absence of any Policy.

--- a/fv/pre_dnat_test.go
+++ b/fv/pre_dnat_test.go
@@ -54,7 +54,6 @@ var _ = infrastructure.DatastoreDescribe("pre-dnat with initialized Felix, 2 wor
 	)
 
 	BeforeEach(func() {
-		var err error
 		infra = getInfra()
 
 		options := infrastructure.DefaultTopologyOptions()
@@ -63,8 +62,7 @@ var _ = infrastructure.DatastoreDescribe("pre-dnat with initialized Felix, 2 wor
 		felix, client = infrastructure.StartSingleNodeTopology(options, infra)
 
 		// Install a default profile that allows all ingress and egress, in the absence of any Policy.
-		err = infra.AddDefaultAllow()
-		Expect(err).NotTo(HaveOccurred())
+		infra.AddDefaultAllow()
 
 		// Create workloads, using that profile.
 		for ii := range w {

--- a/fv/pre_dnat_test.go
+++ b/fv/pre_dnat_test.go
@@ -55,8 +55,7 @@ var _ = infrastructure.DatastoreDescribe("pre-dnat with initialized Felix, 2 wor
 
 	BeforeEach(func() {
 		var err error
-		infra, err = getInfra()
-		Expect(err).NotTo(HaveOccurred())
+		infra = getInfra()
 
 		options := infrastructure.DefaultTopologyOptions()
 		// For variety, run this test with IPv6 disabled.


### PR DESCRIPTION
Fixes this flake:

    Expected error:
        <*errors.StatusError | 0xc42059acf0>: {
            ErrStatus: {
                TypeMeta: {Kind: "", APIVersion: ""},
                ListMeta: {SelfLink: "", ResourceVersion: "", Continue: ""},
                Status: "Failure",
                Message: "namespaces is forbidden: User \"system:anonymous\" cannot list namespaces at the cluster scope: RBAC: clusterrole.rbac.authorization.k8s.io \"cluster-admin\" not found",
                Reason: "Forbidden",
                Details: {Name: "", Group: "", Kind: "namespaces", UID: "", Causes: nil, RetryAfterSeconds: 0},
                Code: 403,
            },
        }
        namespaces is forbidden: User "system:anonymous" cannot list namespaces at the cluster scope: RBAC: clusterrole.rbac.authorization.k8s.io "cluster-admin" not found
    not to have occurred

Plus a couple other drive-by FV code improvements.