### PR TITLE
Delete rules using full line instead of line number for non-cali chains

### DIFF
--- a/iptables/rules.go
+++ b/iptables/rules.go
@@ -48,6 +48,12 @@ func (r Rule) RenderInsert(chainName, prefixFragment string, features *Features)
 	return r.renderInner(fragments, prefixFragment, features)
 }
 
+func (r Rule) RenderInsertAtRuleNumber(chainName string, ruleNum int, prefixFragment string, features *Features) string {
+	fragments := make([]string, 0, 7)
+	fragments = append(fragments, "-I", chainName, fmt.Sprintf("%d", ruleNum))
+	return r.renderInner(fragments, prefixFragment, features)
+}
+
 func (r Rule) RenderReplace(chainName string, ruleNum int, prefixFragment string, features *Features) string {
 	fragments := make([]string, 0, 7)
 	fragments = append(fragments, "-R", chainName, fmt.Sprintf("%d", ruleNum))

--- a/iptables/rules_test.go
+++ b/iptables/rules_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Hash extraction tests", func() {
 		Expect(rules).To(Equal(map[string][]string{
 			"FORWARD": {
 				"-A FORWARD -j an-old-rule",
-				"-A FORWARD -j ignore-me",
+				"-",
 			},
 		}))
 	})
@@ -154,7 +154,7 @@ var _ = Describe("Hash extraction tests", func() {
 			"FORWARD": {
 				"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD",
 				"-A FORWARD -m comment --comment \"cali:abcdefghij1234-_\" -j cali-FORWARD",
-				"-A FORWARD --src '1.2.3.4'",
+				"-",
 				"-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD",
 			},
 		}))
@@ -179,7 +179,7 @@ var _ = Describe("Hash extraction tests", func() {
 		}))
 		Expect(rules).To(Equal(map[string][]string{
 			"FORWARD": {
-				"-A FORWARD --src '1.2.3.4'",
+				"-",
 				"-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD",
 			},
 		}))

--- a/iptables/rules_test.go
+++ b/iptables/rules_test.go
@@ -94,14 +94,20 @@ var _ = Describe("Hash extraction tests", func() {
 	})
 
 	It("should extract an old felix rule by prefix", func() {
-		hashes, err := table.readHashesFrom(newClosableBuf("-A FORWARD -j felix-FORWARD\n"))
+		hashes, rules, hashesToRules, err := table.readHashesAndRulesFrom(newClosableBuf("-A FORWARD -j felix-FORWARD\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
 			"FORWARD": []string{"OLD INSERT RULE"},
 		}))
+		Expect(rules).To(Equal(map[string][]string{
+			"FORWARD": []string{"-A FORWARD -j felix-FORWARD"},
+		}))
+		Expect(hashesToRules).To(HaveKeyWithValue("OLD INSERT RULE", "-A FORWARD -j felix-FORWARD"))
+
+		Expect(rules).To(Not(BeEmpty()))
 	})
 	It("should extract an old felix rule by special case", func() {
-		hashes, err := table.readHashesFrom(newClosableBuf(
+		hashes, rules, hashesToRules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A FORWARD -j an-old-rule\n" +
 				"-A FORWARD -j ignore-me\n",
 		))
@@ -112,17 +118,31 @@ var _ = Describe("Hash extraction tests", func() {
 				"",
 			},
 		}))
+		Expect(rules).To(Equal(map[string][]string{
+			"FORWARD": {
+				"-A FORWARD -j an-old-rule",
+				"-A FORWARD -j ignore-me",
+			},
+		}))
+		Expect(hashesToRules).To(HaveKeyWithValue("OLD INSERT RULE", "-A FORWARD -j an-old-rule"))
+		Expect(hashesToRules).To(HaveKeyWithValue("", "-A FORWARD -j ignore-me"))
 	})
