### PR TITLE
bpf: fix endianess of state->{sd}port for encap traffic

### DIFF
--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -1032,7 +1032,7 @@ nat_encap:
 		goto  deny;
 	}
 
-	state->sport = state->dport = host_to_be16(CALI_VXLAN_PORT);
+	state->sport = state->dport = CALI_VXLAN_PORT;
 	state->ip_proto = IPPROTO_UDP;
 
 	if (CALI_F_INGRESS) {


### PR DESCRIPTION
state ports are always in host endianess as well as CALI_VXLAN_PORT is.
Turning it around results in failed FIB lookup.

<idle>-0     [004] ..s. 11070.719656: 0: eno1-----I: FIB sport=46354
<idle>-0     [004] ..s. 11070.719656: 0: eno1-----I: FIB dport=46354

46354 /* 0xb512 */
4789 /* 0x12b5 */

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
