### PR TITLE
 Fix Felix readiness check when Typha is down at startup

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -451,11 +451,14 @@ configRetry:
 				if err == nil {
 					break
 				}
-				log.WithError(err).Debug("Retrying to start Typha")
+				log.WithError(err).Debug("Retrying Typha connection")
 				time.Sleep(1 * time.Second)
 			}
 			if err != nil {
 				log.WithError(err).Fatal("Failed to connect to Typha")
+			} else {
+				log.Info("Connected to Typha after retries.")
+				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
 			}
 		}
 		go func() {

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -80,7 +80,7 @@ func (c *Container) Stop() {
 	startTime := time.Now()
 	for {
 		if !c.ListedInDockerPS() {
-			// Container has stopped.  Mkae sure the docker CLI command is dead (it should be already)
+			// Container has stopped.  Make sure the docker CLI command is dead (it should be already)
 			// and wait for its log.
 			logCxt.Info("Container stopped (no longer listed in 'docker ps')")
 			withTimeoutPanic(logCxt, 5*time.Second, func() { c.signalDockerRun(os.Kill) })


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

- Fix missing call to report ready after successfully connecting to Typha after a retry.
- Add FV test.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
