### PR TITLE
ICMP errors generated by tracked flows treated as related traffic

### DIFF
--- a/bpf-gpl/icmp.h
+++ b/bpf-gpl/icmp.h
@@ -207,4 +207,30 @@ static CALI_BPF_INLINE bool icmp_type_is_err(__u8 type)
 	return false;
 }
 
+static CALI_BPF_INLINE bool icmp_skb_get_hdr(struct __sk_buff *skb, struct icmphdr **icmp)
+{
+	struct iphdr *ip;
+	long ip_off;
+	int minsz;
+
+	ip_off = skb_iphdr_offset(skb);
+	minsz = ip_off + sizeof(struct iphdr) + sizeof(struct icmphdr) + sizeof(struct iphdr) + 8;
+
+	if (skb_shorter(skb, minsz)) {
+		CALI_DEBUG("ICMP: %d shorter than %d\n", skb_len_dir_access(skb), minsz);
+		return false;
+	}
+
+	ip = skb_iphdr(skb);
+
+	if (ip->ihl != 5) {
+		CALI_INFO("ICMP: ip options unsupported\n");
+		return false;
+	}
+
+	*icmp = (struct icmphdr *)(ip + 1);
+
+	return true;
+}
+
 #endif /* __CALI_ICMP_H__ */

--- a/bpf-gpl/icmp.h
+++ b/bpf-gpl/icmp.h
@@ -193,4 +193,18 @@ static CALI_BPF_INLINE int icmp_v4_ttl_exceeded(struct __sk_buff *skb)
 	return icmp_v4_reply(skb, ICMP_TIME_EXCEEDED, ICMP_EXC_TTL, 0);
 }
 
+static CALI_BPF_INLINE bool icmp_type_is_err(__u8 type)
+{
+	switch (type) {
+	case ICMP_DEST_UNREACH:
+	case ICMP_SOURCE_QUENCH:
+	case ICMP_REDIRECT:
+	case ICMP_TIME_EXCEEDED:
+	case ICMP_PARAMETERPROB:
+		return true;
+	}
+
+	return false;
+}
+
 #endif /* __CALI_ICMP_H__ */

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -37,6 +37,8 @@
 
 #define skb_len_dir_access(skb) skb_tail_len(skb, skb_start_ptr(skb))
 
+#define skb_seen(skb) ((skb)->mark & CALI_SKB_MARK_SEEN)
+
 #define IPV4_UDP_SIZE		(sizeof(struct iphdr) + sizeof(struct udphdr))
 #define ETH_IPV4_UDP_SIZE	(sizeof(struct ethhdr) + IPV4_UDP_SIZE)
 

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -35,6 +35,8 @@
 #define skb_ptr(skb, off) ((void *)((long)(skb)->data + (off)))
 #define skb_ptr_after(skb, ptr) ((void *)((ptr) + 1))
 
+#define skb_len_dir_access(skb) skb_tail_len(skb, skb_start_ptr(skb))
+
 #define IPV4_UDP_SIZE		(sizeof(struct iphdr) + sizeof(struct udphdr))
 #define ETH_IPV4_UDP_SIZE	(sizeof(struct ethhdr) + IPV4_UDP_SIZE)
 

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -476,7 +476,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 		break;
 	case IPPROTO_ICMP:
 		icmp_header = (void*)(ip_header+1);
-		CALI_DEBUG("ICMP; ports: type=%d code=%d\n",
+		CALI_DEBUG("ICMP; type=%d code=%d\n",
 				icmp_header->type, icmp_header->code);
 		break;
 	case 4:

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -508,6 +508,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	}
 
 	struct ct_ctx ct_lookup_ctx = {
+		.skb = skb,
 		.proto	= state.ip_proto,
 		.src	= state.ip_src,
 		.sport	= state.sport,

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -781,6 +781,12 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 				ct_rc = CALI_CT_ESTABLISHED_DNAT;
 				break;
 			case CALI_CT_ESTABLISHED_DNAT:
+				if (CALI_F_FROM_HEP && state->nat_tun_src && !state->ct_result.tun_ret_ip) {
+					/* Packet is returning from a NAT tunnel, just forward it. */
+					seen_mark = CALI_SKB_MARK_BYPASS_FWD;
+					CALI_DEBUG("ICMP related returned from NAT tunnel\n");
+					goto allow;
+				}
 				ct_rc = CALI_CT_ESTABLISHED_SNAT;
 				break;
 			}

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -710,11 +710,9 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 		seen_mark = CALI_SKB_MARK_SEEN;
 	}
 
