### PR TITLE
Deflake tests that dump BPF maps

### DIFF
--- a/bpf/proxy/kube-proxy.go
+++ b/bpf/proxy/kube-proxy.go
@@ -66,7 +66,7 @@ func StartKubeProxy(k8s kubernetes.Interface, hostname string,
 	go func() {
 		err := kp.start()
 		if err != nil {
-			log.Panic("kube-proxy failed to start")
+			log.WithError(err).Panic("kube-proxy failed to start")
 		}
 	}()
 

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -535,6 +535,11 @@ func (c *Container) CopyFileIntoContainer(hostPath, containerPath string) error 
 	return cmd.Run()
 }
 
+func (c *Container) FileExists(path string) bool {
+	err := c.ExecMayFail("test", "-e", path)
+	return err == nil
+}
+
 func (c *Container) Exec(cmd ...string) {
 	log.WithField("container", c.Name).WithField("command", cmd).Info("Running command")
 	arg := []string{"exec", c.Name}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

I think this flake https://tigera.semaphoreci.com/jobs/eddef13a-0cef-4740-9480-6cfc2d7d8e21# may have been caused by trying to dump the BPF map before it had been created.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
