### PR TITLE
Upgrade reuse lib and don't fork sctp lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,17 +15,16 @@ require (
 	github.com/gxed/eventfd v0.0.0-20160916113412-80a92cca79a8 // indirect
 	github.com/hashicorp/go-version v1.2.0
 	github.com/ipfs/go-log v0.0.0-20180611222144-5dc2060baaf8 // indirect
-	github.com/ishidawataru/sctp v0.0.0-20190922091402-408ec287e38c
+	github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/kelseyhightower/envconfig v0.0.0-20180517194557-dd1402a4d99d
-	github.com/libp2p/go-reuseport v0.0.0-20180924121034-dd0c37d7767b
+	github.com/libp2p/go-reuseport v0.0.1
 	github.com/libp2p/go-sockaddr v0.0.0-20190411201116-52957a0228cc // indirect
 	github.com/mattn/go-colorable v0.0.0-20190708054220-c52ace132bf4 // indirect
 	github.com/mipearson/rfw v0.0.0-20170619235010-6f0a6f3266ba
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
 	github.com/opentracing/opentracing-go v0.0.0-20190704175813-135aa78c6f95 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
 	github.com/projectcalico/libcalico-go v1.7.2-0.20191214003639-2449a6f3ad4f
 	github.com/projectcalico/pod2daemon v0.0.0-20190730210055-df57fc59e2e1
 	github.com/projectcalico/typha v0.0.0-20191214040624-782d297f33cb
@@ -56,5 +55,3 @@ require (
 )
 
 replace github.com/sirupsen/logrus => github.com/projectcalico/logrus v1.0.4-calico
-
-replace github.com/ishidawataru/sctp => github.com/projectcalico/sctp v0.0.0-20191213163756-51fb0a816876

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/ipfs/go-log v0.0.0-20180611222144-5dc2060baaf8 h1:qIhWHcss7jC9N0n30nt
 github.com/ipfs/go-log v0.0.0-20180611222144-5dc2060baaf8/go.mod h1:AKYS9u+ECLT8t30brTaoVwu3f1FpGx6C0352oI1zQ0Q=
 github.com/ishidawataru/sctp v0.0.0-20190922091402-408ec287e38c h1:PwVcPU2rqkJIG0Lz/UGbGcbfi/HhEbOIId+w4xkbGHQ=
 github.com/ishidawataru/sctp v0.0.0-20190922091402-408ec287e38c/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
+github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07 h1:rw3IAne6CDuVFlZbPOkA7bhxlqawFh7RJJ+CejfMaxE=
+github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
@@ -191,6 +193,8 @@ github.com/leodido/go-urn v0.0.0-20181204092800-a67a23e1c1af h1:EhEGUQX36JFkvSWz
 github.com/leodido/go-urn v0.0.0-20181204092800-a67a23e1c1af/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
 github.com/libp2p/go-reuseport v0.0.0-20180924121034-dd0c37d7767b h1:aMR7gRGtIrahvQNtYrdXKaLYv/RT20mnwWtT3qwhgaE=
 github.com/libp2p/go-reuseport v0.0.0-20180924121034-dd0c37d7767b/go.mod h1:UeLFiw50cCfyDHBpU0sXBR8ul1MO/m51mXpRO/SYjCE=
+github.com/libp2p/go-reuseport v0.0.1 h1:7PhkfH73VXfPJYKQ6JwS5I/eVcoyYi9IMNGc6FWpFLw=
+github.com/libp2p/go-reuseport v0.0.1/go.mod h1:jn6RmB1ufnQwl0Q1f+YxAj8isJgDCQzaaxIFYDhcYEA=
 github.com/libp2p/go-sockaddr v0.0.0-20190411201116-52957a0228cc h1:W3yN/EbItWRhQlK18dUTzr2AKxMQlkKpCUg3xl6MpA8=
 github.com/libp2p/go-sockaddr v0.0.0-20190411201116-52957a0228cc/go.mod h1:EBeYKMYs5LFgoaBSN2nA2jPQVmnA4gv7WkY64CBqYqQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

The original author of the SCTP lib we use for testing accepted my contribution that allows us to set the SO_REUSE* socket options on SCTP sockets. This change
 
 * updates to the latest version of the `reuse` lib (and simplifies our code)
 * uses the upstream `sctp` lib instead of our fork.

After this is merged we can retire https://github.com/projectcalico/sctp

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) Not needed
- [x] Documentation not needed
- [x] Backport not needed
- [x] Release note not needed

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
