### PR TITLE
docker-image: get bpftool from dockerhub

### DIFF
--- a/docker-image/Dockerfile.amd64
+++ b/docker-image/Dockerfile.amd64
@@ -1,30 +1,5 @@
-# Builder image for bpftool
-
-FROM debian:buster-slim as bpftool-build
-RUN apt-get update && \
-apt-get upgrade -y && \
-apt-get install -y --no-install-recommends \
-    gpg gpg-agent libelf-dev libmnl-dev libc-dev iptables libgcc-8-dev \
-    bash-completion binutils binutils-dev ca-certificates make git curl \
-    xz-utils gcc pkg-config bison flex build-essential && \
-apt-get purge --auto-remove && \
-apt-get clean
-
-WORKDIR /tmp
-
-RUN \
-git clone --depth 1 -b master git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git && \
-cd linux/tools/bpf/bpftool/ && \
-sed -i '/CFLAGS += -O2/a CFLAGS += -static' Makefile && \
-sed -i 's/LIBS = -lelf $(LIBBPF)/LIBS = -lelf -lz $(LIBBPF)/g' Makefile && \
-printf 'feature-libbfd=0\nfeature-libelf=1\nfeature-bpf=1\nfeature-libelf-mmap=1' >> FEATURES_DUMP.bpftool && \
-FEATURES_DUMP=`pwd`/FEATURES_DUMP.bpftool make -j `getconf _NPROCESSORS_ONLN` && \
-strip bpftool && \
-ldd bpftool 2>&1 | grep -q -e "Not a valid dynamic program" \
-	-e "not a dynamic executable" || \
-	( echo "Error: bpftool is not statically linked"; false ) && \
-mv bpftool /usr/bin && rm -rf /tmp/linux
-
+# Image containing the bpftool binary
+FROM calico/bpftool:v5.0-amd64 as bpftool
 
 # Main image
 
@@ -41,7 +16,7 @@ ADD calico-felix-wrapper /usr/bin
 # to more easily extract the Felix build artefacts from the container.
 ADD bin/calico-felix-amd64 /code/calico-felix
 RUN ln -s /code/calico-felix /usr/bin
-COPY --from=bpftool-build /usr/bin/bpftool /usr/bin
+COPY --from=bpftool /bpftool /usr/bin
 WORKDIR /code
 
 # Since our binary isn't designed to run as PID 1, run it via the tini init daemon.

--- a/docker-image/Dockerfile.arm64
+++ b/docker-image/Dockerfile.arm64
@@ -1,33 +1,7 @@
 ARG QEMU_IMAGE=calico/go-build:latest
 FROM ${QEMU_IMAGE} as qemu
 
-FROM arm64v8/debian:buster-slim as bpftool-build
-
-COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/
-
-RUN apt-get update && \
-apt-get upgrade -y && \
-apt-get install -y --no-install-recommends \
-    gpg gpg-agent libelf-dev libmnl-dev libc-dev iptables libgcc-8-dev \
-    bash-completion binutils binutils-dev ca-certificates make git curl \
-    xz-utils gcc pkg-config bison flex build-essential && \
-apt-get purge --auto-remove && \
-apt-get clean
-
-WORKDIR /tmp
-
-RUN \
-git clone --depth 1 -b master git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git && \
-cd linux/tools/bpf/bpftool/ && \
-sed -i '/CFLAGS += -O2/a CFLAGS += -static' Makefile && \
-sed -i 's/LIBS = -lelf $(LIBBPF)/LIBS = -lelf -lz $(LIBBPF)/g' Makefile && \
-printf 'feature-libbfd=0\nfeature-libelf=1\nfeature-bpf=1\nfeature-libelf-mmap=1' >> FEATURES_DUMP.bpftool && \
-FEATURES_DUMP=`pwd`/FEATURES_DUMP.bpftool make -j `getconf _NPROCESSORS_ONLN` && \
-strip bpftool && \
-ldd bpftool 2>&1 | grep -q -e "Not a valid dynamic program" \
-	-e "not a dynamic executable" || \
-	( echo "Error: bpftool is not statically linked"; false ) && \
-mv bpftool /usr/bin && rm -rf /tmp/linux
+FROM calico/bpftool:v5.0-arm64 as bpftool
 
 FROM arm64v8/alpine:3.8 as base
 MAINTAINER Shaun Crampton <shaun@tigera.io>
@@ -48,7 +22,7 @@ ADD calico-felix-wrapper /usr/bin
 # to more easily extract the Felix build artefacts from the container.
 ADD bin/calico-felix-arm64 /code/calico-felix
 RUN ln -s /code/calico-felix /usr/bin
-COPY --from=bpftool-build /usr/bin/bpftool /usr/bin
+COPY --from=bpftool /bpftool /usr/bin
 WORKDIR /code
 
 # Since our binary isn't designed to run as PID 1, run it via the tini init daemon.

--- a/docker-image/Dockerfile.ppc64le
+++ b/docker-image/Dockerfile.ppc64le
@@ -1,33 +1,7 @@
 ARG QEMU_IMAGE=calico/go-build:latest
 FROM ${QEMU_IMAGE} as qemu
 
-FROM ppc64le/debian:buster-slim as bpftool-build
-
-COPY --from=qemu /usr/bin/qemu-ppc64le-static /usr/bin/
-
-RUN apt-get update && \
-apt-get upgrade -y && \
-apt-get install -y --no-install-recommends \
-    gpg gpg-agent libelf-dev libmnl-dev libc-dev iptables libgcc-8-dev \
-    bash-completion binutils binutils-dev ca-certificates make git curl \
-    xz-utils gcc pkg-config bison flex build-essential && \
-apt-get purge --auto-remove && \
-apt-get clean
-
-WORKDIR /tmp
-
-RUN \
-git clone --depth 1 -b master git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git && \
-cd linux/tools/bpf/bpftool/ && \
-sed -i '/CFLAGS += -O2/a CFLAGS += -static' Makefile && \
-sed -i 's/LIBS = -lelf $(LIBBPF)/LIBS = -lelf -lz $(LIBBPF)/g' Makefile && \
-printf 'feature-libbfd=0\nfeature-libelf=1\nfeature-bpf=1\nfeature-libelf-mmap=1' >> FEATURES_DUMP.bpftool && \
-FEATURES_DUMP=`pwd`/FEATURES_DUMP.bpftool make -j `getconf _NPROCESSORS_ONLN` && \
-strip bpftool && \
-ldd bpftool 2>&1 | grep -q -e "Not a valid dynamic program" \
-	-e "not a dynamic executable" || \
-	( echo "Error: bpftool is not statically linked"; false ) && \
-mv bpftool /usr/bin && rm -rf /tmp/linux
+FROM calico/bpftool:v5.0-ppc64le as bpftool
 
 FROM ppc64le/alpine:3.8 as base
 MAINTAINER Shaun Crampton <shaun@tigera.io>
@@ -48,7 +22,7 @@ ADD calico-felix-wrapper /usr/bin
 # to more easily extract the Felix build artefacts from the container.
 ADD bin/calico-felix-ppc64le /code/calico-felix
 RUN ln -s /code/calico-felix /usr/bin
-COPY --from=bpftool-build /usr/bin/bpftool /usr/bin
+COPY --from=bpftool /bpftool /usr/bin
 WORKDIR /code
 
 # Since our binary isn't designed to run as PID 1, run it via the tini init daemon.


### PR DESCRIPTION
## Description
This uses the `calico/bpftool` image to get the bpftool binary whenever
possible.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
