### PR TITLE
Ensure table index is assigned to wireguard even when disabled

### DIFF
--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -109,16 +109,16 @@ func StartDataplaneDriver(configParams *config.Config,
 		// to simplify table tidy-up.
 		routeTableIndexAllocator := idalloc.NewIndexAllocator(configParams.RouteTableRange)
 
+		// Always allocate the wireguard table index (even when not enabled). This ensures we can tidy up entries
+		// if wireguard is disabled after being previously enabled.
 		var wireguardEnabled bool
 		var wireguardTableIndex int
-		if configParams.WireguardEnabled {
-			if idx, err := routeTableIndexAllocator.GrabIndex(); err == nil {
-				log.Debugf("Assigned wireguard table index: %d", idx)
-				wireguardEnabled = true
-				wireguardTableIndex = idx
-			} else {
-				log.WithError(err).Warning("Unable to assign table index for wireguard - disabling wireguard on this node")
-			}
+		if idx, err := routeTableIndexAllocator.GrabIndex(); err == nil {
+			log.Debugf("Assigned wireguard table index: %d", idx)
+			wireguardEnabled = configParams.WireguardEnabled
+			wireguardTableIndex = idx
+		} else {
+			log.WithError(err).Warning("Unable to assign table index for wireguard")
 		}
 
 		dpConfig := intdataplane.Config{


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Always assign the wireguard table index. This ensures we can tidy up when wireguard is disabled ... otherwise will cause service impact when turning wireguard off globally.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
