### PR TITLE
BPF: VXLAN tunnel source/dest policing

### DIFF
--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -381,7 +381,7 @@ struct calico_ct_result {
 	__u16 flags;
 	__be32 nat_ip;
 	__u32 nat_port;
-	__be32 tun_ret_ip;
+	__be32 tun_ip;
 };
 
 /* skb_is_icmp_err_unpack fills in ctx, but only what needs to be changed. For instance, keeps the
@@ -605,7 +605,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct ct_ctx
 			result.nat_ip = v->nat_rev_key.addr_a;
 			result.nat_port = v->nat_rev_key.port_a;
 		}
-		result.tun_ret_ip = tracking_v->tun_ip;
+		result.tun_ip = tracking_v->tun_ip;
 		CALI_CT_DEBUG("fwd tun_ip:%x\n", be32_to_host(tracking_v->tun_ip));
 		// flags are in the tracking entry
 		result.flags = tracking_v->flags;
@@ -622,9 +622,9 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct ct_ctx
 		}
 
 		if (CALI_F_FROM_HEP && !ct_result_np_node(result) &&
-				result.tun_ret_ip && result.tun_ret_ip != ctx->tun_ip) {
+				result.tun_ip && result.tun_ip != ctx->tun_ip) {
 			CALI_CT_DEBUG("tunnel src changed from %x to %x\n",
-					be32_to_host(result.tun_ret_ip), be32_to_host(ctx->tun_ip));
+					be32_to_host(result.tun_ip), be32_to_host(ctx->tun_ip));
 			ct_result_set_flag(result.rc, CALI_CT_TUN_SRC_CHANGED);
 		}
 
@@ -640,7 +640,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct ct_ctx
 			dst_to_src = &v->a_to_b;
 		}
 
-		result.tun_ret_ip = v->tun_ip;
+		result.tun_ip = v->tun_ip;
 		CALI_CT_DEBUG("tun_ip:%x\n", be32_to_host(v->tun_ip));
 
 		if (ctx->proto == IPPROTO_ICMP || (related && proto_orig == IPPROTO_ICMP)) {

--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -218,15 +218,19 @@ create:
 	ct_value.flags = ctx->flags;
 	CALI_DEBUG("CT-ALL tracking entry flags 0x%x\n", ct_value.flags);
 
-	if (type == CALI_CT_TYPE_NAT_REV && !(ctx->flags & CALI_CT_FLAG_NP_FWD) && ctx->tun_ip) {
-		struct cali_rt *rt = cali_rt_lookup(ctx->tun_ip);
-		if (!rt || !cali_rt_is_host(rt)) {
-			CALI_DEBUG("CT-ALL nat tunnel IP not a host %x\n", be32_to_host(ctx->tun_ip));
-			err = -1;
-			goto out;
+	if (type == CALI_CT_TYPE_NAT_REV && ctx->tun_ip) {
+		if (ctx->flags & CALI_CT_FLAG_NP_FWD) {
+			CALI_DEBUG("CT-ALL nat tunneled to %x\n", be32_to_host(ctx->tun_ip));
+		} else {
+			struct cali_rt *rt = cali_rt_lookup(ctx->tun_ip);
+			if (!rt || !cali_rt_is_host(rt)) {
+				CALI_DEBUG("CT-ALL nat tunnel IP not a host %x\n", be32_to_host(ctx->tun_ip));
+				err = -1;
+				goto out;
+			}
+			CALI_DEBUG("CT-ALL nat tunneled from %x\n", be32_to_host(ctx->tun_ip));
 		}
 		ct_value.tun_ip = ctx->tun_ip;
-		CALI_DEBUG("CT-ALL nat tunneled from %x\n", be32_to_host(ctx->tun_ip));
 	}
 
 	struct calico_ct_leg *src_to_dst, *dst_to_src;

--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -625,8 +625,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct ct_ctx
 			result.rc =	CALI_CT_ESTABLISHED;
 		}
 
-		if (CALI_F_FROM_HEP && !ct_result_np_node(result) &&
-				result.tun_ip && result.tun_ip != ctx->tun_ip) {
+		if (CALI_F_FROM_HEP && ctx->tun_ip && result.tun_ip && result.tun_ip != ctx->tun_ip) {
 			CALI_CT_DEBUG("tunnel src changed from %x to %x\n",
 					be32_to_host(result.tun_ip), be32_to_host(ctx->tun_ip));
 			ct_result_set_flag(result.rc, CALI_CT_TUN_SRC_CHANGED);

--- a/bpf-gpl/jump.h
+++ b/bpf-gpl/jump.h
@@ -27,7 +27,7 @@ struct cali_tc_state {
 	__be32 ip_src;
 	__be32 ip_dst;
 	__be32 post_nat_ip_dst;
-	__be32 nat_tun_src;
+	__be32 tun_ip;
 	__s32 pol_rc;
 	__u16 sport;
 	union

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -533,6 +533,12 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	/* Do conntrack lookup before anything else */
 	state.ct_result = calico_ct_v4_lookup(&ct_lookup_ctx);
 
