### PR TITLE
Configurable source for routing information

### DIFF
--- a/calc/calc_graph.go
+++ b/calc/calc_graph.go
@@ -310,7 +310,7 @@ func NewCalculationGraph(callbacks PipelineCallbacks, conf *config.Config) *Calc
 		//         |
 		//      <dataplane>
 		//
-		l3RR := NewL3RouteResolver(hostname, callbacks, conf.UseNodeResourceUpdates())
+		l3RR := NewL3RouteResolver(hostname, callbacks, conf.UseNodeResourceUpdates(), conf.RouteSource)
 		l3RR.RegisterWith(allUpdDispatcher, localEndpointDispatcher)
 	}
 

--- a/calc/calc_graph_fv_test.go
+++ b/calc/calc_graph_fv_test.go
@@ -338,6 +338,11 @@ var baseTests = []StateList{
 		vxlanWithBlockNodeRes,
 	},
 	{
+		// Test L3 route resolver in node resource mode using WorkloadIPs as the route source.
+		// Since we get routing information from WEPs and no IPAM, we don't expect any remote workload routes.
+		vxlanWithWorkloadIPs,
+	},
+	{
 		// Test corner case where the IP pool and block share a /32.
 		// Should be able to add or remove the block or pool in either order and get the same result.
 		vxlanSlash32,
@@ -467,6 +472,7 @@ var _ = Describe("Async calculation graph state sequencing tests:", func() {
 					conf.VXLANEnabled = true
 					conf.BPFEnabled = true
 					conf.SetUseNodeResourceUpdates(test.UsesNodeResources())
+					conf.RouteSource = test.RouteSource()
 					outputChan := make(chan interface{})
 					asyncGraph := NewAsyncCalcGraph(conf, []chan<- interface{}{outputChan}, nil)
 					// And a validation filter, with a channel between it
@@ -606,6 +612,7 @@ func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 		conf.VXLANEnabled = true
 		conf.BPFEnabled = true
 		conf.SetUseNodeResourceUpdates(expandedTest.UsesNodeResources())
+		conf.RouteSource = expandedTest.RouteSource()
 		mockDataplane = mock.NewMockDataplane()
 		eventBuf = NewEventSequencer(mockDataplane)
 		eventBuf.Callback = mockDataplane.OnEvent

--- a/calc/calc_graph_fv_test.go
+++ b/calc/calc_graph_fv_test.go
@@ -339,8 +339,12 @@ var baseTests = []StateList{
 	},
 	{
 		// Test L3 route resolver in node resource mode using WorkloadIPs as the route source.
-		// Since we get routing information from WEPs and no IPAM, we don't expect any remote workload routes.
-		vxlanWithWorkloadIPs,
+		// This test starts with a single remote workload, then moves to two remote workloads with the same
+		// IP address on different nodes, and then back to a single workload.
+		vxlanWithWEPIPs,
+		vxlanWithWEPIPsAndWEP,
+		vxlanWithWEPIPsAndWEPDuplicate,
+		vxlanWithWEPIPsAndWEP,
 	},
 	{
 		// Test corner case where the IP pool and block share a /32.

--- a/calc/l3_route_resolver.go
+++ b/calc/l3_route_resolver.go
@@ -107,7 +107,7 @@ func (c *L3RouteResolver) RegisterWith(allUpdDispatcher, localDispatcher *dispat
 	// Depending on if we're using workload endpoints for routing information, we may
 	// need all WEPs, or only local WEPs.
 	logrus.WithField("routeSource", c.routeSource).Info("Registering for L3 route updates")
-	if c.routeSource == "workloadIPs" {
+	if c.routeSource == "WorkloadIPs" {
 		// Driven off of workload IP addressess. Register for all WEP udpates.
 		allUpdDispatcher.Register(model.WorkloadEndpointKey{}, c.OnWorkloadUpdate)
 	} else {
@@ -726,6 +726,9 @@ func (r *RouteTrie) RemoveWEP(cidr ip.V4CIDR, nodename string) {
 		if ri.WEP.RefCount[nodename] < 0 {
 			logrus.WithField("cidr", cidr).Panic("BUG: Asked to decref a workload past 0.")
 		}
+		if len(ri.WEP) == 0 {
+			ri.WEP = nil
+		}
 	})
 }
 
@@ -817,9 +820,11 @@ func (r RouteInfo) IsValidRoute() bool {
 // explicitly copy them so that they are not shared between the copies.
 func (r RouteInfo) Copy() RouteInfo {
 	cp := r
-	cp.WEP.RefCount = map[string]int{}
-	for n, c := range r.WEP.RefCount {
-		cp.WEP.RefCount[n] = c
+	if len(r.WEP) != 0 {
+		cp.WEP.RefCount = map[string]int{}
+		for n, c := range r.WEP.RefCount {
+			cp.WEP.RefCount[n] = c
+		}
 	}
 	return cp
 }

--- a/calc/l3_route_resolver.go
+++ b/calc/l3_route_resolver.go
@@ -64,6 +64,7 @@ type L3RouteResolver struct {
 	allPools               map[string]model.IPPool
 	workloadIDToCIDRs      map[model.WorkloadEndpointKey][]cnet.IPNet
 	useNodeResourceUpdates bool
+	routeSource            string
 }
 
 type l3rrNodeInfo struct {
@@ -75,7 +76,7 @@ func (i l3rrNodeInfo) AddrAsCIDR() ip.V4CIDR {
 	return i.Addr.AsCIDR().(ip.V4CIDR)
 }
 
-func NewL3RouteResolver(hostname string, callbacks PipelineCallbacks, useNodeResourceUpdates bool) *L3RouteResolver {
+func NewL3RouteResolver(hostname string, callbacks PipelineCallbacks, useNodeResourceUpdates bool, routeSource string) *L3RouteResolver {
 	logrus.Info("Creating L3 route resolver")
 	return &L3RouteResolver{
 		myNodeName: hostname,
@@ -88,6 +89,7 @@ func NewL3RouteResolver(hostname string, callbacks PipelineCallbacks, useNodeRes
 		allPools:               map[string]model.IPPool{},
 		workloadIDToCIDRs:      map[model.WorkloadEndpointKey][]cnet.IPNet{},
 		useNodeResourceUpdates: useNodeResourceUpdates,
+		routeSource:            routeSource,
 	}
 }
 
@@ -100,13 +102,22 @@ func (c *L3RouteResolver) RegisterWith(allUpdDispatcher, localDispatcher *dispat
 		allUpdDispatcher.Register(model.HostIPKey{}, c.OnHostIPUpdate)
 	}
 
-	allUpdDispatcher.Register(model.BlockKey{}, c.OnBlockUpdate)
 	allUpdDispatcher.Register(model.IPPoolKey{}, c.OnPoolUpdate)
 
-	localDispatcher.Register(model.WorkloadEndpointKey{}, c.OnLocalWorkloadUpdate)
+	// Depending on if we're using workload endpoints for routing information, we may
+	// need all WEPs, or only local WEPs.
+	logrus.WithField("routeSource", c.routeSource).Info("Registering for L3 route updates")
+	if c.routeSource == "workloadIPs" {
+		// Driven off of workload IP addressess. Register for all WEP udpates.
+		allUpdDispatcher.Register(model.WorkloadEndpointKey{}, c.OnWorkloadUpdate)
+	} else {
+		// Driven off of IPAM data. Register for blocks and local WEP updates.
+		allUpdDispatcher.Register(model.BlockKey{}, c.OnBlockUpdate)
+		localDispatcher.Register(model.WorkloadEndpointKey{}, c.OnWorkloadUpdate)
+	}
 }
 
-func (c *L3RouteResolver) OnLocalWorkloadUpdate(update api.Update) (_ bool) {
+func (c *L3RouteResolver) OnWorkloadUpdate(update api.Update) (_ bool) {
 	defer c.flush()
 
 	key := update.Key.(model.WorkloadEndpointKey)
@@ -130,12 +141,12 @@ func (c *L3RouteResolver) OnLocalWorkloadUpdate(update api.Update) (_ bool) {
 
 	// Incref the new CIDRs.
 	for _, newCIDR := range newCIDRs {
-		c.trie.AddLocalWEP(ip.CIDRFromCalicoNet(newCIDR).(ip.V4CIDR))
+		c.trie.AddWEP(ip.CIDRFromCalicoNet(newCIDR).(ip.V4CIDR), key.Hostname)
 	}
 
 	// Decref the old.
 	for _, oldCIDR := range oldCIDRs {
-		c.trie.RemoveLocalWEP(ip.CIDRFromCalicoNet(oldCIDR).(ip.V4CIDR))
+		c.trie.RemoveWEP(ip.CIDRFromCalicoNet(oldCIDR).(ip.V4CIDR), key.Hostname)
 	}
 
 	if len(newCIDRs) > 0 {
@@ -525,11 +536,20 @@ func (c *L3RouteResolver) flush() {
 					rt.Type = proto.RouteType_REMOTE_HOST
 				}
 			}
-			if ri.LocalWEP.RefCount > 0 {
-				// We have a local WEP with this IP.
-				rt.DstNodeName = c.myNodeName
-				rt.Type = proto.RouteType_LOCAL_WORKLOAD
-				rt.LocalWorkload = true
+
+			for nodename, _ := range ri.WEP.RefCount {
+				// At least one WEP exists with this IP. It may be on this node, or a remote node.
+				// In steady state we only ever expect a single WEP for this CIDR. However there are rare transient
+				// cases we must handle where we may have two WEPs with the same IP. Since this will be transient,
+				// we can always just use one entry from the map.
+				rt.DstNodeName = nodename
+				if nodename == c.myNodeName {
+					rt.Type = proto.RouteType_LOCAL_WORKLOAD
+					rt.LocalWorkload = true
+				} else {
+					rt.Type = proto.RouteType_REMOTE_WORKLOAD
+				}
+				break
 			}
 		}
 
@@ -688,17 +708,23 @@ func (r *RouteTrie) RemoveHost(cidr ip.V4CIDR, nodeName string) {
 	})
 }
 
-func (r *RouteTrie) AddLocalWEP(cidr ip.V4CIDR) {
+func (r *RouteTrie) AddWEP(cidr ip.V4CIDR, nodename string) {
 	r.updateCIDR(cidr, func(ri *RouteInfo) {
-		ri.LocalWEP.RefCount++
+		if ri.WEP.RefCount == nil {
+			ri.WEP.RefCount = map[string]int{}
+		}
+		ri.WEP.RefCount[nodename]++
 	})
 }
 
-func (r *RouteTrie) RemoveLocalWEP(cidr ip.V4CIDR) {
+func (r *RouteTrie) RemoveWEP(cidr ip.V4CIDR, nodename string) {
 	r.updateCIDR(cidr, func(ri *RouteInfo) {
-		ri.LocalWEP.RefCount--
-		if ri.LocalWEP.RefCount < 0 {
-			logrus.WithField("cidr", cidr).Panic("BUG: Asked to decref a local workload past 0.")
+		ri.WEP.RefCount[nodename]--
+		if ri.WEP.RefCount[nodename] == 0 {
+			delete(ri.WEP.RefCount, nodename)
+		}
+		if ri.WEP.RefCount[nodename] < 0 {
+			logrus.WithField("cidr", cidr).Panic("BUG: Asked to decref a workload past 0.")
 		}
 	})
 }
@@ -712,7 +738,7 @@ func (r *RouteTrie) SetRouteSent(cidr ip.V4CIDR, sent bool) {
 func (r RouteTrie) updateCIDR(cidr ip.V4CIDR, updateFn func(info *RouteInfo)) bool {
 	// Get the RouteInfo for the given CIDR and take a copy so we can compare.
 	ri := r.Get(cidr)
-	riCopy := ri
+	riCopy := ri.Copy()
 
 	// Apply the update, whatever that is.
 	updateFn(&ri)
@@ -763,11 +789,12 @@ type RouteInfo struct {
 		NodeNames []string // set if this CIDR _is_ a node's own IP.
 	}
 
-	// LocalWEP contains information extracted from the local workload endpoints.
-	LocalWEP struct {
-		// Count of local WEPs that have this CIDR.  Normally, this will be 0 or 1 but Felix has to be tolerant
-		// to bad data (two local WEPs with the same CIDR) so we do ref counting.
-		RefCount int
+	// WEP contains information extracted from the workload endpoints.
+	WEP struct {
+		// Count of WEPs that have this CIDR.  Normally, this will be 0 or 1 but Felix has to be tolerant
+		// to bad data (two WEPs with the same CIDR) so we do ref counting.
+		// The RefCount is tracked per-node, to properly handle remote weps.
+		RefCount map[string]int
 	}
 
 	// WasSent is set to true when the route is sent downstream.
@@ -783,7 +810,18 @@ func (r RouteInfo) IsValidRoute() bool {
 		r.Block.NodeName != "" ||
 		len(r.Host.NodeNames) > 0 ||
 		r.Pool.NATOutgoing ||
-		r.LocalWEP.RefCount > 0
+		len(r.WEP.RefCount) > 0
+}
+
+// Copy returns a copy of the RouteInfo. Since some fields are pointers, we need to
+// explicitly copy them so that they are not shared between the copies.
+func (r RouteInfo) Copy() RouteInfo {
+	cp := r
+	cp.WEP.RefCount = map[string]int{}
+	for n, c := range r.WEP.RefCount {
+		cp.WEP.RefCount[n] = c
+	}
+	return cp
 }
 
 // IsZero() returns true if this node in the trie now contains no tracking information at all and is

--- a/calc/l3_route_resolver.go
+++ b/calc/l3_route_resolver.go
@@ -726,8 +726,8 @@ func (r *RouteTrie) RemoveWEP(cidr ip.V4CIDR, nodename string) {
 		if ri.WEP.RefCount[nodename] < 0 {
 			logrus.WithField("cidr", cidr).Panic("BUG: Asked to decref a workload past 0.")
 		}
-		if len(ri.WEP) == 0 {
-			ri.WEP = nil
+		if len(ri.WEP.RefCount) == 0 {
+			ri.WEP.RefCount = nil
 		}
 	})
 }
@@ -820,7 +820,7 @@ func (r RouteInfo) IsValidRoute() bool {
 // explicitly copy them so that they are not shared between the copies.
 func (r RouteInfo) Copy() RouteInfo {
 	cp := r
-	if len(r.WEP) != 0 {
+	if len(r.WEP.RefCount) != 0 {
 		cp.WEP.RefCount = map[string]int{}
 		for n, c := range r.WEP.RefCount {
 			cp.WEP.RefCount[n] = c

--- a/calc/l3_route_resolver.go
+++ b/calc/l3_route_resolver.go
@@ -579,7 +579,6 @@ func (c *L3RouteResolver) flush() {
 				} else {
 					rt.Type = proto.RouteType_REMOTE_WORKLOAD
 				}
-				break
 			}
 		}
 

--- a/calc/l3_route_resolver.go
+++ b/calc/l3_route_resolver.go
@@ -878,7 +878,8 @@ func (r RouteInfo) IsValidRoute() bool {
 func (r RouteInfo) Copy() RouteInfo {
 	cp := r
 	if len(r.WEPs) != 0 {
-		cp.WEPs = append(cp.WEPs, r.WEPs...)
+		cp.WEPs = make([]WEP, len(r.WEPs))
+		copy(cp.WEPs, r.WEPs)
 	}
 	return cp
 }

--- a/calc/l3_route_resolver.go
+++ b/calc/l3_route_resolver.go
@@ -366,7 +366,10 @@ func (c *L3RouteResolver) onNodeUpdate(nodeName string, newNodeInfo *l3rrNodeInf
 			// we need to mark each one as dirty, since the routes may need to be reprogrammed.
 			// For example, if the node IP changes.
 			cidrSet.Iter(func(item interface{}) error {
-				cidr, _ := ip.CIDRFromString(item.(string))
+				cidr, err := ip.CIDRFromString(item.(string))
+				if err != nil {
+					logrus.WithError(err).Fatal("Invalid CIDR")
+				}
 				c.trie.MarkCIDRDirty(cidr.(ip.V4CIDR))
 				return nil
 			})
@@ -745,7 +748,7 @@ func (r *RouteTrie) AddWEP(cidr ip.V4CIDR, nodename string) {
 
 		// Groom the nodename slice.
 		ri.WEP.NodeNames = []string{}
-		for nodename, _ := range ri.WEP.RefCount {
+		for nodename := range ri.WEP.RefCount {
 			ri.WEP.NodeNames = append(ri.WEP.NodeNames, nodename)
 		}
 		sort.Strings(ri.WEP.NodeNames)
@@ -753,7 +756,7 @@ func (r *RouteTrie) AddWEP(cidr ip.V4CIDR, nodename string) {
 }
 
 func (r *RouteTrie) RemoveWEP(cidr ip.V4CIDR, nodename string) {
-	removeElement := func(s []string, e string) {
+	removeElement := func(s []string, e string) []string {
 		// Find element index
 		var i int
 		var v string
@@ -769,14 +772,14 @@ func (r *RouteTrie) RemoveWEP(cidr ip.V4CIDR, nodename string) {
 		}
 
 		// Remove it.
-		s = append(s[:i], s[i+1:]...)
+		return append(s[:i], s[i+1:]...)
 	}
 
 	r.updateCIDR(cidr, func(ri *RouteInfo) {
 		ri.WEP.RefCount[nodename]--
 		if ri.WEP.RefCount[nodename] == 0 {
 			delete(ri.WEP.RefCount, nodename)
-			removeElement(ri.WEP.NodeNames, nodename)
+			ri.WEP.NodeNames = removeElement(ri.WEP.NodeNames, nodename)
 		}
 		if ri.WEP.RefCount[nodename] < 0 {
 			logrus.WithField("cidr", cidr).Panic("BUG: Asked to decref a workload past 0.")
@@ -885,9 +888,7 @@ func (r RouteInfo) Copy() RouteInfo {
 			cp.WEP.RefCount[n] = c
 		}
 		cp.WEP.NodeNames = []string{}
-		for _, n := range cp.WEP.NodeNames {
-			cp.WEP.NodeNames = append(cp.WEP.NodeNames, n)
-		}
+		cp.WEP.NodeNames = append(cp.WEP.NodeNames, cp.WEP.NodeNames...)
 	}
 	return cp
 }

--- a/calc/resources_for_test.go
+++ b/calc/resources_for_test.go
@@ -57,10 +57,15 @@ var (
 // Canned workload endpoints.
 
 var localWlEpKey1 = WorkloadEndpointKey{Hostname: localHostname, OrchestratorID: "orch", WorkloadID: "wl1", EndpointID: "ep1"}
-var remoteWlEpKey1 = WorkloadEndpointKey{Hostname: remoteHostname, OrchestratorID: "orch", WorkloadID: "wl1", EndpointID: "ep1"}
 var localWlEp1Id = "orch/wl1/ep1"
 var localWlEpKey2 = WorkloadEndpointKey{Hostname: localHostname, OrchestratorID: "orch", WorkloadID: "wl2", EndpointID: "ep2"}
 var localWlEp2Id = "orch/wl2/ep2"
+
+// A remote workload endpoint
+var remoteWlEpKey1 = WorkloadEndpointKey{Hostname: remoteHostname, OrchestratorID: "orch", WorkloadID: "wl1", EndpointID: "ep1"}
+
+// Same as remoteWlEpKey1 but on a different host.
+var remoteWlEpKey2 = WorkloadEndpointKey{Hostname: remoteHostname2, OrchestratorID: "orch", WorkloadID: "wl1", EndpointID: "ep1"}
 
 var localWlEp1 = WorkloadEndpoint{
 	State:      "active",

--- a/calc/resources_for_test.go
+++ b/calc/resources_for_test.go
@@ -198,6 +198,17 @@ var localWlEp2NoProfiles = WorkloadEndpoint{
 		mustParseNet("fc00:fe11::3/128")},
 }
 
+var remoteWlEp1 = WorkloadEndpoint{
+	State:      "active",
+	Name:       "remote-wep-1",
+	Mac:        mustParseMac("01:02:03:04:05:06"),
+	ProfileIDs: []string{"prof-1", "prof-2", "prof-missing"},
+	IPv4Nets:   []net.IPNet{mustParseNet("10.0.0.5/32")},
+	Labels: map[string]string{
+		"id": "rem-ep-1",
+	},
+}
+
 var hostEpWithName = HostEndpoint{
 	Name:       "eth1",
 	ProfileIDs: []string{"prof-1", "prof-2", "prof-missing"},
@@ -622,6 +633,8 @@ var ipPoolWithVXLAN = IPPool{
 	VXLANMode:  encap.Always,
 	Masquerade: true,
 }
+
+var workloadIPs = "WorkloadIPs"
 
 var ipPoolWithVXLANSlash32 = IPPool{
 	CIDR:       mustParseNet("10.0.0.0/32"),

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -136,6 +136,11 @@ type Config struct {
 	TyphaReadTimeout    time.Duration `config:"seconds;30;local"`
 	TyphaWriteTimeout   time.Duration `config:"seconds;10;local"`
 
+	// Configure where Felix gets its routing information.
+	// - workloadIPs: use workload endpoints to construct routes.
+	// - calicoIPAM: use IPAM data to contruct routes.
+	RouteSource string `config:"oneof(workloadIPs,calicoIPAM);calicoIPAM"`
+
 	// Client-side TLS config for Felix's communication with Typha.  If any of these are
 	// specified, they _all_ must be - except that either TyphaCN or TyphaURISAN may be left
 	// unset.  Felix will then initiate a secure (TLS) connection to Typha.  Typha must present

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -139,7 +139,7 @@ type Config struct {
 	// Configure where Felix gets its routing information.
 	// - workloadIPs: use workload endpoints to construct routes.
 	// - calicoIPAM: use IPAM data to contruct routes.
-	RouteSource string `config:"oneof(workloadIPs,calicoIPAM);calicoIPAM"`
+	RouteSource string `config:"oneof(WorkloadIPs,CalicoIPAM);CalicoIPAM"`
 
 	// Client-side TLS config for Felix's communication with Typha.  If any of these are
 	// specified, they _all_ must be - except that either TyphaCN or TyphaURISAN may be left

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -136,11 +136,6 @@ type Config struct {
 	TyphaReadTimeout    time.Duration `config:"seconds;30;local"`
 	TyphaWriteTimeout   time.Duration `config:"seconds;10;local"`
 
-	// Configure where Felix gets its routing information.
-	// - workloadIPs: use workload endpoints to construct routes.
-	// - calicoIPAM: use IPAM data to contruct routes.
-	RouteSource string `config:"oneof(WorkloadIPs,CalicoIPAM);CalicoIPAM"`
-
 	// Client-side TLS config for Felix's communication with Typha.  If any of these are
 	// specified, they _all_ must be - except that either TyphaCN or TyphaURISAN may be left
 	// unset.  Felix will then initiate a secure (TLS) connection to Typha.  Typha must present
@@ -243,6 +238,11 @@ type Config struct {
 	DebugDisableLogDropping         bool          `config:"bool;false"`
 	DebugSimulateCalcGraphHangAfter time.Duration `config:"seconds;0"`
 	DebugSimulateDataplaneHangAfter time.Duration `config:"seconds;0"`
+
+	// Configure where Felix gets its routing information.
+	// - workloadIPs: use workload endpoints to construct routes.
+	// - calicoIPAM: use IPAM data to contruct routes.
+	RouteSource string `config:"oneof(WorkloadIPs,CalicoIPAM);CalicoIPAM"`
 
 	// State tracking.
 

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -82,11 +82,6 @@ var _ = Describe("FelixConfig vs ConfigParams parity", func() {
 	BeforeEach(func() {
 		fcFields = fieldsByName(v3.FelixConfigurationSpec{})
 
-		// TODO: Once https://github.com/projectcalico/felix/pull/2258 is merged
-		// delete this line. The field RouteSource is in FelixConfigSpec but not
-		// in felix config.
-		delete(fcFields, "RouteSource")
-
 		cpFields = fieldsByName(Config{})
 		for _, name := range cpFieldsToIgnore {
 			delete(cpFields, name)

--- a/fv/vxlan_test.go
+++ b/fv/vxlan_test.go
@@ -41,383 +41,386 @@ import (
 var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs to IP sets", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
 	for _, vxlanM := range []api.VXLANMode{api.VXLANModeCrossSubnet} {
 		vxlanMode := vxlanM
-		Describe(fmt.Sprintf("VXLAN mode set to %s", vxlanMode), func() {
-			var (
-				infra   infrastructure.DatastoreInfra
-				felixes []*infrastructure.Felix
-				client  client.Interface
-				w       [3]*workload.Workload
-				hostW   [3]*workload.Workload
-				cc      *connectivity.Checker
-			)
+		for _, routeSource := range []string{"CalicoIPAM", "WorkloadIPs"} {
+			Describe(fmt.Sprintf("VXLAN mode set to %s, routeSource %s", vxlanMode, routeSource), func() {
+				var (
+					infra   infrastructure.DatastoreInfra
+					felixes []*infrastructure.Felix
+					client  client.Interface
+					w       [3]*workload.Workload
+					hostW   [3]*workload.Workload
+					cc      *connectivity.Checker
+				)
 
-			BeforeEach(func() {
-				infra = getInfra()
-				topologyOptions := infrastructure.DefaultTopologyOptions()
-				topologyOptions.VXLANMode = vxlanMode
-				topologyOptions.IPIPEnabled = false
-				topologyOptions.FelixLogSeverity = "debug"
-				felixes, client = infrastructure.StartNNodeTopology(3, topologyOptions, infra)
+				BeforeEach(func() {
+					infra = getInfra()
+					topologyOptions := infrastructure.DefaultTopologyOptions()
+					topologyOptions.VXLANMode = vxlanMode
+					topologyOptions.IPIPEnabled = false
+					topologyOptions.FelixLogSeverity = "debug"
+					topologyOptions.ExtraEnvVars["FELIX_ROUTESOURCE"] = routeSource
+					felixes, client = infrastructure.StartNNodeTopology(3, topologyOptions, infra)
 
-				// Install a default profile that allows all ingress and egress, in the absence of any Policy.
-				infra.AddDefaultAllow()
+					// Install a default profile that allows all ingress and egress, in the absence of any Policy.
+					infra.AddDefaultAllow()
 
-				// Wait until the vxlan device appears.
-				Eventually(func() error {
-					for i, f := range felixes {
-						out, err := f.ExecOutput("ip", "link")
-						if err != nil {
-							return err
+					// Wait until the vxlan device appears.
+					Eventually(func() error {
+						for i, f := range felixes {
+							out, err := f.ExecOutput("ip", "link")
+							if err != nil {
+								return err
+							}
+							if strings.Contains(out, "vxlan.calico") {
+								continue
+							}
+							return fmt.Errorf("felix %d has no vxlan device", i)
 						}
-						if strings.Contains(out, "vxlan.calico") {
-							continue
-						}
-						return fmt.Errorf("felix %d has no vxlan device", i)
+						return nil
+					}, "10s", "100ms").ShouldNot(HaveOccurred())
+
+					// Create workloads, using that profile.  One on each "host".
+					for ii := range w {
+						wIP := fmt.Sprintf("10.65.%d.2", ii)
+						wName := fmt.Sprintf("w%d", ii)
+						err := client.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+							IP:       net.MustParseIP(wIP),
+							HandleID: &wName,
+							Attrs: map[string]string{
+								ipam.AttributeNode: felixes[ii].Hostname,
+							},
+							Hostname: felixes[ii].Hostname,
+						})
+						Expect(err).NotTo(HaveOccurred())
+
+						w[ii] = workload.Run(felixes[ii], wName, "default", wIP, "8055", "tcp")
+						w[ii].ConfigureInDatastore(infra)
+
+						hostW[ii] = workload.Run(felixes[ii], fmt.Sprintf("host%d", ii), "", felixes[ii].IP, "8055", "tcp")
 					}
-					return nil
-				}, "10s", "100ms").ShouldNot(HaveOccurred())
 
-				// Create workloads, using that profile.  One on each "host".
-				for ii := range w {
-					wIP := fmt.Sprintf("10.65.%d.2", ii)
-					wName := fmt.Sprintf("w%d", ii)
-					err := client.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-						IP:       net.MustParseIP(wIP),
-						HandleID: &wName,
-						Attrs: map[string]string{
-							ipam.AttributeNode: felixes[ii].Hostname,
-						},
-						Hostname: felixes[ii].Hostname,
-					})
-					Expect(err).NotTo(HaveOccurred())
+					cc = &connectivity.Checker{}
+				})
 
-					w[ii] = workload.Run(felixes[ii], wName, "default", wIP, "8055", "tcp")
-					w[ii].ConfigureInDatastore(infra)
+				AfterEach(func() {
+					if CurrentGinkgoTestDescription().Failed {
+						for _, felix := range felixes {
+							felix.Exec("iptables-save", "-c")
+							felix.Exec("ipset", "list")
+							felix.Exec("ip", "r")
+							felix.Exec("ip", "a")
+						}
+					}
 
-					hostW[ii] = workload.Run(felixes[ii], fmt.Sprintf("host%d", ii), "", felixes[ii].IP, "8055", "tcp")
-				}
-
-				cc = &connectivity.Checker{}
-			})
-
-			AfterEach(func() {
-				if CurrentGinkgoTestDescription().Failed {
+					for _, wl := range w {
+						wl.Stop()
+					}
+					for _, wl := range hostW {
+						wl.Stop()
+					}
 					for _, felix := range felixes {
-						felix.Exec("iptables-save", "-c")
-						felix.Exec("ipset", "list")
-						felix.Exec("ip", "r")
-						felix.Exec("ip", "a")
+						felix.Stop()
 					}
-				}
 
-				for _, wl := range w {
-					wl.Stop()
-				}
-				for _, wl := range hostW {
-					wl.Stop()
-				}
-				for _, felix := range felixes {
-					felix.Stop()
-				}
-
-				if CurrentGinkgoTestDescription().Failed {
-					infra.DumpErrorData()
-				}
-				infra.Stop()
-			})
-
-			It("should use the --random-fully flag in the MASQUERADE rules", func() {
-				for _, felix := range felixes {
-					Eventually(func() string {
-						out, _ := felix.ExecOutput("iptables-save", "-c")
-						return out
-					}, "10s", "100ms").Should(ContainSubstring("--random-fully"))
-				}
-			})
-			It("should have workload to workload connectivity", func() {
-				cc.ExpectSome(w[0], w[1])
-				cc.ExpectSome(w[1], w[0])
-				cc.CheckConnectivity()
-			})
-
-			It("should have host to workload connectivity", func() {
-				cc.ExpectSome(felixes[0], w[1])
-				cc.ExpectSome(felixes[0], w[0])
-				cc.CheckConnectivity()
-			})
-
-			It("should have host to host connectivity", func() {
-				cc.ExpectSome(felixes[0], hostW[1])
-				cc.ExpectSome(felixes[1], hostW[0])
-				cc.CheckConnectivity()
-			})
-
-			Context("with host protection policy in place", func() {
-				BeforeEach(func() {
-					// Make sure our new host endpoints don't cut felix off from the datastore.
-					err := infra.AddAllowToDatastore("host-endpoint=='true'")
-					Expect(err).NotTo(HaveOccurred())
-
-					ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-					defer cancel()
-
-					for _, f := range felixes {
-						hep := api.NewHostEndpoint()
-						hep.Name = "eth0-" + f.Name
-						hep.Labels = map[string]string{
-							"host-endpoint": "true",
-						}
-						hep.Spec.Node = f.Hostname
-						hep.Spec.ExpectedIPs = []string{f.IP}
-						_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
-						Expect(err).NotTo(HaveOccurred())
+					if CurrentGinkgoTestDescription().Failed {
+						infra.DumpErrorData()
 					}
+					infra.Stop()
 				})
 
-				It("should have workload connectivity but not host connectivity", func() {
-					// Host endpoints (with no policies) block host-host traffic due to default drop.
-					cc.ExpectNone(felixes[0], hostW[1])
-					cc.ExpectNone(felixes[1], hostW[0])
-					// But the rules to allow VXLAN between our hosts let the workload traffic through.
+				It("should use the --random-fully flag in the MASQUERADE rules", func() {
+					for _, felix := range felixes {
+						Eventually(func() string {
+							out, _ := felix.ExecOutput("iptables-save", "-c")
+							return out
+						}, "10s", "100ms").Should(ContainSubstring("--random-fully"))
+					}
+				})
+				It("should have workload to workload connectivity", func() {
 					cc.ExpectSome(w[0], w[1])
 					cc.ExpectSome(w[1], w[0])
 					cc.CheckConnectivity()
 				})
-			})
 
-			Context("with all-interfaces host protection policy in place", func() {
-				BeforeEach(func() {
-					// Make sure our new host endpoints don't cut felix off from the datastore.
-					err := infra.AddAllowToDatastore("host-endpoint=='true'")
-					Expect(err).NotTo(HaveOccurred())
-
-					ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-					defer cancel()
-
-					for _, f := range felixes {
-						hep := api.NewHostEndpoint()
-						hep.Name = "all-interfaces-" + f.Name
-						hep.Labels = map[string]string{
-							"host-endpoint": "true",
-							"hostname":      f.Hostname,
-						}
-						hep.Spec.Node = f.Hostname
-						hep.Spec.ExpectedIPs = []string{f.IP}
-						hep.Spec.InterfaceName = "*"
-						_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
-						Expect(err).NotTo(HaveOccurred())
-					}
-				})
-
-				It("should have workload connectivity but not host connectivity", func() {
-					// Host endpoints (with no policies) block host-host traffic due to default drop.
-					cc.ExpectNone(felixes[0], hostW[1])
-					cc.ExpectNone(felixes[1], hostW[0])
-
-					// Host => workload is not allowed
-					cc.ExpectNone(felixes[0], w[1])
-					cc.ExpectNone(felixes[1], w[0])
-
-					// But host => own-workload is allowed
+				It("should have host to workload connectivity", func() {
+					cc.ExpectSome(felixes[0], w[1])
 					cc.ExpectSome(felixes[0], w[0])
-					cc.ExpectSome(felixes[1], w[1])
-
-					// But the rules to allow VXLAN between our hosts let the workload traffic through.
-					cc.ExpectSome(w[0], w[1])
-					cc.ExpectSome(w[1], w[0])
 					cc.CheckConnectivity()
 				})
 
-				It("should allow felixes[0] to reach felixes[1] if ingress and egress policies are in place", func() {
-					// Create a policy selecting felix[0] that allows egress.
-					policy := api.NewGlobalNetworkPolicy()
-					policy.Name = "f0-egress"
-					policy.Spec.Egress = []api.Rule{{Action: api.Allow}}
-					policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[0].Hostname)
-					_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
-					Expect(err).NotTo(HaveOccurred())
-
-					// But there is no policy allowing ingress into felix[1].
-					cc.ExpectNone(felixes[0], hostW[1])
-
-					// felixes[1] can't reach felixes[0].
-					cc.ExpectNone(felixes[1], hostW[0])
-
-					// Workload connectivity is unchanged.
-					cc.ExpectSome(w[0], w[1])
-					cc.ExpectSome(w[1], w[0])
-					cc.CheckConnectivity()
-
-					cc.ResetExpectations()
-
-					// Now add a policy selecting felix[1] that allows ingress.
-					policy = api.NewGlobalNetworkPolicy()
-					policy.Name = "f1-ingress"
-					policy.Spec.Ingress = []api.Rule{{Action: api.Allow}}
-					policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[1].Hostname)
-					_, err = client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
-					Expect(err).NotTo(HaveOccurred())
-
-					// Now felixes[0] can reach felixes[1].
+				It("should have host to host connectivity", func() {
 					cc.ExpectSome(felixes[0], hostW[1])
-
-					// felixes[1] still can't reach felixes[0].
-					cc.ExpectNone(felixes[1], hostW[0])
-
-					// Workload connectivity is unchanged.
-					cc.ExpectSome(w[0], w[1])
-					cc.ExpectSome(w[1], w[0])
+					cc.ExpectSome(felixes[1], hostW[0])
 					cc.CheckConnectivity()
 				})
-			})
 
-			Context("after removing BGP address from third node", func() {
-				// Simulate having a host send VXLAN traffic from an unknown source, should get blocked.
-				BeforeEach(func() {
-					Eventually(func() int {
-						return getNumIPSetMembers(felixes[0].Container, "cali40all-vxlan-net")
-					}, "5s", "200ms").Should(Equal(len(felixes) - 1))
+				Context("with host protection policy in place", func() {
+					BeforeEach(func() {
+						// Make sure our new host endpoints don't cut felix off from the datastore.
+						err := infra.AddAllowToDatastore("host-endpoint=='true'")
+						Expect(err).NotTo(HaveOccurred())
 
-					ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-					defer cancel()
-					node, err := client.Nodes().Get(ctx, felixes[2].Hostname, options.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
+						ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+						defer cancel()
 
-					// Pause felix so it can't touch the dataplane!
-					pid := felixes[2].GetFelixPID()
-					felixes[2].Exec("kill", "-STOP", fmt.Sprint(pid))
+						for _, f := range felixes {
+							hep := api.NewHostEndpoint()
+							hep.Name = "eth0-" + f.Name
+							hep.Labels = map[string]string{
+								"host-endpoint": "true",
+							}
+							hep.Spec.Node = f.Hostname
+							hep.Spec.ExpectedIPs = []string{f.IP}
+							_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
+							Expect(err).NotTo(HaveOccurred())
+						}
+					})
 
-					node.Spec.BGP = nil
-					_, err = client.Nodes().Update(ctx, node, options.SetOptions{})
+					It("should have workload connectivity but not host connectivity", func() {
+						// Host endpoints (with no policies) block host-host traffic due to default drop.
+						cc.ExpectNone(felixes[0], hostW[1])
+						cc.ExpectNone(felixes[1], hostW[0])
+						// But the rules to allow VXLAN between our hosts let the workload traffic through.
+						cc.ExpectSome(w[0], w[1])
+						cc.ExpectSome(w[1], w[0])
+						cc.CheckConnectivity()
+					})
 				})
 
-				It("should have no connectivity from third felix and expected number of IPs in whitelist", func() {
-					Eventually(func() int {
-						return getNumIPSetMembers(felixes[0].Container, "cali40all-vxlan-net")
-					}, "5s", "200ms").Should(Equal(len(felixes) - 2))
+				Context("with all-interfaces host protection policy in place", func() {
+					BeforeEach(func() {
+						// Make sure our new host endpoints don't cut felix off from the datastore.
+						err := infra.AddAllowToDatastore("host-endpoint=='true'")
+						Expect(err).NotTo(HaveOccurred())
 
-					cc.ExpectSome(w[0], w[1])
-					cc.ExpectSome(w[1], w[0])
-					cc.ExpectNone(w[0], w[2])
-					cc.ExpectNone(w[1], w[2])
-					cc.ExpectNone(w[2], w[0])
-					cc.ExpectNone(w[2], w[1])
-					cc.CheckConnectivity()
+						ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+						defer cancel()
+
+						for _, f := range felixes {
+							hep := api.NewHostEndpoint()
+							hep.Name = "all-interfaces-" + f.Name
+							hep.Labels = map[string]string{
+								"host-endpoint": "true",
+								"hostname":      f.Hostname,
+							}
+							hep.Spec.Node = f.Hostname
+							hep.Spec.ExpectedIPs = []string{f.IP}
+							hep.Spec.InterfaceName = "*"
+							_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
+							Expect(err).NotTo(HaveOccurred())
+						}
+					})
+
+					It("should have workload connectivity but not host connectivity", func() {
+						// Host endpoints (with no policies) block host-host traffic due to default drop.
+						cc.ExpectNone(felixes[0], hostW[1])
+						cc.ExpectNone(felixes[1], hostW[0])
+
+						// Host => workload is not allowed
+						cc.ExpectNone(felixes[0], w[1])
+						cc.ExpectNone(felixes[1], w[0])
+
+						// But host => own-workload is allowed
+						cc.ExpectSome(felixes[0], w[0])
+						cc.ExpectSome(felixes[1], w[1])
+
+						// But the rules to allow VXLAN between our hosts let the workload traffic through.
+						cc.ExpectSome(w[0], w[1])
+						cc.ExpectSome(w[1], w[0])
+						cc.CheckConnectivity()
+					})
+
+					It("should allow felixes[0] to reach felixes[1] if ingress and egress policies are in place", func() {
+						// Create a policy selecting felix[0] that allows egress.
+						policy := api.NewGlobalNetworkPolicy()
+						policy.Name = "f0-egress"
+						policy.Spec.Egress = []api.Rule{{Action: api.Allow}}
+						policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[0].Hostname)
+						_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+						Expect(err).NotTo(HaveOccurred())
+
+						// But there is no policy allowing ingress into felix[1].
+						cc.ExpectNone(felixes[0], hostW[1])
+
+						// felixes[1] can't reach felixes[0].
+						cc.ExpectNone(felixes[1], hostW[0])
+
+						// Workload connectivity is unchanged.
+						cc.ExpectSome(w[0], w[1])
+						cc.ExpectSome(w[1], w[0])
+						cc.CheckConnectivity()
+
+						cc.ResetExpectations()
+
+						// Now add a policy selecting felix[1] that allows ingress.
+						policy = api.NewGlobalNetworkPolicy()
+						policy.Name = "f1-ingress"
+						policy.Spec.Ingress = []api.Rule{{Action: api.Allow}}
+						policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[1].Hostname)
+						_, err = client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+						Expect(err).NotTo(HaveOccurred())
+
+						// Now felixes[0] can reach felixes[1].
+						cc.ExpectSome(felixes[0], hostW[1])
+
+						// felixes[1] still can't reach felixes[0].
+						cc.ExpectNone(felixes[1], hostW[0])
+
+						// Workload connectivity is unchanged.
+						cc.ExpectSome(w[0], w[1])
+						cc.ExpectSome(w[1], w[0])
+						cc.CheckConnectivity()
+					})
 				})
-			})
 
-			// Explicitly verify that the VXLAN whitelist IP set is doing its job (since Felix makes multiple dataplane
-			// changes when the BGP IP disappears and we want to make sure that its the whitelist that's causing the
-			// connectivity to drop).
-			Context("after removing BGP address from third node, all felixes paused", func() {
-				// Simulate having a host send VXLAN traffic from an unknown source, should get blocked.
-				BeforeEach(func() {
-					// Check we initially have the expected number of whitelist entries.
-					for _, f := range felixes {
-						// Wait for Felix to set up the whitelist.
+				Context("after removing BGP address from third node", func() {
+					// Simulate having a host send VXLAN traffic from an unknown source, should get blocked.
+					BeforeEach(func() {
 						Eventually(func() int {
-							return getNumIPSetMembers(f.Container, "cali40all-vxlan-net")
+							return getNumIPSetMembers(felixes[0].Container, "cali40all-vxlan-net")
 						}, "5s", "200ms").Should(Equal(len(felixes) - 1))
-					}
 
-					// Wait until dataplane has settled.
-					cc.ExpectSome(w[0], w[1])
-					cc.ExpectSome(w[0], w[2])
-					cc.ExpectSome(w[1], w[2])
-					cc.CheckConnectivity()
-					cc.ResetExpectations()
+						ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+						defer cancel()
+						node, err := client.Nodes().Get(ctx, felixes[2].Hostname, options.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
 
-					// Then pause all the felixes.
-					for _, f := range felixes {
-						pid := f.GetFelixPID()
-						f.Exec("kill", "-STOP", fmt.Sprint(pid))
-					}
-				})
+						// Pause felix so it can't touch the dataplane!
+						pid := felixes[2].GetFelixPID()
+						felixes[2].Exec("kill", "-STOP", fmt.Sprint(pid))
 
-				if vxlanMode == api.VXLANModeAlways {
-					It("after manually removing third node from whitelist should have expected connectivity", func() {
-						felixes[0].Exec("ipset", "del", "cali40all-vxlan-net", felixes[2].IP)
+						node.Spec.BGP = nil
+						_, err = client.Nodes().Update(ctx, node, options.SetOptions{})
+					})
+
+					It("should have no connectivity from third felix and expected number of IPs in whitelist", func() {
+						Eventually(func() int {
+							return getNumIPSetMembers(felixes[0].Container, "cali40all-vxlan-net")
+						}, "5s", "200ms").Should(Equal(len(felixes) - 2))
 
 						cc.ExpectSome(w[0], w[1])
 						cc.ExpectSome(w[1], w[0])
-						cc.ExpectSome(w[1], w[2])
+						cc.ExpectNone(w[0], w[2])
+						cc.ExpectNone(w[1], w[2])
 						cc.ExpectNone(w[2], w[0])
+						cc.ExpectNone(w[2], w[1])
 						cc.CheckConnectivity()
 					})
-				}
+				})
+
+				// Explicitly verify that the VXLAN whitelist IP set is doing its job (since Felix makes multiple dataplane
+				// changes when the BGP IP disappears and we want to make sure that its the whitelist that's causing the
+				// connectivity to drop).
+				Context("after removing BGP address from third node, all felixes paused", func() {
+					// Simulate having a host send VXLAN traffic from an unknown source, should get blocked.
+					BeforeEach(func() {
+						// Check we initially have the expected number of whitelist entries.
+						for _, f := range felixes {
+							// Wait for Felix to set up the whitelist.
+							Eventually(func() int {
+								return getNumIPSetMembers(f.Container, "cali40all-vxlan-net")
+							}, "5s", "200ms").Should(Equal(len(felixes) - 1))
+						}
+
+						// Wait until dataplane has settled.
+						cc.ExpectSome(w[0], w[1])
+						cc.ExpectSome(w[0], w[2])
+						cc.ExpectSome(w[1], w[2])
+						cc.CheckConnectivity()
+						cc.ResetExpectations()
+
+						// Then pause all the felixes.
+						for _, f := range felixes {
+							pid := f.GetFelixPID()
+							f.Exec("kill", "-STOP", fmt.Sprint(pid))
+						}
+					})
+
+					if vxlanMode == api.VXLANModeAlways {
+						It("after manually removing third node from whitelist should have expected connectivity", func() {
+							felixes[0].Exec("ipset", "del", "cali40all-vxlan-net", felixes[2].IP)
+
+							cc.ExpectSome(w[0], w[1])
+							cc.ExpectSome(w[1], w[0])
+							cc.ExpectSome(w[1], w[2])
+							cc.ExpectNone(w[2], w[0])
+							cc.CheckConnectivity()
+						})
+					}
+				})
+
+				It("should configure the vxlan device correctly", func() {
+					// The VXLAN device should appear with default MTU, etc.
+					for _, felix := range felixes {
+						Eventually(func() string {
+							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+							return out
+						}, "10s", "100ms").Should(ContainSubstring("mtu 1410"))
+						Eventually(func() string {
+							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+							return out
+						}, "10s", "100ms").Should(ContainSubstring("vxlan id 4096"))
+						Eventually(func() string {
+							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+							return out
+						}, "10s", "100ms").Should(ContainSubstring("dstport 4789"))
+					}
+
+					// Change the MTU.
+					felixConfig, err := client.FelixConfigurations().Get(context.Background(), "default", options.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					mtu := 1400
+					vni := 4097
+					port := 4790
+					felixConfig.Spec.VXLANMTU = &mtu
+					felixConfig.Spec.VXLANPort = &port
+					felixConfig.Spec.VXLANVNI = &vni
+					_, err = client.FelixConfigurations().Update(context.Background(), felixConfig, options.SetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					// Expect the settings to be changed on the device.
+					for _, felix := range felixes {
+						Eventually(func() string {
+							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+							return out
+						}, "10s", "100ms").Should(ContainSubstring("mtu 1400"))
+						Eventually(func() string {
+							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+							return out
+						}, "10s", "100ms").Should(ContainSubstring("vxlan id 4097"))
+						Eventually(func() string {
+							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+							return out
+						}, "10s", "100ms").Should(ContainSubstring("dstport 4790"))
+					}
+				})
+
+				It("should delete the vxlan device when vxlan is disabled", func() {
+					// Wait for the VXLAN device to be created.
+					for _, felix := range felixes {
+						Eventually(func() string {
+							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+							return out
+						}, "10s", "100ms").Should(ContainSubstring("mtu 1410"))
+					}
+
+					// Disable VXLAN in Felix.
+					felixConfig, err := client.FelixConfigurations().Get(context.Background(), "default", options.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					enabled := false
+					felixConfig.Spec.VXLANEnabled = &enabled
+					_, err = client.FelixConfigurations().Update(context.Background(), felixConfig, options.SetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					// Expect the VXLAN device to be deleted.
+					for _, felix := range felixes {
+						Eventually(func() string {
+							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+							return out
+						}, "10s", "100ms").ShouldNot(ContainSubstring("mtu 1410"))
+					}
+				})
 			})
-
-			It("should configure the vxlan device correctly", func() {
-				// The VXLAN device should appear with default MTU, etc.
-				for _, felix := range felixes {
-					Eventually(func() string {
-						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-						return out
-					}, "10s", "100ms").Should(ContainSubstring("mtu 1410"))
-					Eventually(func() string {
-						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-						return out
-					}, "10s", "100ms").Should(ContainSubstring("vxlan id 4096"))
-					Eventually(func() string {
-						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-						return out
-					}, "10s", "100ms").Should(ContainSubstring("dstport 4789"))
-				}
-
-				// Change the MTU.
-				felixConfig, err := client.FelixConfigurations().Get(context.Background(), "default", options.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				mtu := 1400
-				vni := 4097
-				port := 4790
-				felixConfig.Spec.VXLANMTU = &mtu
-				felixConfig.Spec.VXLANPort = &port
-				felixConfig.Spec.VXLANVNI = &vni
-				_, err = client.FelixConfigurations().Update(context.Background(), felixConfig, options.SetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				// Expect the settings to be changed on the device.
-				for _, felix := range felixes {
-					Eventually(func() string {
-						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-						return out
-					}, "10s", "100ms").Should(ContainSubstring("mtu 1400"))
-					Eventually(func() string {
-						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-						return out
-					}, "10s", "100ms").Should(ContainSubstring("vxlan id 4097"))
-					Eventually(func() string {
-						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-						return out
-					}, "10s", "100ms").Should(ContainSubstring("dstport 4790"))
-				}
-			})
-
-			It("should delete the vxlan device when vxlan is disabled", func() {
-				// Wait for the VXLAN device to be created.
-				for _, felix := range felixes {
-					Eventually(func() string {
-						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-						return out
-					}, "10s", "100ms").Should(ContainSubstring("mtu 1410"))
-				}
-
-				// Disable VXLAN in Felix.
-				felixConfig, err := client.FelixConfigurations().Get(context.Background(), "default", options.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				enabled := false
-				felixConfig.Spec.VXLANEnabled = &enabled
-				_, err = client.FelixConfigurations().Update(context.Background(), felixConfig, options.SetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				// Expect the VXLAN device to be deleted.
-				for _, felix := range felixes {
-					Eventually(func() string {
-						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-						return out
-					}, "10s", "100ms").ShouldNot(ContainSubstring("mtu 1410"))
-				}
-			})
-		})
+		}
 	}
 })


### PR DESCRIPTION
This PR introduces a config option to allow configuration of different
sources of routing information in Felix's L3 route resolver. 

For now, it supports two modes:
- calicoIPAM: current behavior, drive routing decisions off Calico IPAM.
- workloadIPs: new option, driven based off WEP IP addresses.

The `workloadIPs` option allows Felix to be used for routing even if not
using Calico IPAM (felix is currently used for routing of VXLAN routes
and when using the eBPF tech-preview dataplane.

A few things left:
- [x] Expose as an option on FelixConfiguration API in libcalico
- [x] Decide if we need to also generate routes for
node.spec.BGP.XTunnelAddress IPs.
- [x] Test using eBPF dataplane on live cluster. 



## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix can now calculate routes without dependency on Calico IPAM.
```