### PR TITLE
Return os.ErrNotExists from map deletes.

### DIFF
--- a/bpf/maps.go
+++ b/bpf/maps.go
@@ -222,14 +222,9 @@ func (b *PinnedMap) Delete(k []byte) error {
 	cmd := exec.Command("bpftool", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		if strings.Contains(string(out), "No such file or directory") {
-			// Check that the error wasn't about the map as a whole being missing.
-			if _, statErr := os.Stat(b.versionedFilename()); statErr == nil {
-				// We expect failures due to the entry being missing, return a dedicated error
-				// and avoid logging a scary warning.
-				logrus.WithField("k", k).Debug("Item didn't exist.")
-				return os.ErrNotExist
-			}
+		if strings.Contains(string(out), "delete failed: No such file or directory") {
+			logrus.WithField("k", k).Debug("Item didn't exist.")
+			return os.ErrNotExist
 		}
 		logrus.WithField("out", string(out)).Error("Failed to run bpftool")
 	}

--- a/bpf/maps.go
+++ b/bpf/maps.go
@@ -222,6 +222,15 @@ func (b *PinnedMap) Delete(k []byte) error {
 	cmd := exec.Command("bpftool", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if strings.Contains(string(out), "No such file or directory") {
+			// Check that the error wasn't about the map as a whole being missing.
+			if _, statErr := os.Stat(b.versionedFilename()); statErr == nil {
+				// We expect failures due to the entry being missing, return a dedicated error
+				// and avoid logging a scary warning.
+				logrus.WithField("k", k).Debug("Item didn't exist.")
+				return os.ErrNotExist
+			}
+		}
 		logrus.WithField("out", string(out)).Error("Failed to run bpftool")
 	}
 	return err

--- a/bpf/ut/maps_test.go
+++ b/bpf/ut/maps_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/bpf/conntrack"
+)
+
+func TestMapEntryDeletion(t *testing.T) {
+	RegisterTestingT(t)
+	k := conntrack.NewKey(1, net.ParseIP("10.0.0.1"), 51234, net.ParseIP("10.0.0.2"), 8080)
+	v := conntrack.Value{}
+	for i := range v {
+		v[i] = uint8(i)
+	}
+	err1 := ctMap.Update(k.AsBytes(), v[:])
+	err2 := ctMap.Delete(k.AsBytes())
+	err3 := ctMap.Delete(k.AsBytes())
+
+	// Defer error checking since the Delete calls do the cleanup for this test...
+	Expect(err1).NotTo(HaveOccurred(), "Failed to create map entry")
+	Expect(err2).NotTo(HaveOccurred(), "Failed to delete map entry")
+	Expect(err3).To(Equal(os.ErrNotExist), "Error from deletion of non-existent entry was incorrect")
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Avoids log spam in this expected case.

Calling code was already expecting the new error.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, fix spurious "Failed to run bpftool" logs.
```
