### PR TITLE
#1945: Adding support for regular expression values for the Interface Exclude parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 
 # IDE files.
 /.idea/
+/.vscode/
 
 # Patterns to match files from older releases (prevents lots of
 # untracked files from showing up when switching from a maintenance branch.

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -244,8 +244,17 @@ func (c *Config) InterfacePrefixes() []string {
 	return strings.Split(c.InterfacePrefix, ",")
 }
 
-func (c *Config) InterfaceExcludes() []string {
-	return strings.Split(c.InterfaceExclude, ",")
+func (c *Config) InterfaceExcludes() []*regexp.Regexp {
+	log.Debugf("Compiling regexp values for InterfaceExclude %s \n", c.InterfaceExclude)
+
+	strValues := strings.Split(c.InterfaceExclude, ",")
+	regexpValues := make([]*regexp.Regexp, len(strValues))
+
+	for _, strValue := range strValues {
+		// Will panic if any individual regexp string is invalid (not parsable)
+		regexpValues = append(regexpValues, regexp.MustCompile(strValue))
+	}
+	return regexpValues
 }
 
 func (config *Config) OpenstackActive() bool {
@@ -508,6 +517,7 @@ func loadParams() {
 		case "millis":
 			param = &MillisParam{}
 		case "iface-list":
+			// TODO: What should we allow here given that it's now a regexp?
 			param = &RegexpParam{Regexp: IfaceListRegexp,
 				Msg: "invalid Linux interface name"}
 		case "iface-param":

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -257,19 +257,18 @@ func (config *Config) InterfacePrefixes() []string {
 // panic if any individual value cannot be parsed / compiled into a Regexp.
 func (config *Config) InterfaceExcludes() []*regexp.Regexp {
 	log.Debugf("Compiling regexp values for InterfaceExclude %s \n", config.InterfaceExclude)
-
 	strValues := strings.Split(config.InterfaceExclude, ",")
 	regexpValues := make([]*regexp.Regexp, len(strValues))
 
-	for _, strValue := range strValues {
-		// All values in interface excludes list will be treated as regular
+	for i, strValue := range strValues {
+		// All values in interface exclude list will be treated as regular
 		// expressions; any value not in regexp format will be converted into
 		// equivalent regexp that tests for exact match
 		if !RegexpIfaceElemRegexp.Match([]byte(strValue)) {
 			convertedValue := fmt.Sprintf("^%s$", strValue)
-			regexpValues = append(regexpValues, regexp.MustCompile(convertedValue))
+			regexpValues[i] = regexp.MustCompile(convertedValue)
 		} else {
-			regexpValues = append(regexpValues, regexp.MustCompile(strValue))
+			regexpValues[i] = regexp.MustCompile(strValue)
 		}
 	}
 	return regexpValues

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -116,8 +116,7 @@ func fieldsByName(example interface{}) map[string]reflect.StructField {
 var _ = DescribeTable("Config parsing",
 	func(key, value string, expected interface{}, errorExpected ...bool) {
 		config := New()
-		config.UpdateFrom(map[string]string{key: value},
-			EnvironmentVariable)
+		config.UpdateFrom(map[string]string{key: value}, EnvironmentVariable)
 		configPtr := reflect.ValueOf(config)
 		configElem := configPtr.Elem()
 		fieldRef := configElem.FieldByName(key)
@@ -158,8 +157,15 @@ var _ = DescribeTable("Config parsing",
 
 	Entry("InterfacePrefix", "InterfacePrefix", "tap", "tap"),
 	Entry("InterfacePrefix list", "InterfacePrefix", "tap,cali", "tap,cali"),
-	Entry("InterfaceExclude", "InterfaceExclude", "kube-ipvs0", "kube-ipvs0"),
-	Entry("InterfaceExclude list", "InterfaceExclude", "kube-ipvs0,dummy", "kube-ipvs0,dummy"),
+
+	Entry("InterfaceExclude one value no regexp", "InterfaceExclude", "kube-ipvs0", "kube-ipvs0"),
+	Entry("InterfaceExclude list no regexp", "InterfaceExclude", "kube-ipvs0,dummy", "kube-ipvs0,dummy"),
+	Entry("InterfaceExclude one value regexp", "InterfaceExclude", "/kube-ipvs/", "/kube-ipvs/"),
+	Entry("InterfaceExclude list regexp", "InterfaceExclude", "kube-ipvs0,dummy,/^veth*$/", "kube-ipvs0,dummy,/^veth*$/"),
+	Entry("InterfaceExclude no regexp", "InterfaceExclude", "/^kube.*/,/veth/", "/^kube.*/,/veth/"),
+	Entry("InterfaceExclude list regexp invalid", "InterfaceExclude", "kube,//", "kube-ipvs0", true),             // empty regexp value
+	Entry("InterfaceExclude list regexp invalid comma", "InterfaceExclude", "/kube,/,dummy", "kube-ipvs0", true), // bad comma use
+	Entry("InterfaceExclude list regexp invalid comma", "InterfaceExclude", `/^kube\K/`, "kube-ipvs0", true),     // Invalid regexp
 
 	Entry("ChainInsertMode append", "ChainInsertMode", "append", "append"),
 	Entry("ChainInsertMode append", "ChainInsertMode", "Append", "append"),

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -166,9 +166,9 @@ var _ = DescribeTable("Config parsing",
 	Entry("InterfaceExclude one value regexp", "InterfaceExclude", "/kube-ipvs/", "/kube-ipvs/"),
 	Entry("InterfaceExclude list regexp", "InterfaceExclude", "kube-ipvs0,dummy,/^veth*$/", "kube-ipvs0,dummy,/^veth*$/"),
 	Entry("InterfaceExclude no regexp", "InterfaceExclude", "/^kube.*/,/veth/", "/^kube.*/,/veth/"),
-	Entry("InterfaceExclude list regexp empty", "InterfaceExclude", "kube,//", "kube-ipvs0", true),               // empty regexp value
-	Entry("InterfaceExclude list regexp invalid comma", "InterfaceExclude", "/kube,/,dummy", "kube-ipvs0", true), // bad comma use
-	Entry("InterfaceExclude list regexp invalid symbol", "InterfaceExclude", `/^kube\K/`, "kube-ipvs0", true),    // Invalid regexp
+	Entry("InterfaceExclude list empty regexp", "InterfaceExclude", "kube,//", "kube-ipvs0"),
+	Entry("InterfaceExclude list bad comma use", "InterfaceExclude", "/kube,/,dummy", "kube-ipvs0"),
+	Entry("InterfaceExclude list invalid regexp symbol", "InterfaceExclude", `/^kube\K/`, "kube-ipvs0"),
 
 	Entry("ChainInsertMode append", "ChainInsertMode", "append", "append"),
 	Entry("ChainInsertMode append", "ChainInsertMode", "Append", "append"),

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -15,8 +15,9 @@
 package config_test
 
 import (
-	. "github.com/projectcalico/felix/config"
 	"regexp"
+
+	. "github.com/projectcalico/felix/config"
 
 	"net"
 	"reflect"
@@ -30,7 +31,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/libcalico-go/lib/apis/v3"
+	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
 

--- a/config/param_types.go
+++ b/config/param_types.go
@@ -188,21 +188,31 @@ type RegexpPatternListParam struct {
 // Validation is dictated by two regexp patterns: one for valid regular expression
 // values, another for non-regular expressions.
 func (p *RegexpPatternListParam) Parse(raw string) (interface{}, error) {
-	// Split into individual elements and validate each one
+	var result []*regexp.Regexp
+	// Split into individual elements, then validate each one and compile to regexp
 	tokens := strings.Split(raw, p.Delimiter)
 	for _, t := range tokens {
 		if p.RegexpElemRegexp.Match([]byte(t)) {
 			// Need to remove the start and end symbols that wrap the actual regexp
+			// Note: There's a coupling here with the assumed pattern in RegexpElemRegexp
+			// i.e. that each value is wrapped by a single char symbol on either side
 			regexpValue := t[1 : len(t)-1]
-			_, compileErr := regexp.Compile(regexpValue)
+			compiledRegexp, compileErr := regexp.Compile(regexpValue)
 			if compileErr != nil {
 				return nil, p.parseFailed(raw, p.Msg)
 			}
-		} else if !p.NonRegexpElemRegexp.Match([]byte(t)) {
+			result = append(result, compiledRegexp)
+		} else if p.NonRegexpElemRegexp.Match([]byte(t)) {
+			compiledRegexp, compileErr := regexp.Compile("^" + regexp.QuoteMeta(t) + "$")
+			if compileErr != nil {
+				return nil, p.parseFailed(raw, p.Msg)
+			}
+			result = append(result, compiledRegexp)
+		} else {
 			return nil, p.parseFailed(raw, p.Msg)
 		}
 	}
-	return raw, nil
+	return result, nil
 }
 
 type FileParam struct {

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ func StartDataplaneDriver(configParams *config.Config,
 
 		dpConfig := intdataplane.Config{
 			IfaceMonitorConfig: ifacemonitor.Config{
-				InterfaceExcludes: configParams.InterfaceExcludes(),
+				InterfaceExcludes: configParams.InterfaceExclude,
 			},
 			RulesConfig: rules.Config{
 				WorkloadIfacePrefixes: configParams.InterfacePrefixes(),

--- a/dataplane/linux/int_dataplane_test.go
+++ b/dataplane/linux/int_dataplane_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,10 +35,10 @@ var _ = Describe("Constructor test", func() {
 
 	JustBeforeEach(func() {
 		configParams = config.New()
-		configParams.InterfaceExclude = "/^kube.*/,/veth/,eth2"
+		configParams.UpdateFrom(map[string]string{"InterfaceExclude": "/^kube.*/,/veth/,eth2"}, config.EnvironmentVariable)
 		dpConfig = intdataplane.Config{
 			IfaceMonitorConfig: ifacemonitor.Config{
-				InterfaceExcludes: configParams.InterfaceExcludes(),
+				InterfaceExcludes: configParams.InterfaceExclude,
 			},
 			RulesConfig: rules.Config{
 				WorkloadIfacePrefixes: configParams.InterfacePrefixes(),

--- a/dataplane/linux/int_dataplane_test.go
+++ b/dataplane/linux/int_dataplane_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Constructor test", func() {
 
 	JustBeforeEach(func() {
 		configParams = config.New()
+		configParams.InterfaceExclude = "/^kube.*/,/veth/,eth2"
 		dpConfig = intdataplane.Config{
 			IfaceMonitorConfig: ifacemonitor.Config{
 				InterfaceExcludes: configParams.InterfaceExcludes(),

--- a/ifacemonitor/iface_monitor.go
+++ b/ifacemonitor/iface_monitor.go
@@ -15,6 +15,7 @@
 package ifacemonitor
 
 import (
+	"regexp"
 	"syscall"
 	"time"
 
@@ -45,7 +46,7 @@ type AddrStateCallback func(ifaceName string, addrs set.Set)
 
 type Config struct {
 	// List of interface names that dataplane receives no callbacks from them.
-	InterfaceExcludes []string
+	InterfaceExcludes []*regexp.Regexp
 }
 type InterfaceMonitor struct {
 	Config
@@ -136,8 +137,8 @@ readLoop:
 }
 
 func (m *InterfaceMonitor) isExcludedInterface(ifName string) bool {
-	for _, name := range m.InterfaceExcludes {
-		if ifName == name {
+	for _, nameExp := range m.InterfaceExcludes {
+		if nameExp.Match([]byte(ifName)) {
 			return true
 		}
 	}

--- a/ifacemonitor/iface_monitor.go
+++ b/ifacemonitor/iface_monitor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ifacemonitor/iface_monitor.go
+++ b/ifacemonitor/iface_monitor.go
@@ -142,7 +142,6 @@ func (m *InterfaceMonitor) isExcludedInterface(ifName string) bool {
 			return true
 		}
 	}
-
 	return false
 }
 


### PR DESCRIPTION
Closes #1945. 

## Description
This PR contains: 
- modifying logic for interface exclude mechanism to allow for regular expressions instead of just exact string matches (#1945) 
- modified existing and added new unit tests (check the commits)
- this component affects `felix` and also documentation for `calico` and `libcalico-go`: 
  - https://github.com/projectcalico/libcalico-go/pull/1061
  - https://github.com/projectcalico/calico/pull/2494

## Todos
- [x] Unit tests (full coverage)
    - Modified existing test
- [ ] ~~Integration tests (delete as appropriate) In plan/Not needed/Done~~
- [x] Documentation
- [ ] ~~Backport~~
- [x] Release note

## Release Note

```release-note
Allow the entries for the exclude interface parameter to be regular expression patterns
```
