### PR TITLE
Fix tilde heuristic for initial 'v'

### DIFF
--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -63,7 +63,7 @@ function git_version_to_deb {
     # So, for now, the best thing is no change at all.  As soon as our
     # base version is 3.7.1 (or 3.8.0, or 4.0.0), we should do the
     # correct tilde translation.
-    if [[ "$1" < "3.7.1" ]]; then
+    if [[ "$1" < "v3.7.1" ]]; then
 	echo $1
     else
 	echo $1 | sed 's/\([0-9]\)-0.dev/\1~0.dev/'


### PR DESCRIPTION
The version passed to git_version_to_deb is like 'v3.7.0-0.dev', not
'3.7.0-0.dev, so we need to compare against 'v3.7.1', not '3.7.1'.
