### PR TITLE
bpf: do not override fib=false if no forward

### DIFF
--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -919,9 +919,6 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 			CALI_DEBUG("rt found for 0x%x\n", be32_to_host(state->post_nat_ip_dst));
 
 			encap_needed = !cali_rt_is_local(rt);
-
-			/* We cannot enforce RPF check on encapped traffic, do FIB if you can */
-			fib = true;
 		}
 
 		/* We have not created the conntrack yet since we did not know
@@ -945,6 +942,10 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 			state->ip_src = HOST_IP;
 			state->ip_dst = cali_rt_is_workload(rt) ? rt->next_hop : state->post_nat_ip_dst;
 			seen_mark = CALI_SKB_MARK_BYPASS_FWD;
+
+			/* We cannot enforce RPF check on encapped traffic, do FIB if you can */
+			fib = true;
+
 			goto nat_encap;
 		}
 


### PR DESCRIPTION
If the backend workload for for the a NodePort is local, no tunnel
forwarding happens, we can still use local kernel to reliably do RPF
check for us if we think it is needed.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
