### PR TITLE
Add support for NATOutgoingAddress option

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -199,6 +199,7 @@ type Config struct {
 
 	KubeNodePortRanges []numorstring.Port `config:"portrange-list;30000:32767"`
 	NATPortRange       numorstring.Port   `config:"portrange;"`
+	NATOutgoingAddress net.IP             `config:"ipv4;"`
 
 	UsageReportingEnabled          bool          `config:"bool;true"`
 	UsageReportingInitialDelaySecs time.Duration `config:"seconds;300"`

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -139,6 +139,7 @@ func StartDataplaneDriver(configParams *config.Config,
 
 				NATPortRange:                       configParams.NATPortRange,
 				IptablesNATOutgoingInterfaceFilter: configParams.IptablesNATOutgoingInterfaceFilter,
+				NATOutgoingAddress:                 configParams.NATOutgoingAddress,
 			},
 			IPIPMTU:                        configParams.IpInIpMtu,
 			VXLANMTU:                       configParams.VXLANMTU,

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5f28536f6050febec6ccd41f3ed07f0eb4eb0c6626f47b20c98e47bf2bc13276
-updated: 2019-06-03T15:44:43.522431177Z
+hash: 1df24442d78735fb3e658b1aa82bb9d61e476ec4ad4d3eccdac1ff3f6e6837e8
+updated: 2019-06-06T09:06:07.065507121Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -31,7 +31,6 @@ imports:
   - etcdserver/api/v3rpc/rpctypes
   - etcdserver/etcdserverpb
   - mvcc/mvccpb
-  - pkg/srv
   - pkg/tlsutil
   - pkg/transport
   - pkg/types
@@ -243,7 +242,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 7c769d6cd9819ef13852d50eb68dc75bddb696f2
+  version: 9131cbc3d1e68099b7f89d2de0b3704542d4a772
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -285,7 +284,7 @@ imports:
   subpackages:
   - binder
 - name: github.com/projectcalico/typha
-  version: e119a742499f66ee45b94304af2a78e30fa1fcea
+  version: 78910db37d8ae6e1a62cc69059e421bf5d001ef9
   subpackages:
   - pkg/syncclient
   - pkg/syncproto

--- a/glide.yaml
+++ b/glide.yaml
@@ -69,7 +69,7 @@ import:
   - lib/set
   - lib/validator/v1
 - package: github.com/projectcalico/typha
-  version: e119a742499f66ee45b94304af2a78e30fa1fcea
+  version: 78910db37d8ae6e1a62cc69059e421bf5d001ef9
   subpackages:
   - pkg/syncclient
   - pkg/tlsutils

--- a/rules/nat.go
+++ b/rules/nat.go
@@ -48,18 +48,28 @@ func (r *DefaultRuleRenderer) MakeNatOutgoingRule(protocol string, action iptabl
 func (r *DefaultRuleRenderer) NATOutgoingChain(natOutgoingActive bool, ipVersion uint8) *iptables.Chain {
 	var rules []iptables.Rule
 	if natOutgoingActive {
+		var defaultSnatRule iptables.Action = iptables.MasqAction{}
+		if r.Config.NATOutgoingAddress != nil {
+			defaultSnatRule = iptables.SNATAction{ToAddr: r.Config.NATOutgoingAddress.String()}
+		}
+
 		if r.Config.NATPortRange.MaxPort > 0 {
 			toPorts := fmt.Sprintf("%d-%d", r.Config.NATPortRange.MinPort, r.Config.NATPortRange.MaxPort)
+			var portRangeSnatRule iptables.Action = iptables.MasqAction{ToPorts: toPorts}
+			if r.Config.NATOutgoingAddress != nil {
+				toAddress := fmt.Sprintf("%s:%s", r.Config.NATOutgoingAddress.String(), toPorts)
+				portRangeSnatRule = iptables.SNATAction{ToAddr: toAddress}
+			}
 			rules = []iptables.Rule{
-				r.MakeNatOutgoingRule("tcp", iptables.MasqAction{ToPorts: toPorts}, ipVersion),
+				r.MakeNatOutgoingRule("tcp", portRangeSnatRule, ipVersion),
 				r.MakeNatOutgoingRule("tcp", iptables.ReturnAction{}, ipVersion),
-				r.MakeNatOutgoingRule("udp", iptables.MasqAction{ToPorts: toPorts}, ipVersion),
+				r.MakeNatOutgoingRule("udp", portRangeSnatRule, ipVersion),
 				r.MakeNatOutgoingRule("udp", iptables.ReturnAction{}, ipVersion),
-				r.MakeNatOutgoingRule("", iptables.MasqAction{}, ipVersion),
+				r.MakeNatOutgoingRule("", defaultSnatRule, ipVersion),
 			}
 		} else {
 			rules = []iptables.Rule{
-				r.MakeNatOutgoingRule("", iptables.MasqAction{}, ipVersion),
+				r.MakeNatOutgoingRule("", defaultSnatRule, ipVersion),
 			}
 		}
 	}

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -257,6 +257,8 @@ type Config struct {
 
 	NATPortRange                       numorstring.Port
 	IptablesNATOutgoingInterfaceFilter string
+
+	NATOutgoingAddress net.IP
 }
 
 func (c *Config) validate() {


### PR DESCRIPTION
## Description
Related to https://github.com/projectcalico/libcalico-go/pull/1089.

As in that PR, this is for addressing projectcalico/calico#2222. We chose to implement this by allowing users to specify the IP address being used rather than using the BGP address by default because it seemed more flexible. For our use case we are using the Kubernetes downward API to supply this address. I've tested this by setting/unsetting FELIX_NATOUTGOINGADDRESS in a calico node container using the modified felix.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
