### PR TITLE
Configurable prometheus host.  Default value for prometheus host: empty

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -46,7 +46,7 @@ var (
 	StringRegexp             = regexp.MustCompile(`^.*$`)
 	IfaceParamRegexp         = regexp.MustCompile(`^[a-zA-Z0-9:._+-]{1,15}$`)
 	// Hostname  have to be valid ipv4, ipv6 or strings up to 64 characters.
-	PrometheusHostRegexp = regexp.MustCompile(`^[a-zA-Z0-9:._+-]{1,64}$`)
+	HostAddressRegexp = regexp.MustCompile(`^[a-zA-Z0-9:._+-]{1,64}$`)
 )
 
 const (
@@ -191,9 +191,9 @@ type Config struct {
 
 	HealthEnabled                   bool   `config:"bool;false"`
 	HealthPort                      int    `config:"int(0,65535);9099"`
-	HealthHost                      string `config:"string;localhost"`
+	HealthHost                      string `config:"host-address;localhost"`
 	PrometheusMetricsEnabled        bool   `config:"bool;false"`
-	PrometheusMetricsHost           string `config:"prometheus-host;"`
+	PrometheusMetricsHost           string `config:"host-address;"`
 	PrometheusMetricsPort           int    `config:"int(0,65535);9091"`
 	PrometheusGoMetricsEnabled      bool   `config:"bool;true"`
 	PrometheusProcessMetricsEnabled bool   `config:"bool;true"`
@@ -561,9 +561,9 @@ func loadParams() {
 		case "hostname":
 			param = &RegexpParam{Regexp: HostnameRegexp,
 				Msg: "invalid hostname"}
-		case "prometheus-host":
-			param = &RegexpParam{Regexp: PrometheusHostRegexp,
-				Msg: "invalid host for Prometheus"}
+		case "host-address":
+			param = &RegexpParam{Regexp: HostAddressRegexp,
+				Msg: "invalid host address"}
 		case "region":
 			param = &RegionParam{}
 		case "oneof":

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -45,6 +45,8 @@ var (
 	HostnameRegexp           = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 	StringRegexp             = regexp.MustCompile(`^.*$`)
 	IfaceParamRegexp         = regexp.MustCompile(`^[a-zA-Z0-9:._+-]{1,15}$`)
+	// Hostname  have to be valid ipv4, ipv6 or strings up to 64 characters.
+	PrometheusHostRegexp = regexp.MustCompile(`^[a-zA-Z0-9:._+-]{1,64}$`)
 )
 
 const (
@@ -191,6 +193,7 @@ type Config struct {
 	HealthPort                      int    `config:"int(0,65535);9099"`
 	HealthHost                      string `config:"string;localhost"`
 	PrometheusMetricsEnabled        bool   `config:"bool;false"`
+	PrometheusMetricsHost           string `config:"prometheus-host;"`
 	PrometheusMetricsPort           int    `config:"int(0,65535);9091"`
 	PrometheusGoMetricsEnabled      bool   `config:"bool;true"`
 	PrometheusProcessMetricsEnabled bool   `config:"bool;true"`
@@ -558,6 +561,9 @@ func loadParams() {
 		case "hostname":
 			param = &RegexpParam{Regexp: HostnameRegexp,
 				Msg: "invalid hostname"}
+		case "prometheus-host":
+			param = &RegexpParam{Regexp: PrometheusHostRegexp,
+				Msg: "invalid host for Prometheus"}
 		case "region":
 			param = &RegionParam{}
 		case "oneof":

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -259,6 +259,7 @@ var _ = DescribeTable("Config parsing",
 	Entry("HealthPort", "HealthPort", "1234", int(1234)),
 
 	Entry("PrometheusMetricsEnabled", "PrometheusMetricsEnabled", "true", true),
+	Entry("PrometheusMetricsHost", "PrometheusMetricsHost", "10.0.0.1", "10.0.0.1"),
 	Entry("PrometheusMetricsPort", "PrometheusMetricsPort", "1234", int(1234)),
 	Entry("PrometheusGoMetricsEnabled", "PrometheusGoMetricsEnabled", "false", false),
 	Entry("PrometheusProcessMetricsEnabled", "PrometheusProcessMetricsEnabled", "false", false),

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -32,7 +32,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/projectcalico/felix/buildinfo"
 	"github.com/projectcalico/felix/calc"
@@ -527,7 +527,10 @@ configRetry:
 
 func servePrometheusMetrics(configParams *config.Config) {
 	for {
-		log.WithField("port", configParams.PrometheusMetricsPort).Info("Starting prometheus metrics endpoint")
+		log.WithFields(log.Fields{
+			"host": configParams.PrometheusMetricsHost,
+			"port": configParams.PrometheusMetricsPort,
+		}).Info("Starting prometheus metrics endpoint")
 		if configParams.PrometheusGoMetricsEnabled && configParams.PrometheusProcessMetricsEnabled {
 			log.Info("Including Golang & Process metrics")
 		} else {
@@ -541,7 +544,8 @@ func servePrometheusMetrics(configParams *config.Config) {
 			}
 		}
 		http.Handle("/metrics", promhttp.Handler())
-		err := http.ListenAndServe(fmt.Sprintf(":%v", configParams.PrometheusMetricsPort), nil)
+		err := http.ListenAndServe(fmt.Sprintf("[%v]:%v",
+			configParams.PrometheusMetricsHost, configParams.PrometheusMetricsPort), nil)
 		log.WithError(err).Error(
 			"Prometheus metrics endpoint failed, trying to restart it...")
 		time.Sleep(1 * time.Second)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -26,6 +26,7 @@ import (
 	"os/signal"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -544,8 +545,7 @@ func servePrometheusMetrics(configParams *config.Config) {
 			}
 		}
 		http.Handle("/metrics", promhttp.Handler())
-		err := http.ListenAndServe(fmt.Sprintf("[%v]:%v",
-			configParams.PrometheusMetricsHost, configParams.PrometheusMetricsPort), nil)
+		err := http.ListenAndServe(net.JoinHostPort(configParams.PrometheusMetricsHost, strconv.Itoa(configParams.PrometheusMetricsPort)), nil)
 		log.WithError(err).Error(
 			"Prometheus metrics endpoint failed, trying to restart it...")
 		time.Sleep(1 * time.Second)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5a620df90fa3ce041dba08bf35ef80fcefe027b09943fc7e66c69a6e58d87c43
-updated: 2019-07-05T11:02:54.742623973Z
+hash: 96d56cac420a39da3bbb468ce89239e36f14a162f13e50c866a696dde6b7a9bf
+updated: 2019-07-17T17:01:33.035216696-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -210,7 +210,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 714ce2bcad0cc2fc765ee63370904d7c2c473af4
+  version: e3e8f00211f91ffce4087eada516076549cbfb75
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -252,7 +252,7 @@ imports:
   subpackages:
   - binder
 - name: github.com/projectcalico/typha
-  version: 9446918cdcabadf48f10c5a3115a92b3e667bc50
+  version: cbe2224d1228911293b7c4ab8fde79d49c4d85fc
   subpackages:
   - pkg/syncclient
   - pkg/syncproto

--- a/glide.yaml
+++ b/glide.yaml
@@ -69,7 +69,7 @@ import:
   - lib/set
   - lib/validator/v1
 - package: github.com/projectcalico/typha
-  version: 9446918cdcabadf48f10c5a3115a92b3e667bc50
+  version: cbe2224d1228911293b7c4ab8fde79d49c4d85fc
   subpackages:
   - pkg/syncclient
   - pkg/tlsutils


### PR DESCRIPTION
Make prometheus host configurable.

This change was requested in https://github.com/projectcalico/felix/issues/1948

Other related PR's including documentation:
projectcalico/libcalico-go#1106
projectcalico/libcalico-go#1108
projectcalico/calico#2728
projectcalico/typha#284
projectcalico/confd/pull/254

## Release Note
If you wish to override the default settings for the prometheus host/ip, you can do this by modifying your FelixConfiguration.
