### PR TITLE
Cherry-pick iptables race fix for v3.7

### DIFF
--- a/iptables/rules.go
+++ b/iptables/rules.go
@@ -48,6 +48,12 @@ func (r Rule) RenderInsert(chainName, prefixFragment string, features *Features)
 	return r.renderInner(fragments, prefixFragment, features)
 }
 
+func (r Rule) RenderInsertAtRuleNumber(chainName string, ruleNum int, prefixFragment string, features *Features) string {
+	fragments := make([]string, 0, 7)
+	fragments = append(fragments, "-I", chainName, fmt.Sprintf("%d", ruleNum))
+	return r.renderInner(fragments, prefixFragment, features)
+}
+
 func (r Rule) RenderReplace(chainName string, ruleNum int, prefixFragment string, features *Features) string {
 	fragments := make([]string, 0, 7)
 	fragments = append(fragments, "-R", chainName, fmt.Sprintf("%d", ruleNum))

--- a/iptables/rules_test.go
+++ b/iptables/rules_test.go
@@ -90,14 +90,17 @@ var _ = Describe("Hash extraction tests", func() {
 	})
 
 	It("should extract an old felix rule by prefix", func() {
-		hashes, err := table.readHashesFrom(newClosableBuf("-A FORWARD -j felix-FORWARD\n"))
+		hashes, rules, err := table.readHashesAndRulesFrom(newClosableBuf("-A FORWARD -j felix-FORWARD\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
 			"FORWARD": []string{"OLD INSERT RULE"},
 		}))
+		Expect(rules).To(Equal(map[string][]string{
+			"FORWARD": []string{"-A FORWARD -j felix-FORWARD"},
+		}))
 	})
 	It("should extract an old felix rule by special case", func() {
-		hashes, err := table.readHashesFrom(newClosableBuf(
+		hashes, rules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A FORWARD -j an-old-rule\n" +
 				"-A FORWARD -j ignore-me\n",
 		))
@@ -108,17 +111,28 @@ var _ = Describe("Hash extraction tests", func() {
 				"",
 			},
 		}))
+		Expect(rules).To(Equal(map[string][]string{
+			"FORWARD": {
+				"-A FORWARD -j an-old-rule",
+				"-",
+			},
+		}))
 	})
