### PR TITLE
Rebase BPF route manager onto new route format

### DIFF
--- a/bpf-gpl/routes.h
+++ b/bpf-gpl/routes.h
@@ -34,12 +34,13 @@ union cali_rt_lpm_key {
 };
 
 enum cali_rt_flags {
-	CALI_RT_UNKNOWN  = 0x00,
-	CALI_RT_IN_POOL  = 0x01,
-	CALI_RT_NAT_OUT  = 0x02,
-	CALI_RT_WORKLOAD = 0x04,
-	CALI_RT_LOCAL    = 0x08,
-	CALI_RT_HOST     = 0x10,
+	CALI_RT_UNKNOWN     = 0x00,
+	CALI_RT_IN_POOL     = 0x01,
+	CALI_RT_NAT_OUT     = 0x02,
+	CALI_RT_WORKLOAD    = 0x04,
+	CALI_RT_LOCAL       = 0x08,
+	CALI_RT_HOST        = 0x10,
+	CALI_RT_SAME_SUBNET = 0x20,
 };
 
 struct cali_rt {

--- a/bpf/routes/map.go
+++ b/bpf/routes/map.go
@@ -63,6 +63,7 @@ const (
 	FlagWorkload    Flags = 0x04
 	FlagLocal       Flags = 0x08
 	FlagHost        Flags = 0x10
+	FlagSameSubnet  Flags = 0x20
 
 	FlagsUnknown        Flags = 0
 	FlagsRemoteWorkload       = FlagWorkload
@@ -126,6 +127,10 @@ func (v Value) String() string {
 
 	if typeFlags&FlagNATOutgoing != 0 {
 		parts = append(parts, "nat-out")
+	}
+
+	if typeFlags&FlagSameSubnet != 0 {
+		parts = append(parts, "same-subnet")
 	}
 
 	if typeFlags&FlagLocal != 0 && typeFlags&FlagWorkload != 0 {

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -135,19 +135,21 @@ func withUDPConnectedRecvMsg() bpfTestOpt {
 	}
 }
 
-const expectedRouteDump = `10.65.0.2/32: local workload in-pool nat-out idx -
+const expectedRouteDump = `10.65.0.0/16: remote in-pool nat-out
+10.65.0.2/32: local workload in-pool nat-out idx -
 10.65.0.3/32: local workload in-pool nat-out idx -
-10.65.1.0/26: remote workload in-pool nh FELIX_1
-10.65.2.0/26: remote workload in-pool nh FELIX_2
+10.65.1.0/26: remote workload in-pool nat-out nh FELIX_1
+10.65.2.0/26: remote workload in-pool nat-out nh FELIX_2
 FELIX_0/32: local host
 FELIX_1/32: remote host
 FELIX_2/32: remote host`
 
-const expectedRouteDumpIPIP = `10.65.0.1/32: local host in-pool nat-out
+const expectedRouteDumpIPIP = `10.65.0.0/16: remote in-pool nat-out
+10.65.0.1/32: local host
 10.65.0.2/32: local workload in-pool nat-out idx -
 10.65.0.3/32: local workload in-pool nat-out idx -
-10.65.1.0/26: remote workload in-pool nh FELIX_1
-10.65.2.0/26: remote workload in-pool nh FELIX_2
+10.65.1.0/26: remote workload in-pool nat-out nh FELIX_1
+10.65.2.0/26: remote workload in-pool nat-out nh FELIX_2
 FELIX_0/32: local host
 FELIX_1/32: remote host
 FELIX_2/32: remote host`


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Most BPF routes now come entirely from the calc graph, including routes for the IP pools.  However, there are a couple of wrinkles:

* Local host IPs are collected by the dataplane and routes for those are synthesised.  This can result in missing flags if there's no corresponsing calc graph route.  However, we don't use those flags for local host routes right now.
* Local workload routes need to include the interface index so there's some book-keeping to find the right one.

As part of this work, I refactored to maintain a dirty set of CIDRs.  So, the flow is now:

* Accept updates from calc graph and other sources; cache the information from the updates and mark any touched CIDRs as dirty.
* In CompleteDeferredWork, loop over the dirty CIDRs and recalculate the route for each one from scratch and update the cache of desired dataplane routes.  Mark updated dataplane routes as dirty.
* Finally, send any dataplane route updates to the BPF map.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
