### PR TITLE
Don't interpret glide WARN as a problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ DOCKER_RUN := mkdir -p .go-pkg-cache && \
                               $(EXTRA_DOCKER_ARGS) \
                               -e LOCAL_USER_ID=$(LOCAL_USER_ID) \
                               -e GOCACHE=/gocache \
+                              -v $(HOME)/.glide:/home/user/.glide:rw \
                               -v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \
                               -v $(CURDIR)/.go-pkg-cache:/gocache:rw \
                               -w /go/src/$(PACKAGE_NAME) \
@@ -296,9 +297,7 @@ update-typha:
         echo "Old version: $$OLD_VER";\
         if [ $(TYPHA_VERSION) != $$OLD_VER ]; then \
           sed -i "s/$$OLD_VER/$(TYPHA_VERSION)/" glide.yaml && \
-          OUTPUT=`mktemp`;\
-          glide up --strip-vendor; glide up --strip-vendor 2>&1 | tee $$OUTPUT; \
-          if ! grep -v "github.com/onsi/gomega" $$OUTPUT | grep -v "golang.org/x/sys" | grep -v "github.com/onsi/ginkgo" | grep "\[WARN\]"; then true; else false; fi; \
+          glide up --strip-vendor || glide up --strip-vendor; \
         fi'
 
 bin/calico-felix: bin/calico-felix-$(ARCH)


### PR DESCRIPTION
Doing so causes our CI and automatic updating to fail unnecessarily.

1. From the perspective of "shall we commit this automatic update or
not", the relevant test is whether "make test" passes following "make
update-libcalico", and the Semaphore triggers already have this logic;
i.e. they only commit and push the glide.yaml and glide.lock changes if
"make test" passes.

2. When the automatic process fails, and I do it manually instead, I've
seen many cases where the glide update emits both WARNs and ERRORs, but
the glide.lock and glide.yaml are as expected and "make test" still
passes anyway.  Hence there are many cases where WARNs and ERRORs are
benign.

3. We can avoid tripping over benign WARNs by removing the extra grep,
as in this commit.  Then the remaining conditions will be (a) that glide
itself completes with successful exit status, and (b) that "make test"
passes following the update.  Which I believe is what we want.

Also:
- map in the Glide cache
- only run glide up twice if the first time fails

