### PR TITLE
Fix that Typha was failing to start in k8sfv tests.

### DIFF
--- a/k8sfv/calc_graph_test.go
+++ b/k8sfv/calc_graph_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017,2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ var _ = Describe("calculation graph scale test", func() {
 		log.Info(">>> BeforeEach <<<")
 		clientset = initialize(k8sServerEndpoint)
 		nsPrefix = getNamespacePrefix()
+		expectFelixReady()
 	})
 
 	It("should run label rotation test", func() {

--- a/k8sfv/k8sfv.go
+++ b/k8sfv/k8sfv.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2019 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -211,6 +211,7 @@ func cleanupAll(clientset *kubernetes.Clientset, nsPrefix string) {
 
 func panicIfError(err error) {
 	if err != nil {
+		log.WithError(err).Error("About to panic...")
 		panic(err)
 	}
 }

--- a/k8sfv/k8sfv_suite_test.go
+++ b/k8sfv/k8sfv_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017,2019 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ func init() {
 
 func TestMain(t *testing.T) {
 	RegisterFailHandler(Fail)
-	junitReporter := reporters.NewJUnitReporter("../report/k8sfv_suite.xml")
+	// The run-test script runs this file from k8sfv/output.
+	junitReporter := reporters.NewJUnitReporter("../../report/k8sfv_suite.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "Felix/KDD FV tests", []Reporter{junitReporter})
 }

--- a/k8sfv/leastsquares_test.go
+++ b/k8sfv/leastsquares_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2019 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import (
 )
 
 var _ = Context("least squares", func() {
-
 	It("should fit a straight line", func() {
 		p := []leastsquares.Point{
 			{X: 1, Y: 1},

--- a/k8sfv/metric.go
+++ b/k8sfv/metric.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2019 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,14 @@ func getFelixFloatMetric(name string) float64 {
 	metricS, err := getFelixMetric(name)
 	panicIfError(err)
 	metric, err := strconv.ParseFloat(metricS, 64)
+	panicIfError(err)
+	return metric
+}
+
+func getFelixIntMetric(name string) int64 {
+	metricS, err := getFelixMetric(name)
+	panicIfError(err)
+	metric, err := strconv.ParseInt(metricS, 10, 64)
 	panicIfError(err)
 	return metric
 }

--- a/k8sfv/metric.go
+++ b/k8sfv/metric.go
@@ -46,7 +46,7 @@ func getFelixMetric(name string) (metric string, err error) {
 	return
 }
 
-func getFelixFloatMetric(name string) float64 {
+func getFelixFloatMetricOrPanic(name string) float64 {
 	metricS, err := getFelixMetric(name)
 	panicIfError(err)
 	metric, err := strconv.ParseFloat(metricS, 64)
@@ -54,12 +54,16 @@ func getFelixFloatMetric(name string) float64 {
 	return metric
 }
 
-func getFelixIntMetric(name string) int64 {
+func getFelixIntMetric(name string) (int64, error) {
 	metricS, err := getFelixMetric(name)
-	panicIfError(err)
+	if err != nil {
+		return -1, err
+	}
 	metric, err := strconv.ParseInt(metricS, 10, 64)
-	panicIfError(err)
-	return metric
+	if err != nil {
+		return -1, err
+	}
+	return metric, nil
 }
 
 func getNumEndpoints() (int64, error) {

--- a/k8sfv/namespace.go
+++ b/k8sfv/namespace.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2019 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -86,9 +86,7 @@ func cleanupAllNamespaces(clientset *kubernetes.Clientset, nsPrefix string) {
 	for _, ns := range nsList.Items {
 		if strings.HasPrefix(ns.ObjectMeta.Name, nsPrefix) {
 			err = clientset.CoreV1().Namespaces().Delete(ns.ObjectMeta.Name, deleteImmediately)
-			if err != nil {
-				panic(err)
-			}
+			panicIfError(err)
 		} else {
 			log.WithField("name", ns.ObjectMeta.Name).Debug("Namespace skipped")
 		}
@@ -119,7 +117,7 @@ func createNetworkPolicy(clientset *kubernetes.Clientset, namespace string) {
 			},
 		},
 	}
-	_, err := clientset.NetworkingV1().NetworkPolicies("").Create(&np)
+	_, err := clientset.NetworkingV1().NetworkPolicies(namespace).Create(&np)
 	if err != nil {
 		log.WithField("name", namespace).WithError(err).Error("failed to create namespace for network policy")
 	}

--- a/k8sfv/pod.go
+++ b/k8sfv/pod.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -197,25 +197,20 @@ func removeLocalPodNetworking(pod *v1.Pod) {
 	if ln != nil {
 		log.WithField("key", key).Info("Cleanup local networking")
 
-		// Delete pod-side interface.
-		err := ln.namespace.Do(func(_ ns.NetNS) error {
-			return netlink.LinkDel(ln.podIf)
-		})
+		// Delete host-side interface.  This deletes the pod-side as a side-effect.
+		err := netlink.LinkDel(ln.hostIf)
 		panicIfError(err)
-
-		// Delete host-side interface.  Actually it seems this has already happened as part
-		// of the pod-side interface being deleted just above; so we don't need a separate
-		// operation here.
-		//err = netlink.LinkDel(ln.hostIf)
-		//panicIfError(err)
+		log.WithField("key", key).Info("Cleaned up pod iface")
 
 		// Delete namespace.
 		err = ln.namespace.Close()
 		panicIfError(err)
+		log.WithField("key", key).Info("Closed namespace")
 
 		// Delete local networking details.
 		delete(localNetworkingMap, key)
 	}
+	log.WithField("key", key).Info("Removed pod networking")
 }
 
 var GetNextPodAddr = ipAddrAllocator("10.28.%d.%d")
@@ -223,9 +218,8 @@ var GetNextPodAddr = ipAddrAllocator("10.28.%d.%d")
 func cleanupAllPods(clientset *kubernetes.Clientset, nsPrefix string) {
 	log.WithField("nsPrefix", nsPrefix).Info("Cleaning up all pods...")
 	nsList, err := clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
-	if err != nil {
-		panic(err)
-	}
+	panicIfError(err)
+
 	log.WithField("count", len(nsList.Items)).Info("Namespaces present")
 	podsDeleted := 0
 	admission := make(chan int, 10)
@@ -233,21 +227,24 @@ func cleanupAllPods(clientset *kubernetes.Clientset, nsPrefix string) {
 	waiter.Add(len(nsList.Items))
 	for _, ns := range nsList.Items {
 		nsName := ns.ObjectMeta.Name
+		log.Infof("Queueing examination of namespace: %v", nsName)
 		go func() {
 			admission <- 1
 			if strings.HasPrefix(nsName, nsPrefix) {
+				log.Infof("Namespace matches prefix, getting pods: %v", nsName)
+
 				podList, err := clientset.CoreV1().Pods(nsName).List(metav1.ListOptions{})
-				if err != nil {
-					panic(err)
-				}
+				panicIfError(err)
+
 				log.WithField("count", len(podList.Items)).WithField("namespace", nsName).Debug(
 					"Pods present")
 				for _, pod := range podList.Items {
+					log.Infof("Deleting pod: %v", pod.ObjectMeta.Name)
 					err = clientset.CoreV1().Pods(nsName).Delete(pod.ObjectMeta.Name, deleteImmediately)
-					if err != nil {
-						panic(err)
-					}
+					panicIfError(err)
+					log.Infof("Deleted pod, cleaning up its netns: %v", pod.ObjectMeta.Name)
 					removeLocalPodNetworking(&pod)
+					log.Infof("Cleaned up pod netns: %v", pod.ObjectMeta.Name)
 				}
 				podsDeleted += len(podList.Items)
 			}
@@ -257,11 +254,12 @@ func cleanupAllPods(clientset *kubernetes.Clientset, nsPrefix string) {
 	}
 	waiter.Wait()
 
+	log.WithField("podsDeleted", podsDeleted).Info("Cleaned up all pods, checking metrics...")
 	Eventually(getNumEndpointsDefault(-1), "30s", "1s").Should(
 		BeNumerically("==", 0),
 		"Removal of pods wasn't reflected in Felix metrics",
 	)
-	log.WithField("podsDeleted", podsDeleted).Info("Cleaned up all pods")
+	log.WithField("podsDeleted", podsDeleted).Info("Pod cleanup done.")
 }
 
 var zeroGracePeriod int64 = 0

--- a/k8sfv/run-test
+++ b/k8sfv/run-test
@@ -68,8 +68,8 @@ fi
 : ${USE_TYPHA:=true}
 #
 if  ${USE_TYPHA} && test -z "${FV_TYPHAIMAGE}" ; then
-	echo FV_TYPHAIMAGE must be set to indicate the hyperkube image to use.
-	exit -1
+	echo FV_TYPHAIMAGE must be set to indicate the Typha image to use.
+	exit 1
 fi
 #
 # Typha logging level.
@@ -86,6 +86,7 @@ prefix=k8sfv${UNIQUE}
 # we create.
 function cleanup {
     # Clean up the containers that this script generates.
+    echo "run-test cleanup running..."
     docker rm -f ${prefix}-felix || true
     docker rm -f ${prefix}-typha || true
     docker rm -f ${prefix}-controller-manager || true
@@ -93,6 +94,7 @@ function cleanup {
     docker rm -f ${prefix}-etcd || true
     # List all remaining containers.
     docker ps -a
+    echo "run-test cleanup done."
 }
 if ${CLEANUP}; then
     trap cleanup EXIT SIGINT SIGQUIT
@@ -200,8 +202,8 @@ if ${USE_TYPHA}; then
        -e K8S_CA_FILE=/testcode/k8sfv/output/apiserver.crt \
        -v ${PWD}:/testcode \
        -w /testcode/k8sfv/output \
-       $FV_TYPHAIMAGE \
-       /bin/sh -c "for n in 1 2; do calico-typha; done"
+       --restart=on-failure:2 \
+       $FV_TYPHAIMAGE
     typha_ip=$(get_container_ip ${prefix}-typha)
     typha_hostname=$(get_container_hostname ${prefix}-typha)
     typha_felix_args="-e FELIX_TYPHAADDR=${typha_ip}:5473"
@@ -250,6 +252,7 @@ elif ${JUST_A_MINUTE}; then
     cmdStatus=${PIPESTATUS[0]}
     if [ $cmdStatus -ne 0 ]; then
         echo "docker or k7sfv.test command failed with RC $cmdStatus"
+        echo "Status 137 can be caused by the felix container (in which we run the test binary) dying."
         rm -f $tmp
         exit 1
     fi


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

AFAICT, Typha has been failing to start in the k8sfv framework since the change to use scratch.  

* The tests that we run on a regular basis were only examining Felix's memory usage so they didn't spot that Felix wasn't actually in-sync with the datastore.  
* Felix now waits for some time before exiting if Typha isn't contactable (to prevent log spam and thundering herd), making the failures less frequent.
* Some of the time, the tests would pass because the whole test ran before Felix decided to exit.

This change:

- Fixes the underlying problem (removes the `sh` wrapper around the calico-typha command).
- Adds a bunch of diags.
- Adds a check that Felix is in-sync before each test (by checking its prometheus metric for datastore state).

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