-	It("should extract a hash", func() {
-		hashes, err := table.readHashesFrom(newClosableBuf(
+	It("should extract a rule with a hash", func() {
+		hashes, rules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
 			"FORWARD": []string{"wUHhoiAYhphO9Mso"},
 		}))
+		Expect(rules).To(Equal(map[string][]string{
+			"FORWARD": {
+				"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD",
+			},
+		}))
 	})
 	It("should extract a hash or a gap from each rule", func() {
-		hashes, err := table.readHashesFrom(newClosableBuf(
+		hashes, rules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD\n" +
 				"-A FORWARD -m comment --comment \"cali:abcdefghij1234-_\" -j cali-FORWARD\n" +
 				"-A FORWARD --src '1.2.3.4'\n" +
@@ -132,9 +146,18 @@ var _ = Describe("Hash extraction tests", func() {
 				"1234567890093213",
 			},
 		}))
+		Expect(rules).To(Equal(map[string][]string{
+			"FORWARD": {
+				"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD",
+				"-A FORWARD -m comment --comment \"cali:abcdefghij1234-_\" -j cali-FORWARD",
+				"-",
+				"-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD",
+			},
+		}))
 	})
+
 	It("should handle multiple chains", func() {
-		hashes, err := table.readHashesFrom(newClosableBuf(
+		hashes, rules, err := table.readHashesAndRulesFrom(newClosableBuf(
 			"-A cali-abcd -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD\n" +
 				"-A cali-abcd -m comment --comment \"cali:abcdefghij1234-_\" -j cali-FORWARD\n" +
 				"-A FORWARD --src '1.2.3.4'\n" +
@@ -148,6 +171,12 @@ var _ = Describe("Hash extraction tests", func() {
 			"FORWARD": []string{
 				"",
 				"1234567890093213",
+			},
+		}))
+		Expect(rules).To(Equal(map[string][]string{
+			"FORWARD": {
+				"-",
+				"-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD",
 			},
 		}))
 	})

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -205,6 +205,10 @@ type Table struct {
 	// to what we calculate from chainToContents.
 	chainToDataplaneHashes map[string][]string
 
+	// chainToFullRules contains the full rules for any chains that we may be hooking into, mapped from chain name
+	// to slices of rules in that chain.
+	chainToFullRules map[string][]string
+
 	// hashCommentPrefix holds the prefix that we prepend to our rule-tracking hashes.
 	hashCommentPrefix string
 	// hashCommentRegexp matches the rule-tracking comment, capturing the rule hash.
@@ -348,6 +352,7 @@ func NewTable(
 		chainNameToChain:       map[string]*Chain{},
 		dirtyChains:            set.New(),
 		chainToDataplaneHashes: map[string][]string{},
+		chainToFullRules:       map[string][]string{},
 		logCxt: log.WithFields(log.Fields{
 			"ipVersion": ipVersion,
 			"table":     name,
@@ -459,7 +464,7 @@ func (t *Table) loadDataplaneState() {
 	// Load the hashes from the dataplane.
 	t.logCxt.Info("Loading current iptables state and checking it is correct.")
 	t.lastReadTime = t.timeNow()
-	dataplaneHashes := t.getHashesFromDataplane()
+	dataplaneHashes, dataplaneRules := t.getHashesAndRulesFromDataplane()
 
 	// Check that the rules we think we've programmed are still there and mark any inconsistent
 	// chains for refresh.
@@ -552,6 +557,7 @@ func (t *Table) loadDataplaneState() {
 
 	t.logCxt.Debug("Finished loading iptables state")
 	t.chainToDataplaneHashes = dataplaneHashes
+	t.chainToFullRules = dataplaneRules
 	t.inSyncWithDataPlane = true
 }
 
@@ -578,18 +584,20 @@ func (t *Table) expectedHashesForInsertChain(
 	return
 }
 
-// getHashesFromDataplane loads the current state of our table and parses out the hashes that we
-// add to rules.  It returns a map with an entry for each chain in the table.  Each entry is a slice
-// containing the hashes for the rules in that table.  Rules with no hashes are represented by
-// an empty string.
-func (t *Table) getHashesFromDataplane() map[string][]string {
+// getHashesAndRulesFromDataplane loads the current state of our table. It parses out the hashes that we
+// add to rules and, for chains that we insert into, the full rules. The 'hashes' map contains an entry for each chain
+// in the table. Each entry is a slice containing the hashes for the rules in that table. Rules with no hashes are
+// represented by an empty string. The 'rules' map contains an entry for each non-Calico chain in the table that
+// contains inserts. It is used to generate deletes using the full rule, rather than deletes by line number, to avoid
+// race conditions on chains we don't fully control.
+func (t *Table) getHashesAndRulesFromDataplane() (hashes map[string][]string, rules map[string][]string) {
 	retries := 3
 	retryDelay := 100 * time.Millisecond
 
 	// Retry a few times before we panic.  This deals with any transient errors and it prevents
 	// us from spamming a panic into the log when we're being gracefully shut down by a SIGTERM.
 	for {
-		hashes, err := t.attemptToGetHashesFromDataplane()
+		hashes, rules, err := t.attemptToGetHashesAndRulesFromDataplane()
 		if err != nil {
 			countNumSaveErrors.Inc()
 			var stderr string
@@ -607,13 +615,13 @@ func (t *Table) getHashesFromDataplane() map[string][]string {
 			continue
 		}
 
-		return hashes
+		return hashes, rules
 	}
 }
 
-// attemptToGetHashesFromDataplane starts an iptables-save subprocess and feeds its output to
-// readHashesFrom() via a pipe.  It handles the various error cases.
-func (t *Table) attemptToGetHashesFromDataplane() (hashes map[string][]string, err error) {
+// attemptToGetHashesAndRulesFromDataplane starts an iptables-save subprocess and feeds its output to
+// readHashesAndRulesFrom() via a pipe.  It handles the various error cases.
+func (t *Table) attemptToGetHashesAndRulesFromDataplane() (hashes map[string][]string, rules map[string][]string, err error) {
 	cmd := t.newCmd(t.iptablesSaveCmd, "-t", t.Name)
 	countNumSaveCalls.Inc()
 
@@ -633,9 +641,9 @@ func (t *Table) attemptToGetHashesFromDataplane() (hashes map[string][]string, e
 		}
 		return
 	}
-	hashes, err = t.readHashesFrom(stdout)
+	hashes, rules, err = t.readHashesAndRulesFrom(stdout)
 	if err != nil {
-		// In case readHashesFrom() returned due to an error that didn't cause the
+		// In case readHashesAndRulesFrom() returned due to an error that didn't cause the
 		// process to exit, kill it now.
 		log.WithError(err).Warnf("Killing %s process after a failure", t.iptablesSaveCmd)
 		killErr := cmd.Kill()
@@ -655,15 +663,20 @@ func (t *Table) attemptToGetHashesFromDataplane() (hashes map[string][]string, e
 	return
 }
 
-// readHashesFrom scans the given reader containing iptables-save output for this table, extracting
-// our rule hashes.  Entries in the returned map are indexed by chain name.  For rules that we
-// wrote, the hash is extracted from a comment that we added to the rule.  For rules written by
-// previous versions of Felix, returns a dummy non-zero value.  For rules not written by Felix,
+// readHashesAndRulesFrom scans the given reader containing iptables-save output for this table, extracting
+// our rule hashes and, for all chains we insert into, the full rules.  Entries in the returned map are indexed by
+// chain name.  For rules that we wrote, the hash is extracted from a comment that we added to the rule.
+// For rules written by previous versions of Felix, returns a dummy non-zero value.  For rules not written by Felix,
 // returns a zero string.  Hence, the lengths of the returned values are the lengths of the chains
 // whether written by Felix or not.
-func (t *Table) readHashesFrom(r io.ReadCloser) (hashes map[string][]string, err error) {
+func (t *Table) readHashesAndRulesFrom(r io.ReadCloser) (hashes map[string][]string, rules map[string][]string, err error) {
 	hashes = map[string][]string{}
+	rules = map[string][]string{}
 	scanner := bufio.NewScanner(r)
+
+	// Keep track of whether the non-Calico chain has inserts. If the chain does not have inserts, we'll remove the
+	// full rules for that chain.
+	chainHasCalicoRule := set.New()
 
 	// Figure out if debug logging is enabled so we can skip some WithFields() calls in the
 	// tight loop below if the log wouldn't be emitted anyway.
@@ -714,21 +727,45 @@ func (t *Table) readHashesFrom(r io.ReadCloser) (hashes map[string][]string, err
 			if debug {
 				logCxt.WithField("hash", hash).Debug("Found hash in rule")
 			}
+			chainHasCalicoRule.Add(chainName)
 		} else if t.oldInsertRegexp.Find(line) != nil {
 			logCxt.WithFields(log.Fields{
 				"rule":      line,
 				"chainName": chainName,
 			}).Info("Found inserted rule from previous Felix version, marking for cleanup.")
 			hash = "OLD INSERT RULE"
+			chainHasCalicoRule.Add(chainName)
 		}
 		hashes[chainName] = append(hashes[chainName], hash)
+
+		// Not our chain so cache the full rule in case we need to generate deletes later on.
+		// After scanning the input, we prune any chains of full rules that do not contain inserts.
+		if !t.ourChainsRegexp.MatchString(chainName) {
+			// Only store the full rule for Calico rules. Otherwise, we just use the placeholder "-".
+			fullRule := "-"
+			if captures := t.hashCommentRegexp.FindSubmatch(line); captures != nil {
+				fullRule = string(line)
+			} else if t.oldInsertRegexp.Find(line) != nil {
+				fullRule = string(line)
+			}
+
+			rules[chainName] = append(rules[chainName], fullRule)
+		}
 	}
 	if scanner.Err() != nil {
 		log.WithError(scanner.Err()).Error("Failed to read hashes from dataplane")
-		return nil, scanner.Err()
+		return nil, nil, scanner.Err()
+	}
+
+	// Remove full rules for the non-Calico chain if it does not have inserts.
+	for chainName, _ := range rules {
+		if !chainHasCalicoRule.Contains(chainName) {
+			delete(rules, chainName)
+		}
 	}
 	t.logCxt.Debugf("Read hashes from dataplane: %#v", hashes)
-	return hashes, nil
+	t.logCxt.Debugf("Read rules from dataplane: %#v", rules)
+	return hashes, rules, nil
 }
 
 func (t *Table) InvalidateDataplaneCache(reason string) {
@@ -886,7 +923,7 @@ func (t *Table) applyUpdates() error {
 				} else if i < len(previousHashes) {
 					// previousHashes was longer, remove the old rules from the end.
 					ruleNum := len(currentHashes) + 1 // 1-indexed
-					line = deleteRule(chainName, ruleNum)
+					line = t.renderDeleteByIndexLine(chainName, ruleNum)
 				} else {
 					// currentHashes was longer.  Append.
 					prefixFrag := t.commentFrag(currentHashes[i])
@@ -900,11 +937,21 @@ func (t *Table) applyUpdates() error {
 		return nil // Delay clearing the set until we've programmed iptables.
 	})
 
-	// Now calculate iptables updates for our inserted rules, which are used to hook top-level
-	// chains.
+	// Make a copy of our full rules map and keep track of all changes made while processing dirtyInserts.
+	// When we've successfully updated iptables, we'll update our cache of chainToFullRules with this map.
+	newChainToFullRules := map[string][]string{}
+	for chain, rules := range t.chainToFullRules {
+		newChainToFullRules[chain] = make([]string, len(rules))
+		copy(newChainToFullRules[chain], rules)
+	}
+
+	// Now calculate iptables updates for our inserted rules, which are used to hook top-level chains.
+	var deleteRenderingErr error
+	var line string
 	t.dirtyInserts.Iter(func(item interface{}) error {
 		chainName := item.(string)
 		previousHashes := t.chainToDataplaneHashes[chainName]
+		newRules := newChainToFullRules[chainName]
 
 		// Calculate the hashes for our inserted rules.
 		newChainHashes, newRuleHashes := t.expectedHashesForInsertChain(
@@ -917,20 +964,29 @@ func (t *Table) applyUpdates() error {
 
 		// For simplicity, if we've discovered that we're out-of-sync, remove all our
 		// rules from this chain, then re-insert/re-append them below.
-		//
-		// Remove in reverse order so that we don't disturb the rule numbers of rules we're
-		// about to remove.
-		for i := len(previousHashes) - 1; i >= 0; i-- {
+		for i := 0; i < len(previousHashes); i++ {
 			if previousHashes[i] != "" {
-				ruleNum := i + 1
-				line := deleteRule(chainName, ruleNum)
+				line, deleteRenderingErr = t.renderDeleteByValueLine(chainName, i)
+				if deleteRenderingErr != nil {
+					return set.StopIteration
+				}
 				inputBuf.WriteString(line)
 				inputBuf.WriteString("\n")
 				t.countNumLinesExecuted.Inc()
 			}
 		}
 
+		// Go over our slice of "new" rules and create a copy of the slice with just the rules we didn't empty out.
+		copyOfNewRules := []string{}
+		for _, rule := range newRules {
+			if rule != "" {
+				copyOfNewRules = append(copyOfNewRules, rule)
+			}
+		}
+		newRules = copyOfNewRules
 		rules := t.chainToInsertedRules[chainName]
+		insertRuleLines := make([]string, len(rules))
+
 		if t.insertMode == "insert" {
 			t.logCxt.Debug("Rendering insert rules.")
 			// Since each insert is pushed onto the top of the chain, do the inserts in
@@ -942,7 +998,9 @@ func (t *Table) applyUpdates() error {
 				inputBuf.WriteString(line)
 				inputBuf.WriteString("\n")
 				t.countNumLinesExecuted.Inc()
+				insertRuleLines[i] = line
 			}
+			newRules = append(insertRuleLines, newRules...)
 		} else {
 			t.logCxt.Debug("Rendering append rules.")
 			for i := 0; i < len(rules); i++ {
@@ -951,13 +1009,20 @@ func (t *Table) applyUpdates() error {
 				inputBuf.WriteString(line)
 				inputBuf.WriteString("\n")
 				t.countNumLinesExecuted.Inc()
+				insertRuleLines[i] = line
 			}
+			newRules = append(newRules, insertRuleLines...)
 		}
 
 		newHashes[chainName] = newChainHashes
+		newChainToFullRules[chainName] = newRules
 
 		return nil // Delay clearing the set until we've programmed iptables.
 	})
+	// If rendering a delete by line number reached an unexpected state, error out so applyUpdates() can be retried.
+	if deleteRenderingErr != nil {
+		return deleteRenderingErr
+	}
 
 	// Do deletions at the end.  This ensures that we don't try to delete any chains that
 	// are still referenced (because we'll have removed the references in the modify pass
@@ -1050,6 +1115,7 @@ func (t *Table) applyUpdates() error {
 			t.chainToDataplaneHashes[chainName] = hashes
 		}
 	}
+	t.chainToFullRules = newChainToFullRules
 
 	return nil
 }
@@ -1058,8 +1124,24 @@ func (t *Table) commentFrag(hash string) string {
 	return fmt.Sprintf(`-m comment --comment "%s%s"`, t.hashCommentPrefix, hash)
 }
 
-func deleteRule(chainName string, ruleNum int) string {
+// renderDeleteByIndexLine produces a delete line by rule number. This function is used for cali chains.
+func (t *Table) renderDeleteByIndexLine(chainName string, ruleNum int) string {
 	return fmt.Sprintf("-D %s %d", chainName, ruleNum)
+}
+
+// renderDeleteByValueLine produces a delete line by the full rule at the given rule number. This function is
+// used for non-Calico chains.
+func (t *Table) renderDeleteByValueLine(chainName string, ruleNum int) (string, error) {
+	// For non-cali chains, get the rule by number but delete using the full rule instead of rule number.
+	rules, ok := t.chainToFullRules[chainName]
+	if !ok || ruleNum >= len(rules) {
+		return "", fmt.Errorf("Rendering delete for non-existent rule: Rule %d in %q", ruleNum, chainName)
+	}
+
+	rule := rules[ruleNum]
+
+	// Make the append a delete.
+	return strings.Replace(rule, "-A", "-D", 1), nil
 }
 
 func calculateRuleInsertHashes(chainName string, rules []Rule, features *Features) []string {

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -412,6 +412,198 @@ var _ = Describe("Table with an empty dataplane", func() {
 			})
 		})
 	})
+
+	Describe("applying updates when underlying iptables have changed in a whitelisted chain", func() {
+		BeforeEach(func() {
+			table.SetRuleInsertions("FORWARD", []Rule{
+				{Action: AcceptAction{}},
+				{Action: DropAction{}},
+			})
+			table.UpdateChains([]*Chain{
+				{Name: "cali-foobar", Rules: []Rule{
+					{Action: AcceptAction{}},
+					{Action: DropAction{}},
+				}},
+			})
+			table.Apply()
+		})
+		It("should be in the dataplane", func() {
+			Expect(dataplane.Chains).To(Equal(map[string][]string{
+				"FORWARD": {
+					"-m comment --comment \"cali:3gUkOfVeYRgMeHF4\" --jump ACCEPT",
+					"-m comment --comment \"cali:8MgbRleZ5Rc5cBEf\" --jump DROP",
+				},
+				"INPUT":  {},
+				"OUTPUT": {},
+				"cali-foobar": {
+					"-m comment --comment \"cali:42h7Q64_2XDzpwKe\" --jump ACCEPT",
+					"-m comment --comment \"cali:0sUFHicPNNqNyNx8\" --jump DROP",
+				},
+			}))
+		})
+		Describe("then truncating the chain, with the iptables changed before iptables-restore", func() {
+			BeforeEach(func() {
+				dataplane.OnPreRestore = func() {
+					log.Warn("Simulating an insert in FORWARD chain before iptables-restore happens")
+					if chain, found := dataplane.Chains["FORWARD"]; found {
+						log.Warn("FORWARD chain exists; inserting random rule in FORWARD chain")
+						lines := prependLine(chain, "-j randomly-inserted-rule")
+						dataplane.Chains["FORWARD"] = lines
+					}
+				}
+
+				table.SetRuleInsertions("FORWARD", []Rule{
+					{Action: DropAction{}, Comment: "new drop rule"},
+				})
+				table.Apply()
+			})
+			It("should be updated", func() {
+				Expect(dataplane.Chains).To(Equal(map[string][]string{
+					"FORWARD": {
+						"-m comment --comment \"cali:67cGS74-1PBXlOtK\" -m comment --comment \"new drop rule\" --jump DROP",
+						"-j randomly-inserted-rule",
+					},
+					"INPUT":  {},
+					"OUTPUT": {},
+					"cali-foobar": {
+						"-m comment --comment \"cali:42h7Q64_2XDzpwKe\" --jump ACCEPT",
+						"-m comment --comment \"cali:0sUFHicPNNqNyNx8\" --jump DROP",
+					},
+				}))
+			})
+		})
+	})
+
+	Describe("applying updates when underlying iptables have changed in a non-whitelisted chain", func() {
+		BeforeEach(func() {
+			table.UpdateChains([]*Chain{
+				{Name: "non-cali-chain", Rules: []Rule{
+					{Action: AcceptAction{}, Comment: "non-cali 1"},
+					{Action: DropAction{}, Comment: "non-cali 2"},
+				}},
+				{Name: "cali-foobar", Rules: []Rule{
+					{Action: AcceptAction{}, Comment: "cali 1"},
+					{Action: DropAction{}, Comment: "cali 2"},
+				}},
+			})
+			table.Apply()
+		})
+		It("should be in the dataplane", func() {
+			Expect(dataplane.Chains).To(Equal(map[string][]string{
+				"FORWARD": {},
+				"INPUT":   {},
+				"OUTPUT":  {},
+				"non-cali-chain": {
+					"-m comment --comment \"cali:Z-OWODLe_LbHxmqg\" -m comment --comment \"non-cali 1\" --jump ACCEPT",
+					"-m comment --comment \"cali:tq-yEo1_1XQHZnMs\" -m comment --comment \"non-cali 2\" --jump DROP",
+				},
+				"cali-foobar": {
+					"-m comment --comment \"cali:cxE-1zsuD12R9YEG\" -m comment --comment \"cali 1\" --jump ACCEPT",
+					"-m comment --comment \"cali:1cpbPOGLTROlH4Sj\" -m comment --comment \"cali 2\" --jump DROP",
+				},
+			}))
+		})
+		Describe("then truncating the chain, with the iptables changed before iptables-restore", func() {
+			BeforeEach(func() {
+				dataplane.OnPreRestore = func() {
+					log.Warn("Simulating an insert in non-cali-chain before iptables-restore happens")
+					if chain, found := dataplane.Chains["non-cali-chain"]; found {
+						log.Warn("non-cali-chain exists; inserting random rule in non-cali-chain")
+						lines := prependLine(chain, "-j randomly-inserted-rule")
+						dataplane.Chains["non-cali-chain"] = lines
+					}
+				}
+
+				table.SetRuleInsertions("non-cali-chain", []Rule{
+					{Action: DropAction{}, Comment: "new drop rule"},
+				})
+				table.Apply()
+			})
+			It("should be updated", func() {
+				Expect(dataplane.Chains).To(Equal(map[string][]string{
+					"FORWARD": {},
+					"INPUT":   {},
+					"OUTPUT":  {},
+					"non-cali-chain": {
+						"-m comment --comment \"cali:O9yEP97Dd2y-EskM\" -m comment --comment \"new drop rule\" --jump DROP",
+						"-j randomly-inserted-rule"},
+					"cali-foobar": {
+						"-m comment --comment \"cali:cxE-1zsuD12R9YEG\" -m comment --comment \"cali 1\" --jump ACCEPT",
+						"-m comment --comment \"cali:1cpbPOGLTROlH4Sj\" -m comment --comment \"cali 2\" --jump DROP",
+					},
+				}))
+			})
+		})
+	})
+
+	Describe("inserting into a non-Calico chain results in the expected writes", func() {
+		BeforeEach(func() {
+			table.SetRuleInsertions("FORWARD", []Rule{
+				{Action: DropAction{}, Comment: "a drop rule"},
+				{Action: AcceptAction{}, Comment: "an accept rule"},
+			})
+			table.Apply()
+		})
+		It("should update the dataplane", func() {
+			Expect(dataplane.Chains).To(Equal(map[string][]string{
+				"FORWARD": {
+					"-m comment --comment \"cali:upaItQyFMdN7MTTl\" -m comment --comment \"a drop rule\" --jump DROP",
+					"-m comment --comment \"cali:EpCg3AYNp_DftVFS\" -m comment --comment \"an accept rule\" --jump ACCEPT",
+				},
+				"INPUT":  {},
+				"OUTPUT": {},
+			}))
+			Expect(dataplane.CmdNames).To(ConsistOf("iptables", "iptables-save", "iptables-restore"))
+		})
+		Describe("then inserting the same rules", func() {
+			BeforeEach(func() {
+				table.SetRuleInsertions("FORWARD", []Rule{
+					{Action: DropAction{}, Comment: "a drop rule"},
+					{Action: AcceptAction{}, Comment: "an accept rule"},
+				})
+				dataplane.ResetCmds()
+				table.Apply()
+			})
+			It("should result in no inserts", func() {
+				// Do an iptables-save but not a iptables-restore.
+				Expect(dataplane.CmdNames).To(ConsistOf("iptables", "iptables-save"))
+
+				Expect(dataplane.Chains).To(Equal(map[string][]string{
+					"FORWARD": {
+						"-m comment --comment \"cali:upaItQyFMdN7MTTl\" -m comment --comment \"a drop rule\" --jump DROP",
+						"-m comment --comment \"cali:EpCg3AYNp_DftVFS\" -m comment --comment \"an accept rule\" --jump ACCEPT",
+					},
+					"INPUT":  {},
+					"OUTPUT": {},
+				}))
+			})
+		})
+		Describe("then inserting different rules", func() {
+			BeforeEach(func() {
+				table.SetRuleInsertions("FORWARD", []Rule{
+					{Action: DropAction{}, Comment: "a drop rule"},
+					{Action: AcceptAction{}, Comment: "an accept rule"},
+					{Action: DropAction{}, Comment: "a second drop rule"},
+				})
+				dataplane.ResetCmds()
+				table.Apply()
+			})
+			It("should result in modifications", func() {
+				// Do an iptables-save and, this time, an iptables-restore.
+				Expect(dataplane.CmdNames).To(ConsistOf("iptables", "iptables-save", "iptables-restore"))
+
+				Expect(dataplane.Chains).To(Equal(map[string][]string{
+					"FORWARD": {
+						"-m comment --comment \"cali:upaItQyFMdN7MTTl\" -m comment --comment \"a drop rule\" --jump DROP",
+						"-m comment --comment \"cali:EpCg3AYNp_DftVFS\" -m comment --comment \"an accept rule\" --jump ACCEPT",
+						"-m comment --comment \"cali:-rA8o5kyVSTHJMe8\" -m comment --comment \"a second drop rule\" --jump DROP",
+					},
+					"INPUT":  {},
+					"OUTPUT": {},
+				}))
+			})
+		})
+	})
 })
 
 var _ = Describe("Tests of post-update recheck behaviour with refresh timer", func() {

--- a/iptables/utils_for_test.go
+++ b/iptables/utils_for_test.go
@@ -285,11 +285,22 @@ func (d *restoreCmd) Run() error {
 			Expect(chains[chainName]).NotTo(BeNil(), "Insert to unknown chain: "+chainName)
 			chains[chainName] = append(chains[chainName], "") // Make room
 			chain := chains[chainName]
-			for i := len(chain) - 1; i > 0; i-- {
-				chain[i] = chain[i-1]
+
+			// If the first arg after the chain name is a line number, then insert by line number.
+			if lineNum, err := strconv.Atoi(parts[2]); err == nil {
+				ruleIdx := lineNum - 1 // 0-indexed
+				chain = append(chain, "")
+				copy(chain[ruleIdx+1:], chain[ruleIdx:])
+				chain[ruleIdx] = rest
+				d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: lineNum})
+			} else {
+				// Otherwise insert at the top.
+				for i := len(chain) - 1; i > 0; i-- {
+					chain[i] = chain[i-1]
+				}
+				chain[0] = rest
+				d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: 1})
 			}
-			chain[0] = rest
-			d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: 1})
 		case "-R", "--replace":
 			chainName = parts[1]
 			ruleNum, err := strconv.Atoi(parts[2]) // 1-indexed position of rule.
@@ -302,20 +313,47 @@ func (d *restoreCmd) Run() error {
 			d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: ruleNum})
 		case "-D", "--delete":
 			chainName = parts[1]
-			Expect(len(parts)).To(Equal(3), "--delete only expects two arguments")
-			ruleNum, err := strconv.Atoi(parts[2]) // 1-indexed position of rule.
-			Expect(err).NotTo(HaveOccurred())
-			ruleIdx := ruleNum - 1 // 0-indexed array index of rule.
-			chain := chains[chainName]
-			Expect(len(chain)).To(BeNumerically(">", ruleIdx), "Delete of non-existent rule")
-			for i := ruleIdx; i < len(chain)-1; i++ {
-				chain[i] = chain[i+1]
+
+			// If second arg is numeric, this is a delete by line number.
+			if ruleNum, err := strconv.Atoi(parts[2]); err == nil {
+				Expect(parts).To(HaveLen(3), "Unexpected argument after rule position in --delete")
+				Expect(chainName).To(HavePrefix("cali"), "Deleting rule from non-calico chain by number can cause races")
+
+				ruleIdx := ruleNum - 1 // 0-indexed array index of rule.
+				chain := chains[chainName]
+				Expect(len(chain)).To(BeNumerically(">", ruleIdx), "Delete of non-existent rule")
+
+				for i := ruleIdx; i < len(chain)-1; i++ {
+					chain[i] = chain[i+1]
+				}
+				chains[chainName] = chain[:len(chain)-1]
+				d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: ruleNum})
+			} else {
+				// Otherwise, treat this as a delete by full rule.
+
+				// Rule is inserted without chain name
+				rule := strings.Join(parts[2:], " ")
+				chain := chains[chainName]
+				i := 0
+
+				newChain := []string{}
+				var found bool
+				for ; i < len(chain); i++ {
+					if chain[i] == rule {
+						found = true
+						continue
+					}
+					newChain = append(newChain, chain[i])
+				}
+
+				Expect(found).To(BeTrue(), "Delete of non-existent rule")
+				chains[chainName] = newChain
+				d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: i})
+
 			}
-			chains[chainName] = chain[:len(chain)-1]
-			d.Dataplane.ChainMods.Add(chainMod{name: chainName, ruleNum: ruleNum})
 		case "-X", "--delete-chain":
 			chainName = parts[1]
-			Expect(len(parts)).To(Equal(2), "--delete-chain only has one argument")
+			Expect(parts).To(HaveLen(2), "--delete-chain only has one argument")
 			Expect(chains[chainName]).To(Equal([]string{}), "Only empty chains can be deleted")
 			delete(chains, chainName)
 			d.Dataplane.DeletedChains.Add(chainName)
@@ -327,6 +365,16 @@ func (d *restoreCmd) Run() error {
 	}
 	Expect(commitSeen).To(BeTrue())
 	return nil
+}
+
+func prependLine(src []string, line string) []string {
+	// Make space for the line - the value doesn't matter.
+	src = append(src, "")
+	// "Shift" the elements to the right
+	copy(src[1:], src[0:])
+
+	src[0] = line
+	return src
 }
 
 type saveCmd struct {


### PR DESCRIPTION
Fixes a race condition where a non-Calico iptables rule may be removed.

From https://github.com/projectcalico/felix/pull/2088

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix race condition where a non-Calico rule may be deleted.
```
