### PR TITLE
Allow ipV6LinkLocalCIDR route to be programmed other than by us

### DIFF
--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -543,7 +543,7 @@ func (r *RouteTable) syncRoutesForLink(ifaceName string) error {
 		if !r.deviceRouteSourceAddress.Equal(route.Src) {
 			routeProblems = append(routeProblems, "incorrect source address")
 		}
-		if r.deviceRouteProtocol != route.Protocol {
+		if dest != ipV6LinkLocalCIDR && r.deviceRouteProtocol != route.Protocol {
 			routeProblems = append(routeProblems, "incorrect protocol")
 		}
 		if len(routeProblems) == 0 {


### PR DESCRIPTION
This was a regression accidentally introduced by #2118 . The IPv6 link local route is critical to IPv6 operation, so we mustn't remove it.