### PR TITLE
Fix lint

### DIFF
--- a/fv/test-connection/test-connection.go
+++ b/fv/test-connection/test-connection.go
@@ -434,6 +434,10 @@ func (tc *testConn) tryConnectOnceOff() error {
 	}
 
 	mtuPair.End, err = tc.protocol.MTU()
+	if err != nil {
+		log.WithError(err).Error("could not get MTU")
+		return err
+	}
 
 	res := connectivity.Result{
 		LastResponse: resp,

--- a/fv/test-workload/test-workload.go
+++ b/fv/test-workload/test-workload.go
@@ -383,7 +383,7 @@ func main() {
 					}
 					err = wrt.Flush()
 					if err != nil {
-						log.Errorf("Writing to connection failed to flush out", request.ResponseSize-n)
+						log.WithError(err).Error("Writing to connection failed to flush out")
 						break
 					}
 				}

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -534,8 +534,6 @@ func (w *Workload) PathMTU(ip string) (int, error) {
 			return strconv.Atoi(m[1])
 		}
 	}
-
-	return 0, nil
 }
 
 type SpoofedWorkload struct {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
```

Starting with UID : 1002
--
205 | fv/test-workload/test-workload.go:386:17: printf: Errorf call has arguments but no formatting directives (govet)
206 | log.Errorf("Writing to connection failed to flush out", request.ResponseSize-n)
206 | ^
208 | fv/workload/workload.go:538:2: unreachable: unreachable code (govet)
208 | return 0, nil
209 | ^
211 | fv/test-connection/test-connection.go:436:15: SA4006: this value of `err` is never used (staticcheck)
211 | mtuPair.End, err = tc.protocol.MTU()
213 | ^
213 | Makefile.common:323: recipe for target 'golangci-lint' failed
215 | make[1]: *** [golangci-lint] Error 1



```
## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
