### PR TITLE
Validate OpenstackRegion value as a DNS label

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ var (
 	AuthorityRegexp = regexp.MustCompile(`^[^:/]+:\d+$`)
 	HostnameRegexp  = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 	StringRegexp    = regexp.MustCompile(`^.*$`)
+	DNS1123Regexp   = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 )
 
 const (
@@ -139,7 +140,7 @@ type Config struct {
 	MetadataAddr string `config:"hostname;127.0.0.1;die-on-fail"`
 	MetadataPort int    `config:"int(0,65535);8775;die-on-fail"`
 
-	OpenstackRegion string `config:"string;;local"`
+	OpenstackRegion string `config:"dns1123;;local,die-on-fail"`
 
 	InterfacePrefix  string `config:"iface-list;cali;non-zero,die-on-fail"`
 	InterfaceExclude string `config:"iface-list;kube-ipvs0"`
@@ -528,6 +529,9 @@ func loadParams() {
 		case "hostname":
 			param = &RegexpParam{Regexp: HostnameRegexp,
 				Msg: "invalid hostname"}
+		case "dns1123":
+			param = &RegexpParam{Regexp: DNS1123Regexp,
+				Msg: "invalid DNS label"}
 		case "oneof":
 			options := strings.Split(kindParams, ",")
 			lowerCaseToCanon := make(map[string]string)

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -37,7 +37,6 @@ var (
 	AuthorityRegexp = regexp.MustCompile(`^[^:/]+:\d+$`)
 	HostnameRegexp  = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 	StringRegexp    = regexp.MustCompile(`^.*$`)
-	DNS1123Regexp   = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 )
 
 const (
@@ -140,7 +139,7 @@ type Config struct {
 	MetadataAddr string `config:"hostname;127.0.0.1;die-on-fail"`
 	MetadataPort int    `config:"int(0,65535);8775;die-on-fail"`
 
-	OpenstackRegion string `config:"dns1123;;local,die-on-fail"`
+	OpenstackRegion string `config:"region;;local,die-on-fail"`
 
 	InterfacePrefix  string `config:"iface-list;cali;non-zero,die-on-fail"`
 	InterfaceExclude string `config:"iface-list;kube-ipvs0"`
@@ -529,9 +528,8 @@ func loadParams() {
 		case "hostname":
 			param = &RegexpParam{Regexp: HostnameRegexp,
 				Msg: "invalid hostname"}
-		case "dns1123":
-			param = &RegexpParam{Regexp: DNS1123Regexp,
-				Msg: "invalid DNS label"}
+		case "region":
+			param = &RegionParam{}
 		case "oneof":
 			options := strings.Split(kindParams, ",")
 			lowerCaseToCanon := make(map[string]string)

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -397,9 +397,12 @@ var _ = Describe("DatastoreConfig tests", func() {
 var _ = DescribeTable("Config validation",
 	func(settings map[string]string, ok bool) {
 		cfg := New()
-		cfg.UpdateFrom(settings, ConfigFile)
-		err := cfg.Validate()
-		log.WithError(err).Info("Validation result")
+		_, err := cfg.UpdateFrom(settings, ConfigFile)
+		log.WithError(err).Info("UpdateFrom result")
+		if err == nil {
+			err = cfg.Validate()
+			log.WithError(err).Info("Validation result")
+		}
 		if !ok {
 			Expect(err).To(HaveOccurred())
 		} else {
@@ -435,4 +438,16 @@ var _ = DescribeTable("Config validation",
 		"TyphaCN":       "typha-peer",
 		"TyphaURISAN":   "spiffe://k8s.example.com/typha-peer",
 	}, true),
+	Entry("valid OpenstackRegion", map[string]string{
+		"OpenstackRegion": "region1",
+	}, true),
+	Entry("OpenstackRegion with uppercase", map[string]string{
+		"OpenstackRegion": "RegionOne",
+	}, false),
+	Entry("OpenstackRegion with slash", map[string]string{
+		"OpenstackRegion": "us/east",
+	}, false),
+	Entry("OpenstackRegion with underscore", map[string]string{
+		"OpenstackRegion": "my_region",
+	}, false),
 )

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -450,4 +450,7 @@ var _ = DescribeTable("Config validation",
 	Entry("OpenstackRegion with underscore", map[string]string{
 		"OpenstackRegion": "my_region",
 	}, false),
+	Entry("OpenstackRegion too long", map[string]string{
+		"OpenstackRegion": "my-region-has-a-very-long-and-extremely-interesting-name",
+	}, false),
 )


### PR DESCRIPTION
Because we're going to insert openstack_region into etcd paths that need to be Kubernetes-compatible, and also construct a Calico/Kubernetes namespace from it, OpenstackRegion needs to conform to DNS label syntax as validated at https://github.com/kubernetes/apimachinery/blob/master/pkg/util/validation/validation.go#L110
