### PR TITLE
In BPF mode, add bpf to cluster type

### DIFF
--- a/usagerep/usagerep_test.go
+++ b/usagerep/usagerep_test.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package usagerep
 
 import (
@@ -88,6 +87,7 @@ var _ = Describe("UsageReporter with mocked URL and short interval", func() {
 				"ClusterGUID":   "someguid",
 				"ClusterType":   "openstack,k8s,kdd",
 				"CalicoVersion": "v2.6.3",
+				"BPFEnabled":    "false",
 			}
 		}
 
@@ -176,6 +176,7 @@ var _ = Describe("UsageReporter with mocked URL and short interval", func() {
 						"ClusterType":          "openstack,k8s,kdd,typha",
 						"CalicoVersion":        "v3.0.0",
 						"PolicySyncPathPrefix": "/var/run/nodeagent",
+						"BPFEnabled":           "true",
 					}
 				})
 
@@ -190,7 +191,7 @@ var _ = Describe("UsageReporter with mocked URL and short interval", func() {
 					q := url.Query()
 					Expect(q).To(HaveLen(expectedNumberOfURLParams), "unexpected number of URL parameters")
 					Expect(q.Get("guid")).To(Equal("someguid2"))
-					Expect(q.Get("type")).To(Equal("openstack,k8s,kdd,typha"))
+					Expect(q.Get("type")).To(Equal("openstack,k8s,kdd,typha,bpf"))
 					Expect(q.Get("cal_ver")).To(Equal("v3.0.0"))
 					Expect(q.Get("k8s_ver")).To(Equal("v1.17.0"))
 					Expect(q.Get("alp")).To(Equal("true"))
@@ -238,7 +239,7 @@ var _ = Describe("UsageReporter with default URL", func() {
 	})
 
 	It("should calculate correct URL mainline", func() {
-		rawURL := u.calculateURL("theguid", "atype", "testVer", true, calc.StatsUpdate{
+		rawURL := u.calculateURL("theguid", "atype", "testVer", true, false, calc.StatsUpdate{
 			NumHostEndpoints:     123,
 			NumWorkloadEndpoints: 234,
 			NumHosts:             10,
@@ -263,7 +264,7 @@ var _ = Describe("UsageReporter with default URL", func() {
 		Expect(url.Path).To(Equal("/UsageCheck/calicoVersionCheck"))
 	})
 	It("should default cluster type, GUID, and Calico Version", func() {
-		rawURL := u.calculateURL("", "", "", false, calc.StatsUpdate{
+		rawURL := u.calculateURL("", "", "", false, false, calc.StatsUpdate{
 			NumHostEndpoints:     123,
 			NumWorkloadEndpoints: 234,
 			NumHosts:             10,


### PR DESCRIPTION
The changes adds the bpf string to the clustertype, based on whether BPF is enabled or not.
## Todos
UT logs attached
[bpf-365_ut.log](https://github.com/projectcalico/felix/files/4492096/bpf-365_ut.log)

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
