### PR TITLE
bpf: add and update copyright headers on BPF files

### DIFF
--- a/bpf/include/bpf.h
+++ b/bpf/include/bpf.h
@@ -1,3 +1,18 @@
+// Copyright (c) 2017 Authors of Cilium
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // from kernel headers
 #include <asm/byteorder.h>
 #include <stdint.h>

--- a/bpf/sockmap/redir.c
+++ b/bpf/sockmap/redir.c
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <linux/bpf.h>
 #include <iproute2/bpf_elf.h>
 

--- a/bpf/sockmap/sockops.c
+++ b/bpf/sockmap/sockops.c
@@ -1,3 +1,18 @@
+// Copyright (c) 2017 Authors of Cilium
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <linux/bpf.h>
 #include <iproute2/bpf_elf.h>
 #include <sys/socket.h>

--- a/bpf/sockmap/sockops.h
+++ b/bpf/sockmap/sockops.h
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "../include/bpf.h"
 
 #define ENVOY_IP 0x100007f

--- a/bpf/xdp/filter.c
+++ b/bpf/xdp/filter.c
@@ -1,3 +1,4 @@
+// Copyright (c) 2017 Authors of Cilium
 // Copyright (c) 2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This adds to BPF files:
    * Attribution to Cilium authors
    * Missing copyright headers

Thanks to @tgraf and the Cilium team for re-licensing some of the Cilium code to Apache 2.0.