### PR TITLE
v3.6 Cherry-pick: Fix slow leak in endpoint_mgr

### DIFF
--- a/dataplane/linux/endpoint_mgr.go
+++ b/dataplane/linux/endpoint_mgr.go
@@ -492,6 +492,7 @@ func (m *endpointManager) resolveWorkloadEndpoints() {
 		} else {
 			logCxt.Info("Workload removed, deleting its chains.")
 			m.filterTable.RemoveChains(m.activeWlIDToChains[id])
+			delete(m.activeWlIDToChains, id)
 			if oldWorkload != nil {
 				m.epMarkMapper.ReleaseEndpointMark(oldWorkload.Name)
 				// Remove any routes from the routing table.  The RouteTable will


### PR DESCRIPTION
- This leak was noticed with lots of churn ran multiple times.

Cherry-pick of #2023 

## Release Note

```release-note
Fixed slow memory leak that was noticed with lots of workload churn.
```