+	/* check if someone is trying to spoof a tunnel packet */
+	if (CALI_F_FROM_HEP && ct_result_tun_src_changed(state.ct_result.rc)) {
+		CALI_DEBUG("dropping tunnel pkt with changed source node\n");
+		goto deny;
+	}
+
 	if (state.ct_result.flags & CALI_CT_FLAG_NAT_OUT) {
 		state.flags |= CALI_ST_NAT_OUTGOING;
 	}

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -781,7 +781,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 			/* if we do SNAT ... */
 			outer_ip_snat = ct_rc == CALI_CT_ESTABLISHED_SNAT;
 			/* ... there is a return path to the tunnel ... */
-			outer_ip_snat = outer_ip_snat && state->ct_result.tun_ret_ip;
+			outer_ip_snat = outer_ip_snat && state->ct_result.tun_ip;
 			/* ... and should do encap and it is not DSR or it is leaving host
 			 * and either DSR from WEP or originated at host ... */
 			outer_ip_snat = outer_ip_snat &&
@@ -814,7 +814,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 			switch (ct_rc) {
 			case CALI_CT_ESTABLISHED_SNAT:
 				/* handle the DSR case, see CALI_CT_ESTABLISHED_SNAT where nat is done */
-				if (dnat_return_should_encap() && state->ct_result.tun_ret_ip) {
+				if (dnat_return_should_encap() && state->ct_result.tun_ip) {
 					if (CALI_F_DSR) {
 						/* SNAT will be done after routing, when leaving HEP */
 						CALI_DEBUG("DSR enabled, skipping SNAT + encap\n");
@@ -1022,11 +1022,11 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 		 * are, we need to fail anyway.
 		 */
 		if (ct_related && state->ip_proto == IPPROTO_ICMP
-				&& state->ct_result.tun_ret_ip
+				&& state->ct_result.tun_ip
 				&& !CALI_F_DSR) {
 			if (dnat_return_should_encap()) {
 				CALI_DEBUG("Returning related ICMP from workload to tunnel\n");
-				state->ip_dst = state->ct_result.tun_ret_ip;
+				state->ip_dst = state->ct_result.tun_ip;
 				seen_mark = CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP;
 				goto nat_encap;
 			} else if (CALI_F_TO_HEP) {
@@ -1041,7 +1041,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 				 */
 				CALI_DEBUG("Returning related ICMP from host to tunnel\n");
 				state->ip_src = HOST_IP;
-				state->ip_dst = state->ct_result.tun_ret_ip;
+				state->ip_dst = state->ct_result.tun_ip;
 				goto nat_encap;
 			}
 		}
@@ -1055,7 +1055,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 		CALI_DEBUG("CT: SNAT from %x:%d\n",
 				be32_to_host(state->ct_result.nat_ip), state->ct_result.nat_port);
 
-		if (dnat_return_should_encap() && state->ct_result.tun_ret_ip) {
+		if (dnat_return_should_encap() && state->ct_result.tun_ip) {
 			if (CALI_F_DSR) {
 				/* SNAT will be done after routing, when leaving HEP */
 				CALI_DEBUG("DSR enabled, skipping SNAT + encap\n");
@@ -1103,8 +1103,8 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 			goto deny;
 		}
 
-		if (dnat_return_should_encap() && state->ct_result.tun_ret_ip) {
-			state->ip_dst = state->ct_result.tun_ret_ip;
+		if (dnat_return_should_encap() && state->ct_result.tun_ip) {
+			state->ip_dst = state->ct_result.tun_ip;
 			seen_mark = CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP;
 			goto nat_encap;
 		}

--- a/bpf/conntrack/map.go
+++ b/bpf/conntrack/map.go
@@ -129,8 +129,9 @@ const (
 	TypeNATForward
 	TypeNATReverse
 
-	FlagNATOut    uint8 = 0x01
-	FlagNATRwdDsr uint8 = 0x02
+	FlagNATOut    uint8 = (1 << 0)
+	FlagNATFwdDsr uint8 = (1 << 1)
+	FlagNATNPFwd  uint8 = (1 << 2)
 )
 
 func (e Value) ReverseNATKey() Key {
@@ -241,7 +242,7 @@ func (e Value) String() string {
 			flagsStr += " nat-out"
 		}
 
-		if flags&FlagNATRwdDsr != 0 {
+		if flags&FlagNATFwdDsr != 0 {
 			flagsStr += " fwd-dsr"
 		}
 	}
@@ -262,7 +263,7 @@ func (e Value) String() string {
 }
 
 func (e Value) IsForwardDSR() bool {
-	return e.Flags()&FlagNATRwdDsr != 0
+	return e.Flags()&FlagNATFwdDsr != 0
 }
 
 var MapParams = bpf.MapParameters{

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -69,6 +69,15 @@ var (
 	node1ip           = net.IPv4(10, 10, 0, 1).To4()
 	node1ip2          = net.IPv4(10, 10, 2, 1).To4()
 	node2ip           = net.IPv4(10, 10, 0, 2).To4()
+
+	node1CIDR = net.IPNet{
+		IP:   node1ip,
+		Mask: net.IPv4Mask(255, 255, 255, 255),
+	}
+	node2CIDR = net.IPNet{
+		IP:   node2ip,
+		Mask: net.IPv4Mask(255, 255, 255, 255),
+	}
 )
 
 // Globals that we use to configure the next test run.

--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -312,6 +312,16 @@ func TestNATNodePort(t *testing.T) {
 		routes.NewValueWithNextHop(routes.FlagsRemoteWorkload, ip.FromNetIP(node2ip).(ip.V4Addr)).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node1CIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsLocalHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node2CIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsRemoteHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
 	dumpRTMap(rtMap)
 
 	vni := uint32(0)
@@ -388,13 +398,14 @@ func TestNATNodePort(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// we must know that the encaped packet src ip if from a known host
-	node1CIDR := net.IPNet{
-		IP:   node1ip,
-		Mask: net.IPv4Mask(255, 255, 255, 255),
-	}
 	err = rtMap.Update(
 		routes.NewKey(ip.CIDRFromIPNet(&node1CIDR).(ip.V4CIDR)).AsBytes(),
 		routes.NewValue(routes.FlagsRemoteHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node2CIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsLocalHost).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -628,6 +639,24 @@ func TestNATNodePort(t *testing.T) {
 	})
 
 	dumpCTMap(ctMap)
+
+	// Another pkt arriving at node 1 - uses existing CT entries
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv4L := pktR.Layer(layers.LayerTypeIPv4)
+		Expect(ipv4L).NotTo(BeNil())
+		ipv4R := ipv4L.(*layers.IPv4)
+		Expect(ipv4R.SrcIP.String()).To(Equal(hostIP.String()))
+		Expect(ipv4R.DstIP.String()).To(Equal(node2ip.String()))
+
+		checkVxlanEncap(pktR, false, ipv4, udp, payload)
+	})
 
 	/*
 	 * TEST that unknown VNI is passed through
@@ -1284,6 +1313,9 @@ func TestNATAffinity(t *testing.T) {
 func TestNATNodePortIngressDSR(t *testing.T) {
 	RegisterTestingT(t)
 
+	bpfIfaceName = "DSR1"
+	defer func() { bpfIfaceName = "" }()
+
 	_, ipv4, l4, payload, pktBytes, err := testPacketUDPDefault()
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
@@ -1362,5 +1394,5 @@ func TestNATNodePortIngressDSR(t *testing.T) {
 	v, ok := ct[conntrack.NewKey(uint8(ipv4.Protocol), ipv4.SrcIP, uint16(udp.SrcPort), natIP.To4(), natPort)]
 	Expect(ok).To(BeTrue())
 	Expect(v.Type()).To(Equal(conntrack.TypeNATReverse))
-	Expect(v.Flags()).To(Equal(conntrack.FlagNATRwdDsr))
+	Expect(v.Flags()).To(Equal(conntrack.FlagNATFwdDsr | conntrack.FlagNATNPFwd))
 }

--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -607,6 +607,15 @@ func TestNATNodePort(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
+	// try a spoofed tunnel packet returnign back, should be dropped and have no effect
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		// modify the only known good src IP, we do not care about csums at this point
+		encapedPkt[26] = 235
+		res, err := bpfrun(encapedPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
 	skbMark = 0xca100000 | 0x30000 // CALI_SKB_MARK_BYPASS_FWD
 
 	// Response leaving to original source

--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -386,6 +386,18 @@ func TestNATNodePort(t *testing.T) {
 		routes.NewValue(routes.FlagsLocalWorkload).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
+
+	// we must know that the encaped packet src ip if from a known host
+	node1CIDR := net.IPNet{
+		IP:   node1ip,
+		Mask: net.IPv4Mask(255, 255, 255, 255),
+	}
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node1CIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsRemoteHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
 	dumpRTMap(rtMap)
 
 	// now we are at the node with local workload

--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -454,6 +454,15 @@ func TestNATNodePort(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
+	// try a spoofed tunnel packet, should be dropped and have no effect
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		// modify the only known good src IP, we do not care about csums at this point
+		encapedPkt[26] = 234
+		res, err := bpfrun(encapedPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
 	hostIP = net.IPv4(0, 0, 0, 0) // workloads do not have it set
 
 	skbMark = 0xca100000 // CALI_SKB_MARK_SEEN


### PR DESCRIPTION
## Description

    bpf: check source of tunnel pkts on both nodes
    
    Since we also record the next hop node when we first receive the
    nodeport packet, we can also change if we receive the packets from the
    same node back.

    bpf: no RP lookup for conntracked nodeport tunnel
    
    We remember the destination node when we first create the conntrack
    entry and we use the recorded destination node when we do consequent
    conntrack lookups.

    bpf rename calico_ct_result->tun_ret_ip to tun_ip

    bpf: rename ct_ctx->nat_tun_src to tun_ip
    
    the same for state

    bpf: store tunnel dest in conntrack

    bpf: check source of tunnel pkts on dest node
    
    The source node IP gets recorded when we first approve it and when we
    first create a conntrack record. If the source node IP changed, we drop
    such packets unless we are able to confirm that the node IP changed but
    the node is the same. We cannot do that atm.

    bpf: do not accept tunnel from non-node src IP
    
    Prevent accepting decaped packet if sent from a src IP that is not a
    known node IP. We fail to create the necessary conntrack entry and that
    drop the packet.
    
    We defer the check to conntrack creation as if done earlier, we would
    need to do a routing lookup for every packet.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
