### PR TITLE
bpf: fix FIB lookup for NP tunnels and ICMP error replies

### DIFF
--- a/bpf-gpl/jump.h
+++ b/bpf-gpl/jump.h
@@ -64,4 +64,11 @@ struct bpf_map_def_extended __attribute__((section("maps"))) cali_jump = {
 #endif
 };
 
+static CALI_BPF_INLINE void tc_state_fill_from_iphdr(struct cali_tc_state *state, struct iphdr *ip)
+{
+	state->ip_src = ip->saddr;
+	state->ip_dst = ip->daddr;
+	state->ip_proto = ip->protocol;
+}
+
 #endif /* __CALI_BPF_JUMP_H__ */

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -347,7 +347,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	}
 
 	struct iphdr *ip_header;
-	if (CALI_F_TO_HEP) {
+	if (CALI_F_TO_HEP || CALI_F_TO_WEP) {
 		switch (skb->mark) {
 		case CALI_SKB_MARK_BYPASS_FWD:
 			CALI_DEBUG("Packet approved for forward.\n");

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -992,8 +992,6 @@ icmp_too_big:
 		goto deny;
 	}
 
-	seen_mark = CALI_SKB_MARK_BYPASS_FWD;
-
 	/* XXX we might use skb->ifindex to redirect it straight back
 	 * to where it came from if it is guaranteed to be the path
 	 */
@@ -1016,6 +1014,9 @@ icmp_allow:
 	ip_header = skb_iphdr(skb);
 	tc_state_fill_from_iphdr(state, ip_header);
 	state->sport = state->dport = 0;
+
+	/* packet was created because of approved traffic, treat it as related */
+	seen_mark = CALI_SKB_MARK_BYPASS_FWD;
 
 	goto allow;
 

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -228,14 +228,8 @@ static CALI_BPF_INLINE int forward_or_drop(struct __sk_buff *skb,
 		/* set the ipv4 here, otherwise the ipv4/6 unions do not get
 		 * zeroed properly
 		 */
-		if (fwd->fib_flags & BPF_FIB_LOOKUP_OUTPUT) {
-			// Flip src/dest.
-			fib_params.ipv4_src = state->ip_dst;
-			fib_params.ipv4_dst = state->ip_src;
-		} else {
-			fib_params.ipv4_src = state->ip_src;
-			fib_params.ipv4_dst = state->ip_dst;
-		}
+		fib_params.ipv4_src = state->ip_src;
+		fib_params.ipv4_dst = state->ip_dst;
 
 		CALI_DEBUG("FIB family=%d\n", fib_params.family);
 		CALI_DEBUG("FIB tot_len=%d\n", fib_params.tot_len);


### PR DESCRIPTION
This reverts commit 779dacf2f2161fdaa5971939738058b1e1cf0546.

The verted change causes FIB to fail and thus the packet must take the
slow path through Linux ip stack. Linux delivers the packet correctly
as the packet has the right addresses in the right places.

Fix the state on the ICMP path.

Fix approval of the  ICMP error replies as related traffic.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
