### PR TITLE
BPF map versioning

### DIFF
--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -198,4 +198,46 @@ CALI_CONFIGURABLE_DEFINE(tunnel_mtu, 0x55544d54) /* be 0x55544d54 = ASCII(TMTU) 
 #define HOST_IP		CALI_CONFIGURABLE(host_ip)
 #define TUNNEL_MTU 	CALI_CONFIGURABLE(tunnel_mtu)
 
+#define MAP_PIN_GLOBAL	2
+
+#ifndef __BPFTOOL_LOADER__
+#define CALI_MAP_TC_EXT_PIN(pin)	.pinning_strategy = pin,
+#else
+#define CALI_MAP_TC_EXT_PIN(pin)
+#endif
+
+#define map_symbol(name, ver) name##_##ver
+
+#define MAP_LOOKUP_FN(name, ver) \
+static CALI_BPF_INLINE void * name##_lookup_elem(const void* key)	\
+{									\
+	return bpf_map_lookup_elem(&map_symbol(name, ver), key);	\
+}
+
+#define MAP_UPDATE_FN(name, ver) \
+static CALI_BPF_INLINE int name##_update_elem(const void* key, const void* value, __u64 flags)\
+{										\
+	return bpf_map_update_elem(&map_symbol(name, ver), key, value, flags);	\
+}
+
+#define MAP_DELETE_FN(name, ver) \
+static CALI_BPF_INLINE int name##_delete_elem(const void* key)	\
+{									\
+	return bpf_map_delete_elem(&map_symbol(name, ver), key);	\
+}
+
+#define CALI_MAP(name, ver,  map_type, key_type, val_type, size, flags, pin) 		\
+struct bpf_map_def_extended __attribute__((section("maps"))) map_symbol(name, ver) = {	\
+	.type = map_type,								\
+	.key_size = sizeof(key_type),							\
+	.value_size = sizeof(val_type),							\
+	.map_flags = flags,								\
+	.max_entries = size,								\
+	CALI_MAP_TC_EXT_PIN(pin)							\
+};											\
+											\
+	MAP_LOOKUP_FN(name, ver)							\
+	MAP_UPDATE_FN(name, ver)							\
+	MAP_DELETE_FN(name, ver)
+
 #endif /* __CALI_BPF_H__ */

--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -206,7 +206,7 @@ CALI_CONFIGURABLE_DEFINE(tunnel_mtu, 0x55544d54) /* be 0x55544d54 = ASCII(TMTU) 
 #define CALI_MAP_TC_EXT_PIN(pin)
 #endif
 
-#define map_symbol(name, ver) name##_##ver
+#define map_symbol(name, ver) name##ver
 
 #define MAP_LOOKUP_FN(name, ver) \
 static CALI_BPF_INLINE void * name##_lookup_elem(const void* key)	\
@@ -239,5 +239,9 @@ struct bpf_map_def_extended __attribute__((section("maps"))) map_symbol(name, ve
 	MAP_LOOKUP_FN(name, ver)							\
 	MAP_UPDATE_FN(name, ver)							\
 	MAP_DELETE_FN(name, ver)
+
+#define CALI_MAP_V1(name, map_type, key_type, val_type, size, flags, pin) 	\
+		CALI_MAP(name,, map_type, key_type, val_type, size, flags, pin)
+
 
 #endif /* __CALI_BPF_H__ */

--- a/bpf-gpl/connect_balancer.c
+++ b/bpf-gpl/connect_balancer.c
@@ -66,7 +66,7 @@ static CALI_BPF_INLINE void do_nat_common(struct bpf_sock_addr *ctx, uint8_t pro
 		 */
 	};
 