-	It("should extract a hash", func() {
-		hashes, err := table.readHashesFrom(newClosableBuf(
+	It("should extract a rule with a hash", func() {
+		hashes, rules, hashesToRules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
 			"FORWARD": []string{"wUHhoiAYhphO9Mso"},
 		}))
+		Expect(rules).To(Equal(map[string][]string{
+			"FORWARD": {
+				"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD",
+			},
+		}))
+		Expect(hashesToRules).To(HaveKeyWithValue("wUHhoiAYhphO9Mso", "-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD"))
 	})
 	It("should extract a hash or a gap from each rule", func() {
-		hashes, err := table.readHashesFrom(newClosableBuf(
+		hashes, rules, hashesToRules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD\n" +
 				"-A FORWARD -m comment --comment \"cali:abcdefghij1234-_\" -j cali-FORWARD\n" +
 				"-A FORWARD --src '1.2.3.4'\n" +
@@ -136,9 +156,22 @@ var _ = Describe("Hash extraction tests", func() {
 				"1234567890093213",
 			},
 		}))
+		Expect(rules).To(Equal(map[string][]string{
+			"FORWARD": {
+				"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD",
+				"-A FORWARD -m comment --comment \"cali:abcdefghij1234-_\" -j cali-FORWARD",
+				"-A FORWARD --src '1.2.3.4'",
+				"-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD",
+			},
+		}))
+		Expect(hashesToRules).To(HaveKeyWithValue("wUHhoiAYhphO9Mso", "-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD"))
+		Expect(hashesToRules).To(HaveKeyWithValue("abcdefghij1234-_", "-A FORWARD -m comment --comment \"cali:abcdefghij1234-_\" -j cali-FORWARD"))
+		Expect(hashesToRules).To(HaveKeyWithValue("", "-A FORWARD --src '1.2.3.4'"))
+		Expect(hashesToRules).To(HaveKeyWithValue("1234567890093213", "-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD"))
 	})
+
 	It("should handle multiple chains", func() {
-		hashes, err := table.readHashesFrom(newClosableBuf(
+		hashes, rules, hashesToRules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A cali-abcd -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD\n" +
 				"-A cali-abcd -m comment --comment \"cali:abcdefghij1234-_\" -j cali-FORWARD\n" +
 				"-A FORWARD --src '1.2.3.4'\n" +
@@ -154,6 +187,14 @@ var _ = Describe("Hash extraction tests", func() {
 				"1234567890093213",
 			},
 		}))
+		Expect(rules).To(Equal(map[string][]string{
+			"FORWARD": {
+				"-A FORWARD --src '1.2.3.4'",
+				"-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD",
+			},
+		}))
+		Expect(hashesToRules).To(HaveKeyWithValue("", "-A FORWARD --src '1.2.3.4'"))
+		Expect(hashesToRules).To(HaveKeyWithValue("1234567890093213", "-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD"))
 	})
 })
 

