### PR TITLE
Increase timeout on SCTP FV tests

### DIFF
--- a/fv/named_ports_test.go
+++ b/fv/named_ports_test.go
@@ -248,7 +248,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 			cc.ExpectSome(w[1], w[0].Port(4000))
 			cc.ExpectSome(w[2], w[0].Port(4000))
 
-			cc.CheckConnectivityWithTimeout(timeout)
+			cc.CheckConnectivityWithDiagsTimeout(felix.Name, timeout)
 		})
 	})
 
@@ -390,7 +390,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 			cc.ExpectSome(w[0], w[1].Port(w1Port))
 			cc.ExpectSome(w[0], w[2].Port(w2Port))
 
-			cc.CheckConnectivityWithTimeout(timeout, dumpResource(pol))
+			cc.CheckConnectivityWithDiagsTimeout(felix.Name, timeout, dumpResource(pol))
 		},
 
 		// Non-negated named port match.  The rule will allow traffic to the named port.
@@ -489,7 +489,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 			cc.ExpectSome(w[3], w[0].Port(4000))       // Numeric port in list.
 			cc.ExpectNone(w[2], w[0].Port(3000))       // Numeric port not in list.
 
-			cc.CheckConnectivityWithTimeout(timeout, dumpResource(policy))
+			cc.CheckConnectivityWithDiagsTimeout(felix.Name, timeout, dumpResource(policy))
 		}
 		It("should have expected connectivity", expectBaselineConnectivity)
 
@@ -514,7 +514,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 				cc.ExpectSome(w[3], w[0].Port(4000))       // No change.
 				cc.ExpectNone(w[2], w[0].Port(3000))       // No change.
 
-				cc.CheckConnectivityWithTimeout(timeout, dumpResource(policy))
+				cc.CheckConnectivityWithDiagsTimeout(felix.Name, timeout, dumpResource(policy))
 			})
 		})
 
@@ -542,7 +542,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 				cc.ExpectSome(w[3], w[0].Port(4000))       // No change.
 				cc.ExpectNone(w[2], w[0].Port(3000))       // No change.
 
-				cc.CheckConnectivityWithTimeout(timeout, dumpResource(policy))
+				cc.CheckConnectivityWithDiagsTimeout(felix.Name, timeout, dumpResource(policy))
 			})
 		})
 
@@ -559,7 +559,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 			cc.ExpectNone(w[2], w[0].Port(4000))
 			cc.ExpectNone(w[2], w[0].Port(3000))
 
-			cc.CheckConnectivityWithTimeout(timeout, dumpResource(policy))
+			cc.CheckConnectivityWithDiagsTimeout(felix.Name, timeout, dumpResource(policy))
 		}
 
 		Describe("with "+oppositeDir+" selectors, removing w[2] and w[3]", func() {
@@ -682,7 +682,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 					cc.ExpectSome(w[3], w[0].Port(4000))       // No change.
 					cc.ExpectNone(w[2], w[0].Port(3000))       // No change.
 
-					cc.CheckConnectivityWithTimeout(timeout, dumpResource(policy))
+					cc.CheckConnectivityWithDiagsTimeout(felix.Name, timeout, dumpResource(policy))
 				})
 			})
 		})
@@ -713,7 +713,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 				cc.ExpectNone(w[3], w[0].Port(4000))       // Numeric port in NotPorts list.
 				cc.ExpectNone(w[2], w[0].Port(3000))       // No change
 
-				cc.CheckConnectivityWithTimeout(timeout, dumpResource(policy))
+				cc.CheckConnectivityWithDiagsTimeout(felix.Name, timeout, dumpResource(policy))
 			})
 		})
 	})

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -63,6 +63,8 @@ var workloadIdx = 0
 var sideServIdx = 0
 var permConnIdx = 0
 
+const DefaultConnectivityCheckTimeout = 10 * time.Second
+
 func (w *Workload) Stop() {
 	if w == nil {
 		log.Info("Stop no-op because nil workload")
@@ -673,11 +675,11 @@ func (c *ConnectivityChecker) ExpectedConnectivity() []string {
 }
 
 func (c *ConnectivityChecker) CheckConnectivityOffset(offset int, optionalDescription ...interface{}) {
-	c.CheckConnectivityWithTimeoutOffset(offset+2, 10*time.Second, optionalDescription...)
+	c.CheckConnectivityWithTimeoutOffset(offset+2, DefaultConnectivityCheckTimeout, optionalDescription...)
 }
 
 func (c *ConnectivityChecker) CheckConnectivity(optionalDescription ...interface{}) {
-	c.CheckConnectivityWithTimeoutOffset(2, 10*time.Second, optionalDescription...)
+	c.CheckConnectivityWithTimeoutOffset(2, DefaultConnectivityCheckTimeout, optionalDescription...)
 }
 
 func (c *ConnectivityChecker) CheckConnectivityWithTimeout(timeout time.Duration, optionalDescription ...interface{}) {

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,7 @@ github.com/projectcalico/libcalico-go v1.7.2-0.20191211192103-ee42d4b5eaf9 h1:YP
 github.com/projectcalico/libcalico-go v1.7.2-0.20191211192103-ee42d4b5eaf9/go.mod h1:5Upl9epOoyHRS1D4O9nckdFUtB0munzl4T1yoW52S14=
 github.com/projectcalico/libcalico-go v1.7.2-0.20191213004157-43756ead7b6c h1:7VcUE3UmT+8lChuKtAR13boRSgR4UefFbl4WoGI4enw=
 github.com/projectcalico/libcalico-go v1.7.2-0.20191213004157-43756ead7b6c/go.mod h1:5Upl9epOoyHRS1D4O9nckdFUtB0munzl4T1yoW52S14=
+github.com/projectcalico/libcalico-go v1.7.2-0.20191214003639-2449a6f3ad4f h1:N1vtiA7i9GbCnWa1B67QGZ5jPPJllPd9g1odqUqGdbk=
 github.com/projectcalico/libcalico-go v1.7.2-0.20191214003639-2449a6f3ad4f/go.mod h1:5Upl9epOoyHRS1D4O9nckdFUtB0munzl4T1yoW52S14=
 github.com/projectcalico/logrus v1.0.4-calico h1:bHJ2KLGTFzoWpRISe13CO7HVxxrKunDjyUz/wFiBY8c=
 github.com/projectcalico/logrus v1.0.4-calico/go.mod h1:DfgrchabbtEO9wjOz5lVae+XRvjFKKWEA9GTMme6A8g=


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
SCTP tests seem to take a bit longer than TCP/UDP tests to converge, especially when running in a single batch.  This increases the connectivity convergence timeout, but only for those tests.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