-	if (bpf_map_update_elem(&cali_v4_srmsg, &key, &val, 0)) {
+	if (cali_v4_srmsg_update_elem(&key, &val, 0)) {
 		/* if this happens things are really bad! report */
 		CALI_INFO("Failed to update map\n");
 		goto out;
@@ -148,7 +148,7 @@ int cali_ctlb_recvmsg_v4(struct bpf_sock_addr *ctx)
 		.cookie	= cookie,
 	};
 
-	struct sendrecv4_val *revnat = bpf_map_lookup_elem(&cali_v4_srmsg, &key);
+	struct sendrecv4_val *revnat = cali_v4_srmsg_lookup_elem(&key);
 
 	if (revnat == NULL) {
 		CALI_DEBUG("revnat miss for %x:%d\n",

--- a/bpf-gpl/connect_balancer_v6.c
+++ b/bpf-gpl/connect_balancer_v6.c
@@ -68,7 +68,7 @@ v4:
 		.cookie	= bpf_get_socket_cookie(ctx),
 	};
 
-	struct sendrecv4_val *revnat = bpf_map_lookup_elem(&cali_v4_srmsg, &key);
+	struct sendrecv4_val *revnat = cali_v4_srmsg_lookup_elem(&key);
 
 	if (revnat == NULL) {
 		CALI_DEBUG("revnat miss for %x:%d\n",

--- a/bpf-gpl/jump.h
+++ b/bpf-gpl/jump.h
@@ -43,15 +43,11 @@ enum cali_state_flags {
 	CALI_ST_NAT_OUTGOING = 1,
 };
 
-struct bpf_map_def_extended __attribute__((section("maps"))) cali_v4_state = {
-	.type           = BPF_MAP_TYPE_PERCPU_ARRAY,
-	.key_size       = sizeof(uint32_t),
-	.value_size     = sizeof(struct cali_tc_state),
-	.max_entries    = 1,
-#ifndef __BPFTOOL_LOADER__
-	.pinning_strategy = 2 /* global namespace */,
-#endif
-};
+CALI_MAP_V1(cali_v4_state,
+		BPF_MAP_TYPE_PERCPU_ARRAY,
+		uint32_t, struct cali_tc_state,
+		1, 0, MAP_PIN_GLOBAL)
+
 
 struct bpf_map_def_extended __attribute__((section("maps"))) cali_jump = {
 	.type = BPF_MAP_TYPE_PROG_ARRAY,

--- a/bpf-gpl/policy.h
+++ b/bpf-gpl/policy.h
@@ -58,7 +58,7 @@ struct bpf_map_def_extended __attribute__((section("maps"))) cali_v4_ip_sets = {
 	.max_entries    = 1024*1024,
 	.map_flags      = BPF_F_NO_PREALLOC,
 #ifndef __BPFTOOL_LOADER__
-	.pinning_strategy        = 2 /* global namespace */,
+	.pinning_strategy        = MAP_PIN_GLOBAL,
 #endif
 };
 

--- a/bpf-gpl/routes.h
+++ b/bpf-gpl/routes.h
@@ -53,23 +53,17 @@ struct cali_rt {
 	};
 };
 
-struct bpf_map_def_extended __attribute__((section("maps"))) cali_v4_routes = {
-	.type           = BPF_MAP_TYPE_LPM_TRIE,
-	.key_size       = sizeof(union cali_rt_lpm_key),
-	.value_size     = sizeof(struct cali_rt),
-	.max_entries    = 1024*1024,
-	.map_flags      = BPF_F_NO_PREALLOC,
-#ifndef __BPFTOOL_LOADER__
-	.pinning_strategy        = 2 /* global namespace */,
-#endif
-};
+CALI_MAP_V1(cali_v4_routes,
+		BPF_MAP_TYPE_LPM_TRIE,
+		union cali_rt_lpm_key, struct cali_rt,
+		1024*1024, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
 
 static CALI_BPF_INLINE struct cali_rt *cali_rt_lookup(__be32 addr)
 {
 	union cali_rt_lpm_key k;
 	k.key.prefixlen = 32;
 	k.key.addr = addr;
-	return bpf_map_lookup_elem(&cali_v4_routes, &k);
+	return cali_v4_routes_lookup_elem(&k);
 }
 
 static CALI_BPF_INLINE enum cali_rt_flags cali_rt_lookup_flags(__be32 addr)

--- a/bpf-gpl/sendrecv.h
+++ b/bpf-gpl/sendrecv.h
@@ -14,15 +14,10 @@ struct sendrecv4_val {
 	uint32_t port; /* because bpf_sock_addr uses 32bit and we would need padding */
 };
 
-struct bpf_map_def_extended __attribute__((section("maps"))) cali_v4_srmsg = {
-	.type = BPF_MAP_TYPE_LRU_HASH,
-	.key_size = sizeof(struct sendrecv4_key),
-	.value_size = sizeof(struct sendrecv4_val),
-	.max_entries = 510000, // arbitrary
-#ifndef __BPFTOOL_LOADER__
-	.pinning_strategy = 2 /* global namespace */,
-#endif
-};
+CALI_MAP_V1(cali_v4_srmsg,
+		BPF_MAP_TYPE_LRU_HASH,
+		struct sendrecv4_key, struct sendrecv4_val,
+		510000, 0, MAP_PIN_GLOBAL)
 
 static CALI_BPF_INLINE uint16_t ctx_port_to_host(__u32 port)
 {

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -97,7 +97,7 @@ int calico_tc_norm_pol_tail(struct __sk_buff *skb)
 	CALI_DEBUG("Entering normal policy tail call\n");
 
 	__u32 key = 0;
-	struct cali_tc_state *state = bpf_map_lookup_elem(&cali_v4_state, &key);
+	struct cali_tc_state *state = cali_v4_state_lookup_elem(&key);
 	if (!state) {
 	        CALI_DEBUG("State map lookup failed: DROP\n");
 	        goto deny;
@@ -614,7 +614,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 
 	// Set up an entry in the state map and then jump to the normal policy program.
 	int key = 0;
-	struct cali_tc_state *map_state = bpf_map_lookup_elem(&cali_v4_state, &key);
+	struct cali_tc_state *map_state = cali_v4_state_lookup_elem(&key);
 	if (!map_state) {
 		// Shouldn't be possible; the map is pre-allocated.
 		CALI_INFO("State map lookup failed: DROP\n");

--- a/bpf/conntrack/map.go
+++ b/bpf/conntrack/map.go
@@ -273,6 +273,7 @@ var MapParams = bpf.MapParameters{
 	MaxEntries: 512000,
 	Name:       "cali_v4_ct",
 	Flags:      unix.BPF_F_NO_PREALLOC,
+	Version:    2,
 }
 
 func Map(mc *bpf.MapContext) bpf.Map {


### PR DESCRIPTION
## Description

    bpf: conntrack table V2
    
    Setup general code infrastructure to versioning maps. In principle,
    the map name is extended by a single or a double digit number suffix.
    
    In Golang, the the version can be bumped up by changing
    MapParams.Version and a versioned map in C can be define using
    CALI_MAP() macro that also defines version-less access functions to
    the versioned map. This way no irrelevant code needs to be change
    except bumping up the versions in C/bpf and golang.
    
    Obviously, accessing new members etc. will be added/changed in the
    current code, but access to the maps does not need to change.
    
    This way upgraded felix does not use the old incompatible maps.
    
    This does not implement any conversion from old to newer version.

    bpf: v1 maps defined using CALI_MAP_V1() macro

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
