### PR TITLE
Tweak VXLAN defaults and logging.

### DIFF
--- a/calc/vxlan_resolver.go
+++ b/calc/vxlan_resolver.go
@@ -351,7 +351,7 @@ func (c *VXLANResolver) routeReady(r vxlanRoute) bool {
 	logCxt := logrus.WithField("route", r)
 	gw := c.determineGatewayForRoute(r)
 	if gw == "" {
-		logCxt.Debug("No gateway yet for VXLAN route, skip")
+		logCxt.Info("No gateway yet for VXLAN route, skip")
 		return false
 	}
 	if !c.routeWithinVXLANPool(r) {
@@ -359,7 +359,7 @@ func (c *VXLANResolver) routeReady(r vxlanRoute) bool {
 		return false
 	}
 	if !c.vtepSent(r.node) {
-		logCxt.Debug("Haven't sent VTEP yet for route")
+		logCxt.Info("Don't yet know the VTEP for this route")
 		return false
 	}
 	return true
@@ -395,12 +395,12 @@ func (c *VXLANResolver) sendVTEPUpdate(node string) bool {
 	logCxt := logrus.WithField("node", node)
 	tunlAddr, ok := c.nodeNameToVXLANTunnelAddr[node]
 	if !ok {
-		logCxt.Debug("Missing vxlan tunnel address for node, cannot send VTEP")
+		logCxt.Info("Missing vxlan tunnel address for node, cannot send VTEP yet")
 		return false
 	}
 	parentDeviceIP, ok := c.nodeNameToIPAddr[node]
 	if !ok {
-		logCxt.Debug("Missing IP for node, cannot send VTEP")
+		logCxt.Info("Missing IP for node, cannot send VTEP yet")
 		return false
 	}
 

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -165,8 +165,8 @@ type Config struct {
 	LogSeveritySys    string `config:"oneof(DEBUG,INFO,WARNING,ERROR,FATAL);INFO"`
 
 	VXLANEnabled        bool   `config:"bool;false"`
-	VXLANPort           int    `config:"int;0"`
-	VXLANVNI            int    `config:"int;0"`
+	VXLANPort           int    `config:"int;4789"`
+	VXLANVNI            int    `config:"int;4096"`
 	VXLANMTU            int    `config:"int;1410;non-zero"`
 	IPv4VXLANTunnelAddr net.IP `config:"ipv4;"`
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

- Use a VNI >=4096 for future compatibility with Windows, which requires that.
- Use port 4789, for same reason.
- Tweak log levels to make it easier to see why a VTEP isn't sent.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
