### PR TITLE
Disable node CIDR allocation and defer cleanup

### DIFF
--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -134,10 +134,15 @@ func runK8sControllerManager(apiserverIp string) *containers.Container {
 		utils.Config.K8sImage,
 		"/hyperkube", "controller-manager",
 		fmt.Sprintf("--master=%v:8080", apiserverIp),
+		// We run trivially small clusters, so increase the QPS to get the
+		// cluster to start up as fast as possible.
+		"--kube-api-qps=100",
+		"--kube-api-burst=200",
 		"--min-resync-period=3m",
-		"--allocate-node-cidrs=true",
-		"--cluster-cidr=192.168.0.0/16",
-		"--v=5",
+		// Disable node CIDRs since the controller manager stalls for 10s if
+		// they are enabled.
+		"--allocate-node-cidrs=false",
+		"--v=3",
 		"--service-account-private-key-file=/private.key",
 	)
 	return c


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
* Enabling CIDR allocation makes the controller manager stall for 10s.
* Deferring cleanup saves 2-3s when running a single test for debugging.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
