### PR TITLE
Fix nft mode failures due to u32 match

### DIFF
--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -164,8 +164,7 @@ func chainsForIfaces(ifaceMetadata []string,
 	dropEncapRules := []iptables.Rule{
 		{
 			Match: iptables.Match().ProtocolNum(ProtoUDP).
-				DestPorts(uint16(VXLANPort)).
-				VXLANVNI(uint32(VXLANVNI)),
+				DestPorts(uint16(VXLANPort)),
 			Action:  iptables.DropAction{},
 			Comment: "Drop VXLAN encapped packets originating in pods",
 		},

--- a/iptables/match_builder.go
+++ b/iptables/match_builder.go
@@ -282,6 +282,9 @@ func (m MatchCriteria) NotICMPV6TypeAndCode(t, c uint8) MatchCriteria {
 
 // VXLANVNI matches on the VNI contained within the VXLAN header.  It assumes that this is indeed a VXLAN
 // packet; i.e. it should be used with a protocol==UDP and port==VXLAN port match.
+//
+// Note: the -m u32 option is not supported on iptables in NFT mode.
+// https://wiki.nftables.org/wiki-nftables/index.php/Supported_features_compared_to_xtables#u32
 func (m MatchCriteria) VXLANVNI(vni uint32) MatchCriteria {
 	// This uses the U32 module, a simple VM for extracting bytes from a packet.  See
 	// http://www.stearns.org/doc/iptables-u32.current.html

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -311,8 +311,7 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 	if dropEncap {
 		rules = append(rules, Rule{
 			Match: Match().ProtocolNum(ProtoUDP).
-				DestPorts(uint16(r.Config.VXLANPort)).
-				VXLANVNI(uint32(r.Config.VXLANVNI)),
+				DestPorts(uint16(r.Config.VXLANPort)),
 			Action:  DropAction{},
 			Comment: "Drop VXLAN encapped packets originating in pods",
 		})

--- a/rules/endpoints_test.go
+++ b/rules/endpoints_test.go
@@ -76,8 +76,7 @@ var _ = Describe("Endpoints", func() {
 
 		dropVXLANRule := Rule{
 			Match: Match().ProtocolNum(ProtoUDP).
-				DestPorts(uint16(VXLANPort)).
-				VXLANVNI(uint32(VXLANVNI)),
+				DestPorts(uint16(VXLANPort)),
 			Action:  DropAction{},
 			Comment: "Drop VXLAN encapped packets originating in pods",
 		}

--- a/rules/static.go
+++ b/rules/static.go
@@ -225,23 +225,21 @@ func (r *DefaultRuleRenderer) filterInputChain(ipVersion uint8) *Chain {
 	}
 
 	if ipVersion == 4 && r.VXLANEnabled {
-		// VXLAN is enabled, filter incoming VXLAN packets that match our VXLAN port and VNI to ensure they
+		// VXLAN is enabled, filter incoming VXLAN packets that match our VXLAN port to ensure they
 		// come from a recognised host and are going to a local address on the host.
 		inputRules = append(inputRules,
 			Rule{
 				Match: Match().ProtocolNum(ProtoUDP).
 					DestPorts(uint16(r.Config.VXLANPort)).
 					SourceIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets)).
-					DestAddrType(AddrTypeLocal).
-					VXLANVNI(uint32(r.Config.VXLANVNI)), /* relies on protocol and port check */
+					DestAddrType(AddrTypeLocal),
 				Action:  r.filterAllowAction,
 				Comment: "Allow VXLAN packets from whitelisted hosts",
 			},
 			Rule{
 				Match: Match().ProtocolNum(ProtoUDP).
 					DestPorts(uint16(r.Config.VXLANPort)).
-					DestAddrType(AddrTypeLocal).
-					VXLANVNI(uint32(r.Config.VXLANVNI)), /* relies on protocol and port check */
+					DestAddrType(AddrTypeLocal),
 				Action:  DropAction{},
 				Comment: "Drop VXLAN packets from non-whitelisted hosts",
 			},
@@ -610,8 +608,7 @@ func (r *DefaultRuleRenderer) filterOutputChain(ipVersion uint8) *Chain {
 				Match: Match().ProtocolNum(ProtoUDP).
 					DestPorts(uint16(r.Config.VXLANPort)).
 					SrcAddrType(AddrTypeLocal, false).
-					DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets)).
-					VXLANVNI(uint32(r.Config.VXLANVNI)),
+					DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets)),
 				Action:  r.filterAllowAction,
 				Comment: "Allow VXLAN packets to other whitelisted hosts",
 			},


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

NFT mode doesn't support the u32 match which we use for VXLAN VNI
matching. This PR removes that additional match, making our rules a bit
more broad. I think this is OK, since we primarily use this to restrict
outgoing VXLAN from pods and we don't expect pods to be sending VXLAN
traffic direclty over the Calico network.

We also use this to allow VXLAN traffic between Calico nodes. Again, it
seems OK to allow VXLAN traffic in general since the VTEP on the other
side will only accept traffic to the right VNI anyway.

- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```