### PR TITLE
Fix vxlan device recreation

### DIFF
--- a/dataplane/linux/vxlan_mgr.go
+++ b/dataplane/linux/vxlan_mgr.go
@@ -187,6 +187,7 @@ func (m *vxlanManager) KeepVXLANDeviceInSync(mtu int) {
 			time.Sleep(1 * time.Second)
 			continue
 		}
+		logrus.Info("VXLAN tunnel device configured")
 		time.Sleep(10 * time.Second)
 	}
 }
@@ -248,12 +249,9 @@ func (m *vxlanManager) configureVXLANDevice(mtu int, localVTEP *proto.VXLANTunne
 		}
 
 		// The device now exists - requery it to check that the link exists and is a vxlan device.
-		link, err = netlink.LinkByIndex(vxlan.Index)
+		link, err = netlink.LinkByName(m.vxlanDevice)
 		if err != nil {
-			return fmt.Errorf("can't locate created vxlan device with index %v", vxlan.Index)
-		}
-		if _, ok := link.(*netlink.Vxlan); !ok {
-			return fmt.Errorf("created vxlan device with index %v is not vxlan", vxlan.Index)
+			return fmt.Errorf("can't locate created vxlan device %v", m.vxlanDevice)
 		}
 	}
 

--- a/dataplane/linux/vxlan_mgr.go
+++ b/dataplane/linux/vxlan_mgr.go
@@ -216,62 +216,61 @@ func (m *vxlanManager) getParentInterface(localVTEP *proto.VXLANTunnelEndpointUp
 func (m *vxlanManager) configureVXLANDevice(mtu int, localVTEP *proto.VXLANTunnelEndpointUpdate) error {
 	logCxt := logrus.WithFields(logrus.Fields{"device": m.vxlanDevice})
 	logCxt.Debug("Configuring VXLAN tunnel device")
+	parent, err := m.getParentInterface(localVTEP)
+	if err != nil {
+		return err
+	}
+	mac, err := net.ParseMAC(localVTEP.Mac)
+	if err != nil {
+		return err
+	}
+	vxlan := &netlink.Vxlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:         m.vxlanDevice,
+			HardwareAddr: mac,
+		},
+		VxlanId:      m.vxlanID,
+		Port:         m.vxlanPort,
+		VtepDevIndex: parent.Attrs().Index,
+		SrcAddr:      ip.FromString(localVTEP.ParentDeviceIp).AsNetIP(),
+	}
+
+	// Try to get the device.
 	link, err := netlink.LinkByName(m.vxlanDevice)
 	if err != nil {
 		logrus.WithError(err).Info("Failed to get VXLAN tunnel device, assuming it isn't present")
-		parent, err := m.getParentInterface(localVTEP)
-		if err != nil {
-			return err
-		}
-		mac, err := net.ParseMAC(localVTEP.Mac)
-		if err != nil {
-			return err
-		}
-		vxlan := &netlink.Vxlan{
-			LinkAttrs: netlink.LinkAttrs{
-				Name:         m.vxlanDevice,
-				HardwareAddr: mac,
-			},
-			VxlanId:      m.vxlanID,
-			Port:         m.vxlanPort,
-			VtepDevIndex: parent.Attrs().Index,
-			SrcAddr:      ip.FromString(localVTEP.ParentDeviceIp).AsNetIP(),
-		}
-
 		if err := netlink.LinkAdd(vxlan); err == syscall.EEXIST {
-			// If the device already exists, we need to check to see if it is
-			// configured properly.
-			logrus.Debug("VXLAN device already exists")
-			existing, err := netlink.LinkByName(vxlan.Name)
-			if err != nil {
-				return err
-			}
-
-			// Check for mismatched configuration. If they match, then we can simply return.
-			incompat := vxlanLinksIncompat(vxlan, existing)
-			if incompat == "" {
-				return nil
-			}
-
-			// Existing device doesn't match desired configuration - delete it and recreate.
-			logrus.Warningf("%q already exists with incompatable configuration: %v; recreating device", vxlan.Name, incompat)
-			if err = netlink.LinkDel(existing); err != nil {
-				return fmt.Errorf("failed to delete interface: %v", err)
-			}
-			if err = netlink.LinkAdd(vxlan); err != nil {
-				return fmt.Errorf("failed to create vxlan interface: %v", err)
-			}
+			// Device already exists - likely a race.
+			logrus.Debug("VXLAN device already exists, likely created by someone else.")
 		} else if err != nil {
+			// Error other than "device exists" - return it.
 			return err
 		}
 
-		ifindex := vxlan.Index
+		// The device now exists - requery it to check that the link exists and is a vxlan device.
 		link, err = netlink.LinkByIndex(vxlan.Index)
 		if err != nil {
-			return fmt.Errorf("can't locate created vxlan device with index %v", ifindex)
+			return fmt.Errorf("can't locate created vxlan device with index %v", vxlan.Index)
 		}
 		if _, ok := link.(*netlink.Vxlan); !ok {
-			return fmt.Errorf("created vxlan device with index %v is not vxlan", ifindex)
+			return fmt.Errorf("created vxlan device with index %v is not vxlan", vxlan.Index)
+		}
+	}
+
+	// At this point, we have successfully queried the existing device, or made sure it exists if it didn't
+	// already. Check for mismatched configuration. If they don't match, recreate the device.
+	if incompat := vxlanLinksIncompat(vxlan, link); incompat != "" {
+		// Existing device doesn't match desired configuration - delete it and recreate.
+		logrus.Warningf("%q exists with incompatable configuration: %v; recreating device", vxlan.Name, incompat)
+		if err = netlink.LinkDel(link); err != nil {
+			return fmt.Errorf("failed to delete interface: %v", err)
+		}
+		if err = netlink.LinkAdd(vxlan); err != nil {
+			return fmt.Errorf("failed to create vxlan interface: %v", err)
+		}
+		link, err = netlink.LinkByName(vxlan.Name)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/fv/infrastructure/felix.go
+++ b/fv/infrastructure/felix.go
@@ -29,6 +29,9 @@ type Felix struct {
 	// ExpectedIPIPTunnelAddr contains the IP that the infrastructure expects to
 	// get assigned to the IPIP tunnel.  Filled in by AddNode().
 	ExpectedIPIPTunnelAddr string
+	// ExpectedVXLANTunnelAddr contains the IP that the infrastructure expects to
+	// get assigned to the VXLAN tunnel.  Filled in by AddNode().
+	ExpectedVXLANTunnelAddr string
 }
 
 func (f *Felix) GetFelixPID() int {

--- a/fv/infrastructure/infra_etcd.go
+++ b/fv/infrastructure/infra_etcd.go
@@ -85,9 +85,16 @@ func (eds *EtcdDatastoreInfra) SetExpectedIPIPTunnelAddr(felix *Felix, idx int, 
 	}
 }
 
+func (eds *EtcdDatastoreInfra) SetExpectedVXLANTunnelAddr(felix *Felix, idx int, needBGP bool) {
+	if needBGP {
+		felix.ExpectedVXLANTunnelAddr = fmt.Sprintf("10.65.%d.0", idx)
+	}
+}
+
 func (eds *EtcdDatastoreInfra) AddNode(felix *Felix, idx int, needBGP bool) {
 	felixNode := api.NewNode()
 	felixNode.Name = felix.Hostname
+	felixNode.Spec.IPv4VXLANTunnelAddr = felix.ExpectedVXLANTunnelAddr
 	if needBGP {
 		felixNode.Spec.BGP = &api.NodeBGPSpec{
 			IPv4Address:        felix.IP,

--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -27,7 +27,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -402,6 +402,10 @@ func (kds *K8sDatastoreInfra) SetExpectedIPIPTunnelAddr(felix *Felix, idx int, n
 	felix.ExpectedIPIPTunnelAddr = fmt.Sprintf("10.65.%d.1", idx)
 }
 
+func (kds *K8sDatastoreInfra) SetExpectedVXLANTunnelAddr(felix *Felix, idx int, needBGP bool) {
+	felix.ExpectedVXLANTunnelAddr = fmt.Sprintf("10.65.%d.0", idx)
+}
+
 func (kds *K8sDatastoreInfra) AddNode(felix *Felix, idx int, needBGP bool) {
 	node_in := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -414,6 +418,9 @@ func (kds *K8sDatastoreInfra) AddNode(felix *Felix, idx int, needBGP bool) {
 	}
 	if felix.ExpectedIPIPTunnelAddr != "" {
 		node_in.Annotations["projectcalico.org/IPv4IPIPTunnelAddr"] = felix.ExpectedIPIPTunnelAddr
+	}
+	if felix.ExpectedVXLANTunnelAddr != "" {
+		node_in.Annotations["projectcalico.org/IPv4VXLANTunnelAddr"] = felix.ExpectedVXLANTunnelAddr
 	}
 	log.WithField("node_in", node_in).Debug("Node defined")
 	node_out, err := kds.K8sClient.CoreV1().Nodes().Create(node_in)

--- a/fv/infrastructure/infrastructure.go
+++ b/fv/infrastructure/infrastructure.go
@@ -38,6 +38,10 @@ type DatastoreInfra interface {
 	// ExpectedIPIPTunnelAddr field, if we expect Felix to see that field being
 	// set after it has started up for the first time.
 	SetExpectedIPIPTunnelAddr(felix *Felix, idx int, needBGP bool)
+	// SetExpectedVXLANTunnelAddr will set the Felix object's
+	// ExpectedVXLANTunnelAddr field, if we expect Felix to see that field being
+	// set after it has started up for the first time.
+	SetExpectedVXLANTunnelAddr(felix *Felix, idx int, needBGP bool)
 	// AddNode will take the appropriate steps to add a node to the datastore.
 	// From the passed in felix the Hostname and IPv4 address will be pulled
 	// and added to the Node appropriately.


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Previously, we were only checking if the device needed to be recreated if it didn't already exist, which is just wrong really since if the device doesn't exist then we can create it exactly how we want it!

This moves that logic outside of the "failed to query device" branch, and instead will perform the check of every time, even if the device exists. 

- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```