### PR TITLE
bpf: require kernel v4.20 for sockmap acceleration

### DIFF
--- a/bpf/bpf.go
+++ b/bpf/bpf.go
@@ -93,9 +93,9 @@ var (
 	// v4Dot16Dot0 is the first kernel version that has all the
 	// required features we use for XDP filtering
 	v4Dot16Dot0 = versionparse.MustParseVersion("4.16.0")
-	// v4Dot19Dot0 is the first kernel version that has all the
+	// v4Dot20Dot0 is the first kernel version that has all the
 	// required features we use for sidecar acceleration
-	v4Dot19Dot0 = versionparse.MustParseVersion("4.19.0")
+	v4Dot20Dot0 = versionparse.MustParseVersion("4.20.0")
 )
 
 func init() {
@@ -2285,7 +2285,7 @@ func isAtLeastKernel(v *version.Version) error {
 }
 
 func SupportsSockmap() error {
-	if err := isAtLeastKernel(v4Dot19Dot0); err != nil {
+	if err := isAtLeastKernel(v4Dot20Dot0); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Testing with v4.19 made istio pods not being able to run.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
