### PR TITLE
Workaround goimports removing packr-generated import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,6 +433,7 @@ bpf/bpf-packr.go bpf/packrd/packed-packr.go: bpf/xdp/generated/xdp.o bpf/sockmap
 	              calico-build/bpf-clang \
 	              /bin/sh -c \
 	              "cd /go/src/$(PACKAGE_NAME)/bpf && /go/bin/packr2"
+	sed -i 's,^	"github.com/gobuffalo/packr/v2",	packr "github.com/gobuffalo/packr/v2",' bpf/packrd/packed-packr.go
 	$(DOCKER_RUN) $(CALICO_BUILD) goimports -w -local github.com/projectcalico/ bpf/packrd/packed-packr.go bpf/bpf-packr.go
 
 ###############################################################################

--- a/bpf/packrd/packed-packr.go
+++ b/bpf/packrd/packed-packr.go
@@ -6,7 +6,7 @@
 package packrd
 
 import (
-	"github.com/gobuffalo/packr/v2"
+	packr "github.com/gobuffalo/packr/v2"
 	"github.com/gobuffalo/packr/v2/file/resolver"
 )
 


### PR DESCRIPTION
In wavetank (e.g. [1]), when building bin/calico-felix-amd64, we get this:

  ```
  github.com/projectcalico/felix/vendor/github.com/hashicorp/go-version
  github.com/projectcalico/felix/bpf/packrd
  # github.com/projectcalico/felix/bpf/packrd
  bpf/packrd/packed-packr.go:14:7: undefined: packr
  bpf/packrd/packed-packr.go:26:8: undefined: packr
  bpf/packrd/packed-packr.go:27:28: undefined: packr
  bpf/packrd/packed-packr.go:28:30: undefined: packr
  bpf/packrd/packed-packr.go:32:8: undefined: packr
  bpf/packrd/packed-packr.go:33:26: undefined: packr
  github.com/projectcalico/felix/vendor/github.com/vishvananda/netns
  ```

I also get that when running `make bin/calico-felix` or `make deb` on my
own laptop.

In semaphore (e.g. [2]), for some reason we don't get that same problem.

[1] https://wavetank.tigera.io/view/Openstack/job/openstack-felix-build-package/45/console
[2] https://semaphoreci.com/calico/felix-2/branches/master/builds/1662

When it occurs, the problem seems to be that packr2 generates this
import:

	"github.com/gobuffalo/packr/v2"

and then goimports removes that again because it thinks it isn't
needed.  But the import _is_ needed, and removing it causes the build to
fail as above.

goimports is buggy here, and is incorrectly removing a needed import.
This change works around that by naming the import, because goimports
does not remove named imports.
