### PR TITLE
BPF: MTU fix for 3.13

### DIFF
--- a/bpf-gpl/icmp.h
+++ b/bpf-gpl/icmp.h
@@ -130,7 +130,7 @@ static CALI_BPF_INLINE int icmp_v4_reply(struct __sk_buff *skb,
 #ifdef CALI_PARANOID
 	/* XXX verify that ip_orig.daddr is always the node's IP
 	 *
-	 * we only call this function because of NodePOrt encap
+	 * we only call this function because of NodePort encap
 	 */
 	if (ip_orig.daddr != cali_host_ip()) {
 		CALI_DEBUG("ICMP v4 reply: ip_orig.daddr != cali_host_ip() 0x%x\n", ip_orig.daddr);
@@ -180,7 +180,6 @@ static CALI_BPF_INLINE int icmp_v4_too_big(struct __sk_buff *skb)
 		__be16  unused;
 		__be16  mtu;
 	} frag = {
-		// ICMP MTU ignores the ethernet header.
 		.mtu = host_to_be16(TUNNEL_MTU),
 	};
 

--- a/bpf-gpl/icmp.h
+++ b/bpf-gpl/icmp.h
@@ -130,7 +130,7 @@ static CALI_BPF_INLINE int icmp_v4_reply(struct __sk_buff *skb,
 #ifdef CALI_PARANOID
 	/* XXX verify that ip_orig.daddr is always the node's IP
 	 *
-	 * we only call this function because of NodePort encap
+	 * we only call this function because of NodePOrt encap
 	 */
 	if (ip_orig.daddr != cali_host_ip()) {
 		CALI_DEBUG("ICMP v4 reply: ip_orig.daddr != cali_host_ip() 0x%x\n", ip_orig.daddr);
@@ -180,8 +180,8 @@ static CALI_BPF_INLINE int icmp_v4_too_big(struct __sk_buff *skb)
 		__be16  unused;
 		__be16  mtu;
 	} frag = {
-		// ICMP MTU refers to the IP packet size.
-		.mtu = host_to_be16(TNNL_INNER_IP_MTU),
+		// ICMP MTU ignores the ethernet header.
+		.mtu = host_to_be16(TUNNEL_MTU),
 	};
 
 	CALI_DEBUG("Sending ICMP too big mtu=%d\n", be16_to_host(frag.mtu));

--- a/bpf-gpl/nat.h
+++ b/bpf-gpl/nat.h
@@ -365,8 +365,8 @@ static CALI_BPF_INLINE int vxlan_v4_encap(struct __sk_buff *skb,  __be32 ip_src,
 	eth_inner = (void *)(vxlan+1);
 	ip_inner = (void*)(eth_inner+1);
 
-	/* Copy the original IP header. Since it is aready DNATed, the dest IP is
-	 * already set. All we need to do it to change the source IP
+	/* Copy the original IP header. Since it is already DNATed, the dest IP is
+	 * already set. All we need to do is to change the source IP
 	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,2,0)
 	*ip = *ip_inner;
@@ -450,6 +450,11 @@ static CALI_BPF_INLINE bool vxlan_v4_encap_too_big(struct __sk_buff *skb)
 {
 	__u32 mtu = TUNNEL_MTU;
 
+	/* RFC-1191: MTU is the size in octets of the largest datagram that
+	 * could be forwarded, along the path of the original datagram, without
+	 * being fragmented at this router.  The size includes the IP header and
+	 * IP data, and does not include any lower-level headers.
+	 */
 	if (skb->len - sizeof(struct ethhdr) > mtu) {
 		CALI_DEBUG("SKB too long (len=%d) vs limit=%d\n", skb->len, mtu);
 		return true;

--- a/bpf-gpl/nat.h
+++ b/bpf-gpl/nat.h
@@ -455,7 +455,7 @@ static CALI_BPF_INLINE bool vxlan_v4_encap_too_big(struct __sk_buff *skb)
 	 * being fragmented at this router.  The size includes the IP header and
 	 * IP data, and does not include any lower-level headers.
 	 */
-	if (skb->len - sizeof(struct ethhdr) > mtu) {
+	if (skb->len > sizeof(struct ethhdr) + mtu) {
 		CALI_DEBUG("SKB too long (len=%d) vs limit=%d\n", skb->len, mtu);
 		return true;
 	}

--- a/bpf-gpl/nat.h
+++ b/bpf-gpl/nat.h
@@ -37,14 +37,19 @@
 #define dnat_return_should_encap() (CALI_F_FROM_WEP && !CALI_F_TUNNEL)
 #define dnat_should_decap() (CALI_F_FROM_HEP && !CALI_F_TUNNEL)
 
-#define CALI_ENCAP_EXTRA_SIZE	50
+/* Number of bytes we add to a packet when we do encap. */
+#define VXLAN_ENCAP_SIZE	(sizeof(struct ethhdr) + sizeof(struct iphdr) + \
+				sizeof(struct udphdr) + sizeof(struct vxlanhdr))
+
+#define CALI_ENCAP_SIZE	VXLAN_ENCAP_SIZE
+
 
 #ifndef CALI_MTU
 #define CALI_MTU 1460
 #endif
 
 #ifndef CALI_NAT_TUNNEL_MTU
-#define CALI_NAT_TUNNEL_MTU	(CALI_MTU - CALI_ENCAP_EXTRA_SIZE) /* defaults to 1410 */
+#define CALI_NAT_TUNNEL_MTU	(CALI_MTU - CALI_ENCAP_SIZE) /* defaults to 1410 */
 #endif
 
 #ifndef CALI_NAT_TUNNEL_HEP_MTU
@@ -52,7 +57,11 @@
 #endif
 
 #ifndef CALI_NAT_TUNNEL_WEP_MTU
-#define CALI_NAT_TUNNEL_WEP_MTU	(CALI_NAT_TUNNEL_MTU - 20) /* cali ifaces reserve 20 for ipip */
+#define CALI_NAT_TUNNEL_WEP_MTU	(CALI_NAT_TUNNEL_MTU - 50) /* defaults to 1360 as cali ifaces' mtu
+							    * is 50 bytes smaller than the host
+							    * ifaces mtu in the anticipation of ipip
+							    * or vxlan overlay
+							    */
 #endif
 
 #if CALI_F_HEP

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -876,7 +876,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 				CALI_DEBUG("DSR enabled, skipping SNAT + encap\n");
 				goto allow;
 			}
-			/* XXX do this before NAT until we can track the icmp back */
+
 			if (!(state->ip_proto == IPPROTO_TCP && skb_is_gso(skb)) &&
 					ip_is_dnf(ip_header) && vxlan_v4_encap_too_big(skb)) {
 				CALI_DEBUG("Return ICMP mtu is too big\n");

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -188,7 +188,7 @@ static CALI_BPF_INLINE int forward_or_drop(struct __sk_buff *skb,
 		/* Swap the MACs as we are turning it back */
 		struct ethhdr *eth_hdr = (void *)(long)skb->data;
 		unsigned char mac[ETH_ALEN];
-		__builtin_memcpy(mac, &eth_hdr->h_source, ETH_ALEN);
+		__builtin_memcpy(mac, &eth_hdr->h_dest, ETH_ALEN);
 		__builtin_memcpy(&eth_hdr->h_dest, &eth_hdr->h_source, ETH_ALEN);
 		__builtin_memcpy(&eth_hdr->h_source, mac, ETH_ALEN);
 

--- a/bpf/ut/icmp_too_big_test.go
+++ b/bpf/ut/icmp_too_big_test.go
@@ -43,7 +43,10 @@ func TestICMPTooBig(t *testing.T) {
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)
 
-		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU-50 /* compiled as WEP */)
+		// The program is compiled and run as WEP and thus the expected MTU is
+		// 50 less due to the 50 byte difference between HEP and WEP mtu. See
+		// definition of TUNNEL_MTU in bpf-gpl/nat.h
+		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU-50)
 	})
 }
 

