### PR TITLE
Fix removing programs that have unallowed mode (for v3.7)

### DIFF
--- a/bpf/bpf.go
+++ b/bpf/bpf.go
@@ -890,7 +890,11 @@ func (b *BPFLib) loadXDPRaw(objPath, ifName string, mode XDPMode, mapArgs []stri
 	printCommand(prog, args...)
 	output, err = exec.Command(prog, args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to attach XDP program (%s) to %s: %s\n%s", progPath, ifName, err, output)
+		if removeErr := os.Remove(progPath); removeErr != nil {
+			return fmt.Errorf("failed to attach XDP program (%s) to %s: %s (also failed to remove the pinned program: %s)\n%s", progPath, ifName, err, removeErr, output)
+		} else {
+			return fmt.Errorf("failed to attach XDP program (%s) to %s: %s\n%s", progPath, ifName, err, output)
+		}
 	}
 
 	return nil

--- a/bpf/bpf_test.go
+++ b/bpf/bpf_test.go
@@ -447,6 +447,15 @@ func TestXDP(t *testing.T) {
 		t.Fatalf("bad xdp id: %v", xdpID)
 	}
 
+	t.Log("Getting the XDP program mode from an iface with an XDP program attached should succeed")
+	xdpMode, err := bpfDP.GetXDPMode("test_A")
+	if err != nil {
+		t.Fatalf("cannot get xdp id: %v", err)
+	}
+	if xdpMode != XDPGeneric {
+		t.Fatalf("bad xdp mode: %v, should be %s", xdpMode.String(), XDPGeneric.String())
+	}
+
 	t.Log("Removing an XDP program from a veth iface should succeed")
 	err = bpfDP.RemoveXDP("test_A", XDPGeneric)
 	if err != nil {
@@ -456,6 +465,11 @@ func TestXDP(t *testing.T) {
 	_, err = bpfDP.GetXDPID("test_A")
 	if err == nil {
 		t.Fatalf("getting xdp id after deletion should have failed: %v", err)
+	}
+
+	_, err = bpfDP.GetXDPMode("test_A")
+	if err == nil {
+		t.Fatalf("getting xdp mode after deletion should have failed: %v", err)
 	}
 
 	_, err = bpfDP.GetMapsFromXDP("test_A")


### PR DESCRIPTION
## Description

This is a backport of a fix from #2012 into the `release-v3.7` branch.

This bug fix allows to mark the programs with unallowed mode to be marked for removal/replacement during resync and to be actually removed when executing the actions. Without this fix, felix could panic when some leftover program with the generic mode remains after restarting felix that does not allow the generic mode any more. The panic happened because applying actions was failing all the time, so felix wanted to wipe the system, which means applying certain actions again, which failed again.

The testing I did was basically to run felix 3.7 with the generic mode enabled in a VM (so the offload and driver mode weren't supported), then apply a global network policy, a global network set and a host endpoint manifests, so the result could be accelerated. Then restarting felix (with the patches) with generic mode disabled should fail to use XDP (because offload and driver modes are not supported in a VM and the generic mode is disabled), which should result in wiping the XDP state successfully and disabling XDP for good.

Added some unit tests too.

The change affects only the xdp state of the internal dataplane.

## Release Note
```release-note
None required
```
