### PR TITLE
Reduce severity of BPF log levels

### DIFF
--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -1104,7 +1104,7 @@ func (d *InternalDataplane) apply() {
 			d.xdpState.UpdateState()
 		}
 		if applyXDPError != nil {
-			log.WithError(applyXDPError).Error("failed to apply XDP actions, disabling XDP")
+			log.WithError(applyXDPError).Info("Applying XDP actions did not succeed, disabling XDP")
 			d.shutdownXDPCompletely()
 		}
 	}
@@ -1227,7 +1227,7 @@ func (d *InternalDataplane) applyXDPActions() error {
 		if err = d.xdpState.ApplyBPFActions(d.ipsetsSourceV4); err == nil {
 			return nil
 		} else {
-			log.WithError(err).Warning("Failed to apply XDP BPF actions, will retry with resync...")
+			log.WithError(err).Info("Applying XDP BPF actions did not succeed, will retry with resync...")
 		}
 	}
 	return err

--- a/dataplane/linux/xdp_state.go
+++ b/dataplane/linux/xdp_state.go
@@ -189,7 +189,7 @@ func (x *xdpState) ApplyBPFActions(isSource ipsetsSource) error {
 		err := x.ipV4State.bpfActions.apply(memberCacheV4, x.ipV4State.ipsetIDsToMembers, newConvertingIPSetsSource(isSource), x.common.xdpModes)
 		x.ipV4State.bpfActions = newXDPBPFActions()
 		if err != nil {
-			log.WithError(err).Warning("Applying BPF actions failed. Queueing XDP resync.")
+			log.WithError(err).Info("Applying BPF actions did not succeed. Queueing XDP resync.")
 			x.QueueResync()
 			return err
 		}
@@ -202,7 +202,7 @@ func (x *xdpState) ProcessMemberUpdates() error {
 		memberCacheV4 := newXDPMemberCache(x.ipV4State.getBpfIPFamily(), x.common.bpfLib)
 		err := x.ipV4State.processMemberUpdates(memberCacheV4)
 		if err != nil {
-			log.WithError(err).Warning("Processing member updates failed. Queueing XDP resync.")
+			log.WithError(err).Info("Processing member updates did not succeed. Queueing XDP resync.")
 			x.QueueResync()
 			return err
 		}


### PR DESCRIPTION
## Description
Since we fallback to iptables if BPF is not able to be applied so reduce the log level when errors happen when applying.

## Todos

## Release Note

```release-note
None required
```