--- a/bpf/ut/icmp_too_big_test.go
+++ b/bpf/ut/icmp_too_big_test.go
@@ -43,7 +43,7 @@ func TestICMPTooBig(t *testing.T) {
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)
 
-		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU-ethernetHeaderSize-20 /* compiled as WEP */)
+		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU-20 /* compiled as WEP */)
 	})
 }
 

--- a/bpf/ut/icmp_too_big_test.go
+++ b/bpf/ut/icmp_too_big_test.go
@@ -43,7 +43,7 @@ func TestICMPTooBig(t *testing.T) {
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)
 
-		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU-20 /* compiled as WEP */)
+		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU-50 /* compiled as WEP */)
 	})
 }
 

--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -582,7 +582,7 @@ func TestNATNodePortICMPTooBig(t *testing.T) {
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)
 
-		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU-ethernetHeaderSize)
+		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU)
 	})
 
 	// clean up


### PR DESCRIPTION
## Description

When a pod responds to traffic initiated through a nodeport (thus encaped in vxlan) and if that packet is non-GSO and close to mtu size so that we cannot grow it to add the encap header, we return an ICMP response DNF MTU too big to let the client adjust its path mtu.

(a) the response has a wrong dest MAC and is dropped by the `ip_rcv_core()` in the pod - we need to swap the MACs

(b) we must check the skb->len > eth + mtu

(c) we must respond with the right mtu in the ICMP - revert previous changes and adjust to the pods 1410 mtu setting

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
