### PR TITLE
Add support for NATOutgoingAddress option

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -229,6 +229,7 @@ type Config struct {
 	GenericXDPEnabled bool `config:"bool;false"`
 
 	SockmapCgroupv2Subdir string `config:"string;;local"`
+	NATOutgoingAddress    net.IP `config:"ipv4;"`
 }
 
 type ProtoPort struct {

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -199,6 +199,7 @@ type Config struct {
 
 	KubeNodePortRanges []numorstring.Port `config:"portrange-list;30000:32767"`
 	NATPortRange       numorstring.Port   `config:"portrange;"`
+	NATOutgoingAddress net.IP             `config:"ipv4;"`
 
 	UsageReportingEnabled          bool          `config:"bool;true"`
 	UsageReportingInitialDelaySecs time.Duration `config:"seconds;300"`
@@ -229,7 +230,6 @@ type Config struct {
 	GenericXDPEnabled bool `config:"bool;false"`
 
 	SockmapCgroupv2Subdir string `config:"string;;local"`
-	NATOutgoingAddress    net.IP `config:"ipv4;"`
 }
 
 type ProtoPort struct {

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -139,6 +139,7 @@ func StartDataplaneDriver(configParams *config.Config,
 
 				NATPortRange:                       configParams.NATPortRange,
 				IptablesNATOutgoingInterfaceFilter: configParams.IptablesNATOutgoingInterfaceFilter,
+				NATOutgoingAddress:                 configParams.NATOutgoingAddress,
 			},
 			IPIPMTU:                        configParams.IpInIpMtu,
 			VXLANMTU:                       configParams.VXLANMTU,

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5f28536f6050febec6ccd41f3ed07f0eb4eb0c6626f47b20c98e47bf2bc13276
-updated: 2019-06-03T15:44:43.522431177Z
+hash: 1df24442d78735fb3e658b1aa82bb9d61e476ec4ad4d3eccdac1ff3f6e6837e8
+updated: 2019-06-06T09:06:07.065507121Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -31,7 +31,6 @@ imports:
   - etcdserver/api/v3rpc/rpctypes
   - etcdserver/etcdserverpb
   - mvcc/mvccpb
-  - pkg/srv
   - pkg/tlsutil
   - pkg/transport
   - pkg/types
@@ -243,7 +242,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 7c769d6cd9819ef13852d50eb68dc75bddb696f2
+  version: 9131cbc3d1e68099b7f89d2de0b3704542d4a772
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -285,7 +284,7 @@ imports:
   subpackages:
   - binder
 - name: github.com/projectcalico/typha
-  version: e119a742499f66ee45b94304af2a78e30fa1fcea
+  version: 78910db37d8ae6e1a62cc69059e421bf5d001ef9
   subpackages:
   - pkg/syncclient
   - pkg/syncproto

--- a/glide.yaml
+++ b/glide.yaml
@@ -69,7 +69,7 @@ import:
   - lib/set
   - lib/validator/v1
 - package: github.com/projectcalico/typha
-  version: e119a742499f66ee45b94304af2a78e30fa1fcea
+  version: 78910db37d8ae6e1a62cc69059e421bf5d001ef9
   subpackages:
   - pkg/syncclient
   - pkg/tlsutils

--- a/rules/nat_test.go
+++ b/rules/nat_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
 package rules_test
 
 import (
+	"fmt"
+	"net"
+
 	. "github.com/projectcalico/felix/rules"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 
@@ -49,6 +52,24 @@ var _ = Describe("NAT", func() {
 			Rules: []Rule{
 				{
 					Action: MasqAction{},
+					Match: Match().
+						SourceIPSet("cali40masq-ipam-pools").
+						NotDestIPSet("cali40all-ipam-pools"),
+				},
+			},
+		}))
+	})
+	It("should render rules when active with an explicit SNAT address", func() {
+		snatAddress := "192.168.0.1"
+		localConfig := rrConfigNormal
+		localConfig.NATOutgoingAddress = net.ParseIP(snatAddress)
+		renderer = NewRenderer(localConfig)
+
+		Expect(renderer.NATOutgoingChain(true, 4)).To(Equal(&Chain{
+			Name: "cali-nat-outgoing",
+			Rules: []Rule{
+				{
+					Action: SNATAction{ToAddr: snatAddress},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
 						NotDestIPSet("cali40all-ipam-pools"),
@@ -144,6 +165,53 @@ var _ = Describe("NAT", func() {
 						SourceIPSet("cali40masq-ipam-pools").
 						NotDestIPSet("cali40all-ipam-pools").
 						OutInterface("cali-123"),
+				},
+			},
+		}))
+	})
+	It("should render rules when active with explicit port range and an explicit SNAT address", func() {
+
+		snatAddress := "192.168.0.1"
+		//copy struct
+		localConfig := rrConfigNormal
+		localConfig.NATPortRange, _ = numorstring.PortFromRange(99, 100)
+		localConfig.NATOutgoingAddress = net.ParseIP(snatAddress)
+		renderer = NewRenderer(localConfig)
+
+		expectedAddress := fmt.Sprintf("%s:%s", snatAddress, "99-100")
+
+		Expect(renderer.NATOutgoingChain(true, 4)).To(Equal(&Chain{
+			Name: "cali-nat-outgoing",
+			Rules: []Rule{
+				{
+					Action: SNATAction{ToAddr: expectedAddress},
+					Match: Match().
+						SourceIPSet("cali40masq-ipam-pools").
+						NotDestIPSet("cali40all-ipam-pools").Protocol("tcp"),
+				},
+				{
+					Action: ReturnAction{},
+					Match: Match().
+						SourceIPSet("cali40masq-ipam-pools").
+						NotDestIPSet("cali40all-ipam-pools").Protocol("tcp"),
+				},
+				{
+					Action: SNATAction{ToAddr: expectedAddress},
+					Match: Match().
+						SourceIPSet("cali40masq-ipam-pools").
+						NotDestIPSet("cali40all-ipam-pools").Protocol("udp"),
+				},
+				{
+					Action: ReturnAction{},
+					Match: Match().
+						SourceIPSet("cali40masq-ipam-pools").
+						NotDestIPSet("cali40all-ipam-pools").Protocol("udp"),
+				},
+				{
+					Action: SNATAction{ToAddr: snatAddress},
+					Match: Match().
+						SourceIPSet("cali40masq-ipam-pools").
+						NotDestIPSet("cali40all-ipam-pools"),
 				},
 			},
 		}))

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -257,6 +257,8 @@ type Config struct {
 
 	NATPortRange                       numorstring.Port
 	IptablesNATOutgoingInterfaceFilter string
+
+	NATOutgoingAddress net.IP
 }
 
 func (c *Config) validate() {


### PR DESCRIPTION
## Description
Related to https://github.com/projectcalico/libcalico-go/pull/1089.

As in that PR, this is for addressing projectcalico/calico#2222. We chose to implement this by allowing users to specify the IP address being used rather than using the BGP address by default because it seemed more flexible. For our use case we are using the Kubernetes downward API to supply this address. I've tested this by setting/unsetting FELIX_NATOUTGOINGADDRESS in a calico node container using the modified felix.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
