### PR TITLE
[v3.14] Backport version check for BPF mode.

### DIFF
--- a/bpf/bpf.go
+++ b/bpf/bpf.go
@@ -94,6 +94,9 @@ var (
 	// v4Dot20Dot0 is the first kernel version that has all the
 	// required features we use for sidecar acceleration
 	v4Dot20Dot0 = versionparse.MustParseVersion("4.20.0")
+	// v5Dot3Dot0 is the first kernel version that has all the
+	// required features we use for BPF dataplane mode
+	v5Dot3Dot0 = versionparse.MustParseVersion("5.3.0")
 )
 
 func (m XDPMode) String() string {
@@ -2177,6 +2180,19 @@ func isAtLeastKernel(v *version.Version) error {
 
 func SupportsSockmap() error {
 	if err := isAtLeastKernel(v4Dot20Dot0); err != nil {
+		return err
+	}
+
+	// Test endianness
+	if nativeEndian != binary.LittleEndian {
+		return fmt.Errorf("this bpf library only supports little endian architectures")
+	}
+
+	return nil
+}
+
+func SupportsBPFDataplane() error {
+	if err := isAtLeastKernel(v5Dot3Dot0); err != nil {
 		return err
 	}
 

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -27,10 +27,11 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/felix/idalloc"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/libcalico-go/lib/names"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
+
+	"github.com/projectcalico/felix/idalloc"
 )
 
 var (
@@ -67,9 +68,10 @@ const (
 	DatastorePerHost
 	ConfigFile
 	EnvironmentVariable
+	InternalOverride
 )
 
-var SourcesInDescendingOrder = []Source{EnvironmentVariable, ConfigFile, DatastorePerHost, DatastoreGlobal}
+var SourcesInDescendingOrder = []Source{InternalOverride, EnvironmentVariable, ConfigFile, DatastorePerHost, DatastoreGlobal}
 
 func (source Source) String() string {
 	switch source {
@@ -83,6 +85,8 @@ func (source Source) String() string {
 		return "config file"
 	case EnvironmentVariable:
 		return "environment variable"
+	case InternalOverride:
+		return "internal override"
 	}
 	return fmt.Sprintf("<unknown(%v)>", uint8(source))
 }
@@ -254,18 +258,23 @@ type Config struct {
 
 	RouteTableRange idalloc.IndexRange `config:"route-table-range;1-250;die-on-fail"`
 
-	// State tracking.
-
-	// nameToSource tracks where we loaded each config param from.
-	sourceToRawConfig map[Source]map[string]string
-	rawValues         map[string]string
-	Err               error
-
 	IptablesNATOutgoingInterfaceFilter string `config:"iface-param;"`
 
 	SidecarAccelerationEnabled bool `config:"bool;false"`
 	XDPEnabled                 bool `config:"bool;true"`
 	GenericXDPEnabled          bool `config:"bool;false"`
+
+	// State tracking.
+
+	// internalOverrides contains our highest priority config source, generated from internal constraints
+	// such as kernel version support.
+	internalOverrides map[string]string
+	// sourceToRawConfig maps each source to the set of config that was give to us via UpdateFrom.
+	sourceToRawConfig map[Source]map[string]string
+	// rawValues maps keys to the current highest-priority raw value.
+	rawValues map[string]string
+	// Err holds the most recent error from a config update.
+	Err error
 
 	loadClientConfigFromEnvironment func() (*apiconfig.CalicoAPIConfig, error)
 
@@ -690,13 +699,22 @@ func (config *Config) SetLoadClientConfigFromEnvironmentFunction(fnc func() (*ap
 	config.loadClientConfigFromEnvironment = fnc
 }
 
+// OverrideParam installs a maximum priority parameter override for the given parameter.  This is useful for
+// disabling features that are found to be unsupported, for example. By using an extra priority class, the
+// override will persist even if the host/global config is updated.
+func (config *Config) OverrideParam(name, value string) (bool, error) {
+	config.internalOverrides[name] = value
+	return config.UpdateFrom(config.internalOverrides, InternalOverride)
+}
+
 func New() *Config {
 	if knownParams == nil {
 		loadParams()
 	}
 	p := &Config{
-		rawValues:         make(map[string]string),
-		sourceToRawConfig: make(map[Source]map[string]string),
+		rawValues:         map[string]string{},
+		sourceToRawConfig: map[Source]map[string]string{},
+		internalOverrides: map[string]string{},
 	}
 	for _, param := range knownParams {
 		param.setDefault(p)

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -59,6 +59,7 @@ var _ = Describe("FelixConfig vs ConfigParams parity", func() {
 
 		"loadClientConfigFromEnvironment",
 		"useNodeResourceUpdates",
+		"internalOverrides",
 	}
 	cpFieldNameToFC := map[string]string{
 		"IpInIpEnabled":                      "IPIPEnabled",
@@ -123,6 +124,44 @@ func fieldsByName(example interface{}) map[string]reflect.StructField {
 	}
 	return fields
 }
+
+var _ = Describe("Config override empty", func() {
+	var cp *Config
+	BeforeEach(func() {
+		cp = New()
+	})
+
+	It("should allow config override", func() {
+		changed, err := cp.OverrideParam("BPFEnabled", "true")
+		Expect(changed).To(BeTrue())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cp.BPFEnabled).To(BeTrue())
+	})
+
+	Describe("with a param set", func() {
+		BeforeEach(func() {
+			_, err := cp.UpdateFrom(map[string]string{"BPFEnabled": "true"}, DatastorePerHost)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should allow config override", func() {
+			By("Having correct initial value")
+			Expect(cp.BPFEnabled).To(BeTrue())
+
+			By("Having correct value after override")
+			changed, err := cp.OverrideParam("BPFEnabled", "false")
+			Expect(changed).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cp.BPFEnabled).To(BeFalse())
+
+			By("Ignoring a lower-priority config update")
+			changed, err = cp.UpdateFrom(map[string]string{"BPFEnabled": "true"}, EnvironmentVariable)
+			Expect(changed).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cp.BPFEnabled).To(BeFalse())
+		})
+	})
+})
 
 var _ = DescribeTable("Config parsing",
 	func(key, value string, expected interface{}, errorExpected ...bool) {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Backport #2287 

Add a kernel version check for BPF mode.

(cherry picked from commit cc68daf45ce1e84fa1ea11e6b150c3089c3e52a7)
## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix now checks the kernel version before enabling BPF mode.
```
