### PR TITLE
Fix memory leak in endpoint_mgr

### DIFF
--- a/intdataplane/endpoint_mgr.go
+++ b/intdataplane/endpoint_mgr.go
@@ -464,6 +464,7 @@ func (m *endpointManager) resolveWorkloadEndpoints() {
 		} else {
 			logCxt.Info("Workload removed, deleting its chains.")
 			m.filterTable.RemoveChains(m.activeWlIDToChains[id])
+			delete(m.activeWlIDToChains, id)
 			if oldWorkload != nil {
 				// Remove any routes from the routing table.  The RouteTable will
 				// remove any conntrack entries as a side-effect.


### PR DESCRIPTION
Backport of https://github.com/projectcalico/felix/pull/2026/files

## Description
Bug fix for memory leak in endpoint_mgr.go

We detected a leak in our calico-node 2.6.12 containers, and we cannot upgrade to the 3.x versions since we require libnetwork support, hence the backport.

This change in Felix reduced the leak by 88% in our testing by continuously spawning and removing containers on the network. I have not found the remaining 12% leak, and it is small enough to possibly be within the margin of error.

Manual testing (in addition to passing unit tests):
```
while true; do
    sudo docker run --rm -d --net exabeam-calico exabeam-mongo sleep 1
    sleep 0.1
done
```

(replace the container ID with the calico-node container)
```
while true; do
    grep "^rss " /sys/fs/cgroup/memory/docker/26728cc58950cecea5d7455c9171df64ec06d0d1eb10e0923ba27e70180568b5/memory.stat >> ~/calico-node_rss
    sleep 1
done
```

We compared the version with the fix and without it, and we saw an 88% reduction in the memory growth. I have not found the remaining 12%, and it is small enough that it may be within the margin of error.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [x] Backport
- [X] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed slow memory leak that was noticed with lots of workload churn.
```
