### PR TITLE
WiP WEP MTU fixes

### DIFF
--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -137,6 +137,8 @@ struct bpf_map_def_extended {
 #define CALI_F_CGROUP	(((CALI_COMPILE_FLAGS) & CALI_CGROUP) != 0)
 #define CALI_F_DSR	(CALI_COMPILE_FLAGS & CALI_TC_DSR)
 
+#define CALI_RES_REDIR_IFINDEX	(TC_ACT_VALUE_MAX + 100) /* packet should be sent back the same iface */
+
 #define COMPILE_TIME_ASSERT(expr) {typedef char array[(expr) ? 1 : -1];}
 static CALI_BPF_INLINE void __compile_asserts(void) {
 #pragma clang diagnostic push

--- a/bpf-gpl/icmp.h
+++ b/bpf-gpl/icmp.h
@@ -181,7 +181,7 @@ static CALI_BPF_INLINE int icmp_v4_too_big(struct __sk_buff *skb)
 		__be16  mtu;
 	} frag = {
 		// ICMP MTU ignores the ethernet header.
-		.mtu = host_to_be16(TUNNEL_MTU - sizeof(struct ethhdr)),
+		.mtu = host_to_be16(TUNNEL_MTU),
 	};
 
 	CALI_DEBUG("Sending ICMP too big mtu=%d\n", be16_to_host(frag.mtu));

--- a/bpf-gpl/nat.h
+++ b/bpf-gpl/nat.h
@@ -441,7 +441,7 @@ static CALI_BPF_INLINE bool vxlan_v4_encap_too_big(struct __sk_buff *skb)
 {
 	__u32 mtu = TUNNEL_MTU;
 
-	if (skb->len > mtu) {
+	if (skb->len - sizeof(struct ethhdr) > mtu) {
 		CALI_DEBUG("SKB too long (len=%d) vs limit=%d\n", skb->len, mtu);
 		return true;
 	}

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -77,4 +77,6 @@ static CALI_BPF_INLINE long skb_l4hdr_offset(struct __sk_buff *skb, __u8 ihl)
 	return skb_iphdr_offset(skb) + ihl;
 }
 
+#define skb_is_gso(skb) ((skb)->gso_segs > 1)
+
 #endif /* __SKB_H__ */

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -72,4 +72,9 @@ static CALI_BPF_INLINE struct iphdr *skb_iphdr(struct __sk_buff *skb)
 	return ip;
 }
 
+static CALI_BPF_INLINE long skb_l4hdr_offset(struct __sk_buff *skb, __u8 ihl)
+{
+	return skb_iphdr_offset(skb) + ihl;
+}
+
 #endif /* __SKB_H__ */

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -843,15 +843,15 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 				be32_to_host(state->ct_result.nat_ip), state->ct_result.nat_port);
 
 		if (dnat_return_should_encap() && state->ct_result.tun_ret_ip) {
-			/* XXX do this before NAT until we can track the icmp back */
-			if (ip_is_dnf(ip_header) && vxlan_v4_encap_too_big(skb)) {
-				CALI_DEBUG("Return ICMP mtu is too big\n");
-				goto icmp_too_big;
-			}
 			if (CALI_F_DSR) {
 				/* SNAT will be done after routing, when leaving HEP */
 				CALI_DEBUG("DSR enabled, skipping SNAT + encap\n");
 				goto allow;
+			}
+			/* XXX do this before NAT until we can track the icmp back */
+			if (ip_is_dnf(ip_header) && vxlan_v4_encap_too_big(skb)) {
+				CALI_DEBUG("Return ICMP mtu is too big\n");
+				goto icmp_too_big;
 			}
 		}
 

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -877,7 +877,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 				goto allow;
 			}
 			/* XXX do this before NAT until we can track the icmp back */
-			if (state->ip_proto != IPPROTO_TCP &&
+			if (!(state->ip_proto == IPPROTO_TCP && skb_is_gso(skb)) &&
 					ip_is_dnf(ip_header) && vxlan_v4_encap_too_big(skb)) {
 				CALI_DEBUG("Return ICMP mtu is too big\n");
 				goto icmp_too_big;

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -839,7 +839,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 		goto allow;
 
 	case CALI_CT_ESTABLISHED_SNAT:
-		CALI_DEBUG("CT: SNAT to %x:%d\n",
+		CALI_DEBUG("CT: SNAT from %x:%d\n",
 				be32_to_host(state->ct_result.nat_ip), state->ct_result.nat_port);
 
 		if (dnat_return_should_encap() && state->ct_result.tun_ret_ip) {

--- a/bpf/ut/icmp_too_big_test.go
+++ b/bpf/ut/icmp_too_big_test.go
@@ -43,7 +43,7 @@ func TestICMPTooBig(t *testing.T) {
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)
 
-		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU-ethernetHeaderSize-20 /* compiled as WEP */)
+		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU-20 /* compiled as WEP */)
 	})
 }
 

--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -582,7 +582,7 @@ func TestNATNodePortICMPTooBig(t *testing.T) {
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)
 
-		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU-ethernetHeaderSize)
+		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU)
 	})
 
 	// clean up


### PR DESCRIPTION
MTU check disabled if packets are TCP & GSO on WEP

When we send a ICMP MTU too big to WEP, we send it straight to the same iface

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
