### PR TITLE
Better VXLAN diags on interface creation failure

### DIFF
--- a/dataplane/linux/vxlan_mgr.go
+++ b/dataplane/linux/vxlan_mgr.go
@@ -304,6 +304,9 @@ func (m *vxlanManager) configureVXLANDevice(mtu int, localVTEP *proto.VXLANTunne
 			return fmt.Errorf("failed to delete interface: %v", err)
 		}
 		if err = netlink.LinkAdd(vxlan); err != nil {
+			if err == syscall.EEXIST {
+				log.Warnf("Failed to create VXLAN device. Another device with this VNI may already exist")
+			}
 			return fmt.Errorf("failed to create vxlan interface: %v", err)
 		}
 		link, err = netlink.LinkByName(vxlan.Name)


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Add a log which provides a clue as to why the creation might have
failed. We saw this recently and it was tricky to debug.

- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```