--- a/iptables/rules_test.go
+++ b/iptables/rules_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Hash extraction tests", func() {
 	})
 
 	It("should extract an old felix rule by prefix", func() {
-		hashes, rules, hashesToRules, err := table.readHashesAndRulesFrom(newClosableBuf("-A FORWARD -j felix-FORWARD\n"))
+		hashes, rules, err := table.readHashesAndRulesFrom(newClosableBuf("-A FORWARD -j felix-FORWARD\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
 			"FORWARD": []string{"OLD INSERT RULE"},
@@ -102,12 +102,9 @@ var _ = Describe("Hash extraction tests", func() {
 		Expect(rules).To(Equal(map[string][]string{
 			"FORWARD": []string{"-A FORWARD -j felix-FORWARD"},
 		}))
-		Expect(hashesToRules).To(HaveKeyWithValue("OLD INSERT RULE", "-A FORWARD -j felix-FORWARD"))
-
-		Expect(rules).To(Not(BeEmpty()))
 	})
 	It("should extract an old felix rule by special case", func() {
-		hashes, rules, hashesToRules, err := table.readHashesAndRulesFrom(newClosableBuf(
+		hashes, rules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A FORWARD -j an-old-rule\n" +
 				"-A FORWARD -j ignore-me\n",
 		))
@@ -124,11 +121,9 @@ var _ = Describe("Hash extraction tests", func() {
 				"-A FORWARD -j ignore-me",
 			},
 		}))
-		Expect(hashesToRules).To(HaveKeyWithValue("OLD INSERT RULE", "-A FORWARD -j an-old-rule"))
-		Expect(hashesToRules).To(HaveKeyWithValue("", "-A FORWARD -j ignore-me"))
 	})
 	It("should extract a rule with a hash", func() {
-		hashes, rules, hashesToRules, err := table.readHashesAndRulesFrom(newClosableBuf(
+		hashes, rules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
@@ -139,10 +134,9 @@ var _ = Describe("Hash extraction tests", func() {
 				"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD",
 			},
 		}))
-		Expect(hashesToRules).To(HaveKeyWithValue("wUHhoiAYhphO9Mso", "-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD"))
 	})
 	It("should extract a hash or a gap from each rule", func() {
-		hashes, rules, hashesToRules, err := table.readHashesAndRulesFrom(newClosableBuf(
+		hashes, rules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD\n" +
 				"-A FORWARD -m comment --comment \"cali:abcdefghij1234-_\" -j cali-FORWARD\n" +
 				"-A FORWARD --src '1.2.3.4'\n" +
@@ -164,14 +158,10 @@ var _ = Describe("Hash extraction tests", func() {
 				"-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD",
 			},
 		}))
-		Expect(hashesToRules).To(HaveKeyWithValue("wUHhoiAYhphO9Mso", "-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD"))
-		Expect(hashesToRules).To(HaveKeyWithValue("abcdefghij1234-_", "-A FORWARD -m comment --comment \"cali:abcdefghij1234-_\" -j cali-FORWARD"))
-		Expect(hashesToRules).To(HaveKeyWithValue("", "-A FORWARD --src '1.2.3.4'"))
-		Expect(hashesToRules).To(HaveKeyWithValue("1234567890093213", "-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD"))
 	})
 
 	It("should handle multiple chains", func() {
-		hashes, rules, hashesToRules, err := table.readHashesAndRulesFrom(newClosableBuf(
+		hashes, rules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A cali-abcd -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD\n" +
 				"-A cali-abcd -m comment --comment \"cali:abcdefghij1234-_\" -j cali-FORWARD\n" +
 				"-A FORWARD --src '1.2.3.4'\n" +
@@ -193,8 +183,6 @@ var _ = Describe("Hash extraction tests", func() {
 				"-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD",
 			},
 		}))
-		Expect(hashesToRules).To(HaveKeyWithValue("", "-A FORWARD --src '1.2.3.4'"))
-		Expect(hashesToRules).To(HaveKeyWithValue("1234567890093213", "-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD"))
 	})
 })
 

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -1035,11 +1035,6 @@ func (t *Table) applyUpdates() error {
 			if previousHashes[i] != "" {
 				line := t.renderDeleteByValueLine(chainName, i)
 				buf.WriteLine(line)
-
-				// Empty out the rule, if it exists.
-				if i < len(newRules) {
-					newRules[i] = ""
-				}
 			}
 		}
 

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -208,8 +208,8 @@ type Table struct {
 	// to what we calculate from chainToContents.
 	chainToDataplaneHashes map[string][]string
 
-	// chainsToFullRules contains the full rules, mapped from chain name to slices of rules in that chain.
-	chainsToFullRules map[string][]string
+	// chainToFullRules contains the full rules, mapped from chain name to slices of rules in that chain.
+	chainToFullRules map[string][]string
 
 	// hashCommentPrefix holds the prefix that we prepend to our rule-tracking hashes.
 	hashCommentPrefix string
@@ -368,7 +368,7 @@ func NewTable(
 		chainNameToChain:       map[string]*Chain{},
 		dirtyChains:            set.New(),
 		chainToDataplaneHashes: map[string][]string{},
-		chainsToFullRules:      map[string][]string{},
+		chainToFullRules:       map[string][]string{},
 		logCxt: log.WithFields(log.Fields{
 			"ipVersion": ipVersion,
 			"table":     name,
@@ -612,7 +612,7 @@ func (t *Table) loadDataplaneState() {
 
 	t.logCxt.Debug("Finished loading iptables state")
 	t.chainToDataplaneHashes = dataplaneHashes
-	t.chainsToFullRules = dataplaneRules
+	t.chainToFullRules = dataplaneRules
 	t.inSyncWithDataPlane = true
 }
 
@@ -1175,7 +1175,7 @@ func (t *Table) renderDeleteByIndexLine(chainName string, ruleNum int) string {
 // used for non-Calico chains.
 func (t *Table) renderDeleteByValueLine(chainName string, ruleNum int) string {
 	// For non-cali chains, get the rule by number but delete using the full rule instead of rule number.
-	rules, ok := t.chainsToFullRules[chainName]
+	rules, ok := t.chainToFullRules[chainName]
 	if !ok || ruleNum >= len(rules) {
 		t.logCxt.WithFields(log.Fields{
 			"chainName": chainName,

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -1017,10 +1017,7 @@ func (t *Table) applyUpdates() error {
 
 		// For simplicity, if we've discovered that we're out-of-sync, remove all our
 		// rules from this chain, then re-insert/re-append them below.
-		//
-		// Remove in reverse order so that we don't disturb the rule numbers of rules we're
-		// about to remove.
-		for i := len(previousHashes) - 1; i >= 0; i-- {
+		for i := 0; i < len(previousHashes); i++ {
 			if previousHashes[i] != "" {
 				line := t.deleteRule(chainName, i)
 				buf.WriteLine(line)

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -989,7 +989,7 @@ func (t *Table) applyUpdates() error {
 				} else if i < len(previousHashes) {
 					// previousHashes was longer, remove the old rules from the end.
 					ruleNum := len(currentHashes) + 1 // 1-indexed
-					line = t.deleteRule(chainName, ruleNum)
+					line = t.renderDeleteByIndexLine(chainName, ruleNum)
 				} else {
 					// currentHashes was longer.  Append.
 					prefixFrag := t.commentFrag(currentHashes[i])
@@ -1019,7 +1019,7 @@ func (t *Table) applyUpdates() error {
 		// rules from this chain, then re-insert/re-append them below.
 		for i := 0; i < len(previousHashes); i++ {
 			if previousHashes[i] != "" {
-				line := t.deleteRule(chainName, i)
+				line := t.renderDeleteByValueLine(chainName, i)
 				buf.WriteLine(line)
 			}
 		}
@@ -1173,11 +1173,14 @@ func (t *Table) commentFrag(hash string) string {
 	return fmt.Sprintf(`-m comment --comment "%s%s"`, t.hashCommentPrefix, hash)
 }
 
-func (t *Table) deleteRule(chainName string, ruleNum int) string {
-	if strings.HasPrefix(chainName, "cali") {
-		return fmt.Sprintf("-D %s %d", chainName, ruleNum)
-	}
+// renderDeleteByIndexLine produces a delete line by rule number. This function is used for cali chains.
+func (t *Table) renderDeleteByIndexLine(chainName string, ruleNum int) string {
+	return fmt.Sprintf("-D %s %d", chainName, ruleNum)
+}
 
+// renderDeleteByValueLine produces a delete line by the full rule at the given rule number. This function is
+// used for non-Calico chains.
+func (t *Table) renderDeleteByValueLine(chainName string, ruleNum int) string {
 	// For non-cali chains, get the rule by number but delete using the full rule instead of rule number.
 	rules, ok := t.chainsToFullRules[chainName]
 	if !ok || ruleNum >= len(rules) {

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -729,7 +729,7 @@ func (t *Table) readHashesAndRulesFrom(r io.ReadCloser) (hashes map[string][]str
 
 	// Keep track of whether the non-Calico chain has inserts. If the chain does not have inserts, we'll remove the
 	// full rules for that chain.
-	chainHasCalicoRule := map[string]bool{}
+	chainHasCalicoRule := set.New()
 
 	// Figure out if debug logging is enabled so we can skip some WithFields() calls in the
 	// tight loop below if the log wouldn't be emitted anyway.
@@ -780,21 +780,28 @@ func (t *Table) readHashesAndRulesFrom(r io.ReadCloser) (hashes map[string][]str
 			if debug {
 				logCxt.WithField("hash", hash).Debug("Found hash in rule")
 			}
-			chainHasCalicoRule[chainName] = true
+			chainHasCalicoRule.Add(chainName)
 		} else if t.oldInsertRegexp.Find(line) != nil {
 			logCxt.WithFields(log.Fields{
 				"rule":      line,
 				"chainName": chainName,
 			}).Info("Found inserted rule from previous Felix version, marking for cleanup.")
 			hash = "OLD INSERT RULE"
-			chainHasCalicoRule[chainName] = true
+			chainHasCalicoRule.Add(chainName)
 		}
 		hashes[chainName] = append(hashes[chainName], hash)
 
 		// Not our chain so cache the full rule in case we need to generate deletes later on.
 		// After scanning the input, we prune any chains of full rules that do not contain inserts.
 		if !t.ourChainsRegexp.MatchString(chainName) {
-			fullRule := string(line)
+			// Only store the full rule for non-Calico rules. Otherwise, we just use the placeholder "-".
+			fullRule := "-"
+			if captures := t.hashCommentRegexp.FindSubmatch(line); captures != nil {
+				fullRule = string(line)
+			} else if t.oldInsertRegexp.Find(line) != nil {
+				fullRule = string(line)
+			}
+
 			rules[chainName] = append(rules[chainName], fullRule)
 		}
 	}
@@ -805,7 +812,7 @@ func (t *Table) readHashesAndRulesFrom(r io.ReadCloser) (hashes map[string][]str
 
 	// Remove full rules for the non-Calico chain if it does not have inserts.
 	for chainName, _ := range rules {
-		if !chainHasCalicoRule[chainName] {
+		if !chainHasCalicoRule.Contains(chainName) {
 			delete(rules, chainName)
 		}
 	}

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -978,26 +978,13 @@ func (t *Table) applyUpdates() error {
 					if previousHashes[i] == currentHashes[i] {
 						continue
 					}
-					// Hash doesn't match, replace the rule. If this is a cali chain, we can replace by
-					// line number. Otherwise, we need to delete the old rule and insert the new rule.
-					if strings.HasPrefix(chainName, "cali") {
-						ruleNum := i + 1 // 1-indexed.
-						prefixFrag := t.commentFrag(currentHashes[i])
-						line = chain.Rules[i].RenderReplace(chainName, ruleNum, prefixFrag, features)
-					} else {
-						line = t.deleteRule(chainName, i)
-						buf.WriteLine(line)
-						prefixFrag := t.commentFrag(currentHashes[i])
-						line = chain.Rules[i].RenderInsertAtRuleNumber(chainName, i+1, prefixFrag, features)
-					}
+					// Hash doesn't match, replace the rule.
+					ruleNum := i + 1 // 1-indexed.
+					prefixFrag := t.commentFrag(currentHashes[i])
+					line = chain.Rules[i].RenderReplace(chainName, ruleNum, prefixFrag, features)
 				} else if i < len(previousHashes) {
 					// previousHashes was longer, remove the old rules from the end.
-					// If this is a cali- chain, we can delete rules by index and pass in an index reflecting that.
-					// Otherwise we need to pass in the index of the actual rule.
-					ruleNum := i
-					if strings.HasPrefix(chainName, "cali") {
-						ruleNum = len(currentHashes) + 1 // 1-indexed
-					}
+					ruleNum := len(currentHashes) + 1 // 1-indexed
 					line = t.deleteRule(chainName, ruleNum)
 				} else {
 					// currentHashes was longer.  Append.

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -18,6 +18,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/projectcalico/libcalico-go/lib/set"
+
 	. "github.com/projectcalico/felix/iptables"
 
 	. "github.com/onsi/ginkgo"
@@ -485,12 +487,11 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 
 	Describe("applying updates when underlying iptables have changed", func() {
 		BeforeEach(func() {
+			table.SetRuleInsertions("FORWARD", []Rule{
+				{Action: AcceptAction{}},
+				{Action: DropAction{}},
+			})
 			table.UpdateChains([]*Chain{
-				{Name: "FORWARD", Rules: []Rule{
-					{Action: AcceptAction{}, Comment: "first"},
-					{Action: ReturnAction{}, Comment: "second"},
-					{Action: DropAction{}, Comment: "third"},
-				}},
 				{Name: "cali-foobar", Rules: []Rule{
 					{Action: AcceptAction{}},
 					{Action: DropAction{}},
@@ -501,9 +502,8 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 		It("should be in the dataplane", func() {
 			Expect(dataplane.Chains).To(Equal(map[string][]string{
 				"FORWARD": {
-					"-m comment --comment \"cali:rG9051jKGMFg8Wml\" -m comment --comment \"first\" --jump ACCEPT",
-					"-m comment --comment \"cali:D4Qxc82HkISWBjxC\" -m comment --comment \"second\" --jump RETURN",
-					"-m comment --comment \"cali:iIVQYhk07jI2vLN3\" -m comment --comment \"third\" --jump DROP",
+					"-m comment --comment \"cali:3gUkOfVeYRgMeHF4\" --jump ACCEPT",
+					"-m comment --comment \"cali:8MgbRleZ5Rc5cBEf\" --jump DROP",
 				},
 				"INPUT":  {},
 				"OUTPUT": {},
@@ -516,26 +516,22 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 		Describe("then truncating the chain, with the iptables changed before iptables-restore", func() {
 			BeforeEach(func() {
 				dataplane.InsertRandomRuleInForward = true
-				table.UpdateChains([]*Chain{
-					{Name: "FORWARD", Rules: []Rule{
-						{Action: DropAction{}, Comment: "third"},
-					}},
-					{Name: "cali-foobar", Rules: []Rule{
-						{Action: AcceptAction{}},
-					}},
+				table.SetRuleInsertions("FORWARD", []Rule{
+					{Action: DropAction{}},
 				})
 				table.Apply()
 			})
 			It("should be updated", func() {
 				Expect(dataplane.Chains).To(Equal(map[string][]string{
 					"FORWARD": {
-						"1 -m comment --comment \"cali:wlVFyGdTOgtWmgk9\" -m comment --comment \"third\" --jump DROP",
+						"-m comment --comment \"cali:hecdSCslEjdBPBPo\" --jump DROP",
 						"-j randomly-inserted-rule",
 					},
 					"INPUT":  {},
 					"OUTPUT": {},
 					"cali-foobar": {
 						"-m comment --comment \"cali:42h7Q64_2XDzpwKe\" --jump ACCEPT",
+						"-m comment --comment \"cali:0sUFHicPNNqNyNx8\" --jump DROP",
 					},
 				}))
 			})
@@ -798,6 +794,7 @@ func describeDirtyDataplaneTests(appendMode bool, dataplaneMode string) {
 				InsertMode:               insertMode,
 				BackendMode:              dataplaneMode,
 				LookPathOverride:         lookPathNoLegacy,
+				TopLevelChainsOverride:   set.From("INPUT", "OUTPUT", "FORWARD", "PREROUTING", "POSTROUTING", "unexpected-insert"),
 			},
 		)
 	})

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -515,7 +515,15 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 		})
 		Describe("then truncating the chain, with the iptables changed before iptables-restore", func() {
 			BeforeEach(func() {
-				dataplane.InsertRandomRuleInForward = true
+				dataplane.OnPreRestore = func() {
+					log.Warn("Simulating an insert in FORWARD chain before iptables-restore happens")
+					if chain, found := dataplane.Chains["FORWARD"]; found {
+						log.Warn("FORWARD chain exists; inserting random rule in FORWARD chain")
+						lines := prependLine(chain, "-j randomly-inserted-rule")
+						dataplane.Chains["FORWARD"] = lines
+					}
+				}
+
 				table.SetRuleInsertions("FORWARD", []Rule{
 					{Action: DropAction{}, Comment: "new drop rule"},
 				})

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -18,8 +18,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/projectcalico/libcalico-go/lib/set"
-
 	. "github.com/projectcalico/felix/iptables"
 
 	. "github.com/onsi/ginkgo"
@@ -794,7 +792,6 @@ func describeDirtyDataplaneTests(appendMode bool, dataplaneMode string) {
 				InsertMode:               insertMode,
 				BackendMode:              dataplaneMode,
 				LookPathOverride:         lookPathNoLegacy,
-				TopLevelChainsOverride:   set.From("INPUT", "OUTPUT", "FORWARD", "PREROUTING", "POSTROUTING", "unexpected-insert"),
 			},
 		)
 	})

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -563,8 +563,8 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 		It("should be in the dataplane", func() {
 			Expect(dataplane.Chains).To(Equal(map[string][]string{
 				"FORWARD": {},
-				"INPUT":  {},
-				"OUTPUT": {},
+				"INPUT":   {},
+				"OUTPUT":  {},
 				"non-cali-chain": {
 					"-m comment --comment \"cali:Z-OWODLe_LbHxmqg\" -m comment --comment \"non-cali 1\" --jump ACCEPT",
 					"-m comment --comment \"cali:tq-yEo1_1XQHZnMs\" -m comment --comment \"non-cali 2\" --jump DROP",
@@ -594,11 +594,11 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 			It("should be updated", func() {
 				Expect(dataplane.Chains).To(Equal(map[string][]string{
 					"FORWARD": {},
-					"INPUT":  {},
-					"OUTPUT": {},
+					"INPUT":   {},
+					"OUTPUT":  {},
 					"non-cali-chain": {
 						"-m comment --comment \"cali:O9yEP97Dd2y-EskM\" -m comment --comment \"new drop rule\" --jump DROP",
-						"-j randomly-inserted-rule",					},
+						"-j randomly-inserted-rule"},
 					"cali-foobar": {
 						"-m comment --comment \"cali:cxE-1zsuD12R9YEG\" -m comment --comment \"cali 1\" --jump ACCEPT",
 						"-m comment --comment \"cali:1cpbPOGLTROlH4Sj\" -m comment --comment \"cali 2\" --jump DROP",

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -515,14 +515,14 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 			BeforeEach(func() {
 				dataplane.InsertRandomRuleInForward = true
 				table.SetRuleInsertions("FORWARD", []Rule{
-					{Action: DropAction{}},
+					{Action: DropAction{}, Comment: "new drop rule"},
 				})
 				table.Apply()
 			})
 			It("should be updated", func() {
 				Expect(dataplane.Chains).To(Equal(map[string][]string{
 					"FORWARD": {
-						"-m comment --comment \"cali:hecdSCslEjdBPBPo\" --jump DROP",
+						"-m comment --comment \"cali:67cGS74-1PBXlOtK\" -m comment --comment \"new drop rule\" --jump DROP",
 						"-j randomly-inserted-rule",
 					},
 					"INPUT":  {},

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -18,8 +18,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/projectcalico/libcalico-go/lib/set"
-
 	. "github.com/projectcalico/felix/iptables"
 
 	. "github.com/onsi/ginkgo"
@@ -625,11 +623,11 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 				"INPUT":  {},
 				"OUTPUT": {},
 			}))
-
-			expectedWrites := set.New()
-			expectedWrites.Add(chainMod{name: "FORWARD", ruleNum: 1})
-			expectedWrites.Add(chainMod{name: "FORWARD", ruleNum: 2})
-			Expect(dataplane.ChainMods.ContainsAll(expectedWrites)).To(BeTrue())
+			if dataplaneMode == "nft" {
+				Expect(dataplane.CmdNames).To(ConsistOf("iptables", "iptables-nft-save", "iptables-nft-restore"))
+			} else {
+				Expect(dataplane.CmdNames).To(ConsistOf("iptables", "iptables-save", "iptables-restore"))
+			}
 		})
 		Describe("then inserting the same rules", func() {
 			BeforeEach(func() {
@@ -656,11 +654,6 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 					"INPUT":  {},
 					"OUTPUT": {},
 				}))
-
-				expectedWrites := set.New()
-				expectedWrites.Add(chainMod{name: "FORWARD", ruleNum: 1})
-				expectedWrites.Add(chainMod{name: "FORWARD", ruleNum: 2})
-				Expect(dataplane.ChainMods.ContainsAll(expectedWrites)).To(BeTrue())
 			})
 		})
 		Describe("then inserting different rules", func() {
@@ -690,12 +683,6 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 					"INPUT":  {},
 					"OUTPUT": {},
 				}))
-
-				expectedWrites := set.New()
-				expectedWrites.Add(chainMod{name: "FORWARD", ruleNum: 1})
-				expectedWrites.Add(chainMod{name: "FORWARD", ruleNum: 2})
-				expectedWrites.Add(chainMod{name: "FORWARD", ruleNum: 3})
-				Expect(dataplane.ChainMods.ContainsAll(expectedWrites)).To(BeTrue())
 			})
 		})
 	})

--- a/iptables/utils_for_test.go
+++ b/iptables/utils_for_test.go
@@ -369,9 +369,7 @@ func (d *restoreCmd) Run() error {
 
 			// Rule is inserted without chain name
 			rule := strings.Join(parts[2:], " ")
-			log.Debugf("--- deleting rule: %#v\n", rule)
 			chain := chains[chainName]
-			log.Debugf("--- deleting rule: chain: %#v\n", chain)
 			i := 0
 
 			newChain := []string{}

--- a/iptables/utils_for_test.go
+++ b/iptables/utils_for_test.go
@@ -325,10 +325,11 @@ func (d *restoreCmd) Run() error {
 
 			// If the first arg after the chain name is a line number, then insert by line number.
 			if lineNum, err := strconv.Atoi(parts[2]); err == nil {
-				lineNum = lineNum - 1 // 0-indexed
-				copy(chain[lineNum+1:], chain[lineNum:])
-				chain[lineNum] = rest
-				d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: lineNum + 1})
+				ruleIdx := lineNum - 1 // 0-indexed
+				chain = append(chain, "")
+				copy(chain[ruleIdx+1:], chain[ruleIdx:])
+				chain[ruleIdx] = rest
+				d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: lineNum})
 			} else {
 				// Otherwise insert at the top.
 				for i := len(chain) - 1; i > 0; i-- {
@@ -353,8 +354,8 @@ func (d *restoreCmd) Run() error {
 
 			// If second arg is numeric, this is a delete by line number.
 			if ruleNum, err := strconv.Atoi(parts[2]); err == nil {
-				Expect(parts).To(HaveLen(3), "calico chain: expected a delete-by-number '--delete '")
-				Expect(chainName).To(HavePrefix("cali"), "deleting non-calico chain by number can cause races")
+				Expect(parts).To(HaveLen(3), "Unexpected argument after rule position in --delete")
+				Expect(chainName).To(HavePrefix("cali"), "Deleting rule from non-calico chain by number can cause races")
 
 				ruleIdx := ruleNum - 1 // 0-indexed array index of rule.
 				chain := chains[chainName]

--- a/iptables/utils_for_test.go
+++ b/iptables/utils_for_test.go
@@ -70,7 +70,6 @@ type mockDataplane struct {
 	FailNextPipeClose              bool
 	FailNextStart                  bool
 	FailNextGetKernelVersionReader bool
-	InsertRandomRuleInForward      bool
 	PipeBuffers                    []*closableBuffer
 	CumulativeSleep                time.Duration
 	Time                           time.Time
@@ -245,15 +244,6 @@ func (d *restoreCmd) Run() error {
 	if d.Dataplane.FailAllRestores {
 		log.Warn("Simulating an iptables-restore failure")
 		return errors.New("Simulated failure")
-	}
-	// Alter the dataplane before the restore is applied.
-	if d.Dataplane.InsertRandomRuleInForward {
-		log.Warn("Simulating an insert in FORWARD chain before iptables-restore happens")
-		if chain, found := d.Dataplane.Chains["FORWARD"]; found {
-			log.Warn("FORWARD chain exists; inserting random rule in FORWARD chain")
-			line := prependLine(chain, "-j randomly-inserted-rule")
-			d.Dataplane.Chains["FORWARD"] = line
-		}
 	}
 
 	// Process it line by line.

--- a/iptables/utils_for_test.go
+++ b/iptables/utils_for_test.go
@@ -336,7 +336,8 @@ func (d *restoreCmd) Run() error {
 					chain[i] = chain[i-1]
 				}
 				chain[0] = rest
-				d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: 1})
+				ruleNum := d.Dataplane.ChainMods.Len() + 1
+				d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: ruleNum})
 			}
 		case "-R", "--replace":
 			Expect(d.Dataplane.NftablesMode).To(BeFalse(), "Replace shouldn't be used in nft mode")

--- a/iptables/utils_for_test.go
+++ b/iptables/utils_for_test.go
@@ -326,8 +326,7 @@ func (d *restoreCmd) Run() error {
 					chain[i] = chain[i-1]
 				}
 				chain[0] = rest
-				ruleNum := d.Dataplane.ChainMods.Len() + 1
-				d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: ruleNum})
+				d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: 1})
 			}
 		case "-R", "--replace":
 			Expect(d.Dataplane.NftablesMode).To(BeFalse(), "Replace shouldn't be used in nft mode")


### PR DESCRIPTION
## Description

For iptables chains that we don't fully control, there is a possible race condition where deleting a rule by rule number may delete the wrong rule if the dataplane state that Felix observed has changed.

This PR addresses that by:
- Storing the full iptables line for non-Calico chains in the new table field `ruleHashToFullRule`
- Deleting non-Calico chains rules using the full rule. For example, the rule `-A FORWARD -m comment "cali1234" -j DROP` would result in `-D FORWARD -m comment "cali1234" -j DROP` (just flipping the `-A` to `-D`). Rules in Calico chains are deleted as before using the rule number.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [x] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix race condition where a non-Calico rule may be deleted.
```
