### PR TITLE
Run FV's in a remote GCP machine too

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,29 +34,31 @@ blocks:
       - >-
         make image fv/fv.test bin/test-workload bin/test-connection
         bin/calico-felix
-      - 'cache store bin-${SEMAPHORE_GIT_SHA} bin'
       - cache store go-pkg-cache .go-pkg-cache
       - 'cache store go-mod-cache ${HOME}/go/pkg/mod/cache'
-      - docker save -o /tmp/calico-felix.tar calico/felix:latest-amd64
-      - 'cache store felix-image-${SEMAPHORE_GIT_SHA} /tmp/calico-felix.tar'
 - name: FV Tests
   dependencies: ["Build"]
   task:
     prologue:
       commands:
       - checkout
-      - cache restore go-pkg-cache
-      - cache restore go-mod-cache
-      - 'cache restore bin-${SEMAPHORE_GIT_SHA}'
-      - 'cache restore felix-image-${SEMAPHORE_GIT_SHA}'
-      - docker load -i /tmp/calico-felix.tar
-      - rm /tmp/calico-felix.tar
-      - touch bin/*
+      - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/secret.google-service-account-key.json
+      - export SHORT_WORKFLOW_ID=$(echo ${SEMAPHORE_WORKFLOW_ID} | sha256sum | cut -c -8)
+      - export VM_NAME=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}-fv-${SEMAPHORE_JOB_INDEX}
+      - echo VM_NAME=${VM_NAME}
+      - ./.semaphore/create-test-vm ${VM_NAME}
     jobs:
-    - name: FV Test matrix
+    - name: FV Test matrix on remote
       commands:
       - make fv FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}" FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT}
+      - gcloud --quiet compute ssh --zone=europe-west3-c ubuntu@${VM_NAME} -- -o ServerAliveInterval=10 make --directory=$(basename $(pwd)) fv FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT} FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}"
       parallelism: 5
+    epilogue:
+      always:
+        commands:
+        - gcloud --quiet compute instances delete ${VM_NAME} --zone=europe-west3-c
+    secrets:
+    - name: google-service-account-for-gce
 - name: BPF UT/FV tests on new kernel
   dependencies: []
   task:
@@ -65,7 +67,7 @@ blocks:
       - checkout
       - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/secret.google-service-account-key.json
       - export SHORT_WORKFLOW_ID=$(echo ${SEMAPHORE_WORKFLOW_ID} | sha256sum | cut -c -8)
-      - export VM_NAME=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}-${SEMAPHORE_JOB_INDEX:-ut}
+      - export VM_NAME=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}-bpf-${SEMAPHORE_JOB_INDEX:ut}
       - echo VM_NAME=${VM_NAME}
       - ./.semaphore/create-test-vm ${VM_NAME}
     jobs:


### PR DESCRIPTION
Semaphore v2 VMs currently only supports Ubuntu 18.04 which runs
the 4.15.0 kernel. xdp tests require at least 4.16.0

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
