### PR TITLE
bpf: Binary.PatchIPv4() logs incorrectly if not IPv4

### DIFF
--- a/bpf/binary.go
+++ b/bpf/binary.go
@@ -64,11 +64,11 @@ func (b *Binary) replaceAllLoadImm32(orig, replacement []byte) {
 
 // PatchIPv4 replaces a place holder with the actual IPv4
 func (b *Binary) PatchIPv4(ip net.IP) error {
-	ip = ip.To4()
-	if ip == nil {
+	ipv4 := ip.To4()
+	if ipv4 == nil {
 		return errors.Errorf("%s is not IPv4", ip)
 	}
-	b.replaceAllLoadImm32([]byte("HOST"), []byte(ip))
+	b.replaceAllLoadImm32([]byte("HOST"), []byte(ipv4))
 
 	return nil
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
