### PR TITLE
Makefile.common.BRANCH should not depend on wget binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ WGET?=/usr/bin/wget
 
 Makefile.common: Makefile.common.$(MAKE_BRANCH)
 	cp "$<" "$@"
-Makefile.common.$(MAKE_BRANCH): $(WGET)
+Makefile.common.$(MAKE_BRANCH):
 	# Clean up any files downloaded from other branches so they don't accumulate.
 	rm -f Makefile.common.*
 	$(WGET) -nv $(MAKE_REPO)/Makefile.common -O "$@"


### PR DESCRIPTION
In general, a newer wget does not mean that we should re-download
Makefile.common.BRANCH.

Specifically, in an environment without /usr/bin/wget, such as the
launchpad build environment, the absence of /usr/bin/wget should not
cause any build to fail, as is currently the case:

    make[1]: *** No rule to make target '/usr/bin/wget', needed by
    'Makefile.common.v0.27'.  Stop.

(For example:
https://launchpad.net/~project-calico/+archive/ubuntu/master/+build/18156203)
