### PR TITLE
Cherry-pick iptables race fix for v3.8

### DIFF
--- a/iptables/rules.go
+++ b/iptables/rules.go
@@ -48,6 +48,12 @@ func (r Rule) RenderInsert(chainName, prefixFragment string, features *Features)
 	return r.renderInner(fragments, prefixFragment, features)
 }
 
+func (r Rule) RenderInsertAtRuleNumber(chainName string, ruleNum int, prefixFragment string, features *Features) string {
+	fragments := make([]string, 0, 7)
+	fragments = append(fragments, "-I", chainName, fmt.Sprintf("%d", ruleNum))
+	return r.renderInner(fragments, prefixFragment, features)
+}
+
 func (r Rule) RenderReplace(chainName string, ruleNum int, prefixFragment string, features *Features) string {
 	fragments := make([]string, 0, 7)
 	fragments = append(fragments, "-R", chainName, fmt.Sprintf("%d", ruleNum))


### PR DESCRIPTION
Fixes a race condition where a non-Calico iptables rule may be removed.

From https://github.com/projectcalico/felix/pull/2088

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix race condition where a non-Calico rule may be deleted.
```
