### PR TITLE
release-v3.8 - Fix dirty builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ FV_SLOW_SPEC_THRESH=90
 # <unknown> if this isn't a git checkout.
 GIT_COMMIT:=$(shell git rev-parse HEAD || echo '<unknown>')
 BUILD_ID:=$(shell git rev-parse HEAD || uuidgen | sed 's/-//g')
-GIT_DESCRIPTION:=$(shell git describe --tags --dirty --always || echo '<unknown>')
+GIT_DESCRIPTION=$(shell git describe --tags --dirty --always || echo '<unknown>')
 ifeq ($(LOCAL_BUILD),true)
 	GIT_DESCRIPTION = $(shell git describe --tags --dirty --always || echo '<unknown>')-dev-build
 endif
@@ -194,7 +194,7 @@ DATE:=$(shell date -u +'%FT%T%z')
 #
 # We use -B to insert a build ID note into the executable, without which, the
 # RPM build tools complain.
-LDFLAGS:=-ldflags "\
+LDFLAGS=-ldflags "\
         -X $(PACKAGE_NAME)/buildinfo.GitVersion=$(GIT_DESCRIPTION) \
         -X $(PACKAGE_NAME)/buildinfo.BuildDate=$(DATE) \
         -X $(PACKAGE_NAME)/buildinfo.GitRevision=$(GIT_COMMIT) \


### PR DESCRIPTION
We were seeing -dirty version strings because sometimes GIT_DESCRIPTION
would be evaluated immediately after a `clean` which deletes some
generated files that are also source-controlled.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
