### PR TITLE
Automated cherry pick of #1932: Specify GitHub organization in release-publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -772,7 +772,7 @@ release-publish: release-prereqs
 	# Push binaries to GitHub release.
 	# Requires ghr: https://github.com/tcnksm/ghr
 	# Requires GITHUB_TOKEN environment variable set.
-	ghr -r felix \
+	ghr -u projectcalico -r felix \
 		-b "Release notes can be found at https://docs.projectcalico.org" \
 		-n $(VERSION) \
 		$(VERSION) ./bin/


### PR DESCRIPTION
Cherry pick of #1932 on release-v3.4.

#1932: Specify GitHub organization in release-publish