### PR TITLE
Allow override of iptable features like "MASQFullyRandom"

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -172,7 +172,7 @@ type Config struct {
 	IptablesLockFilePath               string            `config:"file;/run/xtables.lock"`
 	IptablesLockTimeoutSecs            time.Duration     `config:"seconds;0"`
 	IptablesLockProbeIntervalMillis    time.Duration     `config:"millis;50"`
-	FeatureDetectOverride              map[string]string `config:"keyvaluelist;"";;local"`
+	FeatureDetectOverride              map[string]string `config:"keyvaluelist;;local"`
 	IpsetsRefreshInterval              time.Duration     `config:"seconds;10"`
 	MaxIpsetSize                       int               `config:"int;1048576;non-zero"`
 	XDPRefreshInterval                 time.Duration     `config:"seconds;90"`

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -172,7 +172,7 @@ type Config struct {
 	IptablesLockFilePath               string        `config:"file;/run/xtables.lock"`
 	IptablesLockTimeoutSecs            time.Duration `config:"seconds;0"`
 	IptablesLockProbeIntervalMillis    time.Duration `config:"millis;50"`
-	IptablesFeatureDetectOverride      string        `config:"string;;local"`
+	FeatureDetectOverride              string        `config:"string;;local"`
 	IpsetsRefreshInterval              time.Duration `config:"seconds;10"`
 	MaxIpsetSize                       int           `config:"int;1048576;non-zero"`
 	XDPRefreshInterval                 time.Duration `config:"seconds;90"`

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -172,6 +172,7 @@ type Config struct {
 	IptablesLockFilePath               string        `config:"file;/run/xtables.lock"`
 	IptablesLockTimeoutSecs            time.Duration `config:"seconds;0"`
 	IptablesLockProbeIntervalMillis    time.Duration `config:"millis;50"`
+	IptablesFeatureDetectOverride      string        `config:"string;;local"`
 	IpsetsRefreshInterval              time.Duration `config:"seconds;10"`
 	MaxIpsetSize                       int           `config:"int;1048576;non-zero"`
 	XDPRefreshInterval                 time.Duration `config:"seconds;90"`

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -162,20 +162,20 @@ type Config struct {
 
 	Ipv6Support bool `config:"bool;true"`
 
-	IptablesBackend                    string        `config:"oneof(legacy,nft,auto);legacy"`
-	RouteRefreshInterval               time.Duration `config:"seconds;90"`
-	DeviceRouteSourceAddress           net.IP        `config:"ipv4;"`
-	DeviceRouteProtocol                int           `config:"int;3"`
-	RemoveExternalRoutes               bool          `config:"bool;true"`
-	IptablesRefreshInterval            time.Duration `config:"seconds;90"`
-	IptablesPostWriteCheckIntervalSecs time.Duration `config:"seconds;1"`
-	IptablesLockFilePath               string        `config:"file;/run/xtables.lock"`
-	IptablesLockTimeoutSecs            time.Duration `config:"seconds;0"`
-	IptablesLockProbeIntervalMillis    time.Duration `config:"millis;50"`
-	FeatureDetectOverride              string        `config:"string;;local"`
-	IpsetsRefreshInterval              time.Duration `config:"seconds;10"`
-	MaxIpsetSize                       int           `config:"int;1048576;non-zero"`
-	XDPRefreshInterval                 time.Duration `config:"seconds;90"`
+	IptablesBackend                    string             `config:"oneof(legacy,nft,auto);legacy"`
+	RouteRefreshInterval               time.Duration      `config:"seconds;90"`
+	DeviceRouteSourceAddress           net.IP             `config:"ipv4;"`
+	DeviceRouteProtocol                int                `config:"int;3"`
+	RemoveExternalRoutes               bool               `config:"bool;true"`
+	IptablesRefreshInterval            time.Duration      `config:"seconds;90"`
+	IptablesPostWriteCheckIntervalSecs time.Duration      `config:"seconds;1"`
+	IptablesLockFilePath               string             `config:"file;/run/xtables.lock"`
+	IptablesLockTimeoutSecs            time.Duration      `config:"seconds;0"`
+	IptablesLockProbeIntervalMillis    time.Duration      `config:"millis;50"`
+	FeatureDetectOverride              *map[string]string `config:"keyvaluelist;"";;local"`
+	IpsetsRefreshInterval              time.Duration      `config:"seconds;10"`
+	MaxIpsetSize                       int                `config:"int;1048576;non-zero"`
+	XDPRefreshInterval                 time.Duration      `config:"seconds;90"`
 
 	PolicySyncPathPrefix string `config:"file;;"`
 
@@ -691,6 +691,8 @@ func loadParams() {
 			param = &CIDRListParam{}
 		case "route-table-range":
 			param = &RouteTableRangeParam{}
+		case "keyvaluelist":
+			param = &KeyValueListParam{}
 		default:
 			log.Panicf("Unknown type of parameter: %v", kind)
 		}

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -172,7 +172,7 @@ type Config struct {
 	IptablesLockFilePath               string            `config:"file;/run/xtables.lock"`
 	IptablesLockTimeoutSecs            time.Duration     `config:"seconds;0"`
 	IptablesLockProbeIntervalMillis    time.Duration     `config:"millis;50"`
-	FeatureDetectOverride              map[string]string `config:"keyvaluelist;;local"`
+	FeatureDetectOverride              map[string]string `config:"keyvaluelist;;"`
 	IpsetsRefreshInterval              time.Duration     `config:"seconds;10"`
 	MaxIpsetSize                       int               `config:"int;1048576;non-zero"`
 	XDPRefreshInterval                 time.Duration     `config:"seconds;90"`

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -162,20 +162,20 @@ type Config struct {
 
 	Ipv6Support bool `config:"bool;true"`
 
-	IptablesBackend                    string             `config:"oneof(legacy,nft,auto);legacy"`
-	RouteRefreshInterval               time.Duration      `config:"seconds;90"`
-	DeviceRouteSourceAddress           net.IP             `config:"ipv4;"`
-	DeviceRouteProtocol                int                `config:"int;3"`
-	RemoveExternalRoutes               bool               `config:"bool;true"`
-	IptablesRefreshInterval            time.Duration      `config:"seconds;90"`
-	IptablesPostWriteCheckIntervalSecs time.Duration      `config:"seconds;1"`
-	IptablesLockFilePath               string             `config:"file;/run/xtables.lock"`
-	IptablesLockTimeoutSecs            time.Duration      `config:"seconds;0"`
-	IptablesLockProbeIntervalMillis    time.Duration      `config:"millis;50"`
-	FeatureDetectOverride              *map[string]string `config:"keyvaluelist;"";;local"`
-	IpsetsRefreshInterval              time.Duration      `config:"seconds;10"`
-	MaxIpsetSize                       int                `config:"int;1048576;non-zero"`
-	XDPRefreshInterval                 time.Duration      `config:"seconds;90"`
+	IptablesBackend                    string            `config:"oneof(legacy,nft,auto);legacy"`
+	RouteRefreshInterval               time.Duration     `config:"seconds;90"`
+	DeviceRouteSourceAddress           net.IP            `config:"ipv4;"`
+	DeviceRouteProtocol                int               `config:"int;3"`
+	RemoveExternalRoutes               bool              `config:"bool;true"`
+	IptablesRefreshInterval            time.Duration     `config:"seconds;90"`
+	IptablesPostWriteCheckIntervalSecs time.Duration     `config:"seconds;1"`
+	IptablesLockFilePath               string            `config:"file;/run/xtables.lock"`
+	IptablesLockTimeoutSecs            time.Duration     `config:"seconds;0"`
+	IptablesLockProbeIntervalMillis    time.Duration     `config:"millis;50"`
+	FeatureDetectOverride              map[string]string `config:"keyvaluelist;"";;local"`
+	IpsetsRefreshInterval              time.Duration     `config:"seconds;10"`
+	MaxIpsetSize                       int               `config:"int;1048576;non-zero"`
+	XDPRefreshInterval                 time.Duration     `config:"seconds;90"`
 
 	PolicySyncPathPrefix string `config:"file;;"`
 

--- a/config/param_types.go
+++ b/config/param_types.go
@@ -34,6 +34,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/felix/idalloc"
+	"github.com/projectcalico/felix/stringutils"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
@@ -531,5 +532,17 @@ func (p *RouteTableRangeParam) Parse(raw string) (result interface{}, err error)
 		result = idalloc.IndexRange{Min: min, Max: max}
 		err = nil
 	}
+	return
+}
+
+type KeyValueListParam struct {
+	Metadata
+}
+
+func (p *KeyValueListParam) Parse(raw string) (result interface{}, err error) {
+	if raw == "" {
+		return nil, nil
+	}
+	result, err = stringutils.ParseKeyValueList(raw)
 	return
 }

--- a/config/param_types.go
+++ b/config/param_types.go
@@ -540,9 +540,6 @@ type KeyValueListParam struct {
 }
 
 func (p *KeyValueListParam) Parse(raw string) (result interface{}, err error) {
-	if raw == "" {
-		return nil, nil
-	}
 	result, err = stringutils.ParseKeyValueList(raw)
 	return
 }

--- a/config/param_types_test.go
+++ b/config/param_types_test.go
@@ -59,3 +59,33 @@ var _ = DescribeTable("CIDR list parameter parsing",
 	Entry("Mix of IP and CIDRs", "1.1.1.1/24, 2.2.2.2", []string{"1.1.1.0/24", "2.2.2.2/32"}, true),
 	Entry("Reject IPv6", "aabc::1111/32", []string{}, false),
 )
+
+var _ = DescribeTable("KeyValue list parameter parsing",
+	func(raw string, expectSuccess bool, expected *map[string]string) {
+		p := KeyValueListParam{Metadata{
+			Name: "FeatureOverride",
+		}}
+		actual, err := p.Parse(raw)
+		if expectSuccess {
+			Expect(err).To(BeNil())
+			if raw == "" {
+				Expect(actual).To(BeNil())
+			} else {
+				Expect(actual).To(Equal(expected))
+			}
+		} else {
+			Expect(err).NotTo(BeNil())
+		}
+	},
+	Entry("Empty", "", true, nil),
+	Entry("Single value", "key=value", true, &map[string]string{
+		"key": "value",
+	}),
+	Entry("Malformed", "key=value,malformed", false, &map[string]string{
+		"key": "value",
+	}),
+	Entry("Spaces", "  key=value,  v2= x ,,,,", true, &map[string]string{
+		"key": "value",
+		"v2":  " x ",
+	}),
+)

--- a/config/param_types_test.go
+++ b/config/param_types_test.go
@@ -61,30 +61,24 @@ var _ = DescribeTable("CIDR list parameter parsing",
 )
 
 var _ = DescribeTable("KeyValue list parameter parsing",
-	func(raw string, expectSuccess bool, expected *map[string]string) {
+	func(raw string, expected map[string]string) {
 		p := KeyValueListParam{Metadata{
 			Name: "FeatureOverride",
 		}}
 		actual, err := p.Parse(raw)
-		if expectSuccess {
-			Expect(err).To(BeNil())
-			if raw == "" {
-				Expect(actual).To(BeNil())
-			} else {
-				Expect(actual).To(Equal(expected))
-			}
-		} else {
+		if expected == nil {
 			Expect(err).NotTo(BeNil())
+		} else {
+			Expect(err).To(BeNil())
+			Expect(actual).To(Equal(expected))
 		}
 	},
-	Entry("Empty", "", true, nil),
-	Entry("Single value", "key=value", true, &map[string]string{
+	Entry("Empty", "  ", map[string]string{}),
+	Entry("Single value", "key=value", map[string]string{
 		"key": "value",
 	}),
-	Entry("Malformed", "key=value,malformed", false, &map[string]string{
-		"key": "value",
-	}),
-	Entry("Spaces", "  key=value,  v2= x ,,,,", true, &map[string]string{
+	Entry("Malformed", "key=value,malformed", nil),
+	Entry("Spaces", "  key=value,  v2= x ,,,,", map[string]string{
 		"key": "value",
 		"v2":  " x ",
 	}),

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -38,7 +38,6 @@ import (
 	"github.com/projectcalico/felix/idalloc"
 	"github.com/projectcalico/felix/ifacemonitor"
 	"github.com/projectcalico/felix/ipsets"
-	"github.com/projectcalico/felix/iptables"
 	"github.com/projectcalico/felix/logutils"
 	"github.com/projectcalico/felix/markbits"
 	"github.com/projectcalico/felix/rules"
@@ -272,7 +271,7 @@ func StartDataplaneDriver(configParams *config.Config,
 
 			KubeClientSet: k8sClientSet,
 
-			FeatureDetectOverrides: iptables.ParseFeatureDetectOverrides(configParams.FeatureDetectOverride),
+			FeatureDetectOverrides: configParams.FeatureDetectOverride,
 		}
 
 		if configParams.BPFExternalServiceMode == "dsr" {

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -272,7 +272,7 @@ func StartDataplaneDriver(configParams *config.Config,
 
 			KubeClientSet: k8sClientSet,
 
-			FeatureDetectOverrides: iptables.ParseFeatureDetectOverrides(configParams.IptablesFeatureDetectOverride),
+			FeatureDetectOverrides: iptables.ParseFeatureDetectOverrides(configParams.FeatureDetectOverride),
 		}
 
 		if configParams.BPFExternalServiceMode == "dsr" {

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -38,6 +38,7 @@ import (
 	"github.com/projectcalico/felix/idalloc"
 	"github.com/projectcalico/felix/ifacemonitor"
 	"github.com/projectcalico/felix/ipsets"
+	"github.com/projectcalico/felix/iptables"
 	"github.com/projectcalico/felix/logutils"
 	"github.com/projectcalico/felix/markbits"
 	"github.com/projectcalico/felix/rules"
@@ -270,6 +271,8 @@ func StartDataplaneDriver(configParams *config.Config,
 			RouteTableManager:                  routeTableIndexAllocator,
 
 			KubeClientSet: k8sClientSet,
+
+			FeatureDetectOverrides: iptables.ParseFeatureDetectOverrides(configParams.IptablesFeatureDetectOverride),
 		}
 
 		if configParams.BPFExternalServiceMode == "dsr" {

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -175,7 +175,7 @@ type Config struct {
 
 	KubeClientSet *kubernetes.Clientset
 
-	FeatureDetectOverrides *iptables.FeatureDetectOverrides
+	FeatureDetectOverrides *map[string]string
 }
 
 // InternalDataplane implements an in-process Felix dataplane driver based on iptables

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -175,7 +175,7 @@ type Config struct {
 
 	KubeClientSet *kubernetes.Clientset
 
-	FeatureDetectOverrides *map[string]string
+	FeatureDetectOverrides map[string]string
 }
 
 // InternalDataplane implements an in-process Felix dataplane driver based on iptables

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -174,6 +174,8 @@ type Config struct {
 	LookPathOverride func(file string) (string, error)
 
 	KubeClientSet *kubernetes.Clientset
+
+	FeatureDetectOverrides *iptables.FeatureDetectOverrides
 }
 
 // InternalDataplane implements an in-process Felix dataplane driver based on iptables
@@ -323,7 +325,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		iptablesNATOptions.ExtraCleanupRegexPattern += "|" + rules.HistoricInsertedNATRuleRegex
 	}
 
-	featureDetector := iptables.NewFeatureDetector(nil)
+	featureDetector := iptables.NewFeatureDetector(config.FeatureDetectOverrides)
 	iptablesFeatures := featureDetector.GetFeatures()
 
 	var iptablesLock sync.Locker

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -323,7 +323,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		iptablesNATOptions.ExtraCleanupRegexPattern += "|" + rules.HistoricInsertedNATRuleRegex
 	}
 
-	featureDetector := iptables.NewFeatureDetector()
+	featureDetector := iptables.NewFeatureDetector(nil)
 	iptablesFeatures := featureDetector.GetFeatures()
 
 	var iptablesLock sync.Locker

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/pkg/errors v0.8.1
-	github.com/projectcalico/libcalico-go v1.7.2-0.20200616235442-553c09af3043
+	github.com/projectcalico/libcalico-go v1.7.2-0.20200709141311-ef7c3bc8fea0
 	github.com/projectcalico/pod2daemon v0.0.0-20191223184832-a0e1c4693271
 	github.com/projectcalico/typha v0.7.3-0.20200617040736-8be068576bc6
 	github.com/prometheus/client_golang v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -562,6 +562,8 @@ github.com/projectcalico/libcalico-go v1.7.2-0.20200615154232-dfe3bf9034f6 h1:49
 github.com/projectcalico/libcalico-go v1.7.2-0.20200615154232-dfe3bf9034f6/go.mod h1:1RxboTOZJzpDYDvE03hMlf13b7gR0DPNcO7J/9uv6iY=
 github.com/projectcalico/libcalico-go v1.7.2-0.20200616235442-553c09af3043 h1:XnYPVNvkSP+91ZsLmg6TyekvQ9iSf1G6KqIurwoGBAk=
 github.com/projectcalico/libcalico-go v1.7.2-0.20200616235442-553c09af3043/go.mod h1:1RxboTOZJzpDYDvE03hMlf13b7gR0DPNcO7J/9uv6iY=
+github.com/projectcalico/libcalico-go v1.7.2-0.20200709141311-ef7c3bc8fea0 h1:Jllqmfp0v2EzbgJrVFgocpoMpgl40JTUfk+A9jx37cs=
+github.com/projectcalico/libcalico-go v1.7.2-0.20200709141311-ef7c3bc8fea0/go.mod h1:1RxboTOZJzpDYDvE03hMlf13b7gR0DPNcO7J/9uv6iY=
 github.com/projectcalico/logrus v0.0.0-20180701205716-fc9bbf2f5799 h1:9jp4YoHqZvEKDW3Z9464x/whSRCWEinIo4/JifaKR+g=
 github.com/projectcalico/logrus v0.0.0-20180701205716-fc9bbf2f5799/go.mod h1:DfgrchabbtEO9wjOz5lVae+XRvjFKKWEA9GTMme6A8g=
 github.com/projectcalico/pod2daemon v0.0.0-20191223184832-a0e1c4693271 h1:AOFOckD83tAIMQob6I1FpzSVs+Rn5Td701Q3/aQFqe8=

--- a/iptables/actions.go
+++ b/iptables/actions.go
@@ -14,10 +14,7 @@
 
 package iptables
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 type Action interface {
 	ToFragment(features *Features) string
@@ -156,7 +153,7 @@ type MasqAction struct {
 
 func (g MasqAction) ToFragment(features *Features) string {
 	fullyRand := ""
-	if features.MASQFullyRandom && os.Getenv("FELIX_DISABLE_RANDOM_FULLY") != "true" {
+	if features.MASQFullyRandom {
 		fullyRand = " --random-fully"
 	}
 	if g.ToPorts != "" {

--- a/iptables/actions.go
+++ b/iptables/actions.go
@@ -14,7 +14,10 @@
 
 package iptables
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 type Action interface {
 	ToFragment(features *Features) string
@@ -153,7 +156,7 @@ type MasqAction struct {
 
 func (g MasqAction) ToFragment(features *Features) string {
 	fullyRand := ""
-	if features.MASQFullyRandom {
+	if features.MASQFullyRandom && os.Getenv("FELIX_DISABLE_RANDOM_FULLY") != "true" {
 		fullyRand = " --random-fully"
 	}
 	if g.ToPorts != "" {

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -296,7 +296,7 @@ func ParseFeatureDetectOverrides(param string) *FeatureDetectOverrides {
 		return nil
 	}
 	var overrides FeatureDetectOverrides
-    for _, s := range strings.Split(param, ",") {
+	for _, s := range strings.Split(param, ",") {
 		if strings.HasPrefix(s, "SNATFullyRandom=") {
 			overrides.SNATFullyRandom = strings.Split(s, "=")[1]
 			continue

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -288,3 +288,28 @@ func findBestBinary(lookPath func(file string) (string, error), ipVersion uint8,
 	logCxt.Panic("Failed to find iptables command")
 	return ""
 }
+
+// Parse a comma separated list of overrides, example;
+// "SNATFullyRandom=true,MASQFullyRandom=false"
+func ParseFeatureDetectOverrides(param string) *FeatureDetectOverrides {
+	if param == "" {
+		return nil
+	}
+	var overrides FeatureDetectOverrides
+    for _, s := range strings.Split(param, ",") {
+		if strings.HasPrefix(s, "SNATFullyRandom=") {
+			overrides.SNATFullyRandom = strings.Split(s, "=")[1]
+			continue
+		}
+		if strings.HasPrefix(s, "MASQFullyRandom=") {
+			overrides.MASQFullyRandom = strings.Split(s, "=")[1]
+			continue
+		}
+		if strings.HasPrefix(s, "RestoreSupportsLock=") {
+			overrides.RestoreSupportsLock = strings.Split(s, "=")[1]
+			continue
+		}
+		log.Info("Unknown override", s)
+	}
+	return &overrides
+}

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -26,7 +26,6 @@ import (
 	version "github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/felix/stringutils"
 	"github.com/projectcalico/felix/versionparse"
 )
 
@@ -267,13 +266,4 @@ func findBestBinary(lookPath func(file string) (string, error), ipVersion uint8,
 
 	logCxt.Panic("Failed to find iptables command")
 	return ""
-}
-
-// Allow "nil" as return and ignore parse errors.
-func ParseFeatureDetectOverrides(param string) *map[string]string {
-	if param == "" {
-		return nil
-	}
-	ovr, _ := stringutils.ParseKeyValueList(param)
-	return ovr
 }

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -56,9 +56,18 @@ type Features struct {
 	RestoreSupportsLock bool
 }
 
+// Values; ""|true|false.
+// "" means "detect" and is default. true|false overrides.
+type FeatureDetectOverrides struct {
+	SNATFullyRandom     string
+	MASQFullyRandom     string
+	RestoreSupportsLock string
+}
+
 type FeatureDetector struct {
-	lock         sync.Mutex
-	featureCache *Features
+	lock            sync.Mutex
+	featureCache    *Features
+	featureOverride *FeatureDetectOverrides
 
 	// Path to file with kernel version
 	GetKernelVersionReader func() (io.Reader, error)
@@ -66,10 +75,11 @@ type FeatureDetector struct {
 	NewCmd cmdFactory
 }
 
-func NewFeatureDetector() *FeatureDetector {
+func NewFeatureDetector(overrides *FeatureDetectOverrides) *FeatureDetector {
 	return &FeatureDetector{
 		GetKernelVersionReader: versionparse.GetKernelVersionReader,
 		NewCmd:                 NewRealCmd,
+		featureOverride:        overrides,
 	}
 }
 

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -60,7 +60,7 @@ type Features struct {
 type FeatureDetector struct {
 	lock            sync.Mutex
 	featureCache    *Features
-	featureOverride *map[string]string
+	featureOverride map[string]string
 
 	// Path to file with kernel version
 	GetKernelVersionReader func() (io.Reader, error)
@@ -68,7 +68,7 @@ type FeatureDetector struct {
 	NewCmd cmdFactory
 }
 
-func NewFeatureDetector(overrides *map[string]string) *FeatureDetector {
+func NewFeatureDetector(overrides map[string]string) *FeatureDetector {
 	return &FeatureDetector{
 		GetKernelVersionReader: versionparse.GetKernelVersionReader,
 		NewCmd:                 NewRealCmd,
@@ -108,27 +108,25 @@ func (d *FeatureDetector) refreshFeaturesLockHeld() {
 		RestoreSupportsLock: iptV.Compare(v1Dot6Dot2) >= 0,
 	}
 
-	if d.featureOverride != nil {
-		if value, ok := (*d.featureOverride)["SNATFullyRandom"]; ok {
-			ovr, err := strconv.ParseBool(value)
-			if err == nil {
-				log.WithField("override", ovr).Info("Override feature SNATFullyRandom")
-				features.SNATFullyRandom = ovr
-			}
+	if value, ok := (d.featureOverride)["SNATFullyRandom"]; ok {
+		ovr, err := strconv.ParseBool(value)
+		if err == nil {
+			log.WithField("override", ovr).Info("Override feature SNATFullyRandom")
+			features.SNATFullyRandom = ovr
 		}
-		if value, ok := (*d.featureOverride)["MASQFullyRandom"]; ok {
-			ovr, err := strconv.ParseBool(value)
-			if err == nil {
-				log.WithField("override", ovr).Info("Override feature MASQFullyRandom")
-				features.MASQFullyRandom = ovr
-			}
+	}
+	if value, ok := (d.featureOverride)["MASQFullyRandom"]; ok {
+		ovr, err := strconv.ParseBool(value)
+		if err == nil {
+			log.WithField("override", ovr).Info("Override feature MASQFullyRandom")
+			features.MASQFullyRandom = ovr
 		}
-		if value, ok := (*d.featureOverride)["RestoreSupportsLock"]; ok {
-			ovr, err := strconv.ParseBool(value)
-			if err == nil {
-				log.WithField("override", ovr).Info("Override feature RestoreSupportsLock")
-				features.RestoreSupportsLock = ovr
-			}
+	}
+	if value, ok := (d.featureOverride)["RestoreSupportsLock"]; ok {
+		ovr, err := strconv.ParseBool(value)
+		if err == nil {
+			log.WithField("override", ovr).Info("Override feature RestoreSupportsLock")
+			features.RestoreSupportsLock = ovr
 		}
 	}
 

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -106,25 +106,6 @@ func (d *FeatureDetector) refreshFeaturesLockHeld() {
 	// Get the versions.  If we fail to detect a version for some reason, we use a safe default.
 	log.Debug("Refreshing detected iptables features")
 
-	// Disable checks if all features are overidden (fallback if detection
-	// fails)
-	if d.featureOverride != nil {
-		var features Features
-		var err error
-		features.SNATFullyRandom, err = strconv.ParseBool(d.featureOverride.SNATFullyRandom)
-		if err == nil {
-			features.MASQFullyRandom, err = strconv.ParseBool(d.featureOverride.MASQFullyRandom)
-		}
-		if err == nil {
-			features.RestoreSupportsLock, err = strconv.ParseBool(d.featureOverride.RestoreSupportsLock)
-		}
-		if err == nil {
-			// All features overidden
-			d.featureCache = &features
-			log.Info("All features overidden. Feature detect disabled")
-			return
-		}
-	}
 	iptV := d.getIptablesVersion()
 	kerV := d.getKernelVersion()
 
@@ -138,17 +119,17 @@ func (d *FeatureDetector) refreshFeaturesLockHeld() {
 	if d.featureOverride != nil {
 		value, err := strconv.ParseBool(d.featureOverride.SNATFullyRandom)
 		if err == nil {
-			log.Info("Override feature SNATFullyRandom", value)
+			log.WithField("override", value).Info("Override feature SNATFullyRandom")
 			features.SNATFullyRandom = value
 		}
 		value, err = strconv.ParseBool(d.featureOverride.MASQFullyRandom)
 		if err == nil {
-			log.Info("Override feature MASQFullyRandom", value)
+			log.WithField("override", value).Info("Override feature MASQFullyRandom")
 			features.MASQFullyRandom = value
 		}
 		value, err = strconv.ParseBool(d.featureOverride.RestoreSupportsLock)
 		if err == nil {
-			log.Info("Override feature RestoreSupportsLock", value)
+			log.WithField("override", value).Info("Override feature RestoreSupportsLock")
 			features.RestoreSupportsLock = value
 		}
 	}

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -26,8 +26,8 @@ import (
 	version "github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/felix/versionparse"
 	"github.com/projectcalico/felix/stringutils"
+	"github.com/projectcalico/felix/versionparse"
 )
 
 var (

--- a/iptables/features_detect_test.go
+++ b/iptables/features_detect_test.go
@@ -112,7 +112,7 @@ func TestFeatureDetection(t *testing.T) {
 		t.Run("iptables version "+tst.iptablesVersion+" kernel "+tst.kernelVersion, func(t *testing.T) {
 			RegisterTestingT(t)
 			dataplane := newMockDataplane("filter", map[string][]string{}, "legacy")
-			featureDetector := NewFeatureDetector()
+			featureDetector := NewFeatureDetector(nil)
 			featureDetector.NewCmd = dataplane.newCmd
 			featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 

--- a/iptables/features_detect_test.go
+++ b/iptables/features_detect_test.go
@@ -139,7 +139,7 @@ func TestFeatureDetectionOverride(t *testing.T) {
 	type test struct {
 		iptablesVersion, kernelVersion string
 		features                       Features
-		override                       FeatureDetectOverrides
+		override                       map[string]string
 	}
 	for _, tst := range []test{
 		{
@@ -150,7 +150,7 @@ func TestFeatureDetectionOverride(t *testing.T) {
 				SNATFullyRandom:     true,
 				MASQFullyRandom:     true,
 			},
-			FeatureDetectOverrides{},
+			map[string]string{},
 		},
 		{
 			"iptables v1.6.1",
@@ -160,8 +160,8 @@ func TestFeatureDetectionOverride(t *testing.T) {
 				SNATFullyRandom:     true,
 				MASQFullyRandom:     false,
 			},
-			FeatureDetectOverrides{
-				RestoreSupportsLock: "true",
+			map[string]string{
+				"RestoreSupportsLock": "true",
 			},
 		},
 		{
@@ -172,10 +172,10 @@ func TestFeatureDetectionOverride(t *testing.T) {
 				SNATFullyRandom:     true,
 				MASQFullyRandom:     false,
 			},
-			FeatureDetectOverrides{
-				RestoreSupportsLock: "true",
-				SNATFullyRandom:     "true",
-				MASQFullyRandom:     "false",
+			map[string]string{
+				"RestoreSupportsLock": "true",
+				"SNATFullyRandom":     "true",
+				"MASQFullyRandom":     "false",
 			},
 		},
 	} {

--- a/iptables/features_detect_test.go
+++ b/iptables/features_detect_test.go
@@ -183,7 +183,7 @@ func TestFeatureDetectionOverride(t *testing.T) {
 		t.Run("iptables version "+tst.iptablesVersion+" kernel "+tst.kernelVersion, func(t *testing.T) {
 			RegisterTestingT(t)
 			dataplane := newMockDataplane("filter", map[string][]string{}, "legacy")
-			featureDetector := NewFeatureDetector(&tst.override)
+			featureDetector := NewFeatureDetector(tst.override)
 			featureDetector.NewCmd = dataplane.newCmd
 			featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 

--- a/iptables/features_detect_test.go
+++ b/iptables/features_detect_test.go
@@ -133,6 +133,77 @@ func TestFeatureDetection(t *testing.T) {
 	}
 }
 
+func TestFeatureDetectionOverride(t *testing.T) {
+	RegisterTestingT(t)
+
+	type test struct {
+		iptablesVersion, kernelVersion string
+		features                       Features
+		override                       FeatureDetectOverrides
+	}
+	for _, tst := range []test{
+		{
+			"iptables v1.6.2",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: true,
+				SNATFullyRandom:     true,
+				MASQFullyRandom:     true,
+			},
+			FeatureDetectOverrides{},
+		},
+		{
+			"iptables v1.6.1",
+			"Linux version 3.14.0",
+			Features{
+				RestoreSupportsLock: true,
+				SNATFullyRandom:     true,
+				MASQFullyRandom:     false,
+			},
+			FeatureDetectOverrides{
+				RestoreSupportsLock: "true",
+			},
+		},
+		{
+			"error",
+			"error",
+			Features{
+				RestoreSupportsLock: true,
+				SNATFullyRandom:     true,
+				MASQFullyRandom:     false,
+			},
+			FeatureDetectOverrides{
+				RestoreSupportsLock: "true",
+				SNATFullyRandom:     "true",
+				MASQFullyRandom:     "false",
+			},
+		},
+	} {
+		tst := tst
+		t.Run("iptables version "+tst.iptablesVersion+" kernel "+tst.kernelVersion, func(t *testing.T) {
+			RegisterTestingT(t)
+			dataplane := newMockDataplane("filter", map[string][]string{}, "legacy")
+			featureDetector := NewFeatureDetector(&tst.override)
+			featureDetector.NewCmd = dataplane.newCmd
+			featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
+
+			if tst.iptablesVersion == "error" {
+				dataplane.FailNextVersion = true
+			} else {
+				dataplane.Version = tst.iptablesVersion
+			}
+
+			if tst.kernelVersion == "error" {
+				dataplane.FailNextGetKernelVersionReader = true
+			} else {
+				dataplane.KernelVersion = tst.kernelVersion
+			}
+
+			Expect(featureDetector.GetFeatures()).To(Equal(&tst.features))
+		})
+	}
+}
+
 func TestIptablesBackendDetection(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/iptables/rules_test.go
+++ b/iptables/rules_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Hash extraction tests", func() {
 	var table *Table
 
 	BeforeEach(func() {
-		fd := NewFeatureDetector()
+		fd := NewFeatureDetector(nil)
 		fd.GetKernelVersionReader = func() (io.Reader, error) {
 			return nil, errors.New("not implemented")
 		}
@@ -98,10 +98,10 @@ var _ = Describe("Hash extraction tests", func() {
 		hashes, rules, err := table.readHashesAndRulesFrom(newClosableBuf("-A FORWARD -j felix-FORWARD\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
-			"FORWARD": []string{"OLD INSERT RULE"},
+			"FORWARD": {"OLD INSERT RULE"},
 		}))
 		Expect(rules).To(Equal(map[string][]string{
-			"FORWARD": []string{"-A FORWARD -j felix-FORWARD"},
+			"FORWARD": {"-A FORWARD -j felix-FORWARD"},
 		}))
 	})
 	It("should extract an old felix rule by special case", func() {
@@ -111,7 +111,7 @@ var _ = Describe("Hash extraction tests", func() {
 		))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
-			"FORWARD": []string{
+			"FORWARD": {
 				"OLD INSERT RULE",
 				"",
 			},
@@ -128,7 +128,7 @@ var _ = Describe("Hash extraction tests", func() {
 			"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -j cali-FORWARD\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
-			"FORWARD": []string{"wUHhoiAYhphO9Mso"},
+			"FORWARD": {"wUHhoiAYhphO9Mso"},
 		}))
 		Expect(rules).To(Equal(map[string][]string{
 			"FORWARD": {
@@ -144,7 +144,7 @@ var _ = Describe("Hash extraction tests", func() {
 				"-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
-			"FORWARD": []string{
+			"FORWARD": {
 				"wUHhoiAYhphO9Mso",
 				"abcdefghij1234-_",
 				"",
@@ -169,11 +169,11 @@ var _ = Describe("Hash extraction tests", func() {
 				"-A FORWARD -m comment --comment \"cali:1234567890093213\" -j cali-FORWARD\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
-			"cali-abcd": []string{
+			"cali-abcd": {
 				"wUHhoiAYhphO9Mso",
 				"abcdefghij1234-_",
 			},
-			"FORWARD": []string{
+			"FORWARD": {
 				"",
 				"1234567890093213",
 			},
@@ -191,7 +191,7 @@ var _ = Describe("Hash extraction tests", func() {
 			"-A FORWARD -m comment --comment \"cali:wUHhoiAYhphO9Mso\" -m comment --comment \"key=value\" -j cali-FORWARD\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hashes).To(Equal(map[string][]string{
-			"FORWARD": []string{"wUHhoiAYhphO9Mso"},
+			"FORWARD": {"wUHhoiAYhphO9Mso"},
 		}))
 		Expect(rules).To(Equal(map[string][]string{
 			"FORWARD": {

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Table with an empty dataplane (legacy)", func() {
 			"OUTPUT":  {},
 		}, "legacy")
 		iptLock := &mockMutex{}
-		featureDetector := NewFeatureDetector()
+		featureDetector := NewFeatureDetector(nil)
 		featureDetector.NewCmd = dataplane.newCmd
 		featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 		table := NewTable(
@@ -81,7 +81,7 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 			"OUTPUT":  {},
 		}, dataplaneMode)
 		iptLock = &mockMutex{}
-		featureDetector = NewFeatureDetector()
+		featureDetector = NewFeatureDetector(nil)
 		featureDetector.NewCmd = dataplane.newCmd
 		featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 		table = NewTable(
@@ -868,7 +868,7 @@ func describePostUpdateCheckTests(enableRefresh bool, dataplaneMode string) {
 		if enableRefresh {
 			options.RefreshInterval = 30 * time.Second
 		}
-		featureDetector := NewFeatureDetector()
+		featureDetector := NewFeatureDetector(nil)
 		featureDetector.NewCmd = dataplane.newCmd
 		featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 		table = NewTable(
@@ -1071,7 +1071,7 @@ func describeDirtyDataplaneTests(appendMode bool, dataplaneMode string) {
 		if appendMode {
 			insertMode = "append"
 		}
-		featureDetector := NewFeatureDetector()
+		featureDetector := NewFeatureDetector(nil)
 		featureDetector.NewCmd = dataplane.newCmd
 		featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 		table = NewTable(
@@ -1479,7 +1479,7 @@ func describeInsertAndNonCalicoChainTests(dataplaneMode string) {
 			"non-calico": {"-m comment \"foo\""},
 		}, dataplaneMode)
 		iptLock = &mockMutex{}
-		featureDetector := NewFeatureDetector()
+		featureDetector := NewFeatureDetector(nil)
 		featureDetector.NewCmd = dataplane.newCmd
 		featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 		table = NewTable(

--- a/stringutils/parse_keyvalue_list.go
+++ b/stringutils/parse_keyvalue_list.go
@@ -21,6 +21,10 @@ func ParseKeyValueList(param string) (*map[string]string, error) {
 	}
 	var invalidItems []string
 	for _, item := range strings.Split(param, ",") {
+		if item == "" {
+			// Accept empty items (e.g tailing ",")
+			continue
+		}
 		kv := rex.FindStringSubmatch(item)
 		if kv == nil {
 			invalidItems = append(invalidItems, item)

--- a/stringutils/parse_keyvalue_list.go
+++ b/stringutils/parse_keyvalue_list.go
@@ -1,0 +1,35 @@
+package stringutils
+
+// https://play.golang.org/p/xSEX1CAcQE
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var rex = regexp.MustCompile("\\s*(\\w+)=(.+)")
+
+// ParseKeyValueList parses a comma-separated key=value list to a map.
+// Keys must contain only word characters (leading spaces ignored).
+// A valid map is always returned even when the error is != nil.
+// Spaces in the value are preserved.
+func ParseKeyValueList(param string) (*map[string]string, error) {
+	res := make(map[string]string)
+	if len(strings.TrimSpace(param)) == 0 {
+		return &res, nil
+	}
+	var invalidItems []string
+	for _, item := range strings.Split(param,",") {
+		kv := rex.FindStringSubmatch(item)
+		if kv == nil {
+			invalidItems = append(invalidItems, item)
+			continue
+		}
+		res[kv[1]] = kv[2]
+	}
+	if len(invalidItems) > 0 {
+		return &res, fmt.Errorf("Invalid items %v", invalidItems)
+	}
+	return &res, nil
+}

--- a/stringutils/parse_keyvalue_list.go
+++ b/stringutils/parse_keyvalue_list.go
@@ -14,10 +14,10 @@ var rex = regexp.MustCompile("\\s*(\\w+)=(.+)")
 // Keys must contain only word characters (leading spaces ignored).
 // A valid map is always returned even when the error is != nil.
 // Spaces in the value are preserved.
-func ParseKeyValueList(param string) (*map[string]string, error) {
+func ParseKeyValueList(param string) (map[string]string, error) {
 	res := make(map[string]string)
 	if len(strings.TrimSpace(param)) == 0 {
-		return &res, nil
+		return res, nil
 	}
 	var invalidItems []string
 	for _, item := range strings.Split(param, ",") {
@@ -33,7 +33,7 @@ func ParseKeyValueList(param string) (*map[string]string, error) {
 		res[kv[1]] = kv[2]
 	}
 	if len(invalidItems) > 0 {
-		return &res, fmt.Errorf("Invalid items %v", invalidItems)
+		return nil, fmt.Errorf("Invalid items %v", invalidItems)
 	}
-	return &res, nil
+	return res, nil
 }

--- a/stringutils/parse_keyvalue_list.go
+++ b/stringutils/parse_keyvalue_list.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-var rex = regexp.MustCompile("\\s*(\\w+)=(.+)")
+var rex = regexp.MustCompile("\\s*(\\w+)=(.*)")
 
 // ParseKeyValueList parses a comma-separated key=value list to a map.
 // Keys must contain only word characters (leading spaces ignored).

--- a/stringutils/parse_keyvalue_list.go
+++ b/stringutils/parse_keyvalue_list.go
@@ -1,3 +1,18 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020 Nordix Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package stringutils
 
 // https://play.golang.org/p/xSEX1CAcQE
@@ -8,11 +23,10 @@ import (
 	"strings"
 )
 
-var rex = regexp.MustCompile("\\s*(\\w+)=(.*)")
+var rex = regexp.MustCompile(`\s*(\w+)=(.*)`)
 
 // ParseKeyValueList parses a comma-separated key=value list to a map.
 // Keys must contain only word characters (leading spaces ignored).
-// A valid map is always returned even when the error is != nil.
 // Spaces in the value are preserved.
 func ParseKeyValueList(param string) (map[string]string, error) {
 	res := make(map[string]string)

--- a/stringutils/parse_keyvalue_list.go
+++ b/stringutils/parse_keyvalue_list.go
@@ -20,7 +20,7 @@ func ParseKeyValueList(param string) (*map[string]string, error) {
 		return &res, nil
 	}
 	var invalidItems []string
-	for _, item := range strings.Split(param,",") {
+	for _, item := range strings.Split(param, ",") {
 		kv := rex.FindStringSubmatch(item)
 		if kv == nil {
 			invalidItems = append(invalidItems, item)

--- a/stringutils/parse_keyvalue_list_test.go
+++ b/stringutils/parse_keyvalue_list_test.go
@@ -28,10 +28,10 @@ var _ = DescribeTable("ParseKeyValueList tests",
 	}),
 	Entry("Values with spaces", "key=   ,  v2= x ", false, map[string]string{
 		"key": "   ",
-		"v2": " x ",
+		"v2":  " x ",
 	}),
 	Entry("Value with an equal sign (=)", "key=key = value,v2=7", false, map[string]string{
 		"key": "key = value",
-		"v2": "7",
+		"v2":  "7",
 	}),
 )

--- a/stringutils/parse_keyvalue_list_test.go
+++ b/stringutils/parse_keyvalue_list_test.go
@@ -12,7 +12,7 @@ var _ = DescribeTable("ParseKeyValueList tests",
 		values, err := ParseKeyValueList(input)
 		if expected == nil {
 			// An error is expected
-			Expect(err).To(Not(BeNil()))
+			Expect(err).NotTo(BeNil())
 			Expect(values).To(BeNil())
 		} else {
 			Expect(err).To(BeNil())
@@ -24,7 +24,10 @@ var _ = DescribeTable("ParseKeyValueList tests",
 		"key": "value",
 	}),
 	Entry("A faulty entry", "key=value, none", nil),
-	Entry("An empty entry", "key=value, none=", nil),
+	Entry("An empty entry", "key=value, none=", map[string]string{
+		"key":  "value",
+		"none": "",
+	}),
 	Entry("Values with spaces", "key=   ,  v2= x ", map[string]string{
 		"key": "   ",
 		"v2":  " x ",

--- a/stringutils/parse_keyvalue_list_test.go
+++ b/stringutils/parse_keyvalue_list_test.go
@@ -1,0 +1,37 @@
+package stringutils_test
+
+import (
+	. "github.com/projectcalico/felix/stringutils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeTable("ParseKeyValueList tests",
+	func(input string, expectedErr bool, expected map[string]string) {
+		values, err := ParseKeyValueList(input)
+		By("map")
+		Expect(*values).To(Equal(expected))
+		By("error")
+		Expect(expectedErr).To(Equal(err != nil))
+	},
+	Entry("Empty", "   ", false, map[string]string{}),
+	Entry("Single value", "key=value", false, map[string]string{
+		"key": "value",
+	}),
+	Entry("A faulty entry", "key=value, none", true, map[string]string{
+		"key": "value",
+	}),
+	Entry("An empty entry", "key=value, none=", true, map[string]string{
+		"key": "value",
+	}),
+	Entry("Values with spaces", "key=   ,  v2= x ", false, map[string]string{
+		"key": "   ",
+		"v2": " x ",
+	}),
+	Entry("Value with an equal sign (=)", "key=key = value,v2=7", false, map[string]string{
+		"key": "key = value",
+		"v2": "7",
+	}),
+)

--- a/stringutils/parse_keyvalue_list_test.go
+++ b/stringutils/parse_keyvalue_list_test.go
@@ -3,38 +3,37 @@ package stringutils_test
 import (
 	. "github.com/projectcalico/felix/stringutils"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
 var _ = DescribeTable("ParseKeyValueList tests",
-	func(input string, expectedErr bool, expected map[string]string) {
+	func(input string, expected map[string]string) {
 		values, err := ParseKeyValueList(input)
-		By("map")
-		Expect(*values).To(Equal(expected))
-		By("error")
-		Expect(expectedErr).To(Equal(err != nil))
+		if expected == nil {
+			// An error is expected
+			Expect(err).To(Not(BeNil()))
+			Expect(values).To(BeNil())
+		} else {
+			Expect(err).To(BeNil())
+			Expect(values).To(Equal(expected))
+		}
 	},
-	Entry("Empty", "   ", false, map[string]string{}),
-	Entry("Single value", "key=value", false, map[string]string{
+	Entry("Empty", "   ", map[string]string{}),
+	Entry("Single value", "key=value", map[string]string{
 		"key": "value",
 	}),
-	Entry("A faulty entry", "key=value, none", true, map[string]string{
-		"key": "value",
-	}),
-	Entry("An empty entry", "key=value, none=", true, map[string]string{
-		"key": "value",
-	}),
-	Entry("Values with spaces", "key=   ,  v2= x ", false, map[string]string{
+	Entry("A faulty entry", "key=value, none", nil),
+	Entry("An empty entry", "key=value, none=", nil),
+	Entry("Values with spaces", "key=   ,  v2= x ", map[string]string{
 		"key": "   ",
 		"v2":  " x ",
 	}),
-	Entry("Value with an equal sign (=)", "key=key = value,v2=7", false, map[string]string{
+	Entry("Value with an equal sign (=)", "key=key = value,v2=7", map[string]string{
 		"key": "key = value",
 		"v2":  "7",
 	}),
-	Entry("Empty item, tailing ','", ",  key=value,", false, map[string]string{
+	Entry("Empty item, tailing ','", ",  key=value,", map[string]string{
 		"key": "value",
 	}),
 )

--- a/stringutils/parse_keyvalue_list_test.go
+++ b/stringutils/parse_keyvalue_list_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package stringutils_test
 
 import (

--- a/stringutils/parse_keyvalue_list_test.go
+++ b/stringutils/parse_keyvalue_list_test.go
@@ -34,4 +34,7 @@ var _ = DescribeTable("ParseKeyValueList tests",
 		"key": "key = value",
 		"v2":  "7",
 	}),
+	Entry("Empty item, tailing ','", ",  key=value,", false, map[string]string{
+		"key": "value",
+	}),
 )


### PR DESCRIPTION
## Description

This PR implements override of detected iptable features. It can be used to disable `random-fully` as requested in issue #2089. It makes it possible to disable the randomization by setting an environent variable. Example from a K8s manifest;

```
            - name: FELIX_FEATUREDETECTOVERRIDE
              value: "MASQFullyRandom=false"
```

Randomization of ports can not be done for SCTP since it violates standard `3GPP TS 36.422 section 7` (havn't read it myself).

This is _a_ way to fix the problem fast and simple but a better way would be to insert a new rule for outgoing nat that sorts out SCTP (iptables comments removed);

```
$ ip6tables -t nat -S
...
-A cali-nat-outgoing -p sctp -m set --match-set cali60masq-ipam-pools src -m set ! --match-set cali60all-ipam-pools dst -j MASQUERADE
-A cali-nat-outgoing -m set --match-set cali60masq-ipam-pools src -m set ! --match-set cali60all-ipam-pools dst -j MASQUERADE --random-fully
```

This PR fixes our problem with SCTP but if you think it is better to handle sctp in a separate rule please let me know.

I have built the `calico/node` image with this patch and verified that "--random-fully" was omitted both by listing iptables and manual tests with [ncat](https://nmap.org/ncat/) (which supports sctp) and `tcpdump`.

## Todos
- [x] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note

```release-note
None required
```