-	/* XXX we cannot pass the related ICMP after NATing back yet, so we need
-	 * to act here, we know we are forwarding.
+	/* We check the ttl here to avoid needing complicated handling of
+	 * related trafic back from the host if we let the host to handle it.
 	 */
-
-	/* XXX XXX XXX */
 	CALI_DEBUG("ip->ttl %d\n", ip_header->ttl);
 	if (ip_ttl_exceeded(ip_header)) {
 		switch (ct_rc){

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -738,9 +738,8 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 			outer_ip_snat = ct_rc == CALI_CT_ESTABLISHED_SNAT;
 			/* ... there is a return path to the tunnel ... */
 			outer_ip_snat = outer_ip_snat && state->ct_result.tun_ret_ip;
-			/* ... and should do encap and it is not DSR or it is
-			 * it is leaving host and either DSR from WEP or
-			 * originated at host ... */
+			/* ... and should do encap and it is not DSR or it is leaving host
+			 * and either DSR from WEP or originated at host ... */
 			outer_ip_snat = outer_ip_snat &&
 				((dnat_return_should_encap() && !CALI_F_DSR) ||
 				 (CALI_F_TO_HEP &&

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -593,3 +593,8 @@ func testPacket(ethAlt *layers.Ethernet, ipv4Alt *layers.IPv4, l4Alt gopacket.La
 func testPacketUDPDefault() (*layers.Ethernet, *layers.IPv4, gopacket.Layer, []byte, []byte, error) {
 	return testPacket(nil, nil, nil, nil)
 }
+
+func resetBPFMaps() {
+	resetCTMap(ctMap)
+	resetRTMap(rtMap)
+}

--- a/bpf/ut/icmp_related_test.go
+++ b/bpf/ut/icmp_related_test.go
@@ -142,7 +142,7 @@ func TestICMPRelatedNATPodPod(t *testing.T) {
 		// we have a normal ct record, it is related, must be allowed
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 
-		checkICMP(res.dataOut, ipv4.DstIP, ipv4.SrcIP, ipv4.SrcIP, ipv4.DstIP, ipv4.Protocol,
+		checkICMP(res.dataOut, hostIP, ipv4.SrcIP, ipv4.SrcIP, ipv4.DstIP, ipv4.Protocol,
 			uint16(udp.SrcPort), uint16(udp.DstPort))
 	})
 }

--- a/bpf/ut/icmp_related_test.go
+++ b/bpf/ut/icmp_related_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/bpf/routes"
+	"github.com/projectcalico/felix/proto"
+)
+
+var rulesAllowUDP = [][][]*proto.Rule{{{{
+	Action:   "Allow",
+	Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Name{Name: "udp"}},
+}}}}
+
+func TestICMPRelatedPlain(t *testing.T) {
+	RegisterTestingT(t)
+
+	defer resetBPFMaps()
+
+	_, ipv4, l4, _, pktBytes, err := testPacketUDPDefault()
+	Expect(err).NotTo(HaveOccurred())
+	udp := l4.(*layers.UDP)
+
+	icmpUNreachable := makeICMPError(ipv4, udp, 3 /* Unreachable */, 1 /*Host unreachable error */)
+
+	runBpfTest(t, "calico_to_workload_ep", rulesAllowUDP, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(icmpUNreachable)
+		Expect(err).NotTo(HaveOccurred())
+		// there is no normal CT record yet, must be denied
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
+	// Insert a reverse route for the source workload.
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload, 1).AsBytes()
+	err = rtMap.Update(rtKey, rtVal)
+	Expect(err).NotTo(HaveOccurred())
+
+	runBpfTest(t, "calico_from_workload_ep", rulesAllowUDP, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+
+	runBpfTest(t, "calico_to_workload_ep", rulesAllowUDP, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(icmpUNreachable)
+		Expect(err).NotTo(HaveOccurred())
+		// we have a normal ct record, it is related, must be allowed
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+
+	// fake icmp echo reply, we do not really care about the payload, just the type and code
+	icmpEchoResp := makeICMPError(ipv4, udp, 0 /* Echo reply */, 0)
+
+	runBpfTest(t, "calico_to_workload_ep", rulesAllowUDP, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(icmpEchoResp)
+		Expect(err).NotTo(HaveOccurred())
+		// echo is unrelated, must be denied
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+}
+
+func makeICMPError(ipInner *layers.IPv4, l4 gopacket.SerializableLayer, icmpType, icmpCode uint8) []byte {
+	payloadBuf := gopacket.NewSerializeBuffer()
+	err := gopacket.SerializeLayers(payloadBuf, gopacket.SerializeOptions{}, ipInner, l4)
+	Expect(err).NotTo(HaveOccurred())
+	payload := payloadBuf.Bytes()
+
+	eth := &layers.Ethernet{
+		SrcMAC:       []byte{0xee, 0, 0, 0, 0, 1},
+		DstMAC:       []byte{0xfe, 0, 0, 0, 0, 2},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+
+	ipv4 := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		Flags:    layers.IPv4DontFragment,
+		SrcIP:    net.IPv4(11, 22, 33, 44),
+		DstIP:    ipInner.SrcIP,
+		Protocol: layers.IPProtocolICMPv4,
+		Length:   uint16(20 + len(payload)),
+	}
+
+	icmp := &layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(icmpType, icmpCode),
+	}
+
+	pkt := gopacket.NewSerializeBuffer()
+	err = gopacket.SerializeLayers(pkt, gopacket.SerializeOptions{ComputeChecksums: true},
+		eth, ipv4, icmp, gopacket.Payload(payload))
+	Expect(err).NotTo(HaveOccurred())
+
+	return pkt.Bytes()
+}

--- a/bpf/ut/icmp_related_test.go
+++ b/bpf/ut/icmp_related_test.go
@@ -142,7 +142,7 @@ func TestICMPRelatedNATPodPod(t *testing.T) {
 		// we have a normal ct record, it is related, must be allowed
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 
-		checkICMP(res.dataOut, hostIP, ipv4.SrcIP, ipv4.SrcIP, ipv4.DstIP, ipv4.Protocol,
+		checkICMP(res.dataOut, ipv4.DstIP, ipv4.SrcIP, ipv4.SrcIP, ipv4.DstIP, ipv4.Protocol,
 			uint16(udp.SrcPort), uint16(udp.DstPort))
 	})
 }

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -443,12 +443,10 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					wIP := fmt.Sprintf("10.65.%d.%d", ii, wi+2)
 					wName := fmt.Sprintf("w%d%d", ii, wi)
 
+					w[ii][wi] = workload.New(felixes[ii], wName, "default",
+						wIP, strconv.Itoa(port), testOpts.protocol)
 					if run {
-						w[ii][wi] = workload.Run(felixes[ii], wName, "default",
-							wIP, strconv.Itoa(port), testOpts.protocol)
-					} else {
-						w[ii][wi] = workload.New(felixes[ii], wName, "default",
-							wIP, strconv.Itoa(port), testOpts.protocol)
+						w[ii][wi].Start()
 					}
 
 					labels["name"] = w[ii][wi].Name

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -601,5 +601,5 @@ func (c *Container) CanConnectTo(ip, port, protocol string, opts ...connectivity
 
 // AttachTCPDump returns tcpdump attached to the container
 func (c *Container) AttachTCPDump(iface string) *tcpdump.TCPDump {
-	return tcpdump.Attach(c.Name, "", iface)
+	return tcpdump.AttachUnavailable(c.Name, c.GetID(), iface)
 }

--- a/fv/infrastructure/felix.go
+++ b/fv/infrastructure/felix.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/felix/fv/containers"
+	"github.com/projectcalico/felix/fv/tcpdump"
 	"github.com/projectcalico/felix/fv/utils"
 )
 
@@ -166,4 +167,9 @@ func (f *Felix) Restart() {
 	oldPID := f.GetFelixPID()
 	f.Signal(syscall.SIGHUP)
 	Eventually(f.GetFelixPID, "10s", "100ms").ShouldNot(Equal(oldPID))
+}
+
+// AttachTCPDump returns tcpdump attached to the container
+func (f *Felix) AttachTCPDump(iface string) *tcpdump.TCPDump {
+	return tcpdump.Attach(f.Container.Name, "", iface)
 }

--- a/fv/tcpdump/tcpdump.go
+++ b/fv/tcpdump/tcpdump.go
@@ -16,6 +16,7 @@ package tcpdump
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os/exec"
 
@@ -33,20 +34,39 @@ import (
 	"github.com/projectcalico/felix/fv/utils"
 )
 
+// Attach use if tcpdump is available in the container
 func Attach(containerName, netns, iface string) *TCPDump {
 	t := &TCPDump{
+		exe:              "docker",
 		logEnabled:       true,
 		contName:         containerName,
-		netns:            netns,
-		iface:            iface,
 		matchers:         map[string]*tcpDumpMatcher{},
 		listeningStarted: make(chan struct{}),
 	}
+
+	t.args = []string{"exec", t.contName}
+	if netns != "" {
+		t.args = append(t.args, "ip", "netns", "exec", netns)
+	}
+	t.args = append(t.args, "tcpdump", "-nli", iface)
 
 	t.logString = containerName
 	if netns != "" {
 		t.logString += ":" + netns
 	}
+
+	return t
+}
+
+// AttachUnavailable use if tcpdump is not available in the container
+func AttachUnavailable(containerName, containerID, iface string) *TCPDump {
+	t := Attach(containerName, "", iface)
+
+	t.args = []string{"run",
+		"--rm",
+		fmt.Sprintf("--network=container:%s", containerID),
+		"--privileged",
+		"corfr/tcpdump", "-nli", iface}
 
 	return t
 }
@@ -65,8 +85,8 @@ type TCPDump struct {
 
 	logEnabled       bool
 	contName         string
-	netns            string
-	iface            string
+	exe              string
+	args             []string
 	logString        string
 	cmd              *exec.Cmd
 	out, err         io.ReadCloser
@@ -106,14 +126,8 @@ func (t *TCPDump) MatchCount(name string) int {
 }
 
 func (t *TCPDump) Start(expr ...string) {
-	args := []string{"exec", t.contName}
-	if t.netns != "" {
-		args = append(args, "ip", "netns", "exec", t.netns)
-	}
-	args = append(args, "tcpdump", "-nli", t.iface)
-	args = append(args, expr...)
-
-	t.cmd = utils.Command("docker", args...)
+	args := append(t.args, expr...)
+	t.cmd = utils.Command(t.exe, args...)
 	var err error
 	t.out, err = t.cmd.StdoutPipe()
 	Expect(err).NotTo(HaveOccurred())

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -90,7 +90,7 @@ func Run(c *infrastructure.Felix, name, profile, ip, ports, protocol string) (w 
 	return w
 }
 
-func run(c *infrastructure.Felix, name, profile, ip, ports, protocol string) (w *Workload, err error) {
+func New(c *infrastructure.Felix, name, profile, ip, ports, protocol string) *Workload {
 	workloadIdx++
 	n := fmt.Sprintf("%s-idx%v", name, workloadIdx)
 	interfaceName := conversion.VethNameForWorkload(profile, n)
@@ -99,7 +99,8 @@ func run(c *infrastructure.Felix, name, profile, ip, ports, protocol string) (w 
 	}
 	// Build unique workload name and struct.
 	workloadIdx++
-	w = &Workload{
+
+	return &Workload{
 		C:             c.Container,
 		Name:          n,
 		InterfaceName: interfaceName,
@@ -107,6 +108,12 @@ func run(c *infrastructure.Felix, name, profile, ip, ports, protocol string) (w 
 		Ports:         ports,
 		Protocol:      protocol,
 	}
+}
+
+func run(c *infrastructure.Felix, name, profile, ip, ports, protocol string) (w *Workload, err error) {
+
+	w = New(c, name, profile, ip, ports, protocol)
+	n := w.Name
 
 	// Ensure that the host has the 'test-workload' binary.
 	w.C.EnsureBinary("test-workload")

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -100,20 +100,38 @@ func New(c *infrastructure.Felix, name, profile, ip, ports, protocol string) *Wo
 	// Build unique workload name and struct.
 	workloadIdx++
 
+	wep := api.NewWorkloadEndpoint()
+	wep.Labels = map[string]string{"name": n}
+	wep.Spec.Node = c.Hostname
+	wep.Spec.Orchestrator = "felixfv"
+	wep.Spec.Workload = n
+	wep.Spec.Endpoint = n
+	prefixLen := "32"
+	if strings.Contains(ip, ":") {
+		prefixLen = "128"
+	}
+	wep.Spec.IPNetworks = []string{ip + "/" + prefixLen}
+	wep.Spec.InterfaceName = interfaceName
+	wep.Spec.Profiles = []string{profile}
+
 	return &Workload{
-		C:             c.Container,
-		Name:          n,
-		InterfaceName: interfaceName,
-		IP:            ip,
-		Ports:         ports,
-		Protocol:      protocol,
+		C:                c.Container,
+		Name:             n,
+		InterfaceName:    interfaceName,
+		IP:               ip,
+		Ports:            ports,
+		Protocol:         protocol,
+		WorkloadEndpoint: wep,
 	}
 }
 
 func run(c *infrastructure.Felix, name, profile, ip, ports, protocol string) (w *Workload, err error) {
-
 	w = New(c, name, profile, ip, ports, protocol)
-	n := w.Name
+	return w, w.Start()
+}
+
+func (w *Workload) Start() error {
+	var err error
 
 	// Ensure that the host has the 'test-workload' binary.
 	w.C.EnsureBinary("test-workload")
@@ -121,9 +139,9 @@ func run(c *infrastructure.Felix, name, profile, ip, ports, protocol string) (w 
 	// Start the workload.
 	log.WithField("workload", w).Info("About to run workload")
 	var protoArg string
-	if protocol == "udp" {
+	if w.Protocol == "udp" {
 		protoArg = "--udp"
-	} else if protocol == "sctp" {
+	} else if w.Protocol == "sctp" {
 		protoArg = "--sctp"
 	}
 	w.runCmd = utils.Command("docker", "exec", w.C.Name,
@@ -136,15 +154,15 @@ func run(c *infrastructure.Felix, name, profile, ip, ports, protocol string) (w 
 			w.Ports))
 	w.outPipe, err = w.runCmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("Getting StdoutPipe failed: %v", err)
+		return fmt.Errorf("Getting StdoutPipe failed: %v", err)
 	}
 	w.errPipe, err = w.runCmd.StderrPipe()
 	if err != nil {
-		return nil, fmt.Errorf("Getting StderrPipe failed: %v", err)
+		return fmt.Errorf("Getting StderrPipe failed: %v", err)
 	}
 	err = w.runCmd.Start()
 	if err != nil {
-		return nil, fmt.Errorf("runCmd Start failed: %v", err)
+		return fmt.Errorf("runCmd Start failed: %v", err)
 	}
 
 	// Read the workload's namespace path, which it writes to its standard output.
@@ -161,7 +179,7 @@ func run(c *infrastructure.Felix, name, profile, ip, ports, protocol string) (w 
 				log.WithError(err).Info("End of workload stderr")
 				return
 			}
-			log.Infof("Workload %s stderr: %s", n, strings.TrimSpace(string(line)))
+			log.Infof("Workload %s stderr: %s", w.Name, strings.TrimSpace(string(line)))
 		}
 	}()
 
@@ -170,7 +188,7 @@ func run(c *infrastructure.Felix, name, profile, ip, ports, protocol string) (w 
 		// (Only) if we fail here, wait for the stderr to be output before returning.
 		defer errDone.Wait()
 		if err != nil {
-			return nil, fmt.Errorf("Reading from stdout failed: %v", err)
+			return fmt.Errorf("Reading from stdout failed: %v", err)
 		}
 	}
 
@@ -183,28 +201,13 @@ func run(c *infrastructure.Felix, name, profile, ip, ports, protocol string) (w 
 				log.WithError(err).Info("End of workload stdout")
 				return
 			}
-			log.Infof("Workload %s stdout: %s", name, strings.TrimSpace(string(line)))
+			log.Infof("Workload %s stdout: %s", w.Name, strings.TrimSpace(string(line)))
 		}
 	}()
 
 	log.WithField("workload", w).Info("Workload now running")
 
-	wep := api.NewWorkloadEndpoint()
-	wep.Labels = map[string]string{"name": w.Name}
-	wep.Spec.Node = w.C.Hostname
-	wep.Spec.Orchestrator = "felixfv"
-	wep.Spec.Workload = w.Name
-	wep.Spec.Endpoint = w.Name
-	prefixLen := "32"
-	if strings.Contains(w.IP, ":") {
-		prefixLen = "128"
-	}
-	wep.Spec.IPNetworks = []string{w.IP + "/" + prefixLen}
-	wep.Spec.InterfaceName = w.InterfaceName
-	wep.Spec.Profiles = []string{profile}
-	w.WorkloadEndpoint = wep
-
-	return w, nil
+	return nil
 }
 
 func (w *Workload) IPNet() string {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The BPF dataplane now handles ICMP error messages as "related" traffic so that they follow the same path back through the dataplane as the packet they respond to. This improves compatibility with path MTU detection and other non-mainline traffic.
```
