### PR TITLE
Use node resource updates with Typha

### DIFF
--- a/calc/calc_graph.go
+++ b/calc/calc_graph.go
@@ -310,7 +310,7 @@ func NewCalculationGraph(callbacks PipelineCallbacks, conf *config.Config) *Calc
 	//      <dataplane>
 	//
 	if conf.VXLANEnabled {
-		vxlanResolver := NewVXLANResolver(hostname, callbacks, conf.UseResourceUpdates())
+		vxlanResolver := NewVXLANResolver(hostname, callbacks, conf.UseNodeResourceUpdates())
 		vxlanResolver.RegisterWith(allUpdDispatcher)
 	}
 

--- a/calc/vxlan_resolver.go
+++ b/calc/vxlan_resolver.go
@@ -70,10 +70,10 @@ type VXLANResolver struct {
 	nodeNameToVXLANMac        map[string]string
 	blockToRoutes             map[string]set.Set
 	vxlanPools                map[string]model.IPPool
-	useResourceUpdates        bool
+	useNodeResourceUpdates    bool
 }
 
-func NewVXLANResolver(hostname string, callbacks PipelineCallbacks, useResourceUpdates bool) *VXLANResolver {
+func NewVXLANResolver(hostname string, callbacks PipelineCallbacks, useNodeResourceUpdates bool) *VXLANResolver {
 	return &VXLANResolver{
 		hostname:                  hostname,
 		callbacks:                 callbacks,
@@ -83,12 +83,12 @@ func NewVXLANResolver(hostname string, callbacks PipelineCallbacks, useResourceU
 		nodeNameToVXLANMac:        map[string]string{},
 		blockToRoutes:             map[string]set.Set{},
 		vxlanPools:                map[string]model.IPPool{},
-		useResourceUpdates:        useResourceUpdates,
+		useNodeResourceUpdates:    useNodeResourceUpdates,
 	}
 }
 
 func (c *VXLANResolver) RegisterWith(allUpdDispatcher *dispatcher.Dispatcher) {
-	if c.useResourceUpdates {
+	if c.useNodeResourceUpdates {
 		allUpdDispatcher.Register(model.ResourceKey{}, c.OnResourceUpdate)
 	} else {
 		allUpdDispatcher.Register(model.HostIPKey{}, c.OnHostIPUpdate)
@@ -555,7 +555,7 @@ func (c *VXLANResolver) routeTypeForRoute(r vxlanRoute) (proto.RouteType, error)
 		logCxt.WithField("pool", pool).Debug("pool has VXLAN CrossSubnet mode enabled")
 		// if we're not using resource updates we'll never get the CIDR block need to check if the route's node's subnet
 		// overlaps with this node's subnet
-		if !c.useResourceUpdates {
+		if !c.useNodeResourceUpdates {
 			logCxt.WithField("pool", pool).Warning(
 				"CrossSubnet mode detected on pool but resource updates aren't being used. Defaulting to RouteType_VXLAN")
 			return proto.RouteType_VXLAN, nil

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -238,7 +238,7 @@ type Config struct {
 
 	loadClientConfigFromEnvironment func() (*apiconfig.CalicoAPIConfig, error)
 
-	useResourceUpdates bool
+	useNodeResourceUpdates bool
 }
 
 type ProtoPort struct {
@@ -639,12 +639,12 @@ func loadParams() {
 	}
 }
 
-func (config *Config) SetUseResourceUpdates(b bool) {
-	config.useResourceUpdates = b
+func (config *Config) SetUseNodeResourceUpdates(b bool) {
+	config.useNodeResourceUpdates = b
 }
 
-func (config *Config) UseResourceUpdates() bool {
-	return config.useResourceUpdates
+func (config *Config) UseNodeResourceUpdates() bool {
+	return config.useNodeResourceUpdates
 }
 
 func (config *Config) RawValues() map[string]string {

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -58,7 +58,7 @@ var _ = Describe("FelixConfig vs ConfigParams parity", func() {
 		"loadClientConfigFromEnvironment",
 
 		"loadClientConfigFromEnvironment",
-		"useResourceUpdates",
+		"useNodeResourceUpdates",
 	}
 	cpFieldNameToFC := map[string]string{
 		"IpInIpEnabled":                      "IPIPEnabled",

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -410,14 +410,13 @@ configRetry:
 			}
 		}
 
-		supportsNodeResources, err := typhaConnection.SupportsNodeResourceUpdates(10 * time.Second)
+		supportsNodeResourceUpdates, err := typhaConnection.SupportsNodeResourceUpdates(10 * time.Second)
 		if err != nil {
 			log.WithError(err).Error("Did not get hello message from Typha in time, assuming it does not support node resource updates")
+			return
 		}
-		if supportsNodeResources {
-			log.Info("Using node resource updates with Typha that supports it")
-			configParams.SetUseNodeResourceUpdates(true)
-		}
+		log.Debugf("Typha supports node resource updates: %v", supportsNodeResourceUpdates)
+		configParams.SetUseNodeResourceUpdates(supportsNodeResourceUpdates)
 
 		go func() {
 			typhaConnection.Finished.Wait()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -378,7 +378,7 @@ configRetry:
 		syncer = felixsyncer.New(backendClient, datastoreConfig.Spec, syncerToValidator)
 
 		log.Info("using resource updates where applicable")
-		configParams.SetUseResourceUpdates(true)
+		configParams.SetUseNodeResourceUpdates(true)
 	}
 	log.WithField("syncer", syncer).Info("Created Syncer")
 
@@ -416,7 +416,7 @@ configRetry:
 		}
 		if supportsNodeResources {
 			log.Info("Using node resource updates with Typha that supports it")
-			configParams.SetUseResourceUpdates(true)
+			configParams.SetUseNodeResourceUpdates(true)
 		}
 
 		go func() {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -409,6 +409,16 @@ configRetry:
 				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
 			}
 		}
+
+		supportsNodeResources, err := typhaConnection.SupportsNodeResourceUpdates(10 * time.Second)
+		if err != nil {
+			log.WithError(err).Error("Did not get hello message from Typha in time, assuming it does not support node resource updates")
+		}
+		if supportsNodeResources {
+			log.Info("Using node resource updates with Typha that supports it")
+			configParams.SetUseResourceUpdates(true)
+		}
+
 		go func() {
 			typhaConnection.Finished.Wait()
 			failureReportChan <- "Connection to Typha failed"

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -382,6 +382,39 @@ configRetry:
 	}
 	log.WithField("syncer", syncer).Info("Created Syncer")
 
+	// Start the background processing threads.
+	if syncer != nil {
+		log.Infof("Starting the datastore Syncer")
+		syncer.Start()
+	} else {
+		log.Infof("Starting the Typha connection")
+		err := typhaConnection.Start(context.Background())
+		if err != nil {
+			log.WithError(err).Error("Failed to connect to Typha. Retrying...")
+			startTime := time.Now()
+			for err != nil && time.Since(startTime) < 30*time.Second {
+				// Set Ready to false and Live to true when unable to connect to typha
+				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: false})
+				err = typhaConnection.Start(context.Background())
+				if err == nil {
+					break
+				}
+				log.WithError(err).Debug("Retrying Typha connection")
+				time.Sleep(1 * time.Second)
+			}
+			if err != nil {
+				log.WithError(err).Fatal("Failed to connect to Typha")
+			} else {
+				log.Info("Connected to Typha after retries.")
+				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
+			}
+		}
+		go func() {
+			typhaConnection.Finished.Wait()
+			failureReportChan <- "Connection to Typha failed"
+		}()
+	}
+
 	// Create the ipsets/active policy calculation graph, which will
 	// do the dynamic calculation of ipset memberships and active policies
 	// etc.
@@ -446,38 +479,6 @@ configRetry:
 	// calculation graph.
 	validator := calc.NewValidationFilter(asyncCalcGraph)
 
-	// Start the background processing threads.
-	if syncer != nil {
-		log.Infof("Starting the datastore Syncer")
-		syncer.Start()
-	} else {
-		log.Infof("Starting the Typha connection")
-		err := typhaConnection.Start(context.Background())
-		if err != nil {
-			log.WithError(err).Error("Failed to connect to Typha. Retrying...")
-			startTime := time.Now()
-			for err != nil && time.Since(startTime) < 30*time.Second {
-				// Set Ready to false and Live to true when unable to connect to typha
-				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: false})
-				err = typhaConnection.Start(context.Background())
-				if err == nil {
-					break
-				}
-				log.WithError(err).Debug("Retrying Typha connection")
-				time.Sleep(1 * time.Second)
-			}
-			if err != nil {
-				log.WithError(err).Fatal("Failed to connect to Typha")
-			} else {
-				log.Info("Connected to Typha after retries.")
-				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
-			}
-		}
-		go func() {
-			typhaConnection.Finished.Wait()
-			failureReportChan <- "Connection to Typha failed"
-		}()
-	}
 	go syncerToValidator.SendTo(validator)
 	asyncCalcGraph.Start()
 	log.Infof("Started the processing graph")

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/projectcalico/libcalico-go v0.0.0-20190822155120-15c0fc659f30
 	github.com/projectcalico/pod2daemon v0.0.0-20190730210055-df57fc59e2e1
-	github.com/projectcalico/typha v0.0.0-20190828180207-18a7fc217651
+	github.com/projectcalico/typha v0.0.0-20190829203445-96045911fce7
 	github.com/prometheus/client_golang v0.9.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,8 @@ github.com/projectcalico/pod2daemon v0.0.0-20190730210055-df57fc59e2e1 h1:JPzqAb
 github.com/projectcalico/pod2daemon v0.0.0-20190730210055-df57fc59e2e1/go.mod h1:TgmA+ArLHObRADfET11mFF1aTK5i++4ZhqIuE4IV+IU=
 github.com/projectcalico/typha v0.0.0-20190828180207-18a7fc217651 h1:MfMSrVE12qt4y/KpPXawK5tzAmoDD+/veAS47OiGEZo=
 github.com/projectcalico/typha v0.0.0-20190828180207-18a7fc217651/go.mod h1:h2o4zlbDGHLPtmZ9gnl5WB0BLYH8BmE4GAlGXw2WPDI=
+github.com/projectcalico/typha v0.0.0-20190829203445-96045911fce7 h1:0gOM0U2xBiBJMraQRSPqUPgNxj+CCxiw7mLkxy2Q2Dc=
+github.com/projectcalico/typha v0.0.0-20190829203445-96045911fce7/go.mod h1:h2o4zlbDGHLPtmZ9gnl5WB0BLYH8BmE4GAlGXw2WPDI=
 github.com/projectcalico/typha v3.8.2+incompatible h1:gzjm+SMnol9qLb3Ny46mTODry3o7zq56PNI9pqeHil4=
 github.com/projectcalico/typha v3.8.2+incompatible/go.mod h1:pu3HHmupPjQFDgYi+nF6sG8sRsCKU50Lku1pGBEFQAM=
 github.com/prometheus/client_golang v0.0.0-20171005112915-5cec1d0429b0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=


### PR DESCRIPTION
## Description

Related to: https://github.com/projectcalico/typha/pull/298

This updates the Typha handling to check whether the Typha supports node resource updates. If it does, then we update configParams so the VXLAN resolver knows to properly handle cross-subnet routes.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
