### PR TITLE
Attempt to modprobe nf_conntrack_proto_sctp

### DIFF
--- a/dataplane/linux/modprobe.go
+++ b/dataplane/linux/modprobe.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import "os/exec"
+
+const (
+	// Modprobe binary on the system
+	cmdModProbe = "modprobe"
+
+	// Kernel module needed for SCTP protocol support on some kernels
+	moduleConntrackSCTP = "nf_conntrack_proto_sctp"
+)
+
+type modProbe struct {
+	module string
+	newCmd cmdFactory
+}
+
+type cmdIface interface {
+	Output() ([]byte, error)
+}
+
+type cmdFactory func(name string, arg ...string) cmdIface
+
+func newRealCmd(name string, arg ...string) cmdIface {
+	cmd := exec.Command(name, arg...)
+	return (*cmdAdapter)(cmd)
+}
+
+type cmdAdapter exec.Cmd
+
+func (c *cmdAdapter) Output() ([]byte, error) {
+	return (*exec.Cmd)(c).Output()
+}
+
+func newModProbe(module string, newCmd cmdFactory) modProbe {
+	return modProbe{module, newCmd}
+}
+
+func (m modProbe) Exec() (string, error) {
+	cmd := m.newCmd(cmdModProbe, m.module)
+	out, err := cmd.Output()
+	return string(out), err
+}

--- a/dataplane/linux/modprobe_test.go
+++ b/dataplane/linux/modprobe_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("modprobe", func() {
+	var (
+		cmdRecorder mpTestCmdRecorder
+		uut         modProbe
+	)
+
+	BeforeEach(func() {
+		cmd := &mpTestCmd{output: []byte("test output"), err: errors.New("test mp error")}
+		cmdRecorder = mpTestCmdRecorder{cmds: []*mpTestCmd{cmd}}
+		uut = newModProbe("test_module", cmdRecorder.factory)
+	})
+
+	It("should return command output and error", func() {
+		out, err := uut.Exec()
+		Expect(out).To(Equal("test output"))
+		Expect(err).To(Equal(errors.New("test mp error")))
+		Expect(cmdRecorder.cmds[0].outputCallCount).To(Equal(1))
+	})
+})
+
+type mpTestCmdRecorder struct {
+	cmds []*mpTestCmd
+	next int
+}
+
+type mpTestCmd struct {
+	output          []byte
+	err             error
+	outputCallCount int
+}
+
+func (m *mpTestCmd) Output() ([]byte, error) {
+	m.outputCallCount++
+	return m.output, m.err
+}
+
+func (r *mpTestCmdRecorder) factory(name string, args ...string) cmdIface {
+	cmd := r.cmds[r.next]
+	r.next++
+	return cmd
+}

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,7 @@ github.com/projectcalico/libcalico-go v1.7.2-0.20191211192103-ee42d4b5eaf9 h1:YP
 github.com/projectcalico/libcalico-go v1.7.2-0.20191211192103-ee42d4b5eaf9/go.mod h1:5Upl9epOoyHRS1D4O9nckdFUtB0munzl4T1yoW52S14=
 github.com/projectcalico/libcalico-go v1.7.2-0.20191213004157-43756ead7b6c h1:7VcUE3UmT+8lChuKtAR13boRSgR4UefFbl4WoGI4enw=
 github.com/projectcalico/libcalico-go v1.7.2-0.20191213004157-43756ead7b6c/go.mod h1:5Upl9epOoyHRS1D4O9nckdFUtB0munzl4T1yoW52S14=
+github.com/projectcalico/libcalico-go v1.7.2-0.20191214003639-2449a6f3ad4f h1:N1vtiA7i9GbCnWa1B67QGZ5jPPJllPd9g1odqUqGdbk=
 github.com/projectcalico/libcalico-go v1.7.2-0.20191214003639-2449a6f3ad4f/go.mod h1:5Upl9epOoyHRS1D4O9nckdFUtB0munzl4T1yoW52S14=
 github.com/projectcalico/logrus v1.0.4-calico h1:bHJ2KLGTFzoWpRISe13CO7HVxxrKunDjyUz/wFiBY8c=
 github.com/projectcalico/logrus v1.0.4-calico/go.mod h1:DfgrchabbtEO9wjOz5lVae+XRvjFKKWEA9GTMme6A8g=


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
On some kernels, nf_conntrack_proto_sctp is a loadable kernel module, without which, SCTP connections will fail due to conntrack marking all SCTP packets invalid.  This fix causes Felix to attempt to load the module via `modprobe`.  `modprobe` should be available in the Felix container since `iptables` needs it to load kernel modules as needed (note that this is a conntrack kernel module, so iptables will not automatically load it for us).

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) already covered
- [ ] Documentation TBD
- [ ] Backport TBD
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix will attempt to modprobe nf_conntrack_proto_sctp
```
