### PR TITLE
Allow ipV6LinkLocalCIDR route to be programmed other than by us

### DIFF
--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -543,7 +543,7 @@ func (r *RouteTable) syncRoutesForLink(ifaceName string) error {
 		if !r.deviceRouteSourceAddress.Equal(route.Src) {
 			routeProblems = append(routeProblems, "incorrect source address")
 		}
-		if r.deviceRouteProtocol != route.Protocol {
+		if dest != ipV6LinkLocalCIDR && r.deviceRouteProtocol != route.Protocol {
 			routeProblems = append(routeProblems, "incorrect protocol")
 		}
 		if len(routeProblems) == 0 {

--- a/routetable/route_table_test.go
+++ b/routetable/route_table_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,6 +52,68 @@ var (
 	ip3  = ip.MustParseCIDROrIP("10.0.0.3/32").ToIPNet()
 	ip13 = ip.MustParseCIDROrIP("10.0.1.3/32").ToIPNet()
 )
+
+var _ = Describe("RouteTable v6", func() {
+	var dataplane *mockDataplane
+	var t *mockTime
+	var rt *RouteTable
+
+	BeforeEach(func() {
+		dataplane = &mockDataplane{
+			nameToLink:       map[string]netlink.Link{},
+			routeKeyToRoute:  map[string]netlink.Route{},
+			addedRouteKeys:   set.New(),
+			deletedRouteKeys: set.New(),
+			updatedRouteKeys: set.New(),
+		}
+		startTime, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+		Expect(err).NotTo(HaveOccurred())
+		t = &mockTime{
+			currentTime: startTime,
+		}
+		// Setting an auto-increment greater than the route cleanup delay effectively
+		// disables the grace period for these tests.
+		t.setAutoIncrement(11 * time.Second)
+		rt = NewWithShims(
+			[]string{"cali"},
+			6,
+			dataplane.NewNetlinkHandle,
+			false,
+			10*time.Second,
+			dataplane.AddStaticArpEntry,
+			dataplane,
+			t,
+			nil,
+			FelixRouteProtocol,
+			true,
+		)
+	})
+
+	It("should be constructable", func() {
+		Expect(rt).ToNot(BeNil())
+	})
+
+	It("should not remove the IPv6 link local route", func() {
+		// Route that should be left alone
+		noopLink := dataplane.addIface(4, "cali4", true, true)
+		noopRoute := netlink.Route{
+			LinkIndex: noopLink.attrs.Index,
+			Dst:       mustParseCIDR("fe80::/64"),
+			Type:      syscall.RTN_UNICAST,
+			Protocol:  syscall.RTPROT_KERNEL,
+			Scope:     netlink.SCOPE_LINK,
+		}
+		rt.SetRoutes(noopLink.attrs.Name, []Target{
+			{CIDR: ip.MustParseCIDROrIP("10.0.0.4/32"), DestMAC: mac1},
+		})
+		dataplane.addMockRoute(&noopRoute)
+
+		err := rt.Apply()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dataplane.deletedRouteKeys).ToNot(HaveKey(keyForRoute(&noopRoute)))
+		Expect(dataplane.updatedRouteKeys).ToNot(HaveKey(keyForRoute(&noopRoute)))
+	})
+})
 
 var _ = Describe("RouteTable", func() {
 	var dataplane *mockDataplane


### PR DESCRIPTION
This was a regression accidentally introduced by #2118 . The IPv6 link local route is critical to IPv6 operation, so we mustn't remove it.