### PR TITLE
Backport release changes to v3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,44 +549,46 @@ clean:
 	find . -name ".coverage" -type f -delete
 	find . -name "*.pyc" -type f -delete
 
-.PHONY: release release-once-tagged
-release: clean
-ifndef VERSION
-	$(error VERSION is undefined - run using make release VERSION=X.Y.Z)
+###############################################################################
+# Release
+###############################################################################
+PREVIOUS_RELEASE=$(shell git describe --tags --abbrev=0)
+GIT_VERSION?=$(shell git describe --tags --dirty)
+
+## Tags and builds a release from start to finish.
+release: release-prereqs
+	$(MAKE) VERSION=$(VERSION) release-tag
+	$(MAKE) VERSION=$(VERSION) release-build
+	$(MAKE) VERSION=$(VERSION) release-verify
+
+	@echo ""
+	@echo "Release build complete. Next, push the produced images."
+	@echo ""
+	@echo "  make VERSION=$(VERSION) release-publish"
+	@echo ""
+
+## Produces a git tag for the release.
+release-tag: release-prereqs release-notes
+	git tag $(VERSION) -F release-notes-$(VERSION)
+	@echo ""
+	@echo "Now you can build the release:"
+	@echo ""
+	@echo "  make VERSION=$(VERSION) release-build"
+	@echo ""
+
+## Produces a clean build of release artifacts at the specified version.
+release-build: release-prereqs clean
+# Check that the correct code is checked out.
+ifneq ($(VERSION), $(GIT_VERSION))
+	$(error Attempt to build $(VERSION) from $(GIT_VERSION))
 endif
-ifeq ($(GIT_COMMIT),<unknown>)
-	$(error git commit ID couldn't be determined, releases must be done from a git working copy)
-endif
-	$(DOCKER_GO_BUILD) utils/tag-release.sh $(VERSION)
-
-.PHONY: continue-release
-continue-release:
-	@echo "Edited release notes are:"
-	@echo
-	@cat ./release-notes-$(VERSION)
-	@echo
-	@echo "Hit Return to go ahead and create the tag, or Ctrl-C to cancel."
-	@bash -c read
-	# Create annotated release tag.
-	git tag $(VERSION) -F ./release-notes-$(VERSION)
-	rm ./release-notes-$(VERSION)
-
-	# Now decouple onto another make invocation, as we want some variables
-	# (GIT_DESCRIPTION and BUNDLE_FILENAME) to be recalculated based on the
-	# new tag.
-	$(MAKE) release-once-tagged
-
-release-once-tagged:
-	@echo
-	@echo "Will now build release artifacts..."
-	@echo
 	$(MAKE) bin/calico-felix calico/felix
-	docker tag calico/felix:latest quay.io/calico/felix:latest
 	docker tag calico/felix:latest calico/felix:$(VERSION)
 	docker tag calico/felix:$(VERSION) quay.io/calico/felix:$(VERSION)
-	@echo
-	@echo "Checking built felix has correct version..."
-	@result=true; \
+
+## Verifies the release artifacts produces by `make release-build` are correct.
+release-verify: release-prereqs
+	# Check the reported version is correct for each release artifact.
 	for img in calico/felix:latest quay.io/calico/felix:latest calico/felix:$(VERSION) quay.io/calico/felix:$(VERSION); do \
 	  if docker run $$img calico-felix --version | grep -q '$(VERSION)$$'; \
 	  then \
@@ -595,43 +597,46 @@ release-once-tagged:
 	    echo "Incorrect version in docker image $$img!"; \
 	    result=false; \
 	  fi \
-	done; \
-	$$result
-	@echo
-	@echo "Felix release artifacts have been built:"
-	@echo
-	@echo "- Binary:                 bin/calico-felix"
-	@echo "- Docker container image: calico/felix:$(VERSION)"
-	@echo "- Same, tagged for Quay:  quay.io/calico/felix:$(VERSION)"
-	@echo
-	@echo "Now to publish this release to Github:"
-	@echo
-	@echo "- Push the new tag ($(VERSION)) to https://github.com/projectcalico/felix"
-	@echo "- Go to https://github.com/projectcalico/felix/releases/tag/$(VERSION)"
-	@echo "- Copy the tag content (release notes) shown on that page"
-	@echo "- Go to https://github.com/projectcalico/felix/releases/new?tag=$(VERSION)"
-	@echo "- Name the GitHub release:"
-	@echo "  - For a stable release: 'Felix $(VERSION)'"
-	@echo "  - For a test release:   'Felix $(VERSION) pre-release for testing'"
-	@echo "- Paste the copied tag content into the large textbox"
-	@echo "- Add an introduction message and, for a significant release,"
-	@echo "  append information about where to get the release.  (See the 2.2.0"
-	@echo "  release for an example.)"
-	@echo "- Attach the binary"
-	@echo "- Click the 'This is a pre-release' checkbox, if appropriate"
-	@echo "- Click 'Publish release'"
-	@echo
-	@echo "Then, push the versioned docker images to Dockerhub and Quay:"
-	@echo
-	@echo "- docker push calico/felix:$(VERSION)"
-	@echo "- docker push quay.io/calico/felix:$(VERSION)"
-	@echo
-	@echo "If this is the latest release from the most recent stable"
-	@echo "release series, also push the 'latest' tag:"
-	@echo
-	@echo "- docker push calico/felix:latest"
-	@echo "- docker push quay.io/calico/felix:latest"
-	@echo
-	@echo "If you also want to build Debian/Ubuntu and RPM packages for"
-	@echo "the new release, use 'make deb' and 'make rpm'."
-	@echo
+	done;
+
+## Generates release notes based on commits in this version.
+release-notes: release-prereqs
+	mkdir -p dist
+	echo "# Changelog" > release-notes-$(VERSION)
+	sh -c "git cherry -v $(PREVIOUS_RELEASE) | cut '-d ' -f 2- | sed 's/^/- /' >> release-notes-$(VERSION)"
+
+## Pushes a github release and release artifacts produced by `make release-build`.
+release-publish: release-prereqs
+	# Push the git tag.
+	git push origin $(VERSION)
+
+	# Push images.
+	docker push calico/felix:$(VERSION)
+	docker push quay.io/calico/felix:$(VERSION)
+
+	# Push binaries to GitHub release.
+	# Requires ghr: https://github.com/tcnksm/ghr
+	# Requires GITHUB_TOKEN environment variable set.
+	ghr -u projectcalico -r felix \
+		-b "Release notes can be found at https://docs.projectcalico.org" \
+		-n $(VERSION) \
+		$(VERSION) ./bin/
+
+	@echo "Finalize the GitHub release based on the pushed tag."
+	@echo ""
+	@echo "  https://$(PACKAGE_NAME)/releases/tag/$(VERSION)"
+	@echo ""
+	@echo "Build and publish the debs and rpms for this release."
+	@echo ""
+
+# release-prereqs checks that the environment is configured properly to create a release.
+release-prereqs:
+ifndef VERSION
+	$(error VERSION is undefined - run using make release VERSION=vX.Y.Z)
+endif
+ifeq (, $(shell which ghr))
+	$(error Unable to find `ghr` in PATH, run this: go get -u github.com/tcnksm/ghr)
+endif
+ifndef GITHUB_TOKEN
+	$(error GITHUB_TOKEN must be set for a release)
+endif


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Backport release process changes so it fits better with release automation.

A few things to note:
- This will mean we'll start using the `v` for older releases (e.g., v3.1.x instead of 3.1.x)
- Haven't backported all of the build changes, just the release-* targets.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
