### PR TITLE
Use calico fork of logrus

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -319,7 +319,8 @@ imports:
 - name: github.com/satori/go.uuid
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
-  version: 3e01752db0189b9157070a0e1668a620f9a85da2
+  version: 1f80e3709dfafa8ca8727ba7eb392a11827ac8e2
+  repo: https://github.com/projectcalico/logrus
 - name: github.com/spf13/cobra
   version: ef82de70bb3f60c65fb8eebacbb2d122ef517385
 - name: github.com/spf13/pflag

--- a/glide.yaml
+++ b/glide.yaml
@@ -88,10 +88,12 @@ import:
   subpackages:
   - xfs
 - package: github.com/satori/go.uuid
-# gobuffalo/logger needs the SetOutput function in the Logger type, so pin
-# the first version that introduces it.
+# Use our fork, because v1.0.5 causes test breakages due to problems with our log formatting code,
+# but gobuffalo/logger require newer version because of the SetOutput function. Our fork backports
+# the missing stuff on top of v1.0.4.
 - package: github.com/sirupsen/logrus
-  version: v1.0.6
+  repo: https://github.com/projectcalico/logrus
+  version: v1.0.4-calico
 - package: github.com/vishvananda/netlink
 # containernetworking/cni pulls in an old version, so pin to the version we need here.
   version: f07d9d5231b9cd05ddf2e5a8ef6582f385bc1770


### PR DESCRIPTION
## Description
gobuffalo/logger uses SetOutput method added in logrus 1.0.6, but that
version has a bug somewhere in entry formatting, resulting in `<nil>
<nil>` being printed instead of file and line number. Switch to fork
based on 1.0.4 that also contains the `SetOutput` method.
