### PR TITLE
Automated cherry pick of #2030: Improve calc graph test infra: - avoid adding empty state

### DIFF
--- a/calc/calc_graph_fv_test.go
+++ b/calc/calc_graph_fv_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 package calc_test
 
 import (
+	"os"
+
 	. "github.com/projectcalico/felix/calc"
 	"github.com/projectcalico/felix/dataplane/mock"
 
@@ -296,13 +298,23 @@ var baseTests = []StateList{
 	},
 }
 
-var testExpanders = []func(baseTest StateList) (desc string, mappedTests []StateList){
-	identity,
-	reverseKVOrder,
-	reverseStateOrder,
-	insertEmpties,
-	splitStates,
-	squashStates,
+func testExpanders() (testExpanders []func(baseTest StateList) (desc string, mappedTests []StateList)) {
+	testExpanders = []func(baseTest StateList) (desc string, mappedTests []StateList){
+		identity,
+	}
+
+	if os.Getenv("DISABLE_TEST_EXPANSION") == "true" {
+		log.Info("Test expansion disabled")
+		return
+	}
+	testExpanders = append(testExpanders,
+		reverseKVOrder,
+		reverseStateOrder,
+		insertEmpties,
+		splitStates,
+		squashStates,
+	)
+	return
 }
 
 // These tests drive the calculation graph directly (and synchronously).
@@ -319,15 +331,16 @@ var testExpanders = []func(baseTest StateList) (desc string, mappedTests []State
 var _ = Describe("Calculation graph state sequencing tests:", func() {
 	for _, test := range baseTests {
 		baseTest := test
-		for _, expander := range testExpanders {
+		for _, expander := range testExpanders() {
 			expanderDesc, expandedTests := expander(baseTest)
 			for _, expandedTest := range expandedTests {
-				// Always worth adding an empty to the end of the test.
-				expandedTest = append(expandedTest, empty)
 				desc := fmt.Sprintf("with input states %v %v", baseTest, expanderDesc)
 				Describe(desc+" flushing after each KV", func() {
 					doStateSequenceTest(expandedTest, afterEachKV)
 				})
+				if os.Getenv("DISABLE_TEST_EXPANSION") == "true" {
+					break
+				}
 				Describe(desc+" flushing after each KV and duplicating each update", func() {
 					doStateSequenceTest(expandedTest, afterEachKVAndDupe)
 				})
@@ -352,13 +365,17 @@ var _ = Describe("Calculation graph state sequencing tests:", func() {
 // synchronous test above is passing.  It's much easier to debug a
 // deterministic test!
 var _ = Describe("Async calculation graph state sequencing tests:", func() {
+	if os.Getenv("DISABLE_ASYNC_TESTS") == "true" {
+		log.Info("Async tests disabled")
+		return
+	}
 	for _, test := range baseTests {
 		if len(test) == 0 {
 			continue
 		}
 		baseTest := test
 
-		for _, expander := range testExpanders {
+		for _, expander := range testExpanders() {
 			expanderDesc, expandedTests := expander(baseTest)
 			for _, test := range expandedTests {
 				test := test
@@ -384,7 +401,11 @@ var _ = Describe("Async calculation graph state sequencing tests:", func() {
 						lastState := empty
 						for _, state := range test {
 							log.WithField("state", state).Info("Injecting next state")
+							_, _ = fmt.Fprintf(GinkgoWriter, "       -> Injecting state (single update): %v\n", state)
 							kvDeltas := state.KVDeltas(lastState)
+							for _, kv := range kvDeltas {
+								_, _ = fmt.Fprintf(GinkgoWriter, "            %v = %v\n", kv.Key, kv.Value)
+							}
 							toValidator.OnUpdates(kvDeltas)
 							lastState = state
 						}
@@ -422,38 +443,48 @@ var _ = Describe("Async calculation graph state sequencing tests:", func() {
 							}
 						}
 					}
-					state := test[len(test)-1]
 
-					// Async tests are slower to run so we do all the assertions
-					// on each test rather than as separate It() blocks.
-					Expect(mockDataplane.IPSets()).To(Equal(state.ExpectedIPSets),
-						"IP sets didn't match expected state after moving to state: %v",
-						state.Name)
-
-					Expect(mockDataplane.ActivePolicies()).To(Equal(state.ExpectedPolicyIDs),
-						"Active policy IDs were incorrect after moving to state: %v",
-						state.Name)
-
-					Expect(mockDataplane.ActiveProfiles()).To(Equal(state.ExpectedProfileIDs),
-						"Active profile IDs were incorrect after moving to state: %v",
-						state.Name)
-
-					Expect(mockDataplane.EndpointToPolicyOrder()).To(Equal(state.ExpectedEndpointPolicyOrder),
-						"Endpoint policy order incorrect after moving to state: %v",
-						state.Name)
-
-					Expect(mockDataplane.EndpointToPreDNATPolicyOrder()).To(Equal(state.ExpectedPreDNATEndpointPolicyOrder),
-						"Endpoint pre-DNAT policy order incorrect after moving to state: %v",
-						state.Name)
-
-					Expect(mockDataplane.EndpointToUntrackedPolicyOrder()).To(Equal(state.ExpectedUntrackedEndpointPolicyOrder),
-						"Endpoint untracked policy order incorrect after moving to state: %v",
-						state.Name)
+					// Do the common sync/async assertions.
+					expectCorrectDataplaneState(mockDataplane, test[len(test)-1])
 				})
 			}
 		}
 	}
 })
+
+func expectCorrectDataplaneState(mockDataplane *mock.MockDataplane, state State) {
+	log.WithField("state", state.Name).Info("Doing assertions on state")
+	Expect(mockDataplane.IPSets()).To(Equal(state.ExpectedIPSets),
+		"IP sets didn't match expected state after moving to state: %v",
+		state.Name)
+	Expect(mockDataplane.ActivePolicies()).To(Equal(state.ExpectedPolicyIDs),
+		"Active policy IDs were incorrect after moving to state: %v",
+		state.Name)
+	Expect(mockDataplane.ActiveProfiles()).To(Equal(state.ExpectedProfileIDs),
+		"Active profile IDs were incorrect after moving to state: %v",
+		state.Name)
+	Expect(mockDataplane.ActiveVTEPs()).To(Equal(state.ExpectedVTEPs),
+		"Active VTEPs were incorrect after moving to state: %v",
+		state.Name)
+	Expect(mockDataplane.ActiveRoutes()).To(Equal(state.ExpectedRoutes),
+		"Active routes were incorrect after moving to state: %v",
+		state.Name)
+	Expect(mockDataplane.EndpointToPolicyOrder()).To(Equal(state.ExpectedEndpointPolicyOrder),
+		"Endpoint policy order incorrect after moving to state: %v",
+		state.Name)
+	Expect(mockDataplane.EndpointToUntrackedPolicyOrder()).To(Equal(state.ExpectedUntrackedEndpointPolicyOrder),
+		"Untracked endpoint policy order incorrect after moving to state: %v",
+		state.Name)
+	Expect(mockDataplane.EndpointToPreDNATPolicyOrder()).To(Equal(state.ExpectedPreDNATEndpointPolicyOrder),
+		"Untracked endpoint policy order incorrect after moving to state: %v",
+		state.Name)
+	Expect(mockDataplane.ActiveUntrackedPolicies()).To(Equal(state.ExpectedUntrackedPolicyIDs),
+		"Untracked policies incorrect after moving to state: %v",
+		state.Name)
+	Expect(mockDataplane.ActivePreDNATPolicies()).To(Equal(state.ExpectedPreDNATPolicyIDs),
+		"PreDNAT policies incorrect after moving to state: %v",
+		state.Name)
+}
 
 type flushStrategy int
 
@@ -505,7 +536,7 @@ func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 					ii, lastState.Name, state.Name))
 				kvDeltas := state.KVDeltas(lastState)
 				for _, kv := range kvDeltas {
-					fmt.Fprintf(GinkgoWriter, "       -> Injecting KV: %v\n", kv)
+					_, _ = fmt.Fprintf(GinkgoWriter, "       -> Injecting KV: %v\n", kv)
 					validationFilter.OnUpdates([]api.Update{kv})
 					if flushStrategy == afterEachKV || flushStrategy == afterEachKVAndDupe {
 						if !sentInSync {
@@ -519,7 +550,7 @@ func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 						eventBuf.Flush()
 					}
 				}
-				fmt.Fprintln(GinkgoWriter, "       -- <<FLUSH>>")
+				_, _ = fmt.Fprintln(GinkgoWriter, "       -- <<FLUSH>>")
 				if flushStrategy == afterEachState {
 					if !sentInSync {
 						validationFilter.OnStatusUpdated(api.InSync)
@@ -534,42 +565,21 @@ func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 				}
 				lastState = state
 			}
+			if flushStrategy == atEnd {
+				validationFilter.OnStatusUpdated(api.InSync)
+				eventBuf.Flush()
+				expectation()
+			}
 		}
 	}
 
 	// Note: these used to be separate It() blocks but combining them knocks ~10s off the
 	// runtime, which is worthwhile!
 	It("should result in correct active state", iterStates(func() {
-		Expect(mockDataplane.IPSets()).To(Equal(state.ExpectedIPSets),
-			"IP sets didn't match expected state after moving to state: %v",
-			state.Name)
-		Expect(mockDataplane.ActivePolicies()).To(Equal(state.ExpectedPolicyIDs),
-			"Active policy IDs were incorrect after moving to state: %v",
-			state.Name)
-		Expect(mockDataplane.ActiveProfiles()).To(Equal(state.ExpectedProfileIDs),
-			"Active profile IDs were incorrect after moving to state: %v",
-			state.Name)
-		Expect(mockDataplane.ActiveVTEPs()).To(Equal(state.ExpectedVTEPs),
-			"Active VTEPs were incorrect after moving to state: %v",
-			state.Name)
-		Expect(mockDataplane.ActiveRoutes()).To(Equal(state.ExpectedRoutes),
-			"Active routes were incorrect after moving to state: %v",
-			state.Name)
-		Expect(mockDataplane.EndpointToPolicyOrder()).To(Equal(state.ExpectedEndpointPolicyOrder),
-			"Endpoint policy order incorrect after moving to state: %v",
-			state.Name)
-		Expect(mockDataplane.EndpointToUntrackedPolicyOrder()).To(Equal(state.ExpectedUntrackedEndpointPolicyOrder),
-			"Untracked endpoint policy order incorrect after moving to state: %v",
-			state.Name)
-		Expect(mockDataplane.EndpointToPreDNATPolicyOrder()).To(Equal(state.ExpectedPreDNATEndpointPolicyOrder),
-			"Untracked endpoint policy order incorrect after moving to state: %v",
-			state.Name)
-		Expect(mockDataplane.ActiveUntrackedPolicies()).To(Equal(state.ExpectedUntrackedPolicyIDs),
-			"Untracked policies incorrect after moving to state: %v",
-			state.Name)
-		Expect(mockDataplane.ActivePreDNATPolicies()).To(Equal(state.ExpectedPreDNATPolicyIDs),
-			"PreDNAT policies incorrect after moving to state: %v",
-			state.Name)
+		// Do common sync/async assertions.
+		expectCorrectDataplaneState(mockDataplane, state)
+
+		// We only track stats in the sync tests.
 		Expect(lastStats.NumPolicies).To(Equal(state.NumPolicies()),
 			"number of policies stat incorrect after moving to state: %v\n%+v",
 			state.Name, spew.Sdump(state.DatastoreState))

--- a/calc/calc_graph_fv_test.go
+++ b/calc/calc_graph_fv_test.go
@@ -275,6 +275,21 @@ var baseTests = []StateList{
 		vxlanToIPIPSwitch,
 	},
 	{
+		vxlanWithBlockAndDifferentTunnelIP,
+	},
+	{
+		// This sequence simulates updating a node's tunnel IP.
+		vxlanWithBlock,
+		vxlanWithBlockAndDifferentTunnelIP,
+		vxlanWithBlock,
+	},
+	{
+		// This sequence simulates updating a node's IP.
+		vxlanWithBlock,
+		vxlanWithBlockAndDifferentNodeIP,
+		vxlanWithBlock,
+	},
+	{
 		// Start with a block.
 		vxlanWithBlock,
 
@@ -383,6 +398,7 @@ var _ = Describe("Async calculation graph state sequencing tests:", func() {
 					// Create the calculation graph.
 					conf := config.New()
 					conf.FelixHostname = localHostname
+					conf.VXLANEnabled = true
 					outputChan := make(chan interface{})
 					asyncGraph := NewAsyncCalcGraph(conf, []chan<- interface{}{outputChan}, nil)
 					// And a validation filter, with a channel between it

--- a/calc/resources_for_test.go
+++ b/calc/resources_for_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -704,4 +704,5 @@ func intPtr(i int) *int {
 
 var localHostVXLANTunnelIP = "10.0.0.0"
 var remoteHostVXLANTunnelIP = "10.0.1.0"
+var remoteHostVXLANTunnelIP2 = "10.0.1.1"
 var remoteHost2VXLANTunnelIP = "10.0.2.0"

--- a/calc/states_for_test.go
+++ b/calc/states_for_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1084,9 +1084,14 @@ func reverseKVOrder(baseTests StateList) (desc string, mappedTests []StateList) 
 func insertEmpties(baseTest StateList) (desc string, mappedTests []StateList) {
 	desc = "with empty state inserted between each state"
 	mappedTest := StateList{}
+	first := true
 	for _, state := range baseTest {
+		if !first {
+			mappedTest = append(mappedTest, empty)
+		} else {
+			first = false
+		}
 		mappedTest = append(mappedTest, state)
-		mappedTest = append(mappedTest, empty)
 	}
 	mappedTests = append(mappedTests, mappedTest)
 	return

--- a/calc/states_for_test.go
+++ b/calc/states_for_test.go
@@ -941,6 +941,48 @@ var vxlanWithBlockAndBorrows = vxlanWithBlock.withKVUpdates(
 	},
 )
 
+// vxlanWithBlock but with a different tunnel IP.
+var vxlanWithBlockAndDifferentTunnelIP = vxlanWithBlock.withKVUpdates(
+	KVPair{Key: remoteHostVXLANTunnelConfigKey, Value: remoteHostVXLANTunnelIP2},
+).withName("VXLAN different tunnel IP").withVTEPs(
+	// VTEP for the remote node.
+	proto.VXLANTunnelEndpointUpdate{
+		Node:           remoteHostname,
+		Mac:            "66:3e:ca:a4:db:65",
+		Ipv4Addr:       remoteHostVXLANTunnelIP2,
+		ParentDeviceIp: remoteHostIP.String(),
+	},
+).withRoutes(
+	// Single route for the block.
+	proto.RouteUpdate{
+		Node: remoteHostname,
+		Dst:  "10.0.1.0/29",
+		Gw:   remoteHostVXLANTunnelIP2,
+		Type: proto.RouteType_VXLAN,
+	},
+)
+
+// vxlanWithBlock but with a different node IP.
+var vxlanWithBlockAndDifferentNodeIP = vxlanWithBlock.withKVUpdates(
+	KVPair{Key: remoteHostIPKey, Value: &remoteHost2IP},
+).withName("VXLAN different node IP").withVTEPs(
+	// VTEP for the remote node.
+	proto.VXLANTunnelEndpointUpdate{
+		Node:           remoteHostname,
+		Mac:            "66:3e:ca:a4:db:65",
+		Ipv4Addr:       remoteHostVXLANTunnelIP,
+		ParentDeviceIp: remoteHost2IP.String(),
+	},
+).withRoutes(
+	// Single route for the block.
+	proto.RouteUpdate{
+		Node: remoteHostname,
+		Dst:  "10.0.1.0/29",
+		Gw:   remoteHostVXLANTunnelIP,
+		Type: proto.RouteType_VXLAN,
+	},
+)
+
 // As above but with the owner of the block and the borrows switched.
 var vxlanBlockOwnerSwitch = vxlanWithBlockAndBorrows.withKVUpdates(
 	KVPair{Key: remoteIPAMBlockKey, Value: &remoteIPAMBlockWithBorrowsSwitched},

--- a/calc/vxlan_resolver.go
+++ b/calc/vxlan_resolver.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package calc
 
 import (
@@ -173,6 +187,7 @@ func (c *VXLANResolver) OnHostIPUpdate(update api.Update) (_ bool) {
 				r := item.(vxlanRoute)
 				if r.node == nodeName {
 					c.withdrawRoute(r)
+					pendingSet.Add(r)
 				}
 				return nil
 			})
@@ -235,6 +250,7 @@ func (c *VXLANResolver) OnHostConfigUpdate(update api.Update) (_ bool) {
 					r := item.(vxlanRoute)
 					if r.node == nodeName {
 						c.withdrawRoute(r)
+						pendingSet.Add(r)
 					}
 					return nil
 				})


### PR DESCRIPTION
Cherry pick of #2030 on release-v3.7.

#2030: Improve calc graph test infra: - avoid adding empty state

```release-note
Fix that VXLAN routes were revoked but not re-added if node IP tunnel or main IP changed. (@fasaxc)
```
