### PR TITLE
Fix VXLAN race condition

### DIFF
--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -60,9 +60,8 @@ func init() {
 
 // Constants that are shared with the UT binaries that we build.
 const (
-	natTunnelMTU       = uint16(700)
-	ethernetHeaderSize = 14
-	testVxlanPort      = uint16(5665)
+	natTunnelMTU  = uint16(700)
+	testVxlanPort = uint16(5665)
 )
 
 var (

--- a/calc/vxlan_resolver.go
+++ b/calc/vxlan_resolver.go
@@ -183,6 +183,9 @@ func (c *VXLANResolver) OnResourceUpdate(update api.Update) (_ bool) {
 	logCxt := logrus.WithField("node", nodeName).WithField("update", update)
 	logCxt.Debug("OnResourceUpdate triggered")
 	if update.Value != nil && update.Value.(*apiv3.Node).Spec.BGP != nil {
+		// Calculate the pending and sent sets before adding 'node' to nodeNameToNode.
+		pendingSet, sentSet := c.routeSets()
+
 		node := update.Value.(*apiv3.Node)
 		bgp := node.Spec.BGP
 		c.nodeNameToNode[nodeName] = node
@@ -192,7 +195,7 @@ func (c *VXLANResolver) OnResourceUpdate(update api.Update) (_ bool) {
 			return
 		}
 
-		c.onNodeIPUpdate(nodeName, ipv4.String())
+		c.onNodeIPUpdate(nodeName, ipv4.String(), pendingSet, sentSet)
 	} else {
 		delete(c.nodeNameToNode, nodeName)
 		c.onRemoveNode(nodeName)
@@ -210,20 +213,20 @@ func (c *VXLANResolver) OnHostIPUpdate(update api.Update) (_ bool) {
 	logrus.WithField("node", nodeName).Debug("OnHostIPUpdate triggered")
 
 	if update.Value != nil {
-		c.onNodeIPUpdate(nodeName, update.Value.(*cnet.IP).String())
+		pendingSet, sentSet := c.routeSets()
+		c.onNodeIPUpdate(nodeName, update.Value.(*cnet.IP).String(), pendingSet, sentSet)
 	} else {
 		c.onRemoveNode(nodeName)
 	}
 	return
 }
 
-func (c *VXLANResolver) onNodeIPUpdate(nodeName string, newIP string) {
+func (c *VXLANResolver) onNodeIPUpdate(nodeName string, newIP string, pendingSet set.Set, sentSet set.Set) {
 	logCxt := logrus.WithField("node", nodeName)
 	// Host IP updated or added. If it was added, we should check to see if we're ready
 	// to send a VTEP and associated routes. If we already knew about this one, we need to
 	// see if it has changed. If it has, we should remove and reprogram the VTEP and routes.
 	currIP := c.nodeNameToIPAddr[nodeName]
-	pendingSet, sentSet := c.routeSets()
 	logCxt = logCxt.WithFields(logrus.Fields{"newIP": newIP, "currIP": currIP})
 	if c.vtepSent(nodeName) {
 		if currIP == newIP {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Fixes a race in VXLAN resolver where we don't get cross subnet routes.

Already fixed in master due to a refactoring of the route resolution code by @fasaxc .

This is a small patch to earlier releases to fix the same issue. 

https://github.com/projectcalico/calico/issues/3231

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix race condition in VXLAN CrossSubnet code, issue https://github.com/projectcalico/calico/issues/3231
```