### PR TITLE
Update routetable to accept deltas

### DIFF
--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -375,8 +375,8 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	dp.ipSets = append(dp.ipSets, ipSetsV4)
 
 	if config.RulesConfig.VXLANEnabled {
-		routeTableVXLAN := routetable.New([]string{"vxlan.calico"}, 4, true, config.NetlinkTimeout, config.DeviceRouteSourceAddress,
-			config.DeviceRouteProtocol, true)
+		routeTableVXLAN := routetable.New([]string{"^vxlan.calico$"}, 4, true, config.NetlinkTimeout,
+			config.DeviceRouteSourceAddress, config.DeviceRouteProtocol, true, 0)
 
 		vxlanManager := newVXLANManager(
 			ipSetsV4,
@@ -572,8 +572,12 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		}
 	}
 
-	routeTableV4 := routetable.New(config.RulesConfig.WorkloadIfacePrefixes, 4, false, config.NetlinkTimeout,
-		config.DeviceRouteSourceAddress, config.DeviceRouteProtocol, config.RemoveExternalRoutes)
+	interfaceRegexes := make([]string, len(config.RulesConfig.WorkloadIfacePrefixes))
+	for i, r := range config.RulesConfig.WorkloadIfacePrefixes {
+		interfaceRegexes[i] = "^" + r + ".*"
+	}
+	routeTableV4 := routetable.New(interfaceRegexes, 4, false, config.NetlinkTimeout,
+		config.DeviceRouteSourceAddress, config.DeviceRouteProtocol, config.RemoveExternalRoutes, 0)
 
 	epManager := newEndpointManager(
 		rawTableV4,
@@ -639,7 +643,9 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		dp.iptablesMangleTables = append(dp.iptablesMangleTables, mangleTableV6)
 		dp.iptablesFilterTables = append(dp.iptablesFilterTables, filterTableV6)
 
-		routeTableV6 := routetable.New(config.RulesConfig.WorkloadIfacePrefixes, 6, false, config.NetlinkTimeout, config.DeviceRouteSourceAddress, config.DeviceRouteProtocol, config.RemoveExternalRoutes)
+		routeTableV6 := routetable.New(
+			interfaceRegexes, 6, false, config.NetlinkTimeout,
+			config.DeviceRouteSourceAddress, config.DeviceRouteProtocol, config.RemoveExternalRoutes, 0)
 
 		if !config.BPFEnabled {
 			dp.RegisterManager(newIPSetsManager(ipSetsV6, config.MaxIPSetSize, callbacks))

--- a/dataplane/linux/vxlan_mgr.go
+++ b/dataplane/linux/vxlan_mgr.go
@@ -96,10 +96,10 @@ func newVXLANManager(
 		deviceName,
 		dpConfig,
 		nlHandle,
-		func(interfacePrefixes []string, ipVersion uint8, vxlan bool, netlinkTimeout time.Duration,
+		func(interfaceRegexes []string, ipVersion uint8, vxlan bool, netlinkTimeout time.Duration,
 			deviceRouteSourceAddress net.IP, deviceRouteProtocol int, removeExternalRoutes bool) routeTable {
-			return routetable.New(interfacePrefixes, ipVersion, vxlan, netlinkTimeout,
-				deviceRouteSourceAddress, deviceRouteProtocol, removeExternalRoutes)
+			return routetable.New(interfaceRegexes, ipVersion, vxlan, netlinkTimeout,
+				deviceRouteSourceAddress, deviceRouteProtocol, removeExternalRoutes, 0)
 		},
 	)
 }
@@ -352,7 +352,7 @@ func (m *vxlanManager) KeepVXLANDeviceInSync(mtu int, wait time.Duration) {
 			continue
 		} else {
 			if m.getNoEncapRouteTable() == nil {
-				noEncapRouteTable := m.noEncapRTConstruct([]string{parent.Attrs().Name}, 4, false, m.dpConfig.NetlinkTimeout, m.dpConfig.DeviceRouteSourceAddress,
+				noEncapRouteTable := m.noEncapRTConstruct([]string{"^" + parent.Attrs().Name + "$"}, 4, false, m.dpConfig.NetlinkTimeout, m.dpConfig.DeviceRouteSourceAddress,
 					m.noEncapProtocol, false)
 				m.setNoEncapRouteTable(noEncapRouteTable)
 			}

--- a/netlink/mock/netlink.go
+++ b/netlink/mock/netlink.go
@@ -1,0 +1,579 @@
+package mock
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+
+	"github.com/projectcalico/felix/ip"
+	netlinkshim "github.com/projectcalico/felix/netlink"
+	"github.com/projectcalico/libcalico-go/lib/set"
+)
+
+func NewMockNetlinkDataplane() *MockNetlinkDataplane {
+	return &MockNetlinkDataplane{
+		nameToLink:       map[string]*MockLink{},
+		AddedLinks:       set.New(),
+		DeletedLinks:     set.New(),
+		AddedAddrs:       set.New(),
+		DeletedAddrs:     set.New(),
+		RouteKeyToRoute:  map[string]netlink.Route{},
+		AddedRouteKeys:   set.New(),
+		DeletedRouteKeys: set.New(),
+		UpdatedRouteKeys: set.New(),
+	}
+}
+
+// Validate the mock netlink adheres to the netlink interface.
+var _ netlinkshim.Netlink = NewMockNetlinkDataplane()
+
+var (
+	SimulatedError = errors.New("dummy error")
+	NotFound       = errors.New("not found")
+	AlreadyExists  = errors.New("already exists")
+)
+
+type FailFlags uint32
+
+const (
+	FailNextLinkList FailFlags = 1 << iota
+	FailNextLinkByName
+	FailNextLinkByNameNotFound
+	FailNextRouteList
+	FailNextRouteAdd
+	FailNextRouteDel
+	FailNextAddARP
+	FailNextNewNetlink
+	FailNextSetSocketTimeout
+	FailNextLinkAdd
+	FailNextLinkDel
+	FailNextLinkSetMTU
+	FailNextLinkSetUp
+	FailNextAddrList
+	FailNextAddrAdd
+	FailNextAddrDel
+	FailNextRuleList
+	FailNextRuleAdd
+	FailNextRuleDel
+	FailNone FailFlags = 0
+)
+
+var RoutetableFailureScenarios = []FailFlags{
+	FailNone,
+	FailNextLinkList,
+	FailNextLinkByName,
+	FailNextLinkByNameNotFound,
+	FailNextRouteList,
+	FailNextRouteAdd,
+	FailNextRouteDel,
+	FailNextAddARP,
+	FailNextNewNetlink,
+	FailNextSetSocketTimeout,
+}
+
+func (f FailFlags) String() string {
+	parts := []string{}
+	if f&FailNextLinkList != 0 {
+		parts = append(parts, "FailNextLinkList")
+	}
+	if f&FailNextLinkByName != 0 {
+		parts = append(parts, "FailNextLinkByName")
+	}
+	if f&FailNextLinkByNameNotFound != 0 {
+		parts = append(parts, "FailNextLinkByNameNotFound")
+	}
+	if f&FailNextRouteList != 0 {
+		parts = append(parts, "FailNextRouteList")
+	}
+	if f&FailNextRouteAdd != 0 {
+		parts = append(parts, "FailNextRouteAdd")
+	}
+	if f&FailNextRouteDel != 0 {
+		parts = append(parts, "FailNextRouteDel")
+	}
+	if f&FailNextAddARP != 0 {
+		parts = append(parts, "FailNextAddARP")
+	}
+	if f&FailNextNewNetlink != 0 {
+		parts = append(parts, "FailNextNewNetlink")
+	}
+	if f&FailNextSetSocketTimeout != 0 {
+		parts = append(parts, "FailNextSetSocketTimeout")
+	}
+	if f&FailNextLinkAdd != 0 {
+		parts = append(parts, "FailNextLinkAdd")
+	}
+	if f&FailNextLinkDel != 0 {
+		parts = append(parts, "FailNextLinkDel")
+	}
+	if f&FailNextLinkSetMTU != 0 {
+		parts = append(parts, "FailNextLinkSetMTU")
+	}
+	if f&FailNextLinkSetUp != 0 {
+		parts = append(parts, "FailNextLinkSetUp")
+	}
+	if f&FailNextAddrList != 0 {
+		parts = append(parts, "FailNextAddrList")
+	}
+	if f&FailNextAddrAdd != 0 {
+		parts = append(parts, "FailNextAddrAdd")
+	}
+	if f&FailNextAddrDel != 0 {
+		parts = append(parts, "FailNextAddrDel")
+	}
+	if f&FailNextRuleList != 0 {
+		parts = append(parts, "FailNextRuleList")
+	}
+	if f&FailNextRuleAdd != 0 {
+		parts = append(parts, "FailNextRuleAdd")
+	}
+	if f&FailNextRuleDel != 0 {
+		parts = append(parts, "FailNextRuleDel")
+	}
+	if f == 0 {
+		parts = append(parts, "FailNone")
+	}
+	return strings.Join(parts, "|")
+}
+
+type MockNetlinkDataplane struct {
+	nameToLink   map[string]*MockLink
+	AddedLinks   set.Set
+	DeletedLinks set.Set
+	AddedAddrs   set.Set
+	DeletedAddrs set.Set
+
+	RouteKeyToRoute  map[string]netlink.Route
+	AddedRouteKeys   set.Set
+	DeletedRouteKeys set.Set
+	UpdatedRouteKeys set.Set
+
+	NumNewNetlinkCalls int
+	NetlinkOpen        bool
+
+	PersistentlyFailToConnect bool
+
+	PersistFailures    bool
+	FailuresToSimulate FailFlags
+
+	mutex                   sync.Mutex
+	deletedConntrackEntries []net.IP
+	ConntrackSleep          time.Duration
+}
+
+func (d *MockNetlinkDataplane) ResetDeltas() {
+	d.AddedLinks = set.New()
+	d.DeletedLinks = set.New()
+	d.AddedAddrs = set.New()
+	d.DeletedAddrs = set.New()
+	d.AddedRouteKeys = set.New()
+	d.DeletedRouteKeys = set.New()
+	d.UpdatedRouteKeys = set.New()
+}
+
+func (d *MockNetlinkDataplane) AddIface(idx int, name string, up bool, running bool) *MockLink {
+	flags := net.Flags(0)
+	var rawFlags uint32
+	if up {
+		flags |= net.FlagUp
+		rawFlags |= syscall.IFF_UP
+	}
+	if running {
+		rawFlags |= syscall.IFF_RUNNING
+	}
+	link := &MockLink{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:     name,
+			Flags:    flags,
+			RawFlags: rawFlags,
+			Index:    idx,
+		},
+	}
+	d.nameToLink[name] = link
+	return link
+}
+
+func (d *MockNetlinkDataplane) shouldFail(flag FailFlags) bool {
+	flagPresent := d.FailuresToSimulate&flag != 0
+	if !d.PersistFailures {
+		d.FailuresToSimulate &^= flag
+	}
+	if flagPresent {
+		log.WithField("flag", flag).Warn("Mock dataplane: triggering failure")
+	}
+	return flagPresent
+}
+
+func (d *MockNetlinkDataplane) NewMockNetlink() (netlinkshim.Netlink, error) {
+	d.NumNewNetlinkCalls++
+	if d.PersistentlyFailToConnect || d.shouldFail(FailNextNewNetlink) {
+		return nil, SimulatedError
+	}
+	Expect(d.NetlinkOpen).To(BeFalse())
+	d.NetlinkOpen = true
+	return d, nil
+}
+
+func (d *MockNetlinkDataplane) Delete() {
+	Expect(d.NetlinkOpen).To(BeTrue())
+	d.NetlinkOpen = false
+}
+
+func (d *MockNetlinkDataplane) SetSocketTimeout(to time.Duration) error {
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextSetSocketTimeout) {
+		return SimulatedError
+	}
+	return nil
+}
+
+func (d *MockNetlinkDataplane) LinkList() ([]netlink.Link, error) {
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextLinkList) {
+		return nil, SimulatedError
+	}
+	var links []netlink.Link
+	for _, link := range d.nameToLink {
+		links = append(links, link)
+	}
+	return links, nil
+}
+
+func (d *MockNetlinkDataplane) LinkByName(name string) (netlink.Link, error) {
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextLinkByNameNotFound) {
+		return nil, NotFound
+	}
+	if d.shouldFail(FailNextLinkByName) {
+		return nil, SimulatedError
+	}
+	if link, ok := d.nameToLink[name]; ok {
+		return link, nil
+	}
+	return nil, NotFound
+}
+
+func (d *MockNetlinkDataplane) LinkAdd(link netlink.Link) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextLinkAdd) {
+		return SimulatedError
+	}
+
+	if _, ok := d.nameToLink[link.Attrs().Name]; ok {
+		return AlreadyExists
+	}
+	d.nameToLink[link.Attrs().Name] = &MockLink{
+		LinkAttrs: *link.Attrs(),
+		LinkType:  link.Type(),
+	}
+	d.AddedLinks.Add(link.Attrs().Name)
+	return nil
+}
+
+func (d *MockNetlinkDataplane) LinkDel(link netlink.Link) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextLinkDel) {
+		return SimulatedError
+	}
+
+	if _, ok := d.nameToLink[link.Attrs().Name]; !ok {
+		return NotFound
+	}
+
+	delete(d.nameToLink, link.Attrs().Name)
+	d.DeletedLinks.Add(link.Attrs().Name)
+	return nil
+}
+
+func (d *MockNetlinkDataplane) LinkSetMTU(link netlink.Link, mtu int) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextLinkSetMTU) {
+		return SimulatedError
+	}
+	if link, ok := d.nameToLink[link.Attrs().Name]; ok {
+		link.Attrs().MTU = mtu
+		d.nameToLink[link.Attrs().Name] = link
+		return nil
+	}
+	return NotFound
+}
+
+func (d *MockNetlinkDataplane) LinkSetUp(link netlink.Link) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextLinkSetUp) {
+		return SimulatedError
+	}
+	if link, ok := d.nameToLink[link.Attrs().Name]; ok {
+		link.Attrs().Flags |= net.FlagUp
+		link.Attrs().RawFlags |= syscall.IFF_RUNNING
+		d.nameToLink[link.Attrs().Name] = link
+		return nil
+	}
+	return NotFound
+}
+
+func (d *MockNetlinkDataplane) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextAddrList) {
+		return nil, SimulatedError
+	}
+	if link, ok := d.nameToLink[link.Attrs().Name]; ok {
+		return link.Addrs, nil
+	}
+	return nil, NotFound
+}
+
+func (d *MockNetlinkDataplane) AddrAdd(link netlink.Link, addr *netlink.Addr) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	Expect(addr).NotTo(BeNil())
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextAddrAdd) {
+		return SimulatedError
+	}
+	if link, ok := d.nameToLink[link.Attrs().Name]; ok {
+		for _, linkaddr := range link.Addrs {
+			if linkaddr.Equal(*addr) {
+				return AlreadyExists
+			}
+		}
+		d.AddedAddrs.Add(addr.IPNet.String())
+		link.Addrs = append(link.Addrs, *addr)
+		d.nameToLink[link.Attrs().Name] = link
+		return nil
+	}
+
+	return NotFound
+}
+
+func (d *MockNetlinkDataplane) AddrDel(link netlink.Link, addr *netlink.Addr) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	Expect(addr).NotTo(BeNil())
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextAddrDel) {
+		return SimulatedError
+	}
+	if link, ok := d.nameToLink[link.Attrs().Name]; ok {
+		newIdx := 0
+		for idx, linkaddr := range link.Addrs {
+			if linkaddr.Equal(*addr) {
+				continue
+			}
+			link.Addrs[newIdx] = link.Addrs[idx]
+			newIdx++
+		}
+		Expect(newIdx).To(Equal(len(link.Addrs) - 1))
+		link.Addrs = link.Addrs[:newIdx]
+		d.nameToLink[link.Attrs().Name] = link
+		d.DeletedAddrs.Add(addr.IPNet.String())
+		return nil
+	}
+
+	return nil
+}
+
+func (d *MockNetlinkDataplane) RuleList(family int) ([]netlink.Rule, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextRuleList) {
+		return nil, SimulatedError
+	}
+
+	return nil, nil
+}
+
+func (d *MockNetlinkDataplane) RuleAdd(rule *netlink.Rule) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextRuleAdd) {
+		return SimulatedError
+	}
+
+	return nil
+}
+
+func (d *MockNetlinkDataplane) RuleDel(rule *netlink.Rule) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextRuleDel) {
+		return SimulatedError
+	}
+
+	return nil
+}
+
+func (d *MockNetlinkDataplane) RouteListFiltered(family int, filter *netlink.Route, filterMask uint64) ([]netlink.Route, error) {
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextRouteList) {
+		return nil, SimulatedError
+	}
+	var routes []netlink.Route
+	for _, route := range d.RouteKeyToRoute {
+		log.Debugf("Maybe include route: %v", route)
+		if filter != nil && filterMask&netlink.RT_FILTER_OIF != 0 && route.LinkIndex != filter.LinkIndex {
+			// Filtering by interface and link indices do not match.
+			log.Debug("Does not match link")
+			continue
+		}
+		if route.Table == 0 {
+			// Mimic the kernel - the route table will be filled in.
+			route.Table = unix.RT_TABLE_MAIN
+		}
+		if (filter == nil || filterMask&netlink.RT_FILTER_TABLE == 0) && route.Table != unix.RT_TABLE_MAIN {
+			// Not filtering by table and does not match main table.
+			log.Debug("Does not match main table")
+			continue
+		}
+		if filter != nil && filterMask&netlink.RT_FILTER_TABLE != 0 && route.Table != filter.Table {
+			// Filtering by table and table indices do not match.
+			log.Debugf("Does not match table %d", filter.Table)
+			continue
+		}
+		routes = append(routes, route)
+	}
+	return routes, nil
+}
+
+func (d *MockNetlinkDataplane) AddMockRoute(route *netlink.Route) {
+	key := KeyForRoute(route)
+	r := *route
+	if r.Table == unix.RT_TABLE_MAIN {
+		// Store the main table with index 0 for simplicity with comparisons.
+		r.Table = 0
+	}
+	d.RouteKeyToRoute[key] = r
+}
+
+func (d *MockNetlinkDataplane) RemoveMockRoute(route *netlink.Route) {
+	key := KeyForRoute(route)
+	delete(d.RouteKeyToRoute, key)
+}
+
+func (d *MockNetlinkDataplane) RouteAdd(route *netlink.Route) error {
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextRouteAdd) {
+		return SimulatedError
+	}
+	key := KeyForRoute(route)
+	log.WithField("routeKey", key).Info("Mock dataplane: RouteAdd called")
+	d.AddedRouteKeys.Add(key)
+	if _, ok := d.RouteKeyToRoute[key]; ok {
+		return AlreadyExists
+	} else {
+		r := *route
+		if r.Table == unix.RT_TABLE_MAIN {
+			// Store main table routes with 0 index for simplicity of comparison.
+			r.Table = 0
+		}
+		d.RouteKeyToRoute[key] = r
+		return nil
+	}
+}
+
+func (d *MockNetlinkDataplane) RouteDel(route *netlink.Route) error {
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextRouteDel) {
+		return SimulatedError
+	}
+	key := KeyForRoute(route)
+	log.WithField("routeKey", key).Info("Mock dataplane: RouteDel called")
+	d.DeletedRouteKeys.Add(key)
+	// Route was deleted, but is planned on being readded
+	if _, ok := d.RouteKeyToRoute[key]; ok {
+		delete(d.RouteKeyToRoute, key)
+		d.UpdatedRouteKeys.Add(key)
+		return nil
+	} else {
+		return nil
+	}
+}
+
+func (d *MockNetlinkDataplane) AddStaticArpEntry(cidr ip.CIDR, destMAC net.HardwareAddr, ifaceName string) error {
+	if d.shouldFail(FailNextAddARP) {
+		return SimulatedError
+	}
+	log.WithFields(log.Fields{
+		"cidr":      cidr,
+		"destMac":   destMAC,
+		"ifaceName": ifaceName,
+	}).Info("Mock dataplane: adding ARP entry")
+	return nil
+}
+
+func (d *MockNetlinkDataplane) RemoveConntrackFlows(ipVersion uint8, ipAddr net.IP) {
+	log.WithFields(log.Fields{
+		"ipVersion": ipVersion,
+		"ipAddr":    ipAddr,
+		"sleepTime": d.ConntrackSleep,
+	}).Info("Mock dataplane: Removing conntrack flows")
+	d.mutex.Lock()
+	d.deletedConntrackEntries = append(d.deletedConntrackEntries, ipAddr)
+	d.mutex.Unlock()
+	time.Sleep(d.ConntrackSleep)
+}
+
+func (d *MockNetlinkDataplane) GetDeletedConntrackEntries() []net.IP {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	cpy := make([]net.IP, len(d.deletedConntrackEntries))
+	copy(cpy, d.deletedConntrackEntries)
+	return cpy
+}
+
+func KeyForRoute(route *netlink.Route) string {
+	table := route.Table
+	if table == 0 {
+		table = unix.RT_TABLE_MAIN
+	}
+	key := fmt.Sprintf("%v-%v-%v", table, route.LinkIndex, route.Dst)
+	log.WithField("routeKey", key).Debug("Calculated route key")
+	return key
+}
+
+type MockLink struct {
+	LinkAttrs netlink.LinkAttrs
+	Addrs     []netlink.Addr
+	LinkType  string
+}
+
+func (l *MockLink) Attrs() *netlink.LinkAttrs {
+	return &l.LinkAttrs
+}
+
+func (l *MockLink) Type() string {
+	return l.LinkType
+}

