### PR TITLE
Handle capitalized backend configuration

### DIFF
--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os/exec"
 	"regexp"
+	"strings"
 	"sync"
 
 	version "github.com/hashicorp/go-version"
@@ -194,6 +195,7 @@ func DetectBackend(lookPath func(file string) (string, error), newCmd cmdFactory
 	}
 	log.WithField("detectedBackend", detectedBackend).Debug("Detected Iptables backend")
 
+	specifiedBackend = strings.ToLower(specifiedBackend)
 	if specifiedBackend != "auto" {
 		if specifiedBackend != detectedBackend {
 			log.WithFields(log.Fields{"detectedBackend": detectedBackend, "specifiedBackend": specifiedBackend}).Warn("Iptables backend specified does not match the detected backend, using specified backend")

--- a/iptables/features_detect_test.go
+++ b/iptables/features_detect_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -233,6 +234,8 @@ func TestIptablesBackendDetection(t *testing.T) {
 		t.Run("DetectingBackend, testing "+tst.name, func(t *testing.T) {
 			RegisterTestingT(t)
 			Expect(DetectBackend(lookPathAll, tst.cmdF.NewCmd, tst.spec)).To(Equal(tst.expectedBackend))
+
+			Expect(DetectBackend(lookPathAll, tst.cmdF.NewCmd, strings.ToUpper(tst.spec))).To(Equal(tst.expectedBackend), "Capitalization affected output")
 		})
 	}
 }


### PR DESCRIPTION
## Description
I wasn't thinking about the config being capitalized before. This change should handle that.

## Todos
- [X] Unit tests (full coverage)

## Release Note

```release-note
None required
```
