### PR TITLE
Use go-build v0.30, to revert to go 1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 #
 ###############################################################################
 PACKAGE_NAME?=github.com/projectcalico/felix
-GO_BUILD_VER?=v0.28
+GO_BUILD_VER?=v0.30
 
 ###############################################################################
 # Download and include Makefile.common


### PR DESCRIPTION
Because of https://github.com/golang/go/issues/34773