--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -1,0 +1,32 @@
+package netlink
+
+import (
+	"syscall"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+type Netlink interface {
+	SetSocketTimeout(to time.Duration) error
+	LinkList() ([]netlink.Link, error)
+	LinkByName(name string) (netlink.Link, error)
+	LinkAdd(link netlink.Link) error
+	LinkDel(link netlink.Link) error
+	LinkSetMTU(link netlink.Link, mtu int) error
+	LinkSetUp(link netlink.Link) error
+	RouteListFiltered(family int, filter *netlink.Route, filterMask uint64) ([]netlink.Route, error)
+	RouteAdd(route *netlink.Route) error
+	RouteDel(route *netlink.Route) error
+	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
+	AddrAdd(link netlink.Link, addr *netlink.Addr) error
+	AddrDel(link netlink.Link, addr *netlink.Addr) error
+	RuleList(family int) ([]netlink.Rule, error)
+	RuleAdd(rule *netlink.Rule) error
+	RuleDel(rule *netlink.Rule) error
+	Delete()
+}
+
+func NewRealNetlink() (Netlink, error) {
+	return netlink.NewHandle(syscall.NETLINK_ROUTE)
+}

--- a/routetable/dataplane_shims.go
+++ b/routetable/dataplane_shims.go
@@ -17,10 +17,6 @@ package routetable
 import (
 	"net"
 	"os/exec"
-	"syscall"
-	"time"
-
-	"github.com/vishvananda/netlink"
 
 	"github.com/projectcalico/felix/ip"
 )
@@ -29,42 +25,9 @@ type conntrackIface interface {
 	RemoveConntrackFlows(ipVersion uint8, ipAddr net.IP)
 }
 
-type HandleIface interface {
-	SetSocketTimeout(to time.Duration) error
-	LinkList() ([]netlink.Link, error)
-	LinkByName(name string) (netlink.Link, error)
-	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
-	RouteAdd(route *netlink.Route) error
-	RouteDel(route *netlink.Route) error
-	Delete()
-}
-
-func newNetlinkHandle() (HandleIface, error) {
-	return netlink.NewHandle(syscall.NETLINK_ROUTE)
-}
-
 func addStaticARPEntry(cidr ip.CIDR, destMAC net.HardwareAddr, ifaceName string) error {
 	cmd := exec.Command("arp",
 		"-s", cidr.Addr().String(), destMAC.String(),
 		"-i", ifaceName)
 	return cmd.Run()
 }
-
-// timeIface is our shim interface to the time package.
-type timeIface interface {
-	Now() time.Time
-	Since(t time.Time) time.Duration
-}
-
-// realTime is the real implementation of timeIface, which calls through to the real time package.
-type realTime struct{}
-
-func (realTime) Now() time.Time {
-	return time.Now()
-}
-
-func (realTime) Since(t time.Time) time.Duration {
-	return time.Since(t)
-}
-
-var _ timeIface = realTime{}

--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -17,6 +17,7 @@ package routetable
 import (
 	"errors"
 	"net"
+	"reflect"
 	"regexp"
 	"strings"
 	"syscall"
@@ -29,6 +30,8 @@ import (
 	"github.com/projectcalico/felix/conntrack"
 	"github.com/projectcalico/felix/ifacemonitor"
 	"github.com/projectcalico/felix/ip"
+	netlinkshim "github.com/projectcalico/felix/netlink"
+	timeshim "github.com/projectcalico/felix/time"
 	"github.com/projectcalico/libcalico-go/lib/set"
 )
 
@@ -62,11 +65,25 @@ func init() {
 	prometheus.MustRegister(listIfaceTime, perIfaceSyncTime)
 }
 
+const (
+	// Use this for targets with no outbound interface.
+	InterfaceNone = "*NoOIF*"
+)
+
 type TargetType string
 
 const (
 	TargetTypeVXLAN   TargetType = "vxlan"
 	TargetTypeNoEncap TargetType = "noencap"
+
+	// The following target types should be used with InterfaceNone.
+	TargetTypeBlackhole TargetType = "blackhole"
+	TargetTypeProhibit  TargetType = "prohibit"
+	TargetTypeThrow     TargetType = "throw"
+)
+
+const (
+	maxApplyRetries = 2
 )
 
 type L2Target struct {
@@ -87,6 +104,43 @@ type Target struct {
 	DestMAC net.HardwareAddr
 }
 
+func (t Target) Equal(t2 Target) bool {
+	return reflect.DeepEqual(t, t2)
+}
+
+func (t Target) RouteType() int {
+	switch t.Type {
+	case TargetTypeThrow:
+		return syscall.RTN_THROW
+	case TargetTypeBlackhole:
+		return syscall.RTN_BLACKHOLE
+	case TargetTypeProhibit:
+		return syscall.RTN_PROHIBIT
+	default:
+		return syscall.RTN_UNICAST
+	}
+}
+
+func (t Target) RouteScope() netlink.Scope {
+	switch t.Type {
+	case TargetTypeThrow:
+		return netlink.SCOPE_UNIVERSE
+	case TargetTypeBlackhole:
+		return netlink.SCOPE_UNIVERSE
+	case TargetTypeProhibit:
+		return netlink.SCOPE_UNIVERSE
+	default:
+		return netlink.SCOPE_LINK
+	}
+}
+
+type updateType byte
+
+const (
+	updateTypeFullResync updateType = iota
+	updateTypeDelta
+)
+
 type RouteTable struct {
 	logCxt *log.Entry
 
@@ -97,22 +151,21 @@ type RouteTable struct {
 	// reset on successful connection.
 	numConsistentNetlinkFailures int
 	// Current netlink handle, or nil if we need to reconnect.
-	cachedNetlinkHandle HandleIface
+	cachedNetlinkHandle netlinkshim.Netlink
 
-	dirtyIfaces set.Set
+	// Interface update tracking.
+	reSync                bool
+	ifaceNameToUpdateType map[string]updateType
+	ifacePrefixRegexp     *regexp.Regexp
+	includeNoInterface    bool
 
-	ifacePrefixes     set.Set
-	ifacePrefixRegexp *regexp.Regexp
-
-	ifaceNameToTargets          map[string][]Target
-	ifaceNameToL2Targets        map[string][]L2Target
-	ifaceNameToFirstSeen        map[string]time.Time
-	pendingIfaceNameToTargets   map[string][]Target
-	pendingIfaceNameToL2Targets map[string][]L2Target
+	ifaceNameToTargets             map[string]map[ip.CIDR]Target
+	ifaceNameToL2Targets           map[string][]L2Target
+	ifaceNameToFirstSeen           map[string]time.Time
+	pendingIfaceNameToDeltaTargets map[string]map[ip.CIDR]*Target
+	pendingIfaceNameToL2Targets    map[string][]L2Target
 
 	pendingConntrackCleanups map[ip.Addr]chan struct{}
-
-	inSync bool
 
 	// Whether this route table is managing vxlan routes.
 	vxlan bool
@@ -122,48 +175,65 @@ type RouteTable struct {
 	deviceRouteProtocol  int
 	removeExternalRoutes bool
 
+	// The route table index. A value of 0 defaults to the main table.
+	tableIndex int
+
 	// Testing shims, swapped with mock versions for UT
-	newNetlinkHandle  func() (HandleIface, error)
+	newNetlinkHandle  func() (netlinkshim.Netlink, error)
 	addStaticARPEntry func(cidr ip.CIDR, destMAC net.HardwareAddr, ifaceName string) error
 	conntrack         conntrackIface
-	time              timeIface
+	time              timeshim.Time
 }
 
-func New(interfacePrefixes []string, ipVersion uint8, vxlan bool, netlinkTimeout time.Duration, deviceRouteSourceAddress net.IP, deviceRouteProtocol int, removeExternalRoutes bool) *RouteTable {
+func New(
+	interfaceRegexes []string,
+	ipVersion uint8,
+	vxlan bool,
+	netlinkTimeout time.Duration,
+	deviceRouteSourceAddress net.IP,
+	deviceRouteProtocol int,
+	removeExternalRoutes bool,
+	tableIndex int,
+) *RouteTable {
 	return NewWithShims(
-		interfacePrefixes,
+		interfaceRegexes,
 		ipVersion,
-		newNetlinkHandle,
+		netlinkshim.NewRealNetlink,
 		vxlan,
 		netlinkTimeout,
 		addStaticARPEntry,
 		conntrack.New(),
-		realTime{},
+		timeshim.NewRealTime(),
 		deviceRouteSourceAddress,
 		deviceRouteProtocol,
 		removeExternalRoutes,
+		tableIndex,
 	)
 }
 
 // NewWithShims is a test constructor, which allows netlink, arp and time to be replaced by shims.
 func NewWithShims(
-	interfacePrefixes []string,
+	interfaceRegexes []string,
 	ipVersion uint8,
-	newNetlinkHandle func() (HandleIface, error),
+	newNetlinkHandle func() (netlinkshim.Netlink, error),
 	vxlan bool,
 	netlinkTimeout time.Duration,
 	addStaticARPEntry func(cidr ip.CIDR, destMAC net.HardwareAddr, ifaceName string) error,
 	conntrack conntrackIface,
-	timeShim timeIface,
+	timeShim timeshim.Time,
 	deviceRouteSourceAddress net.IP,
 	deviceRouteProtocol int,
 	removeExternalRoutes bool,
+	tableIndex int,
 ) *RouteTable {
-	prefixSet := set.New()
-	regexpParts := []string{}
-	for _, prefix := range interfacePrefixes {
-		prefixSet.Add(prefix)
-		regexpParts = append(regexpParts, "^"+prefix+".*")
+	var regexpParts []string
+	includeNoOIF := false
+	for _, interfaceRegex := range interfaceRegexes {
+		if interfaceRegex == InterfaceNone {
+			includeNoOIF = true
+		} else {
+			regexpParts = append(regexpParts, interfaceRegex)
+		}
 	}
 
 	ifaceNamePattern := strings.Join(regexpParts, "|")
@@ -180,26 +250,28 @@ func NewWithShims(
 		logCxt: log.WithFields(log.Fields{
 			"ipVersion": ipVersion,
 		}),
-		ipVersion:                   ipVersion,
-		netlinkFamily:               family,
-		ifacePrefixes:               prefixSet,
-		ifacePrefixRegexp:           regexp.MustCompile(ifaceNamePattern),
-		ifaceNameToTargets:          map[string][]Target{},
-		ifaceNameToL2Targets:        map[string][]L2Target{},
-		ifaceNameToFirstSeen:        map[string]time.Time{},
-		pendingIfaceNameToTargets:   map[string][]Target{},
-		pendingIfaceNameToL2Targets: map[string][]L2Target{},
-		dirtyIfaces:                 set.New(),
-		pendingConntrackCleanups:    map[ip.Addr]chan struct{}{},
-		newNetlinkHandle:            newNetlinkHandle,
-		netlinkTimeout:              netlinkTimeout,
-		addStaticARPEntry:           addStaticARPEntry,
-		conntrack:                   conntrack,
-		time:                        timeShim,
-		vxlan:                       vxlan,
-		deviceRouteSourceAddress:    deviceRouteSourceAddress,
-		deviceRouteProtocol:         deviceRouteProtocol,
-		removeExternalRoutes:        removeExternalRoutes,
+		ipVersion:                      ipVersion,
+		netlinkFamily:                  family,
+		ifacePrefixRegexp:              regexp.MustCompile(ifaceNamePattern),
+		includeNoInterface:             includeNoOIF,
+		ifaceNameToTargets:             map[string]map[ip.CIDR]Target{},
+		ifaceNameToL2Targets:           map[string][]L2Target{},
+		ifaceNameToFirstSeen:           map[string]time.Time{},
+		pendingIfaceNameToDeltaTargets: map[string]map[ip.CIDR]*Target{},
+		pendingIfaceNameToL2Targets:    map[string][]L2Target{},
+		reSync:                         true,
+		ifaceNameToUpdateType:          map[string]updateType{},
+		pendingConntrackCleanups:       map[ip.Addr]chan struct{}{},
+		newNetlinkHandle:               newNetlinkHandle,
+		netlinkTimeout:                 netlinkTimeout,
+		addStaticARPEntry:              addStaticARPEntry,
+		conntrack:                      conntrack,
+		time:                           timeShim,
+		vxlan:                          vxlan,
+		deviceRouteSourceAddress:       deviceRouteSourceAddress,
+		deviceRouteProtocol:            deviceRouteProtocol,
+		removeExternalRoutes:           removeExternalRoutes,
+		tableIndex:                     tableIndex,
 	}
 }
 
@@ -211,7 +283,7 @@ func (r *RouteTable) OnIfaceStateChanged(ifaceName string, state ifacemonitor.St
 	}
 	if state == ifacemonitor.StateUp {
 		logCxt.Debug("Interface up, marking for route sync")
-		r.dirtyIfaces.Add(ifaceName)
+		r.ifaceNameToUpdateType[ifaceName] = updateTypeFullResync
 		r.onIfaceSeen(ifaceName)
 	}
 }
@@ -223,22 +295,94 @@ func (r *RouteTable) onIfaceSeen(ifaceName string) {
 	r.ifaceNameToFirstSeen[ifaceName] = r.time.Now()
 }
 
+// markIfaceForUpdate marks an interface update is required. This is either a delta update from a route
+// set, update, or remove, or a full resync triggered from start-up processing, QueueResync or a previous failed update.
+func (r *RouteTable) markIfaceForUpdate(ifaceName string, resync bool) {
+	if resync {
+		// This is a full resync so flag as such.
+		r.ifaceNameToUpdateType[ifaceName] = updateTypeFullResync
+	} else if _, ok := r.ifaceNameToUpdateType[ifaceName]; !ok {
+		// This is not a full resync - set the update status if not already set (because we don't want to "downgrade"
+		// a full-resync to a delta update).
+		r.ifaceNameToUpdateType[ifaceName] = updateTypeDelta
+	}
+}
+
+// SetRoutes sets the full set of targets for the specified interface. This recalculates the deltas from the current
+// set of programmed routes.
 func (r *RouteTable) SetRoutes(ifaceName string, targets []Target) {
-	r.pendingIfaceNameToTargets[ifaceName] = targets
-	r.dirtyIfaces.Add(ifaceName)
+	currentCIDRsToTarget := r.ifaceNameToTargets[ifaceName]
+	deltas := map[ip.CIDR]*Target{}
+
+	// Delete all of the existing targets.
+	for cidr := range currentCIDRsToTarget {
+		deltas[cidr] = nil
+	}
+
+	// Add the new targets.
+	for _, target := range targets {
+		if current, ok := currentCIDRsToTarget[target.CIDR]; ok && current.Equal(target) {
+			// Entry is unchanged.  Remove from the deltas.
+			log.Debugf("Expected target unchanged for CIDR: %v", target.CIDR)
+			delete(deltas, target.CIDR)
+		} else {
+			// Entry has either been modified or been created. If modified then we'll keep the delete followed by a
+			// create.
+			log.Debugf("New target for CIDR: %v", target.CIDR)
+			deltas[target.CIDR] = &target
+		}
+	}
+
+	// Store the routes.  Remove any delta routes since this is a full set of routes.
+	r.pendingIfaceNameToDeltaTargets[ifaceName] = deltas
+	r.markIfaceForUpdate(ifaceName, false)
+}
+
+// RouteUpdate updates the route keyed off the target CIDR. These deltas will be applied to any routes set using
+// SetRoute.
+func (r *RouteTable) RouteUpdate(ifaceName string, target Target) {
+	if r.pendingIfaceNameToDeltaTargets[ifaceName] == nil {
+		r.pendingIfaceNameToDeltaTargets[ifaceName] = map[ip.CIDR]*Target{}
+	}
+	if current, ok := r.ifaceNameToTargets[ifaceName][target.CIDR]; ok && current.Equal(target) {
+		// Target unchanged from current programmed route, remove deltas.
+		r.logCxt.Debugf("Target unchanged for CIDR %s", target.CIDR)
+		delete(r.pendingIfaceNameToDeltaTargets[ifaceName], target.CIDR)
+	} else {
+		// Target new or changed, save delta.
+		r.pendingIfaceNameToDeltaTargets[ifaceName][target.CIDR] = &target
+		r.markIfaceForUpdate(ifaceName, false)
+	}
+}
+
+// RouteRemove removes the route with the specified CIDR. These deltas will be applied to any routes set using
+// SetRoute.
+func (r *RouteTable) RouteRemove(ifaceName string, cidr ip.CIDR) {
+	if r.pendingIfaceNameToDeltaTargets[ifaceName] == nil {
+		r.pendingIfaceNameToDeltaTargets[ifaceName] = map[ip.CIDR]*Target{}
+	}
+	if _, ok := r.ifaceNameToTargets[ifaceName][cidr]; !ok {
+		// Target not programmed, remote deltas.
+		r.logCxt.Debugf("Target is not programmed for CIDR %s", cidr)
+		delete(r.pendingIfaceNameToDeltaTargets[ifaceName], cidr)
+	} else {
+		// Target programmed, set delta for deletion.
+		r.pendingIfaceNameToDeltaTargets[ifaceName][cidr] = nil
+		r.markIfaceForUpdate(ifaceName, false)
+	}
 }
 
 func (r *RouteTable) SetL2Routes(ifaceName string, targets []L2Target) {
 	r.pendingIfaceNameToL2Targets[ifaceName] = targets
-	r.dirtyIfaces.Add(ifaceName)
+	r.markIfaceForUpdate(ifaceName, false)
 }
 
 func (r *RouteTable) QueueResync() {
 	r.logCxt.Info("Queueing a resync of routing table.")
-	r.inSync = false
+	r.reSync = true
 }
 
-func (r *RouteTable) getNetlinkHandle() (HandleIface, error) {
+func (r *RouteTable) getNetlink() (netlinkshim.Netlink, error) {
 	if r.cachedNetlinkHandle == nil {
 		if r.numConsistentNetlinkFailures >= maxConnFailures {
 			log.WithField("numFailures", r.numConsistentNetlinkFailures).Panic(
@@ -270,7 +414,7 @@ func (r *RouteTable) getNetlinkHandle() (HandleIface, error) {
 	return r.cachedNetlinkHandle, nil
 }
 
-func (r *RouteTable) closeNetlinkHandle() {
+func (r *RouteTable) closeNetlink() {
 	if r.cachedNetlinkHandle == nil {
 		return
 	}
@@ -279,10 +423,10 @@ func (r *RouteTable) closeNetlinkHandle() {
 }
 
 func (r *RouteTable) Apply() error {
-	if !r.inSync {
+	if r.reSync {
 		listStartTime := time.Now()
 
-		nl, err := r.getNetlinkHandle()
+		nl, err := r.getNetlink()
 		if err != nil {
 			r.logCxt.WithError(err).Error("Failed to connect to netlink, retrying...")
 			return ConnectFailed
@@ -290,11 +434,11 @@ func (r *RouteTable) Apply() error {
 		links, err := nl.LinkList()
 		if err != nil {
 			r.logCxt.WithError(err).Error("Failed to list interfaces, retrying...")
-			r.closeNetlinkHandle() // Defensive: force a netlink reconnection next time.
+			r.closeNetlink() // Defensive: force a netlink reconnection next time.
 			return ListFailed
 		}
 		// Clear the dirty set; there's no point trying to update non-existent interfaces.
-		r.dirtyIfaces = set.New()
+		r.ifaceNameToUpdateType = map[string]updateType{}
 		for _, link := range links {
 			attrs := link.Attrs()
 			if attrs == nil {
@@ -304,7 +448,7 @@ func (r *RouteTable) Apply() error {
 			if r.ifacePrefixRegexp.MatchString(ifaceName) {
 				r.logCxt.WithField("ifaceName", ifaceName).Debug(
 					"Resync: found calico-owned interface")
-				r.dirtyIfaces.Add(ifaceName)
+				r.markIfaceForUpdate(ifaceName, true)
 				r.onIfaceSeen(ifaceName)
 			}
 		}
@@ -312,11 +456,11 @@ func (r *RouteTable) Apply() error {
 		// Resyncs happen periodically, so the amount of memory leaked to old
 		// first seen timestamps is small.
 		for name, firstSeen := range r.ifaceNameToFirstSeen {
-			if r.dirtyIfaces.Contains(name) {
+			if _, ok := r.ifaceNameToUpdateType[name]; ok {
 				// Interface still present.
 				continue
 			}
-			if time.Since(firstSeen) < cleanupGracePeriod {
+			if r.time.Since(firstSeen) < cleanupGracePeriod {
 				// Interface first seen recently.
 				continue
 			}
@@ -324,115 +468,268 @@ func (r *RouteTable) Apply() error {
 				"Cleaning up timestamp for removed interface.")
 			delete(r.ifaceNameToFirstSeen, name)
 		}
-		r.inSync = true
 
-		listIfaceTime.Observe(time.Since(listStartTime).Seconds())
+		// If we are managing no-OIF routes then add that to our dirty set.
+		if r.includeNoInterface {
+			log.Debug("Flag no OIF for full re-sync")
+			r.markIfaceForUpdate(InterfaceNone, true)
+		}
+
+		r.reSync = false
+		listIfaceTime.Observe(r.time.Since(listStartTime).Seconds())
 	}
 
 	graceIfaces := 0
-	r.dirtyIfaces.Iter(func(item interface{}) error {
-		retries := 2
-		ifaceName := item.(string)
+ifaceLoop:
+	for ifaceName, ia := range r.ifaceNameToUpdateType {
 		logCxt := r.logCxt.WithField("ifaceName", ifaceName)
-		for retries > 0 {
+		fullResync := ia == updateTypeFullResync
+		for retry := 0; retry < maxApplyRetries; retry++ {
+			var err error
 			if r.vxlan {
 				// Sync L2 routes first.
-				err := r.syncL2RoutesForLink(ifaceName)
-				if err == IfaceNotPresent {
-					logCxt.Info("Interface missing, will retry if it appears.")
-					break
-				} else if err == IfaceDown {
-					logCxt.Info("Interface down, will retry if it goes up.")
-					break
-				} else if err != nil {
-					logCxt.WithError(err).Warn("Failed to synchronise routes.")
-					retries--
-					continue
-				}
-				logCxt.Debug("Synchronised L2 routes on interface")
+				err = r.syncL2RoutesForLink(ifaceName)
+			}
+			if err == nil {
+				// No errors syncing L2, sync L3 routes.
+				err = r.syncRoutesForLink(ifaceName, fullResync)
 			}
 
-			// Sync L3 routes.
-			err := r.syncRoutesForLink(ifaceName)
-			if err == IfaceNotPresent {
+			// Handle errors from syncing either L2 or L3 routes.
+			switch err {
+			case nil:
+				logCxt.Debug("Synchronised routes on interface")
+				delete(r.ifaceNameToUpdateType, ifaceName)
+				continue ifaceLoop
+			case IfaceNotPresent:
 				logCxt.Info("Interface missing, will retry if it appears.")
-				break
-			} else if err == IfaceDown {
+				delete(r.ifaceNameToUpdateType, ifaceName)
+				continue ifaceLoop
+			case IfaceDown:
 				logCxt.Info("Interface down, will retry if it goes up.")
-				break
-			} else if err == IfaceGrace {
+				delete(r.ifaceNameToUpdateType, ifaceName)
+				continue ifaceLoop
+			case IfaceGrace:
 				logCxt.Info("Interface in cleanup grace period, will retry after.")
 				graceIfaces++
-				return nil
-			} else if err != nil {
-				logCxt.WithError(err).Warn("Failed to synchronise routes.")
-				retries--
-				continue
+				continue ifaceLoop
 			}
-			logCxt.Debug("Synchronised L3 routes on interface")
-			break
+
+			// We failed to sync the routes, next try perform a full resync.
+			logCxt.WithError(err).Warn("Failed to synchronise routes.")
+			fullResync = true
 		}
-		if retries == 0 {
-			// The interface might be flapping or being deleted.
-			logCxt.Warn("Failed to sync routes to interface even after retries. " +
-				"Leaving it dirty.")
-			return nil
-		}
-		return set.RemoveItem
-	})
+
+		// The interface might be flapping or being deleted. Flag that it will require a full re-sync
+		logCxt.Warn("Failed to sync routes to interface even after retries. " +
+			"Leaving it dirty, requiring a full sync.")
+		r.markIfaceForUpdate(ifaceName, true)
+	}
 
 	r.cleanUpPendingConntrackDeletions()
 
 	// Don't return a failure if there are only interfaces in the cleanup grace period.
 	// They'll be retried on the next invocation (the route refresh timer), and we mustn't
 	// count them as Sync Errors.
-	if r.dirtyIfaces.Len() > graceIfaces {
+	if len(r.ifaceNameToUpdateType) > graceIfaces {
 		r.logCxt.Warn("Some interfaces still out-of sync.")
-		r.inSync = false
 		return UpdateFailed
 	}
 
 	return nil
 }
 
-func (r *RouteTable) ensureL2Dataplane(linkAttrs *netlink.LinkAttrs, target L2Target) error {
-	// For each L2 entry we need to program, program it.
-	// Add a static ARP entry.
-	a := &netlink.Neigh{
-		LinkIndex:    linkAttrs.Index,
-		State:        netlink.NUD_PERMANENT,
-		Type:         syscall.RTN_UNICAST,
-		IP:           target.GW.AsNetIP(),
-		HardwareAddr: target.VTEPMAC,
-	}
-	if err := netlink.NeighSet(a); err != nil {
-		return err
-	}
-	log.WithField("entry", a).Debug("Programmed ARP")
-
-	// Add a FDB entry for this neighbor.
-	n := &netlink.Neigh{
-		LinkIndex:    linkAttrs.Index,
-		State:        netlink.NUD_PERMANENT,
-		Family:       syscall.AF_BRIDGE,
-		Flags:        netlink.NTF_SELF,
-		IP:           target.IP.AsNetIP(),
-		HardwareAddr: target.VTEPMAC,
-	}
-	if err := netlink.NeighSet(n); err != nil {
-		return err
-	}
-	log.WithField("entry", n).Debug("Programmed FDB")
-	return nil
-}
-
-func (r *RouteTable) syncRoutesForLink(ifaceName string) error {
+func (r *RouteTable) syncRoutesForLink(ifaceName string, fullSync bool) error {
 	startTime := time.Now()
 	defer func() {
-		perIfaceSyncTime.Observe(time.Since(startTime).Seconds())
+		perIfaceSyncTime.Observe(r.time.Since(startTime).Seconds())
 	}()
 	logCxt := r.logCxt.WithField("ifaceName", ifaceName)
 	logCxt.Debug("Syncing interface routes")
+
+	// If necessary perform a full resync. This will return a set of routes that need deleting and will update the
+	// deltas to fix any discrepancies with the expected configuration. If this errors, we still apply the deltas
+	// first because this allows us to tidy up configuration for interfaces that no longer have any routes associated
+	// with them.
+	var routesToDelete []netlink.Route
+	var resyncErr error
+	if fullSync {
+		// Performing a full re-sync.  Start by applying the deltas so that we don't delete routes that are required.
+		logCxt.Debug("Reconcile against kernel programming")
+		_, _ = r.applyRouteDeltas(ifaceName)
+
+		// Now do the resync - this will update our deltas again based on what is not programmed (it's a little bit
+		// circuitous, but simplifies the code paths for resync and delta processing).
+		if routesToDelete, resyncErr = r.fullResyncRoutesForLink(logCxt, ifaceName); resyncErr != nil && resyncErr != IfaceGrace {
+			// If we hit anything other than an interface-in-grace error, exit now.
+			r.logCxt.WithError(resyncErr).Info("Hit error doing kernel reconciliation")
+			return r.filterErrorByIfaceState(ifaceName, resyncErr, UpdateFailed)
+		}
+	}
+
+	// Any deleted route that is not being replaced by a route with the same CIDR should have the corresponding
+	// conntrack entry removed.
+	defer func() {
+		cidrsToTarget := r.ifaceNameToTargets[ifaceName]
+		for _, route := range routesToDelete {
+			if cidr := ip.CIDRFromIPNet(route.Dst); cidr == nil {
+				// No parseable CIDR destination in route.
+			} else if _, ok := cidrsToTarget[cidr]; !ok {
+				// Route is deleted and CIDR should not be routable anymore - remove conntrack entries.
+				r.startConntrackDeletion(cidr.Addr())
+			}
+		}
+	}()
+
+	// Update the cached values from the deltas and get the set of targets to create and delete.
+	targetsToCreate, targetsToDelete := r.applyRouteDeltas(ifaceName)
+
+	// Try to get the link.  This may fail if it's been deleted out from under us.
+	linkAttrs, err := r.getLinkAttributes(ifaceName)
+	if err != nil {
+		return err
+	}
+	nl, err := r.getNetlink()
+	if err != nil {
+		logCxt.Debug("Failed to connect to netlink")
+		return ConnectFailed
+	}
+
+	// Add the target deletes to the set of routes to delete (we do this first so that we only have one set of deletion
+	// data that we use to tidy up routes and conntrack entries).
+	for _, target := range targetsToDelete {
+		routesToDelete = append(routesToDelete, r.createL3Route(linkAttrs, target))
+	}
+
+	// Delete the combined set of routes.
+	updatesFailed := false
+	for _, route := range routesToDelete {
+		if err := nl.RouteDel(&route); err != nil {
+			logCxt.WithError(err).Warn("Failed to delete route")
+			updatesFailed = true
+		}
+	}
+
+	// Now add target routes.
+	for _, target := range targetsToCreate {
+		route := r.createL3Route(linkAttrs, target)
+
+		// In case this IP is being re-used, wait for any previous conntrack entry
+		// to be cleaned up.  (No-op if there are no pending deletes.)
+		r.waitForPendingConntrackDeletion(target.CIDR.Addr())
+		if err := nl.RouteAdd(&route); err != nil {
+			logCxt.WithError(err).Warn("Failed to add route")
+			updatesFailed = true
+		}
+		if r.ipVersion == 4 && target.DestMAC != nil {
+			// TODO(smc) clean up/sync old ARP entries
+			err := r.addStaticARPEntry(target.CIDR, target.DestMAC, ifaceName)
+			if err != nil {
+				logCxt.WithError(err).Warn("Failed to set ARP entry")
+				updatesFailed = true
+			}
+		}
+	}
+
+	if updatesFailed {
+		r.closeNetlink() // Defensive: force a netlink reconnection next time.
+
+		// Recheck whether the interface exists so we don't produce spammy logs during
+		// interface removal.
+		return r.filterErrorByIfaceState(ifaceName, UpdateFailed, UpdateFailed)
+	}
+
+	// Return any un-handled re-sync error.
+	return resyncErr
+}
+
+func (r *RouteTable) applyRouteDeltas(ifaceName string) (targetsToCreate, targetsToDelete []Target) {
+	// Determine the set of deleted, created and current targets
+	cidrsToTarget := r.ifaceNameToTargets[ifaceName]
+	if cidrsToTarget == nil {
+		// Police against there being no existing targets, but handling a route update.
+		cidrsToTarget = map[ip.CIDR]Target{}
+	}
+
+	// Now apply deltas to our cache and track targets to delete and create.
+	deltaTargets := r.pendingIfaceNameToDeltaTargets[ifaceName]
+	for cidr, target := range deltaTargets {
+		if current, ok := cidrsToTarget[cidr]; ok {
+			// Previous entry exists, so need to delete it. Note that the SetRoute, RouteAdd and RouteRemove will not
+			// add deltas for unchanged targets, so we don't need to check for target equivalency here.
+			log.Debugf("Deleted or updated CIDR: %v", cidr)
+			targetsToDelete = append(targetsToDelete, current)
+			delete(cidrsToTarget, cidr)
+		}
+		if target != nil {
+			// Delta adds a new entry.
+			log.Debugf("Added or updated CIDR: %v", cidr)
+			targetsToCreate = append(targetsToCreate, *target)
+			cidrsToTarget[cidr] = *target
+		}
+	}
+
+	// Processed the deltas so remove them.
+	delete(r.pendingIfaceNameToDeltaTargets, ifaceName)
+
+	// If there are no more expected targets for this interface then remove from the cache.
+	if len(cidrsToTarget) == 0 {
+		delete(r.ifaceNameToTargets, ifaceName)
+	} else {
+		r.ifaceNameToTargets[ifaceName] = cidrsToTarget
+	}
+
+	return
+}
+
+func (r *RouteTable) createL3Route(linkAttrs *netlink.LinkAttrs, target Target) netlink.Route {
+	log.Debugf("Create L3 route for: %#v", target)
+	var linkIndex int
+	if linkAttrs != nil {
+		linkIndex = linkAttrs.Index
+	}
+	cidr := target.CIDR
+	ipNet := cidr.ToIPNet()
+	route := netlink.Route{
+		LinkIndex: linkIndex,
+		Dst:       &ipNet,
+		Type:      target.RouteType(),
+		Protocol:  r.deviceRouteProtocol,
+		Scope:     target.RouteScope(),
+		Table:     r.tableIndex,
+	}
+
+	if r.deviceRouteSourceAddress != nil {
+		route.Src = r.deviceRouteSourceAddress
+	}
+
+	if target.GW != nil {
+		route.Gw = target.GW.AsNetIP()
+	}
+
+	if target.Type == TargetTypeVXLAN || target.Type == TargetTypeNoEncap {
+		route.Scope = netlink.SCOPE_UNIVERSE
+		route.SetFlag(syscall.RTNH_F_ONLINK)
+	}
+
+	return route
+}
+
+// fullResyncRoutesForLink performs a full resync of the routes by first listing current routes and correlating against
+// the expected set. After correlation, it will create a set of routes to delete and update the delta routes to add
+// back any missing routes.
+func (r *RouteTable) fullResyncRoutesForLink(logCxt *log.Entry, ifaceName string) ([]netlink.Route, error) {
+	// Get the netlink client and the link attributes
+	nl, err := r.getNetlink()
+	if err != nil {
+		logCxt.Debug("Failed to connect to netlink")
+		return nil, ConnectFailed
+	}
+	// Try to get the link.  This may fail if it's been deleted out from under us.
+	linkAttrs, err := r.getLinkAttributes(ifaceName)
+	if err != nil {
+		return nil, err
+	}
 
 	// In order to allow Calico to run without Felix in an emergency, the CNI plugin pre-adds
 	// the route to the interface.  To avoid flapping the route when Felix sees the interface
@@ -440,90 +737,56 @@ func (r *RouteTable) syncRoutesForLink(ifaceName string) error {
 	// see it before we remove routes that we're not expecting.  Check whether the grace period
 	// applies to this interface.
 	ifaceInGracePeriod := r.time.Since(r.ifaceNameToFirstSeen[ifaceName]) < cleanupGracePeriod
-	leaveDirty := false
-
-	// If this is a modify or delete, grab a copy of the existing targets so we can clean up
-	// conntrack entries even if the routes have been removed.  We'll remove any still-required
-	// CIDRs from this set below.  We don't apply the grace period to this calculation because
-	// it only removes routes that the datamodel previously said were there and then were
-	// removed.  In that case, we know we're up to date.
-	oldCIDRs := set.New()
-	if updatedTargets, ok := r.pendingIfaceNameToTargets[ifaceName]; ok {
-		logCxt.Debug("Have updated targets.")
-		oldTargets := r.ifaceNameToTargets[ifaceName]
-		if updatedTargets == nil {
-			delete(r.ifaceNameToTargets, ifaceName)
-		} else {
-			r.ifaceNameToTargets[ifaceName] = updatedTargets
-		}
-		for _, target := range oldTargets {
-			oldCIDRs.Add(target.CIDR)
-		}
-		delete(r.pendingIfaceNameToTargets, ifaceName)
-	}
-
-	expectedTargets := r.ifaceNameToTargets[ifaceName]
-	expectedCIDRs := set.New()
-	for _, t := range expectedTargets {
-		expectedCIDRs.Add(t.CIDR)
-		oldCIDRs.Discard(t.CIDR)
-	}
-	if r.ipVersion == 6 {
-		expectedCIDRs.Add(ipV6LinkLocalCIDR)
-		oldCIDRs.Discard(ipV6LinkLocalCIDR)
-	}
-
-	// The code below may add some more CIDRs to clean up before it is done, make sure we
-	// remove conntrack entries in any case.
-	defer oldCIDRs.Iter(func(item interface{}) error {
-		// Remove and conntrack entries that should no longer be there.
-		dest := item.(ip.CIDR)
-		r.startConntrackDeletion(dest.Addr())
-		return nil
-	})
-
-	// Try to get the link.  This may fail if it's been deleted out from under us.
-	nl, err := r.getNetlinkHandle()
-	if err != nil {
-		r.logCxt.WithError(err).Error("Failed to connect to netlink, retrying...")
-		return ConnectFailed
-	}
-	link, err := nl.LinkByName(ifaceName)
-	if err != nil {
-		// Filter the error so that we don't spam errors if the interface is being torn
-		// down.
-		filteredErr := r.filterErrorByIfaceState(ifaceName, err, GetFailed)
-		if filteredErr == GetFailed {
-			logCxt.WithError(err).Error("Failed to get interface.")
-			r.closeNetlinkHandle() // Defensive: force a netlink reconnection next time.
-		} else {
-			logCxt.WithError(err).Info("Failed to get interface; it's down/gone.")
-		}
-		return filteredErr
-	}
 
 	// Got the link; try to sync its routes.  Note: We used to check if the interface
 	// was oper down before we tried to do the sync but that prevented us from removing
 	// routes from an interface in some corner cases (such as being admin up but oper
 	// down).
-	linkAttrs := link.Attrs()
-	oldRoutes, err := nl.RouteList(link, r.netlinkFamily)
+	routeFilter := &netlink.Route{
+		Table: r.tableIndex,
+	}
+	routeFilterFlags := netlink.RT_FILTER_OIF
+	if r.tableIndex != 0 {
+		routeFilterFlags |= netlink.RT_FILTER_TABLE
+	}
+	if linkAttrs != nil {
+		// Link attributes might be nil for the special "no-OIF" interface name.
+		routeFilter.LinkIndex = linkAttrs.Index
+	}
+	programmedRoutes, err := nl.RouteListFiltered(r.netlinkFamily, routeFilter, routeFilterFlags)
 	if err != nil {
 		// Filter the error so that we don't spam errors if the interface is being torn
 		// down.
 		filteredErr := r.filterErrorByIfaceState(ifaceName, err, ListFailed)
 		if filteredErr == ListFailed {
 			logCxt.WithError(err).Error("Error listing routes")
-			r.closeNetlinkHandle() // Defensive: force a netlink reconnection next time.
+			r.closeNetlink() // Defensive: force a netlink reconnection next time.
 		} else {
 			logCxt.WithError(err).Info("Failed to list routes; interface down/gone.")
 		}
-		return filteredErr
+		return nil, filteredErr
 	}
 
+	// Track any CIDRs in the route table that should not have been programmed.
+	oldCIDRs := set.New()
+	defer oldCIDRs.Iter(func(item interface{}) error {
+		// Remove any conntrack entries that should no longer be there.
+		dest := item.(ip.CIDR)
+		r.startConntrackDeletion(dest.Addr())
+		return nil
+	})
+
+	var routesToDelete []netlink.Route
+	expectedTargets := r.ifaceNameToTargets[ifaceName]
+	pendingDeltaTargets := r.pendingIfaceNameToDeltaTargets[ifaceName]
+	if pendingDeltaTargets == nil {
+		pendingDeltaTargets = map[ip.CIDR]*Target{}
+		r.pendingIfaceNameToDeltaTargets[ifaceName] = pendingDeltaTargets
+	}
 	alreadyCorrectCIDRs := set.New()
-	updatesFailed := false
-	for _, route := range oldRoutes {
+	leaveDirty := false
+	for _, route := range programmedRoutes {
+		logCxt.Debugf("Processing route: %v %v %v", route.Table, route.LinkIndex, route.Dst)
 		var dest ip.CIDR
 		if route.Dst != nil {
 			dest = ip.CIDRFromIPNet(route.Dst)
@@ -535,100 +798,72 @@ func (r *RouteTable) syncRoutesForLink(ifaceName string) error {
 			continue
 		}
 
-		routeExpected := expectedCIDRs.Contains(dest)
+		expectedTarget, expectedTargetFound := expectedTargets[dest]
+		routeExpected := expectedTargetFound || (r.ipVersion == 6 && dest == ipV6LinkLocalCIDR)
 		var routeProblems []string
 		if !routeExpected {
 			routeProblems = append(routeProblems, "unexpected route")
 		}
-		if !r.deviceRouteSourceAddress.Equal(route.Src) {
-			routeProblems = append(routeProblems, "incorrect source address")
-		}
-		if dest != ipV6LinkLocalCIDR && r.deviceRouteProtocol != route.Protocol {
-			routeProblems = append(routeProblems, "incorrect protocol")
+		if dest != ipV6LinkLocalCIDR {
+			if !r.deviceRouteSourceAddress.Equal(route.Src) {
+				routeProblems = append(routeProblems, "incorrect source address")
+			}
+			if r.deviceRouteProtocol != route.Protocol {
+				routeProblems = append(routeProblems, "incorrect protocol")
+			}
+			if expectedTargetFound && expectedTarget.RouteType() != route.Type {
+				routeProblems = append(routeProblems, "incorrect type")
+			}
+			if (route.Gw == nil && expectedTarget.GW != nil) ||
+				(route.Gw != nil && expectedTarget.GW == nil) ||
+				(route.Gw != nil && expectedTarget.GW != nil && !route.Gw.Equal(expectedTarget.GW.AsNetIP())) {
+				routeProblems = append(routeProblems, "incorrect gateway")
+			}
 		}
 		if len(routeProblems) == 0 {
+			logCxt.Debug("Route is correct")
 			alreadyCorrectCIDRs.Add(dest)
 			continue
 		}
-		gracePeriodApplies := ifaceInGracePeriod && !routeExpected && !r.vxlan
-		if gracePeriodApplies {
+		if ifaceInGracePeriod && !routeExpected && !r.vxlan {
 			// Don't remove unexpected routes from interfaces created recently. VXLAN routes don't have a grace period.
 			logCxt.Info("Syncing routes: found unexpected route; ignoring due to grace period.")
 			leaveDirty = true
 			continue
 		}
-		logCxt = logCxt.WithField("routeProblems", routeProblems)
-		logCxt.Info("Syncing routes: removing old route.")
-		if err := nl.RouteDel(&route); err != nil {
-			// Probably a race with the interface being deleted.
-			logCxt.WithError(err).Info("Route deletion failed, assuming someone got there first.")
-			updatesFailed = true
-		}
-		if !routeExpected && dest != nil {
-			// Collect any old route CIDRs that we find in the dataplane so we
-			// can remove their conntrack entries later.
-			oldCIDRs.Add(dest)
-		}
-	}
-	for _, target := range expectedTargets {
-		cidr := target.CIDR
-		if !alreadyCorrectCIDRs.Contains(cidr) {
-			logCxt := logCxt.WithField("targetCIDR", target.CIDR)
-			logCxt.Info("Syncing routes: adding new route.")
-			ipNet := cidr.ToIPNet()
-			route := netlink.Route{
-				LinkIndex: linkAttrs.Index,
-				Dst:       &ipNet,
-				Type:      syscall.RTN_UNICAST,
-				Protocol:  r.deviceRouteProtocol,
-				Scope:     netlink.SCOPE_LINK,
-			}
-
-			if r.deviceRouteSourceAddress != nil {
-				route.Src = r.deviceRouteSourceAddress
-			}
-
-			if target.GW != nil {
-				route.Gw = target.GW.AsNetIP()
-			}
-
-			if target.Type == TargetTypeVXLAN || target.Type == TargetTypeNoEncap {
-				route.Scope = netlink.SCOPE_UNIVERSE
-				route.SetFlag(syscall.RTNH_F_ONLINK)
-			}
-
-			// In case this IP is being re-used, wait for any previous conntrack entry
-			// to be cleaned up.  (No-op if there are no pending deletes.)
-			r.waitForPendingConntrackDeletion(cidr.Addr())
-			if err := nl.RouteAdd(&route); err != nil {
-				logCxt.WithError(err).Warn("Failed to add route")
-				updatesFailed = true
-			}
-		}
-		if r.ipVersion == 4 && target.DestMAC != nil {
-			// TODO(smc) clean up/sync old ARP entries
-			err := r.addStaticARPEntry(cidr, target.DestMAC, ifaceName)
-			if err != nil {
-				logCxt.WithError(err).Warn("Failed to set ARP entry")
-				updatesFailed = true
-			}
-		}
+		logCxt.WithField("routeProblems", routeProblems).Info("Remove old route")
+		routesToDelete = append(routesToDelete, route)
 	}
 
-	if updatesFailed {
-		r.closeNetlinkHandle() // Defensive: force a netlink reconnection next time.
+	// Now loop through the expected CIDRs to Target. Remove any that we did not find, and add them back into our
+	// delta updates (unless the entry is superceded by another update).
+	for cidr, target := range expectedTargets {
+		if alreadyCorrectCIDRs.Contains(cidr) {
+			continue
+		}
+		logCxt := logCxt.WithField("cidr", cidr)
+		logCxt.Info("Deleting from expected targets")
+		delete(expectedTargets, cidr)
 
-		// Recheck whether the interface exists so we don't produce spammy logs during
-		// interface removal.
-		return r.filterErrorByIfaceState(ifaceName, UpdateFailed, UpdateFailed)
+		// If we do not have an update that supercedes this entry, then add it back in as an update so that we add
+		// the route.
+		if pendingTarget, ok := pendingDeltaTargets[cidr]; !ok {
+			logCxt.Info("No pending target update, adding back in as an update")
+			pendingDeltaTargets[cidr] = &target
+		} else if pendingTarget == nil {
+			logCxt.Info("Pending target deletion, removing delete update")
+			delete(pendingDeltaTargets, cidr)
+		} else {
+			logCxt.Info("Pending target update, no changes to deltas required")
+		}
 	}
 
 	if leaveDirty {
 		// Superfluous routes on a recently created interface.  We'll recheck later.
-		return IfaceGrace
+		return routesToDelete, IfaceGrace
 	}
 
-	return nil
+	return routesToDelete, nil
 }
 
 func (r *RouteTable) syncL2RoutesForLink(ifaceName string) error {
@@ -645,25 +880,12 @@ func (r *RouteTable) syncL2RoutesForLink(ifaceName string) error {
 	}
 	expectedTargets := r.ifaceNameToL2Targets[ifaceName]
 
-	// Try to get the link.  This may fail if it's been deleted out from under us.
-	nl, err := r.getNetlinkHandle()
+	// Try to get the link attributes.  This may fail if it's been deleted out from under us.
+	linkAttrs, err := r.getLinkAttributes(ifaceName)
 	if err != nil {
-		r.logCxt.WithError(err).Error("Failed to connect to netlink, retrying...")
-		return ConnectFailed
+		r.logCxt.WithError(err).Error("Failed to get link attributes")
+		return err
 	}
-	link, err := nl.LinkByName(ifaceName)
-	if err != nil {
-		// Filter the error so that we don't spam errors if the interface is being torn down.
-		filteredErr := r.filterErrorByIfaceState(ifaceName, err, GetFailed)
-		if filteredErr == GetFailed {
-			logCxt.WithError(err).Error("Failed to get interface.")
-			r.closeNetlinkHandle() // Defensive: force a netlink reconnection next time.
-		} else {
-			logCxt.WithError(err).Info("Failed to get interface; it's down/gone.")
-		}
-		return filteredErr
-	}
-	linkAttrs := link.Attrs()
 
 	// Build maps based on desired target state, used below to clean up
 	// stale entries. Each L2 target results in an ARP entry as well as
@@ -716,13 +938,44 @@ func (r *RouteTable) syncL2RoutesForLink(ifaceName string) error {
 	}
 
 	if updatesFailed {
-		r.closeNetlinkHandle() // Defensive: force a netlink reconnection next time.
+		r.closeNetlink() // Defensive: force a netlink reconnection next time.
 
 		// Recheck whether the interface exists so we don't produce spammy logs during
 		// interface removal.
 		return r.filterErrorByIfaceState(ifaceName, UpdateFailed, UpdateFailed)
 	}
 
+	return nil
+}
+
+func (r *RouteTable) ensureL2Dataplane(linkAttrs *netlink.LinkAttrs, target L2Target) error {
+	// For each L2 entry we need to program, program it.
+	// Add a static ARP entry.
+	a := &netlink.Neigh{
+		LinkIndex:    linkAttrs.Index,
+		State:        netlink.NUD_PERMANENT,
+		Type:         syscall.RTN_UNICAST,
+		IP:           target.GW.AsNetIP(),
+		HardwareAddr: target.VTEPMAC,
+	}
+	if err := netlink.NeighSet(a); err != nil {
+		return err
+	}
+	log.WithField("entry", a).Debug("Programmed ARP")
+
+	// Add a FDB entry for this neighbor.
+	n := &netlink.Neigh{
+		LinkIndex:    linkAttrs.Index,
+		State:        netlink.NUD_PERMANENT,
+		Family:       syscall.AF_BRIDGE,
+		Flags:        netlink.NTF_SELF,
+		IP:           target.IP.AsNetIP(),
+		HardwareAddr: target.VTEPMAC,
+	}
+	if err := netlink.NeighSet(n); err != nil {
+		return err
+	}
+	log.WithField("entry", n).Debug("Programmed FDB")
 	return nil
 }
 
@@ -773,6 +1026,12 @@ func (r *RouteTable) waitForPendingConntrackDeletion(ipAddr ip.Addr) {
 // returns IfaceDown or IfaceNotPresent, otherwise, it returns the given defaultErr.
 func (r *RouteTable) filterErrorByIfaceState(ifaceName string, currentErr, defaultErr error) error {
 	logCxt := r.logCxt.WithFields(log.Fields{"ifaceName": ifaceName, "error": currentErr})
+	if ifaceName == InterfaceNone {
+		// Short circuit the no-OIF interface name.
+		logCxt.Info("No interface on route.")
+		return defaultErr
+	}
+
 	if strings.Contains(currentErr.Error(), "not found") {
 		// Current error already tells us that the link was not present.  If we re-check
 		// the status in this case, we open a race where the interface gets created and
@@ -782,7 +1041,7 @@ func (r *RouteTable) filterErrorByIfaceState(ifaceName string, currentErr, defau
 	}
 	// If the current error wasn't clear, try to look up the interface to see if there's a
 	// well-understood reason for the failure.
-	nl, err := r.getNetlinkHandle()
+	nl, err := r.getNetlink()
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"ifaceName":  ifaceName,
@@ -812,4 +1071,37 @@ func (r *RouteTable) filterErrorByIfaceState(ifaceName string, currentErr, defau
 		logCxt.WithError(err).Error("Failed to access interface after a failure")
 		return defaultErr
 	}
+}
+
+// getLinkAttributes returns the link attributes for the specified link name. This method returns nil if the
+// interface name is the special "no-OIF" name.
+func (r *RouteTable) getLinkAttributes(ifaceName string) (*netlink.LinkAttrs, error) {
+	if ifaceName == InterfaceNone {
+		// Short circuit the no-OIF interface name.
+		return nil, nil
+	}
+
+	// Try to get the link.  This may fail if it's been deleted out from under us.
+	logCxt := r.logCxt.WithField("ifaceName", ifaceName)
+
+	nl, err := r.getNetlink()
+	if err != nil {
+		r.logCxt.WithError(err).Error("Failed to connect to netlink, retrying...")
+		return nil, ConnectFailed
+	}
+
+	link, err := nl.LinkByName(ifaceName)
+	if err != nil {
+		// Filter the error so that we don't spam errors if the interface is being torn
+		// down.
+		filteredErr := r.filterErrorByIfaceState(ifaceName, err, GetFailed)
+		if filteredErr == GetFailed {
+			logCxt.WithError(err).Error("Failed to get interface.")
+			r.closeNetlink() // Defensive: force a netlink reconnection next time.
+		} else {
+			logCxt.WithError(err).Info("Failed to get interface; it's down/gone.")
+		}
+		return nil, filteredErr
+	}
+	return link.Attrs(), nil
 }

--- a/routetable/route_table_test.go
+++ b/routetable/route_table_test.go
@@ -17,11 +17,8 @@ package routetable_test
 import (
 	. "github.com/projectcalico/felix/routetable"
 
-	"errors"
 	"fmt"
 	"net"
-	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -32,16 +29,13 @@ import (
 
 	"github.com/projectcalico/felix/ifacemonitor"
 	"github.com/projectcalico/felix/ip"
+	mocknetlink "github.com/projectcalico/felix/netlink/mock"
 	"github.com/projectcalico/felix/testutils"
-	"github.com/projectcalico/libcalico-go/lib/set"
+	mocktime "github.com/projectcalico/felix/time/mock"
 )
 
 var (
 	FelixRouteProtocol = syscall.RTPROT_BOOT
-
-	simulatedError = errors.New("dummy error")
-	notFound       = errors.New("not found")
-	alreadyExists  = errors.New("already exists")
 
 	mac1 = testutils.MustParseMAC("00:11:22:33:44:51")
 	mac2 = testutils.MustParseMAC("00:11:22:33:44:52")
@@ -52,30 +46,20 @@ var (
 )
 
 var _ = Describe("RouteTable v6", func() {
-	var dataplane *mockDataplane
-	var t *mockTime
+	var dataplane *mocknetlink.MockNetlinkDataplane
+	var t *mocktime.MockTime
 	var rt *RouteTable
 
 	BeforeEach(func() {
-		dataplane = &mockDataplane{
-			nameToLink:       map[string]netlink.Link{},
-			routeKeyToRoute:  map[string]netlink.Route{},
-			addedRouteKeys:   set.New(),
-			deletedRouteKeys: set.New(),
-			updatedRouteKeys: set.New(),
-		}
-		startTime, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
-		Expect(err).NotTo(HaveOccurred())
-		t = &mockTime{
-			currentTime: startTime,
-		}
+		dataplane = mocknetlink.NewMockNetlinkDataplane()
+		t = mocktime.NewMockTime()
 		// Setting an auto-increment greater than the route cleanup delay effectively
 		// disables the grace period for these tests.
-		t.setAutoIncrement(11 * time.Second)
+		t.SetAutoIncrement(11 * time.Second)
 		rt = NewWithShims(
-			[]string{"cali"},
+			[]string{"^cali.*"},
 			6,
-			dataplane.NewNetlinkHandle,
+			dataplane.NewMockNetlink,
 			false,
 			10*time.Second,
 			dataplane.AddStaticArpEntry,
@@ -84,6 +68,7 @@ var _ = Describe("RouteTable v6", func() {
 			nil,
 			FelixRouteProtocol,
 			true,
+			0,
 		)
 	})
 
@@ -93,51 +78,41 @@ var _ = Describe("RouteTable v6", func() {
 
 	It("should not remove the IPv6 link local route", func() {
 		// Route that should be left alone
-		noopLink := dataplane.addIface(4, "cali4", true, true)
+		noopLink := dataplane.AddIface(4, "cali4", true, true)
 		noopRoute := netlink.Route{
-			LinkIndex: noopLink.attrs.Index,
+			LinkIndex: noopLink.LinkAttrs.Index,
 			Dst:       mustParseCIDR("fe80::/64"),
 			Type:      syscall.RTN_UNICAST,
 			Protocol:  syscall.RTPROT_KERNEL,
 			Scope:     netlink.SCOPE_LINK,
 		}
-		rt.SetRoutes(noopLink.attrs.Name, []Target{
+		rt.SetRoutes(noopLink.LinkAttrs.Name, []Target{
 			{CIDR: ip.MustParseCIDROrIP("10.0.0.4/32"), DestMAC: mac1},
 		})
-		dataplane.addMockRoute(&noopRoute)
+		dataplane.AddMockRoute(&noopRoute)
 
 		err := rt.Apply()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(dataplane.deletedRouteKeys).ToNot(HaveKey(keyForRoute(&noopRoute)))
-		Expect(dataplane.updatedRouteKeys).ToNot(HaveKey(keyForRoute(&noopRoute)))
+		Expect(dataplane.DeletedRouteKeys).ToNot(HaveKey(mocknetlink.KeyForRoute(&noopRoute)))
+		Expect(dataplane.UpdatedRouteKeys).ToNot(HaveKey(mocknetlink.KeyForRoute(&noopRoute)))
 	})
 })
 
 var _ = Describe("RouteTable", func() {
-	var dataplane *mockDataplane
-	var t *mockTime
+	var dataplane *mocknetlink.MockNetlinkDataplane
+	var t *mocktime.MockTime
 	var rt *RouteTable
 
 	BeforeEach(func() {
-		dataplane = &mockDataplane{
-			nameToLink:       map[string]netlink.Link{},
-			routeKeyToRoute:  map[string]netlink.Route{},
-			addedRouteKeys:   set.New(),
-			deletedRouteKeys: set.New(),
-			updatedRouteKeys: set.New(),
-		}
-		startTime, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
-		Expect(err).NotTo(HaveOccurred())
-		t = &mockTime{
-			currentTime: startTime,
-		}
+		dataplane = mocknetlink.NewMockNetlinkDataplane()
+		t = mocktime.NewMockTime()
 		// Setting an auto-increment greater than the route cleanup delay effectively
 		// disables the grace period for these tests.
-		t.setAutoIncrement(11 * time.Second)
+		t.SetAutoIncrement(11 * time.Second)
 		rt = NewWithShims(
-			[]string{"cali"},
+			[]string{"^cali.*"},
 			4,
-			dataplane.NewNetlinkHandle,
+			dataplane.NewMockNetlink,
 			false,
 			10*time.Second,
 			dataplane.AddStaticArpEntry,
@@ -146,6 +121,7 @@ var _ = Describe("RouteTable", func() {
 			nil,
 			FelixRouteProtocol,
 			true,
+			0,
 		)
 	})
 
@@ -153,70 +129,89 @@ var _ = Describe("RouteTable", func() {
 		Expect(rt).ToNot(BeNil())
 	})
 
+	It("should handle unexpected non-calico interface updates", func() {
+		t.SetAutoIncrement(0 * time.Second)
+		rt.OnIfaceStateChanged("calx", ifacemonitor.StateUp)
+		err := rt.Apply()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should handle unexpected calico interface updates", func() {
+		t.SetAutoIncrement(0 * time.Second)
+		rt.OnIfaceStateChanged("cali1", ifacemonitor.StateUp)
+		rt.QueueResync()
+		err := rt.Apply()
+		Expect(err).ToNot(HaveOccurred())
+		t.IncrementTime(11 * time.Second)
+		rt.QueueResync()
+		err = rt.Apply()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	Describe("with some interfaces", func() {
-		var cali1, cali3, eth0 *mockLink
+		var cali1, cali3, eth0 *mocknetlink.MockLink
 		var gatewayRoute, cali1Route, cali1Route2, cali3Route netlink.Route
 		BeforeEach(func() {
-			eth0 = dataplane.addIface(0, "eth0", true, true)
-			cali1 = dataplane.addIface(1, "cali1", true, true)
-			dataplane.addIface(2, "cali2", true, true)
-			cali3 = dataplane.addIface(3, "cali3", true, true)
+			eth0 = dataplane.AddIface(0, "eth0", true, true)
+			cali1 = dataplane.AddIface(1, "cali1", true, true)
+			dataplane.AddIface(2, "cali2", true, true)
+			cali3 = dataplane.AddIface(3, "cali3", true, true)
 			cali1Route = netlink.Route{
-				LinkIndex: cali1.attrs.Index,
+				LinkIndex: cali1.LinkAttrs.Index,
 				Dst:       mustParseCIDR("10.0.0.1/32"),
 				Type:      syscall.RTN_UNICAST,
 				Protocol:  FelixRouteProtocol,
 				Scope:     netlink.SCOPE_LINK,
 			}
-			dataplane.addMockRoute(&cali1Route)
+			dataplane.AddMockRoute(&cali1Route)
 			cali3Route = netlink.Route{
-				LinkIndex: cali3.attrs.Index,
+				LinkIndex: cali3.LinkAttrs.Index,
 				Dst:       mustParseCIDR("10.0.0.3/32"),
 				Type:      syscall.RTN_UNICAST,
 				Protocol:  FelixRouteProtocol,
 				Scope:     netlink.SCOPE_LINK,
 			}
-			dataplane.addMockRoute(&cali3Route)
+			dataplane.AddMockRoute(&cali3Route)
 			gatewayRoute = netlink.Route{
-				LinkIndex: eth0.attrs.Index,
+				LinkIndex: eth0.LinkAttrs.Index,
 				Type:      syscall.RTN_UNICAST,
 				Protocol:  FelixRouteProtocol,
 				Scope:     netlink.SCOPE_LINK,
 				Gw:        net.ParseIP("12.0.0.1"),
 			}
-			dataplane.addMockRoute(&gatewayRoute)
+			dataplane.AddMockRoute(&gatewayRoute)
 		})
 		It("should wait for the route cleanup delay", func() {
-			t.setAutoIncrement(0 * time.Second)
+			t.SetAutoIncrement(0 * time.Second)
 			err := rt.Apply()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dataplane.routeKeyToRoute).To(ConsistOf(cali1Route, cali3Route, gatewayRoute))
-			Expect(dataplane.addedRouteKeys).To(BeEmpty())
-			t.incrementTime(11 * time.Second)
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(cali1Route, cali3Route, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+			t.IncrementTime(11 * time.Second)
 			err = rt.Apply()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dataplane.routeKeyToRoute).To(ConsistOf(gatewayRoute))
-			Expect(dataplane.addedRouteKeys).To(BeEmpty())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
 		})
 		It("should wait for the route cleanup delay when resyncing", func() {
-			t.setAutoIncrement(0 * time.Second)
+			t.SetAutoIncrement(0 * time.Second)
 			rt.QueueResync()
 			err := rt.Apply()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dataplane.routeKeyToRoute).To(ConsistOf(cali1Route, cali3Route, gatewayRoute))
-			Expect(dataplane.addedRouteKeys).To(BeEmpty())
-			t.incrementTime(11 * time.Second)
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(cali1Route, cali3Route, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+			t.IncrementTime(11 * time.Second)
 			rt.QueueResync()
 			err = rt.Apply()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dataplane.routeKeyToRoute).To(ConsistOf(gatewayRoute))
-			Expect(dataplane.addedRouteKeys).To(BeEmpty())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
 		})
 		It("should clean up only our routes", func() {
 			err := rt.Apply()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dataplane.routeKeyToRoute).To(ConsistOf(gatewayRoute))
-			Expect(dataplane.addedRouteKeys).To(BeEmpty())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
 		})
 		It("should delete only our conntrack entries", func() {
 			err := rt.Apply()
@@ -227,17 +222,17 @@ var _ = Describe("RouteTable", func() {
 			))
 		})
 		It("Should clear out a source address when source address is not set", func() {
-			updateLink := dataplane.addIface(5, "cali5", true, true)
+			updateLink := dataplane.AddIface(5, "cali5", true, true)
 			updateRoute := netlink.Route{
-				LinkIndex: updateLink.attrs.Index,
+				LinkIndex: updateLink.LinkAttrs.Index,
 				Dst:       mustParseCIDR("10.0.0.5/32"),
 				Type:      syscall.RTN_UNICAST,
 				Protocol:  FelixRouteProtocol,
 				Scope:     netlink.SCOPE_LINK,
 				Src:       net.ParseIP("192.168.0.1"),
 			}
-			dataplane.addMockRoute(&updateRoute)
-			rt.SetRoutes(updateLink.attrs.Name, []Target{
+			dataplane.AddMockRoute(&updateRoute)
+			rt.SetRoutes(updateLink.LinkAttrs.Name, []Target{
 				{CIDR: ip.MustParseCIDROrIP("10.0.0.5"), DestMAC: mac1},
 			})
 
@@ -246,8 +241,8 @@ var _ = Describe("RouteTable", func() {
 
 			err := rt.Apply()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dataplane.updatedRouteKeys).To(HaveKey(keyForRoute(&updateRoute)))
-			Expect(dataplane.routeKeyToRoute[keyForRoute(&updateRoute)]).To(Equal(fixedRoute))
+			Expect(dataplane.UpdatedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&updateRoute)))
+			Expect(dataplane.RouteKeyToRoute[mocknetlink.KeyForRoute(&updateRoute)]).To(Equal(fixedRoute))
 
 		})
 		Describe("With a device route source address set", func() {
@@ -256,9 +251,9 @@ var _ = Describe("RouteTable", func() {
 			// Modify the route table to have the device route source address set
 			BeforeEach(func() {
 				rt = NewWithShims(
-					[]string{"cali"},
+					[]string{"^cali.*"},
 					4,
-					dataplane.NewNetlinkHandle,
+					dataplane.NewMockNetlink,
 					false,
 					10*time.Second,
 					dataplane.AddStaticArpEntry,
@@ -267,24 +262,25 @@ var _ = Describe("RouteTable", func() {
 					deviceRouteSourceAddress,
 					FelixRouteProtocol,
 					true,
+					0,
 				)
 			})
 			It("Should delete routes without a source address", func() {
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.deletedRouteKeys).To(HaveKey(keyForRoute(&cali3Route)))
-				Expect(dataplane.deletedRouteKeys).To(HaveKey(keyForRoute(&cali1Route)))
+				Expect(dataplane.DeletedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&cali3Route)))
+				Expect(dataplane.DeletedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&cali1Route)))
 			})
 			It("Should add routes with a source address", func() {
 				// Route that needs to be added
-				addLink := dataplane.addIface(6, "cali6", true, true)
-				rt.SetRoutes(addLink.attrs.Name, []Target{
+				addLink := dataplane.AddIface(6, "cali6", true, true)
+				rt.SetRoutes(addLink.LinkAttrs.Name, []Target{
 					{CIDR: ip.MustParseCIDROrIP("10.0.0.6"), DestMAC: mac1},
 				})
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.routeKeyToRoute["6-10.0.0.6/32"]).To(Equal(netlink.Route{
-					LinkIndex: addLink.attrs.Index,
+				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.6/32"]).To(Equal(netlink.Route{
+					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.6/32"),
 					Type:      syscall.RTN_UNICAST,
 					Protocol:  FelixRouteProtocol,
@@ -294,72 +290,72 @@ var _ = Describe("RouteTable", func() {
 			})
 			It("Should not remove routes with a source address", func() {
 				// Route that should be left alone
-				noopLink := dataplane.addIface(4, "cali4", true, true)
+				noopLink := dataplane.AddIface(4, "cali4", true, true)
 				noopRoute := netlink.Route{
-					LinkIndex: noopLink.attrs.Index,
+					LinkIndex: noopLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.4/32"),
 					Type:      syscall.RTN_UNICAST,
 					Protocol:  FelixRouteProtocol,
 					Scope:     netlink.SCOPE_LINK,
 					Src:       deviceRouteSourceAddress,
 				}
-				rt.SetRoutes(noopLink.attrs.Name, []Target{
+				rt.SetRoutes(noopLink.LinkAttrs.Name, []Target{
 					{CIDR: ip.MustParseCIDROrIP("10.0.0.4/32"), DestMAC: mac1},
 				})
-				dataplane.addMockRoute(&noopRoute)
+				dataplane.AddMockRoute(&noopRoute)
 
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.deletedRouteKeys).ToNot(HaveKey(keyForRoute(&noopRoute)))
-				Expect(dataplane.updatedRouteKeys).ToNot(HaveKey(keyForRoute(&noopRoute)))
+				Expect(dataplane.DeletedRouteKeys).ToNot(HaveKey(mocknetlink.KeyForRoute(&noopRoute)))
+				Expect(dataplane.UpdatedRouteKeys).ToNot(HaveKey(mocknetlink.KeyForRoute(&noopRoute)))
 			})
 			It("Should update source addresses from nil to a given source", func() {
 				// Route that needs to be updated
-				updateLink := dataplane.addIface(5, "cali5", true, true)
+				updateLink := dataplane.AddIface(5, "cali5", true, true)
 				updateRoute := netlink.Route{
-					LinkIndex: updateLink.attrs.Index,
+					LinkIndex: updateLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.5/32"),
 					Type:      syscall.RTN_UNICAST,
 					Protocol:  FelixRouteProtocol,
 					Scope:     netlink.SCOPE_LINK,
 				}
-				rt.SetRoutes(updateLink.attrs.Name, []Target{
+				rt.SetRoutes(updateLink.LinkAttrs.Name, []Target{
 					{CIDR: ip.MustParseCIDROrIP("10.0.0.5"), DestMAC: mac1},
 				})
-				dataplane.addMockRoute(&updateRoute)
+				dataplane.AddMockRoute(&updateRoute)
 
 				fixedRoute := updateRoute
 				fixedRoute.Src = deviceRouteSourceAddress
 
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.updatedRouteKeys).To(HaveKey(keyForRoute(&updateRoute)))
-				Expect(dataplane.routeKeyToRoute[keyForRoute(&updateRoute)]).To(Equal(fixedRoute))
+				Expect(dataplane.UpdatedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&updateRoute)))
+				Expect(dataplane.RouteKeyToRoute[mocknetlink.KeyForRoute(&updateRoute)]).To(Equal(fixedRoute))
 			})
 
 			It("Should update source addresses from an old source to a new one", func() {
 				// Route that needs to be updated
-				updateLink := dataplane.addIface(5, "cali5", true, true)
+				updateLink := dataplane.AddIface(5, "cali5", true, true)
 				updateRoute := netlink.Route{
-					LinkIndex: updateLink.attrs.Index,
+					LinkIndex: updateLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.5/32"),
 					Type:      syscall.RTN_UNICAST,
 					Protocol:  FelixRouteProtocol,
 					Scope:     netlink.SCOPE_LINK,
 					Src:       net.ParseIP("192.168.0.2"),
 				}
-				rt.SetRoutes(updateLink.attrs.Name, []Target{
+				rt.SetRoutes(updateLink.LinkAttrs.Name, []Target{
 					{CIDR: ip.MustParseCIDROrIP("10.0.0.5"), DestMAC: mac1},
 				})
-				dataplane.addMockRoute(&updateRoute)
+				dataplane.AddMockRoute(&updateRoute)
 
 				fixedRoute := updateRoute
 				fixedRoute.Src = deviceRouteSourceAddress
 
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.updatedRouteKeys).To(HaveKey(keyForRoute(&updateRoute)))
-				Expect(dataplane.routeKeyToRoute[keyForRoute(&updateRoute)]).To(Equal(fixedRoute))
+				Expect(dataplane.UpdatedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&updateRoute)))
+				Expect(dataplane.RouteKeyToRoute[mocknetlink.KeyForRoute(&updateRoute)]).To(Equal(fixedRoute))
 			})
 		})
 
@@ -368,9 +364,9 @@ var _ = Describe("RouteTable", func() {
 			// Modify the route table to have the device route source address set
 			BeforeEach(func() {
 				rt = NewWithShims(
-					[]string{"cali"},
+					[]string{"^cali.*"},
 					4,
-					dataplane.NewNetlinkHandle,
+					dataplane.NewMockNetlink,
 					false,
 					10*time.Second,
 					dataplane.AddStaticArpEntry,
@@ -379,24 +375,25 @@ var _ = Describe("RouteTable", func() {
 					nil,
 					deviceRouteProtocol,
 					true,
+					0,
 				)
 			})
 			It("Should delete routes without a protocol", func() {
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.deletedRouteKeys).To(HaveKey(keyForRoute(&cali3Route)))
-				Expect(dataplane.deletedRouteKeys).To(HaveKey(keyForRoute(&cali1Route)))
+				Expect(dataplane.DeletedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&cali3Route)))
+				Expect(dataplane.DeletedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&cali1Route)))
 			})
 			It("Should add routes with a protocol", func() {
 				// Route that needs to be added
-				addLink := dataplane.addIface(6, "cali6", true, true)
-				rt.SetRoutes(addLink.attrs.Name, []Target{
+				addLink := dataplane.AddIface(6, "cali6", true, true)
+				rt.SetRoutes(addLink.LinkAttrs.Name, []Target{
 					{CIDR: ip.MustParseCIDROrIP("10.0.0.6"), DestMAC: mac1},
 				})
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.routeKeyToRoute["6-10.0.0.6/32"]).To(Equal(netlink.Route{
-					LinkIndex: addLink.attrs.Index,
+				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.6/32"]).To(Equal(netlink.Route{
+					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.6/32"),
 					Type:      syscall.RTN_UNICAST,
 					Protocol:  deviceRouteProtocol,
@@ -405,69 +402,69 @@ var _ = Describe("RouteTable", func() {
 			})
 			It("Should not remove routes with a protocol", func() {
 				// Route that should be left alone
-				noopLink := dataplane.addIface(4, "cali4", true, true)
+				noopLink := dataplane.AddIface(4, "cali4", true, true)
 				noopRoute := netlink.Route{
-					LinkIndex: noopLink.attrs.Index,
+					LinkIndex: noopLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.4/32"),
 					Type:      syscall.RTN_UNICAST,
 					Protocol:  deviceRouteProtocol,
 					Scope:     netlink.SCOPE_LINK,
 				}
-				rt.SetRoutes(noopLink.attrs.Name, []Target{
+				rt.SetRoutes(noopLink.LinkAttrs.Name, []Target{
 					{CIDR: ip.MustParseCIDROrIP("10.0.0.4/32"), DestMAC: mac1},
 				})
-				dataplane.addMockRoute(&noopRoute)
+				dataplane.AddMockRoute(&noopRoute)
 
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.deletedRouteKeys).ToNot(HaveKey(keyForRoute(&noopRoute)))
-				Expect(dataplane.updatedRouteKeys).ToNot(HaveKey(keyForRoute(&noopRoute)))
+				Expect(dataplane.DeletedRouteKeys).ToNot(HaveKey(mocknetlink.KeyForRoute(&noopRoute)))
+				Expect(dataplane.UpdatedRouteKeys).ToNot(HaveKey(mocknetlink.KeyForRoute(&noopRoute)))
 			})
 			It("Should update protocol from nil to a given protocol", func() {
 				// Route that needs to be updated
-				updateLink := dataplane.addIface(5, "cali5", true, true)
+				updateLink := dataplane.AddIface(5, "cali5", true, true)
 				updateRoute := netlink.Route{
-					LinkIndex: updateLink.attrs.Index,
+					LinkIndex: updateLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.5/32"),
 					Type:      syscall.RTN_UNICAST,
 					Scope:     netlink.SCOPE_LINK,
 				}
-				rt.SetRoutes(updateLink.attrs.Name, []Target{
+				rt.SetRoutes(updateLink.LinkAttrs.Name, []Target{
 					{CIDR: ip.MustParseCIDROrIP("10.0.0.5"), DestMAC: mac1},
 				})
-				dataplane.addMockRoute(&updateRoute)
+				dataplane.AddMockRoute(&updateRoute)
 
 				fixedRoute := updateRoute
 				fixedRoute.Protocol = deviceRouteProtocol
 
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.updatedRouteKeys).To(HaveKey(keyForRoute(&updateRoute)))
-				Expect(dataplane.routeKeyToRoute[keyForRoute(&updateRoute)]).To(Equal(fixedRoute))
+				Expect(dataplane.UpdatedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&updateRoute)))
+				Expect(dataplane.RouteKeyToRoute[mocknetlink.KeyForRoute(&updateRoute)]).To(Equal(fixedRoute))
 			})
 
 			It("Should update protocol from an old protocol to a new one", func() {
 				// Route that needs to be updated
-				updateLink := dataplane.addIface(5, "cali5", true, true)
+				updateLink := dataplane.AddIface(5, "cali5", true, true)
 				updateRoute := netlink.Route{
-					LinkIndex: updateLink.attrs.Index,
+					LinkIndex: updateLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.5/32"),
 					Type:      syscall.RTN_UNICAST,
 					Protocol:  64,
 					Scope:     netlink.SCOPE_LINK,
 				}
-				rt.SetRoutes(updateLink.attrs.Name, []Target{
+				rt.SetRoutes(updateLink.LinkAttrs.Name, []Target{
 					{CIDR: ip.MustParseCIDROrIP("10.0.0.5"), DestMAC: mac1},
 				})
-				dataplane.addMockRoute(&updateRoute)
+				dataplane.AddMockRoute(&updateRoute)
 
 				fixedRoute := updateRoute
 				fixedRoute.Protocol = deviceRouteProtocol
 
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.updatedRouteKeys).To(HaveKey(keyForRoute(&updateRoute)))
-				Expect(dataplane.routeKeyToRoute[keyForRoute(&updateRoute)]).To(Equal(fixedRoute))
+				Expect(dataplane.UpdatedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&updateRoute)))
+				Expect(dataplane.RouteKeyToRoute[mocknetlink.KeyForRoute(&updateRoute)]).To(Equal(fixedRoute))
 			})
 		})
 
@@ -519,11 +516,150 @@ var _ = Describe("RouteTable", func() {
 			})
 		})
 
+		Describe("after syncing, after adding a route and failing the update twice", func() {
+			JustBeforeEach(func() {
+				err := rt.Apply()
+				Expect(err).NotTo(HaveOccurred())
+
+				dataplane.FailuresToSimulate = mocknetlink.FailNextRouteAdd
+				dataplane.PersistFailures = true
+				rt.RouteUpdate("cali3", Target{
+					CIDR: ip.MustParseCIDROrIP("10.20.30.40"),
+				})
+				err = rt.Apply()
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(UpdateFailed))
+
+				dataplane.FailuresToSimulate = 0
+				dataplane.PersistFailures = false
+			})
+
+			It("has not programmed the route", func() {
+				Expect(dataplane.RouteKeyToRoute).NotTo(ContainElement(netlink.Route{
+					LinkIndex: cali3.LinkAttrs.Index,
+					Dst:       mustParseCIDR("10.20.30.40/32"),
+					Type:      syscall.RTN_UNICAST,
+					Protocol:  FelixRouteProtocol,
+					Scope:     netlink.SCOPE_LINK,
+				}))
+			})
+
+			It("resolves on the next apply", func() {
+				err := rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(dataplane.RouteKeyToRoute).To(ContainElement(netlink.Route{
+					LinkIndex: cali3.LinkAttrs.Index,
+					Dst:       mustParseCIDR("10.20.30.40/32"),
+					Type:      syscall.RTN_UNICAST,
+					Protocol:  FelixRouteProtocol,
+					Scope:     netlink.SCOPE_LINK,
+				}))
+			})
+		})
+
+		Describe("after adding two routes to cali3", func() {
+			JustBeforeEach(func() {
+				rt.RouteUpdate("cali3", Target{
+					CIDR: ip.MustParseCIDROrIP("10.20.30.40"),
+				})
+				err := rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+				rt.RouteUpdate("cali3", Target{
+					CIDR: ip.MustParseCIDROrIP("10.0.20.0/24"),
+				})
+				err = rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should have two routes for cali3", func() {
+				Expect(dataplane.RouteKeyToRoute).To(ContainElement(netlink.Route{
+					LinkIndex: cali3.LinkAttrs.Index,
+					Dst:       mustParseCIDR("10.20.30.40/32"),
+					Type:      syscall.RTN_UNICAST,
+					Protocol:  FelixRouteProtocol,
+					Scope:     netlink.SCOPE_LINK,
+				}))
+				Expect(dataplane.RouteKeyToRoute).To(ContainElement(netlink.Route{
+					LinkIndex: cali3.LinkAttrs.Index,
+					Dst:       mustParseCIDR("10.0.20.0/24"),
+					Type:      syscall.RTN_UNICAST,
+					Protocol:  FelixRouteProtocol,
+					Scope:     netlink.SCOPE_LINK,
+				}))
+			})
+
+			It("should make no dataplane updates when deleting, creating and updating back to the same target before the next apply", func() {
+				rt.RouteRemove("cali3", ip.MustParseCIDROrIP("10.0.20.0/24"))
+				rt.RouteUpdate("cali3", Target{
+					CIDR: ip.MustParseCIDROrIP("10.0.20.0/24"),
+					GW:   ip.FromString("1.2.3.4"),
+				})
+				rt.RouteUpdate("cali3", Target{
+					CIDR: ip.MustParseCIDROrIP("10.0.20.0/24"),
+				})
+				dataplane.ResetDeltas()
+
+				err := rt.Apply()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+				Expect(dataplane.DeletedRouteKeys).To(BeEmpty())
+				Expect(dataplane.UpdatedRouteKeys).To(BeEmpty())
+
+				Expect(dataplane.RouteKeyToRoute).To(ContainElement(netlink.Route{
+					LinkIndex: cali3.LinkAttrs.Index,
+					Dst:       mustParseCIDR("10.20.30.40/32"),
+					Type:      syscall.RTN_UNICAST,
+					Protocol:  FelixRouteProtocol,
+					Scope:     netlink.SCOPE_LINK,
+				}))
+				Expect(dataplane.RouteKeyToRoute).To(ContainElement(netlink.Route{
+					LinkIndex: cali3.LinkAttrs.Index,
+					Dst:       mustParseCIDR("10.0.20.0/24"),
+					Type:      syscall.RTN_UNICAST,
+					Protocol:  FelixRouteProtocol,
+					Scope:     netlink.SCOPE_LINK,
+				}))
+			})
+
+			It("should make no dataplane updates when deleting and then setting back to the same target before the next apply", func() {
+				rt.RouteRemove("cali3", ip.MustParseCIDROrIP("10.0.20.0/24"))
+				rt.SetRoutes("cali3", []Target{{
+					CIDR: ip.MustParseCIDROrIP("10.0.20.0/24"),
+				}, {
+					CIDR: ip.MustParseCIDROrIP("10.20.30.40"),
+				}})
+
+				dataplane.ResetDeltas()
+
+				err := rt.Apply()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+				Expect(dataplane.DeletedRouteKeys).To(BeEmpty())
+				Expect(dataplane.UpdatedRouteKeys).To(BeEmpty())
+
+				Expect(dataplane.RouteKeyToRoute).To(ContainElement(netlink.Route{
+					LinkIndex: cali3.LinkAttrs.Index,
+					Dst:       mustParseCIDR("10.20.30.40/32"),
+					Type:      syscall.RTN_UNICAST,
+					Protocol:  FelixRouteProtocol,
+					Scope:     netlink.SCOPE_LINK,
+				}))
+				Expect(dataplane.RouteKeyToRoute).To(ContainElement(netlink.Route{
+					LinkIndex: cali3.LinkAttrs.Index,
+					Dst:       mustParseCIDR("10.0.20.0/24"),
+					Type:      syscall.RTN_UNICAST,
+					Protocol:  FelixRouteProtocol,
+					Scope:     netlink.SCOPE_LINK,
+				}))
+			})
+		})
+
 		// We do the following tests in different failure (and non-failure) scenarios.  In
 		// each case, we make the failure transient so that only the first Apply() should
 		// fail.  Then, at most, the second call to Apply() should succeed.
-		for _, failFlags := range failureScenarios {
-			failFlags := failFlags
+		for _, testFailFlags := range mocknetlink.RoutetableFailureScenarios {
+			failFlags := testFailFlags
 			desc := fmt.Sprintf("with some routes added and failures: %v", failFlags)
 			Describe(desc, func() {
 				BeforeEach(func() {
@@ -536,11 +672,11 @@ var _ = Describe("RouteTable", func() {
 					rt.SetRoutes("cali3", []Target{
 						{CIDR: ip.MustParseCIDROrIP("10.0.1.3/32")},
 					})
-					dataplane.failuresToSimulate = failFlags
+					dataplane.FailuresToSimulate = failFlags
 				})
 				JustBeforeEach(func() {
 					maxTries := 1
-					if failFlags != 0 {
+					if failFlags != mocknetlink.FailNone {
 						maxTries = 2
 					}
 					for try := 0; try < maxTries; try++ {
@@ -551,7 +687,7 @@ var _ = Describe("RouteTable", func() {
 							break
 						}
 					}
-					if failFlags == failNextLinkByNameNotFound {
+					if failFlags == mocknetlink.FailNextLinkByNameNotFound {
 						// Special case: a "not found" error doesn't get
 						// rechecked straight away because it's expected
 						// so we have to give the RouteTable a nudge.
@@ -562,20 +698,21 @@ var _ = Describe("RouteTable", func() {
 				})
 				It("should have consumed all failures", func() {
 					// Check that all the failures we simulated were hit.
-					Expect(dataplane.failuresToSimulate).To(Equal(failNone))
+					Expect(dataplane.FailuresToSimulate).To(Equal(mocknetlink.FailNone))
 				})
 				It("should keep correct route", func() {
-					Expect(dataplane.routeKeyToRoute["1-10.0.0.1/32"]).To(Equal(netlink.Route{
+					Expect(dataplane.RouteKeyToRoute["254-1-10.0.0.1/32"]).To(Equal(netlink.Route{
 						LinkIndex: 1,
 						Dst:       &ip1,
 						Type:      syscall.RTN_UNICAST,
 						Protocol:  FelixRouteProtocol,
 						Scope:     netlink.SCOPE_LINK,
 					}))
-					Expect(dataplane.addedRouteKeys.Contains("1-10.0.0.1/32")).To(BeFalse())
+					Expect(dataplane.AddedRouteKeys.Contains("254-1-10.0.0.1/32")).To(BeFalse())
 				})
 				It("should add new route", func() {
-					Expect(dataplane.routeKeyToRoute["2-10.0.0.2/32"]).To(Equal(netlink.Route{
+					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-2-10.0.0.2/32"))
+					Expect(dataplane.RouteKeyToRoute["254-2-10.0.0.2/32"]).To(Equal(netlink.Route{
 						LinkIndex: 2,
 						Dst:       &ip2,
 						Type:      syscall.RTN_UNICAST,
@@ -584,29 +721,30 @@ var _ = Describe("RouteTable", func() {
 					}))
 				})
 				It("should update changed route", func() {
-					Expect(dataplane.routeKeyToRoute["3-10.0.1.3/32"]).To(Equal(netlink.Route{
+					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-3-10.0.1.3/32"))
+					Expect(dataplane.RouteKeyToRoute["254-3-10.0.1.3/32"]).To(Equal(netlink.Route{
 						LinkIndex: 3,
 						Dst:       &ip13,
 						Type:      syscall.RTN_UNICAST,
 						Protocol:  FelixRouteProtocol,
 						Scope:     netlink.SCOPE_LINK,
 					}))
-					Expect(dataplane.deletedRouteKeys.Contains("3-10.0.0.3/32")).To(BeTrue())
+					Expect(dataplane.DeletedRouteKeys.Contains("254-3-10.0.0.3/32")).To(BeTrue())
 				})
 				It("should have expected number of routes at the end", func() {
-					Expect(len(dataplane.routeKeyToRoute)).To(Equal(4),
+					Expect(len(dataplane.RouteKeyToRoute)).To(Equal(4),
 						fmt.Sprintf("Wrong number of routes %v: %v",
-							len(dataplane.routeKeyToRoute),
-							dataplane.routeKeyToRoute))
+							len(dataplane.RouteKeyToRoute),
+							dataplane.RouteKeyToRoute))
 				})
-				if failFlags&(failNextSetSocketTimeout|
-					failNextNewNetlinkHandle|
-					failNextLinkByName|
-					failNextLinkList|
-					failNextRouteAdd|
-					failNextRouteDel|
-					failNextAddARP|
-					failNextRouteList) != 0 {
+				if failFlags&(mocknetlink.FailNextSetSocketTimeout|
+					mocknetlink.FailNextNewNetlink|
+					mocknetlink.FailNextLinkByName|
+					mocknetlink.FailNextLinkList|
+					mocknetlink.FailNextRouteAdd|
+					mocknetlink.FailNextRouteDel|
+					mocknetlink.FailNextAddARP|
+					mocknetlink.FailNextRouteList) != 0 {
 					It("should reconnect to netlink", func() {
 						Expect(dataplane.NumNewNetlinkCalls).To(Equal(2))
 					})
@@ -619,46 +757,46 @@ var _ = Describe("RouteTable", func() {
 				Describe("after an external route addition with route removal enabled", func() {
 					JustBeforeEach(func() {
 						cali1Route2 = netlink.Route{
-							LinkIndex: cali1.attrs.Index,
+							LinkIndex: cali1.LinkAttrs.Index,
 							Dst:       mustParseCIDR("10.0.0.22/32"),
 							Type:      syscall.RTN_UNICAST,
 							Scope:     netlink.SCOPE_LINK,
 						}
-						dataplane.addMockRoute(&cali1Route2)
+						dataplane.AddMockRoute(&cali1Route2)
 						err := rt.Apply()
 						Expect(err).ToNot(HaveOccurred())
 					})
 
-					It("shouldn't spot the update", func() {
-						Expect(dataplane.routeKeyToRoute).To(HaveLen(5))
-						Expect(dataplane.routeKeyToRoute).To(ContainElement(cali1Route2))
-					})
-					It("after a QueueResync() should not remove the route", func() {
-						rt.QueueResync()
-						err := rt.Apply()
-						Expect(err).ToNot(HaveOccurred())
-						Expect(dataplane.routeKeyToRoute).To(HaveLen(4))
-						Expect(dataplane.routeKeyToRoute).NotTo(ContainElement(cali1Route2))
-					})
-				})
-
-				Describe("after an external route remove with route removal disabled", func() {
-					JustBeforeEach(func() {
-						dataplane.removeMockRoute(&cali1Route)
-						err := rt.Apply()
-						Expect(err).ToNot(HaveOccurred())
-					})
-
-					It("shouldn't spot the update", func() {
-						Expect(dataplane.routeKeyToRoute).To(HaveLen(3))
-						Expect(dataplane.routeKeyToRoute).NotTo(ContainElement(cali1Route))
+					It("shouldn't spot the externally added route until a full resync", func() {
+						Expect(dataplane.RouteKeyToRoute).To(HaveLen(5))
+						Expect(dataplane.RouteKeyToRoute).To(ContainElement(cali1Route2))
 					})
 					It("after a QueueResync() should remove the route", func() {
 						rt.QueueResync()
 						err := rt.Apply()
 						Expect(err).ToNot(HaveOccurred())
-						Expect(dataplane.routeKeyToRoute).To(HaveLen(4))
-						Expect(dataplane.routeKeyToRoute).To(ContainElement(cali1Route))
+						Expect(dataplane.RouteKeyToRoute).To(HaveLen(4))
+						Expect(dataplane.RouteKeyToRoute).NotTo(ContainElement(cali1Route2))
+					})
+				})
+
+				Describe("after an external route remove with route removal disabled", func() {
+					JustBeforeEach(func() {
+						dataplane.RemoveMockRoute(&cali1Route)
+						err := rt.Apply()
+						Expect(err).ToNot(HaveOccurred())
+					})
+
+					It("shouldn't spot the externally deleted route until a full resync", func() {
+						Expect(dataplane.RouteKeyToRoute).To(HaveLen(3))
+						Expect(dataplane.RouteKeyToRoute).NotTo(ContainElement(cali1Route))
+					})
+					It("after a QueueResync() should add the route", func() {
+						rt.QueueResync()
+						err := rt.Apply()
+						Expect(err).ToNot(HaveOccurred())
+						Expect(dataplane.RouteKeyToRoute).To(HaveLen(4))
+						Expect(dataplane.RouteKeyToRoute).To(ContainElement(cali1Route))
 					})
 				})
 			})
@@ -666,52 +804,52 @@ var _ = Describe("RouteTable", func() {
 	})
 
 	Describe("with a down interface", func() {
-		var cali1 *mockLink
+		var cali1 *mocknetlink.MockLink
 		var cali1Route netlink.Route
 		BeforeEach(func() {
-			cali1 = dataplane.addIface(1, "cali1", false, false)
+			cali1 = dataplane.AddIface(1, "cali1", false, false)
 			cali1Route = netlink.Route{
-				LinkIndex: cali1.attrs.Index,
+				LinkIndex: cali1.LinkAttrs.Index,
 				Dst:       mustParseCIDR("10.0.0.1/32"),
 				Type:      syscall.RTN_UNICAST,
 				Protocol:  FelixRouteProtocol,
 				Scope:     netlink.SCOPE_LINK,
 			}
-			dataplane.addMockRoute(&cali1Route)
+			dataplane.AddMockRoute(&cali1Route)
 		})
 		It("with no failures, it should still try to clean up the route", func() {
 			err := rt.Apply()
 			Expect(err).To(BeNil())
-			Expect(dataplane.routeKeyToRoute).To(BeEmpty())
+			Expect(dataplane.RouteKeyToRoute).To(BeEmpty())
 		})
-		for _, failure := range []failFlags{
-			failNextLinkByName,
-			failNextRouteDel,
-			failNextRouteList,
+		for _, failure := range []mocknetlink.FailFlags{
+			mocknetlink.FailNextLinkByName,
+			mocknetlink.FailNextRouteDel,
+			mocknetlink.FailNextRouteList,
 		} {
 			failure := failure
 			It(fmt.Sprintf("with a %v failure, it should give up", failure), func() {
-				dataplane.failuresToSimulate = failure
+				dataplane.FailuresToSimulate = failure
 				err := rt.Apply()
 				Expect(err).To(BeNil())
-				Expect(dataplane.routeKeyToRoute).To(ConsistOf(cali1Route))
+				Expect(dataplane.RouteKeyToRoute).To(ConsistOf(cali1Route))
 			})
 			It(fmt.Sprintf("with a %v failure, it shouldn't leave the interface dirty", failure), func() {
 				// First Apply() with a failure.
-				dataplane.failuresToSimulate = failure
+				dataplane.FailuresToSimulate = failure
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
 				// All failures should have been hit.
-				Expect(dataplane.failuresToSimulate).To(BeZero())
+				Expect(dataplane.FailuresToSimulate).To(BeZero())
 				// Try another Apply(), the interface shouldn't be marked dirty
 				// so nothing should happen.
 				err = rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.routeKeyToRoute).To(ConsistOf(cali1Route))
+				Expect(dataplane.RouteKeyToRoute).To(ConsistOf(cali1Route))
 			})
 			It(fmt.Sprintf("with a %v failure it should ignore Down updates", failure), func() {
 				// First Apply() with a failure.
-				dataplane.failuresToSimulate = failure
+				dataplane.FailuresToSimulate = failure
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
 				// Fire in the update.
@@ -720,30 +858,356 @@ var _ = Describe("RouteTable", func() {
 				// so nothing should happen.
 				err = rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.routeKeyToRoute).To(ConsistOf(cali1Route))
+				Expect(dataplane.RouteKeyToRoute).To(ConsistOf(cali1Route))
 			})
 			It(fmt.Sprintf("with a %v failure, then an interface kick, it should sync", failure), func() {
-				dataplane.failuresToSimulate = failure
+				dataplane.FailuresToSimulate = failure
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
 
 				// Set interface up
 				rt.OnIfaceStateChanged("cali1", ifacemonitor.StateUp)
-				cali1 = dataplane.addIface(1, "cali1", true, true)
+				cali1 = dataplane.AddIface(1, "cali1", true, true)
 
 				// Now, the apply should work.
 				err = rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.routeKeyToRoute).To(BeEmpty())
+				Expect(dataplane.RouteKeyToRoute).To(BeEmpty())
 			})
 		}
+	})
+})
+
+var _ = Describe("RouteTable (main table)", func() {
+	var dataplane *mocknetlink.MockNetlinkDataplane
+	var t *mocktime.MockTime
+	var rt *RouteTable
+
+	BeforeEach(func() {
+		dataplane = mocknetlink.NewMockNetlinkDataplane()
+		t = mocktime.NewMockTime()
+		// Setting an auto-increment greater than the route cleanup delay effectively
+		// disables the grace period for these tests.
+		t.SetAutoIncrement(11 * time.Second)
+		rt = NewWithShims(
+			[]string{"^cali.*"},
+			4,
+			dataplane.NewMockNetlink,
+			false,
+			10*time.Second,
+			dataplane.AddStaticArpEntry,
+			dataplane,
+			t,
+			nil,
+			FelixRouteProtocol,
+			true,
+			0,
+		)
+	})
+
+	It("should be constructable", func() {
+		Expect(rt).ToNot(BeNil())
+	})
+
+	Describe("with some interfaces", func() {
+		var cali1, eth0 *mocknetlink.MockLink
+		var gatewayRoute, cali1Route, cali1RouteTable100 netlink.Route
+		BeforeEach(func() {
+			eth0 = dataplane.AddIface(0, "eth0", true, true)
+			cali1 = dataplane.AddIface(1, "cali1", true, true)
+			cali1Route = netlink.Route{
+				LinkIndex: cali1.LinkAttrs.Index,
+				Dst:       mustParseCIDR("10.0.0.1/32"),
+				Type:      syscall.RTN_UNICAST,
+				Protocol:  FelixRouteProtocol,
+				Scope:     netlink.SCOPE_LINK,
+			}
+			dataplane.AddMockRoute(&cali1Route)
+			cali1RouteTable100 = netlink.Route{
+				LinkIndex: cali1.LinkAttrs.Index,
+				Dst:       mustParseCIDR("10.0.0.3/32"),
+				Type:      syscall.RTN_UNICAST,
+				Protocol:  FelixRouteProtocol,
+				Scope:     netlink.SCOPE_LINK,
+				Table:     100,
+			}
+			dataplane.AddMockRoute(&cali1RouteTable100)
+			gatewayRoute = netlink.Route{
+				LinkIndex: eth0.LinkAttrs.Index,
+				Type:      syscall.RTN_UNICAST,
+				Protocol:  FelixRouteProtocol,
+				Scope:     netlink.SCOPE_LINK,
+				Gw:        net.ParseIP("12.0.0.1"),
+			}
+			dataplane.AddMockRoute(&gatewayRoute)
+		})
+		It("should wait for the route cleanup delay", func() {
+			t.SetAutoIncrement(0 * time.Second)
+			err := rt.Apply()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(cali1Route, cali1RouteTable100, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+			t.IncrementTime(11 * time.Second)
+			err = rt.Apply()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(cali1RouteTable100, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+		})
+		It("should wait for the route cleanup delay when resyncing", func() {
+			t.SetAutoIncrement(0 * time.Second)
+			rt.QueueResync()
+			err := rt.Apply()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(cali1Route, cali1RouteTable100, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+			t.IncrementTime(11 * time.Second)
+			rt.QueueResync()
+			err = rt.Apply()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(cali1RouteTable100, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+		})
+		It("should clean up only routes from the required table", func() {
+			err := rt.Apply()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(cali1RouteTable100, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("RouteTable (table 100)", func() {
+	var dataplane *mocknetlink.MockNetlinkDataplane
+	var t *mocktime.MockTime
+	var rt *RouteTable
+
+	BeforeEach(func() {
+		dataplane = mocknetlink.NewMockNetlinkDataplane()
+		t = mocktime.NewMockTime()
+		// Setting an auto-increment greater than the route cleanup delay effectively
+		// disables the grace period for these tests.
+		t.SetAutoIncrement(11 * time.Second)
+		rt = NewWithShims(
+			[]string{"^cali$", InterfaceNone}, // exact interface match
+			4,
+			dataplane.NewMockNetlink,
+			false,
+			10*time.Second,
+			dataplane.AddStaticArpEntry,
+			dataplane,
+			t,
+			nil,
+			FelixRouteProtocol,
+			true,
+			100,
+		)
+	})
+
+	It("should be constructable", func() {
+		Expect(rt).ToNot(BeNil())
+	})
+
+	Describe("with some interfaces", func() {
+		var cali, eth0 *mocknetlink.MockLink
+		var gatewayRoute, caliRoute, caliRouteTable100, throwRoute netlink.Route
+		BeforeEach(func() {
+			eth0 = dataplane.AddIface(0, "eth0", true, true)
+			cali = dataplane.AddIface(1, "cali", true, true)
+			caliRoute = netlink.Route{
+				LinkIndex: cali.LinkAttrs.Index,
+				Dst:       mustParseCIDR("10.0.0.1/32"),
+				Type:      syscall.RTN_UNICAST,
+				Protocol:  FelixRouteProtocol,
+				Scope:     netlink.SCOPE_LINK,
+			}
+			dataplane.AddMockRoute(&caliRoute)
+			caliRouteTable100 = netlink.Route{
+				LinkIndex: cali.LinkAttrs.Index,
+				Dst:       mustParseCIDR("10.0.0.3/32"),
+				Type:      syscall.RTN_UNICAST,
+				Protocol:  FelixRouteProtocol,
+				Scope:     netlink.SCOPE_LINK,
+				Table:     100,
+			}
+			dataplane.AddMockRoute(&caliRouteTable100)
+			gatewayRoute = netlink.Route{
+				LinkIndex: eth0.LinkAttrs.Index,
+				Type:      syscall.RTN_UNICAST,
+				Protocol:  FelixRouteProtocol,
+				Scope:     netlink.SCOPE_LINK,
+				Gw:        net.ParseIP("12.0.0.1"),
+			}
+			dataplane.AddMockRoute(&gatewayRoute)
+			throwRoute = netlink.Route{
+				LinkIndex: 0,
+				Dst:       mustParseCIDR("10.10.10.10/32"),
+				Type:      syscall.RTN_THROW,
+				Protocol:  FelixRouteProtocol,
+				Scope:     netlink.SCOPE_UNIVERSE,
+				Table:     100,
+			}
+			dataplane.AddMockRoute(&throwRoute)
+		})
+		It("should tidy up non-link routes immediately and wait for the route cleanup delay for interface routes", func() {
+			t.SetAutoIncrement(0 * time.Second)
+			err := rt.Apply()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, caliRouteTable100, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+			t.IncrementTime(11 * time.Second)
+			err = rt.Apply()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+		})
+		It("should wait for the route cleanup delay when resyncing", func() {
+			t.SetAutoIncrement(0 * time.Second)
+			rt.QueueResync()
+			err := rt.Apply()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, caliRouteTable100, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+			t.IncrementTime(11 * time.Second)
+			rt.QueueResync()
+			err = rt.Apply()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+		})
+		It("should clean up only routes from the required table", func() {
+			err := rt.Apply()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute))
+			Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+		})
+
+		Describe("after configuring a throw route", func() {
+			JustBeforeEach(func() {
+				rt.RouteUpdate(InterfaceNone, Target{
+					CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+					Type: TargetTypeThrow,
+				})
+				err := rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("the throw route should remain and the cali route in table 100 should be removed", func() {
+				Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute, throwRoute))
+				Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+				Expect(dataplane.DeletedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&caliRouteTable100)))
+			})
+		})
+
+		Describe("after configuring an existing throw route and then deleting it", func() {
+			JustBeforeEach(func() {
+				rt.RouteUpdate(InterfaceNone, Target{
+					CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+					Type: TargetTypeThrow,
+				})
+				err := rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+				rt.RouteRemove(InterfaceNone, ip.MustParseCIDROrIP("10.10.10.10/32"))
+				err = rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("the route should be removed", func() {
+				Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute))
+				Expect(dataplane.AddedRouteKeys).To(BeEmpty())
+				Expect(dataplane.DeletedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&throwRoute)))
+			})
+		})
+
+		Describe("after configuring a throw route and then replacing it with a blackhole route", func() {
+			JustBeforeEach(func() {
+				rt.RouteUpdate(InterfaceNone, Target{
+					CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+					Type: TargetTypeThrow,
+				})
+				err := rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+				rt.RouteUpdate(InterfaceNone, Target{
+					CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+					Type: TargetTypeBlackhole,
+				})
+				err = rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("the blackhole route should remain", func() {
+				Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute, netlink.Route{
+					LinkIndex: 0,
+					Dst:       mustParseCIDR("10.10.10.10/32"),
+					Type:      syscall.RTN_BLACKHOLE,
+					Protocol:  FelixRouteProtocol,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					Table:     100,
+				}))
+				Expect(dataplane.AddedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
+				Expect(dataplane.DeletedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
+			})
+		})
+
+		Describe("after configuring a blackhole route and then replacing it with a prohibit route", func() {
+			JustBeforeEach(func() {
+				rt.RouteUpdate(InterfaceNone, Target{
+					CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+					Type: TargetTypeBlackhole,
+				})
+				err := rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+				rt.RouteUpdate(InterfaceNone, Target{
+					CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+					Type: TargetTypeProhibit,
+				})
+				err = rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("the prohibit route should remain", func() {
+				Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute, netlink.Route{
+					LinkIndex: 0,
+					Dst:       mustParseCIDR("10.10.10.10/32"),
+					Type:      syscall.RTN_PROHIBIT,
+					Protocol:  FelixRouteProtocol,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					Table:     100,
+				}))
+				Expect(dataplane.AddedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
+				Expect(dataplane.DeletedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
+			})
+		})
 	})
 })
 
 var _ = Describe("Tests to verify netlink interface", func() {
 	It("Should give expected error for missing interface", func() {
 		_, err := netlink.LinkByName("dsfhjakdhfjk")
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+})
+
+var _ = Describe("Tests to verify ip version is policed", func() {
+	It("Should panic with an invalid IP version", func() {
+		Expect(func() {
+			dataplane := mocknetlink.NewMockNetlinkDataplane()
+			t := mocktime.NewMockTime()
+			_ = NewWithShims(
+				[]string{"^cali$", InterfaceNone},
+				5, // invalid IP version
+				dataplane.NewMockNetlink,
+				false,
+				10*time.Second,
+				dataplane.AddStaticArpEntry,
+				dataplane,
+				t,
+				nil,
+				FelixRouteProtocol,
+				true,
+				100,
+			)
+		}).To(Panic())
 	})
 })
 
@@ -751,297 +1215,4 @@ func mustParseCIDR(cidr string) *net.IPNet {
 	_, c, err := net.ParseCIDR(cidr)
 	Expect(err).NotTo(HaveOccurred())
 	return c
-}
-
-type failFlags uint32
-
-const (
-	failNextLinkList failFlags = 1 << iota
-	failNextLinkByName
-	failNextLinkByNameNotFound
-	failNextRouteList
-	failNextRouteAdd
-	failNextRouteDel
-	failNextAddARP
-	failNextNewNetlinkHandle
-	failNextSetSocketTimeout
-	failNone failFlags = 0
-)
-
-var failureScenarios = []failFlags{
-	failNone,
-	failNextLinkList,
-	failNextLinkByName,
-	failNextLinkByNameNotFound,
-	failNextRouteList,
-	failNextRouteAdd,
-	failNextRouteDel,
-	failNextAddARP,
-	failNextNewNetlinkHandle,
-	failNextSetSocketTimeout,
-}
-
-func (f failFlags) String() string {
-	parts := []string{}
-	if f&failNextLinkList != 0 {
-		parts = append(parts, "failNextLinkList")
-	}
-	if f&failNextLinkByName != 0 {
-		parts = append(parts, "failNextLinkByName")
-	}
-	if f&failNextLinkByNameNotFound != 0 {
-		parts = append(parts, "failNextLinkByNameNotFound")
-	}
-	if f&failNextRouteList != 0 {
-		parts = append(parts, "failNextRouteList")
-	}
-	if f&failNextRouteAdd != 0 {
-		parts = append(parts, "failNextRouteAdd")
-	}
-	if f&failNextRouteDel != 0 {
-		parts = append(parts, "failNextRouteDel")
-	}
-	if f&failNextAddARP != 0 {
-		parts = append(parts, "failNextAddARP")
-	}
-	if f&failNextNewNetlinkHandle != 0 {
-		parts = append(parts, "failNextNewNetlinkHandle")
-	}
-	if f&failNextSetSocketTimeout != 0 {
-		parts = append(parts, "failNextSetSocketTimeout")
-	}
-	if f == 0 {
-		parts = append(parts, "failNone")
-	}
-	return strings.Join(parts, "|")
-}
-
-type mockDataplane struct {
-	nameToLink       map[string]netlink.Link
-	routeKeyToRoute  map[string]netlink.Route
-	addedRouteKeys   set.Set
-	deletedRouteKeys set.Set
-	updatedRouteKeys set.Set
-
-	NumNewNetlinkCalls int
-	NetlinkOpen        bool
-
-	PersistentlyFailToConnect bool
-
-	failuresToSimulate failFlags
-
-	mutex                   sync.Mutex
-	deletedConntrackEntries []net.IP
-	ConntrackSleep          time.Duration
-}
-
-func (d *mockDataplane) addIface(idx int, name string, up bool, running bool) *mockLink {
-	flags := net.Flags(0)
-	var rawFlags uint32
-	if up {
-		flags |= net.FlagUp
-		rawFlags |= syscall.IFF_UP
-	}
-	if running {
-		rawFlags |= syscall.IFF_RUNNING
-	}
-	link := &mockLink{
-		attrs: netlink.LinkAttrs{
-			Name:     name,
-			Flags:    flags,
-			RawFlags: rawFlags,
-			Index:    idx,
-		},
-	}
-	d.nameToLink[name] = link
-	return link
-}
-
-func (d *mockDataplane) shouldFail(flag failFlags) bool {
-	flagPresent := d.failuresToSimulate&flag != 0
-	d.failuresToSimulate &^= flag
-	if flagPresent {
-		log.WithField("flag", flag).Warn("Mock dataplane: triggering failure")
-	}
-	return flagPresent
-}
-
-func (d *mockDataplane) NewNetlinkHandle() (HandleIface, error) {
-	d.NumNewNetlinkCalls++
-	if d.PersistentlyFailToConnect || d.shouldFail(failNextNewNetlinkHandle) {
-		return nil, simulatedError
-	}
-	Expect(d.NetlinkOpen).To(BeFalse())
-	d.NetlinkOpen = true
-	return d, nil
-}
-
-func (d *mockDataplane) Delete() {
-	Expect(d.NetlinkOpen).To(BeTrue())
-	d.NetlinkOpen = false
-}
-
-func (d *mockDataplane) SetSocketTimeout(to time.Duration) error {
-	Expect(d.NetlinkOpen).To(BeTrue())
-	if d.shouldFail(failNextSetSocketTimeout) {
-		return simulatedError
-	}
-	return nil
-}
-
-func (d *mockDataplane) LinkList() ([]netlink.Link, error) {
-	Expect(d.NetlinkOpen).To(BeTrue())
-	if d.shouldFail(failNextLinkList) {
-		return nil, simulatedError
-	}
-	var links []netlink.Link
-	for _, link := range d.nameToLink {
-		links = append(links, link)
-	}
-	return links, nil
-}
-
-func (d *mockDataplane) LinkByName(name string) (netlink.Link, error) {
-	Expect(d.NetlinkOpen).To(BeTrue())
-	if d.shouldFail(failNextLinkByNameNotFound) {
-		return nil, notFound
-	}
-	if d.shouldFail(failNextLinkByName) {
-		return nil, simulatedError
-	}
-	if link, ok := d.nameToLink[name]; ok {
-		return link, nil
-	} else {
-		return nil, notFound
-	}
-}
-
-func (d *mockDataplane) RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
-	Expect(d.NetlinkOpen).To(BeTrue())
-	if d.shouldFail(failNextRouteList) {
-		return nil, simulatedError
-	}
-	var routes []netlink.Route
-	for _, route := range d.routeKeyToRoute {
-		if route.LinkIndex == link.Attrs().Index {
-			routes = append(routes, route)
-		}
-	}
-	return routes, nil
-}
-
-func (d *mockDataplane) addMockRoute(route *netlink.Route) {
-	key := keyForRoute(route)
-	d.routeKeyToRoute[key] = *route
-}
-
-func (d *mockDataplane) removeMockRoute(route *netlink.Route) {
-	key := keyForRoute(route)
-	delete(d.routeKeyToRoute, key)
-}
-
-func (d *mockDataplane) RouteAdd(route *netlink.Route) error {
-	Expect(d.NetlinkOpen).To(BeTrue())
-	if d.shouldFail(failNextRouteAdd) {
-		return simulatedError
-	}
-	key := keyForRoute(route)
-	log.WithField("routeKey", key).Info("Mock dataplane: RouteAdd called")
-	d.addedRouteKeys.Add(key)
-	if _, ok := d.routeKeyToRoute[key]; ok {
-		return alreadyExists
-	} else {
-		d.routeKeyToRoute[key] = *route
-		return nil
-	}
-}
-
-func (d *mockDataplane) RouteDel(route *netlink.Route) error {
-	Expect(d.NetlinkOpen).To(BeTrue())
-	if d.shouldFail(failNextRouteDel) {
-		return simulatedError
-	}
-	key := keyForRoute(route)
-	log.WithField("routeKey", key).Info("Mock dataplane: RouteDel called")
-	d.deletedRouteKeys.Add(key)
-	// Route was deleted, but is planned on being readded
-	if _, ok := d.routeKeyToRoute[key]; ok {
-		delete(d.routeKeyToRoute, key)
-		d.updatedRouteKeys.Add(key)
-		return nil
-	} else {
-		return nil
-	}
-}
-
-func (d *mockDataplane) AddStaticArpEntry(cidr ip.CIDR, destMAC net.HardwareAddr, ifaceName string) error {
-	if d.shouldFail(failNextAddARP) {
-		return simulatedError
-	}
-	log.WithFields(log.Fields{
-		"cidr":      cidr,
-		"destMac":   destMAC,
-		"ifaceName": ifaceName,
-	}).Info("Mock dataplane: adding ARP entry")
-	return nil
-}
-
-func (d *mockDataplane) RemoveConntrackFlows(ipVersion uint8, ipAddr net.IP) {
-	log.WithFields(log.Fields{
-		"ipVersion": ipVersion,
-		"ipAddr":    ipAddr,
-		"sleepTime": d.ConntrackSleep,
-	}).Info("Mock dataplane: Removing conntrack flows")
-	d.mutex.Lock()
-	d.deletedConntrackEntries = append(d.deletedConntrackEntries, ipAddr)
-	d.mutex.Unlock()
-	time.Sleep(d.ConntrackSleep)
-}
-
-func (d *mockDataplane) GetDeletedConntrackEntries() []net.IP {
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-	cpy := make([]net.IP, len(d.deletedConntrackEntries))
-	copy(cpy, d.deletedConntrackEntries)
-	return cpy
-}
-
-func keyForRoute(route *netlink.Route) string {
-	key := fmt.Sprintf("%v-%v", route.LinkIndex, route.Dst)
-	log.WithField("routeKey", key).Debug("Calculated route key")
-	return key
-}
-
-type mockLink struct {
-	attrs netlink.LinkAttrs
-}
-
-func (l *mockLink) Attrs() *netlink.LinkAttrs {
-	return &l.attrs
-}
-
-func (l *mockLink) Type() string {
-	return "not-implemented"
-}
-
-type mockTime struct {
-	currentTime   time.Time
-	autoIncrement time.Duration
-}
-
-func (m *mockTime) Now() time.Time {
-	t := m.currentTime
-	m.incrementTime(m.autoIncrement)
-	return t
-}
-func (m *mockTime) Since(t time.Time) time.Duration {
-	return m.Now().Sub(t)
-}
-
-func (m *mockTime) setAutoIncrement(t time.Duration) {
-	m.autoIncrement = t
-}
-
-func (m *mockTime) incrementTime(t time.Duration) {
-	m.currentTime = m.currentTime.Add(t)
 }

--- a/time/mock/time.go
+++ b/time/mock/time.go
@@ -1,0 +1,39 @@
+package mock
+
+import (
+	"time"
+
+	timeshim "github.com/projectcalico/felix/time"
+)
+
+func NewMockTime() *MockTime {
+	startTime, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+	return &MockTime{
+		currentTime: startTime,
+	}
+}
+
+var _ timeshim.Time = NewMockTime()
+
+type MockTime struct {
+	currentTime   time.Time
+	autoIncrement time.Duration
+}
+
+func (m *MockTime) Now() time.Time {
+	t := m.currentTime
+	m.IncrementTime(m.autoIncrement)
+	return t
+}
+
+func (m *MockTime) Since(t time.Time) time.Duration {
+	return m.Now().Sub(t)
+}
+
+func (m *MockTime) SetAutoIncrement(t time.Duration) {
+	m.autoIncrement = t
+}
+
+func (m *MockTime) IncrementTime(t time.Duration) {
+	m.currentTime = m.currentTime.Add(t)
+}

--- a/time/time.go
+++ b/time/time.go
@@ -1,0 +1,26 @@
+package time
+
+import (
+	"time"
+)
+
+// Time is our shim interface to the time package.
+type Time interface {
+	Now() time.Time
+	Since(t time.Time) time.Duration
+}
+
+func NewRealTime() Time {
+	return &realTime{}
+}
+
+// realTime is the real implementation of timeIface, which calls through to the real time package.
+type realTime struct{}
+
+func (realTime) Now() time.Time {
+	return time.Now()
+}
+
+func (realTime) Since(t time.Time) time.Duration {
+	return time.Since(t)
+}


### PR DESCRIPTION
## Description
This enhances the routable module to provide:
-  An interface which accepts delta route programming
-  Exact interface name matches
-  A "None interface" for non-link rules along with handling for throw, blackhole and prohibit route types.
-  Support for table index (rather than just the main table)

## Todos
- [X] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) Not needed
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
