### PR TITLE
Examine the local routing table instead of link addresses

### DIFF
--- a/dataplane/external/ext_dataplane.go
+++ b/dataplane/external/ext_dataplane.go
@@ -124,7 +124,7 @@ func (c *extDataplaneConn) RecvMessage() (msg interface{}, err error) {
 		msg = payload.HostEndpointStatusRemove
 	case *proto.FromDataplane_WireguardStatusUpdate:
 		msg = payload.WireguardStatusUpdate
-		
+
 	default:
 		log.WithField("payload", payload).Warn("Ignoring unknown message from dataplane")
 	}

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -1664,12 +1664,12 @@ func dumpBPFMap(felix *infrastructure.Felix, m bpf.Map, iter bpf.MapIter) {
 		return felix.FileExists(m.Path())
 	}).Should(BeTrue(), fmt.Sprintf("dumpBPFMap: map %s didn't show up inside container", m.Path()))
 	cmd, err := bpf.DumpMapCmd(m)
-	Expect(err).NotTo(HaveOccurred(), "Failed to get BPF map dump command: " + m.Path())
+	Expect(err).NotTo(HaveOccurred(), "Failed to get BPF map dump command: "+m.Path())
 	log.WithField("cmd", cmd).Debug("dumpBPFMap")
 	out, err := felix.ExecOutput(cmd...)
-	Expect(err).NotTo(HaveOccurred(), "Failed to get dump BPF map: " + m.Path())
+	Expect(err).NotTo(HaveOccurred(), "Failed to get dump BPF map: "+m.Path())
 	err = bpf.IterMapCmdOutput([]byte(out), iter)
-	Expect(err).NotTo(HaveOccurred(), "Failed to parse BPF map dump: " + m.Path())
+	Expect(err).NotTo(HaveOccurred(), "Failed to parse BPF map dump: "+m.Path())
 }
 
 func dumpNATMap(felix *infrastructure.Felix) nat.MapMem {

--- a/ifacemonitor/ifacemonitor_test.go
+++ b/ifacemonitor/ifacemonitor_test.go
@@ -27,8 +27,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
-	"github.com/projectcalico/felix/ifacemonitor"
 	"github.com/projectcalico/libcalico-go/lib/set"
+
+	"github.com/projectcalico/felix/ifacemonitor"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -42,7 +43,7 @@ type linkModel struct {
 
 type netlinkTest struct {
 	linkUpdates    chan netlink.LinkUpdate
-	addrUpdates    chan netlink.AddrUpdate
+	routeUpdates   chan netlink.RouteUpdate
 	userSubscribed chan int
 
 	nextIndex int
@@ -198,25 +199,32 @@ func (nl *netlinkTest) signalAddr(name string, addr string, exists bool) {
 		panic("Address parsing failed")
 	}
 	nl.linksMutex.Lock()
-	update := netlink.AddrUpdate{
-		LinkIndex:   nl.links[name].index,
-		NewAddr:     exists,
-		LinkAddress: *net,
+
+	routeUpd := netlink.RouteUpdate{}
+	routeUpd.Dst = net
+	routeUpd.Route.Type = unix.RTN_LOCAL
+	routeUpd.Table = unix.RT_TABLE_LOCAL
+	routeUpd.LinkIndex = nl.links[name].index
+	if exists {
+		routeUpd.Type = unix.RTM_NEWROUTE
+	} else {
+		routeUpd.Type = unix.RTM_DELROUTE
 	}
+
 	nl.linksMutex.Unlock()
 
 	// Send it.
 	log.WithField("channel", nl.linkUpdates).Info("Test code signaling an addr update")
-	nl.addrUpdates <- update
+	nl.routeUpdates <- routeUpd
 	log.Info("Test code signaled an addr update")
 }
 
 func (nl *netlinkTest) Subscribe(
 	linkUpdates chan netlink.LinkUpdate,
-	addrUpdates chan netlink.AddrUpdate,
+	routeUpdates chan netlink.RouteUpdate,
 ) error {
 	nl.linkUpdates = linkUpdates
-	nl.addrUpdates = addrUpdates
+	nl.routeUpdates = routeUpdates
 	nl.userSubscribed <- 1
 	return nil
 }
@@ -239,6 +247,40 @@ func (nl *netlinkTest) LinkList() ([]netlink.Link, error) {
 	}
 	nl.linksMutex.Unlock()
 	return links, nil
+}
+
+func (nl *netlinkTest) ListLocalRoutes(link netlink.Link, family int) ([]netlink.Route, error) {
+	name := link.Attrs().Name
+	nl.linksMutex.Lock()
+	defer nl.linksMutex.Unlock()
+	model, prs := nl.links[name]
+	var routes []netlink.Route
+	if prs {
+		model.addrs.Iter(func(item interface{}) error {
+			addr := item.(string)
+			net, err := netlink.ParseIPNet(addr)
+			if err != nil {
+				panic("Address parsing failed")
+			}
+			if strings.ContainsRune(addr, ':') {
+				if family == netlink.FAMILY_V6 {
+					routes = append(routes, netlink.Route{
+						Type: unix.RTN_LOCAL,
+						Dst:  net,
+					})
+				}
+			} else {
+				if family == netlink.FAMILY_V4 {
+					routes = append(routes, netlink.Route{
+						Type: unix.RTN_LOCAL,
+						Dst:  net,
+					})
+				}
+			}
+			return nil
+		})
+	}
+	return routes, nil
 }
 
 func (nl *netlinkTest) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
@@ -323,18 +365,21 @@ func (dp *mockDataplane) expectAddrStateCb(ifaceName string, addr string, presen
 		"ifaceName": cbIface.ifaceName,
 		"addrs":     cbIface.addrs,
 	}).Debug("Mock dp got addr cb")
-	Expect(cbIface.ifaceName).To(Equal(ifaceName))
+	ExpectWithOffset(1, cbIface.ifaceName).To(Equal(ifaceName),
+		"Got update for unexpected interface name")
 	if (addr == "") && (!present) {
 		// Expected to get a nil addrs.
-		Expect(cbIface.addrs).To(BeNil())
+		ExpectWithOffset(1, cbIface.addrs).To(BeNil(), "Expected no addresses")
 	}
 	if (addr != "") && (!present) && cbIface.addrs != nil {
 		// Expected addr to be missing
-		Expect(cbIface.addrs.Contains(addr)).To(BeFalse())
+		ExpectWithOffset(1, cbIface.addrs.Contains(addr)).To(BeFalse(),
+			fmt.Sprintf("Expected %v not to contain %v", cbIface.addrs, addr))
 	}
 	if (addr != "") && present {
 		// Expected addr to be present
-		Expect(cbIface.addrs.Contains(addr)).To(BeTrue())
+		ExpectWithOffset(1, cbIface.addrs.Contains(addr)).To(BeTrue(),
+			fmt.Sprintf("Expected %v to contain %v", cbIface.addrs, addr))
 	}
 }
 

--- a/ifacemonitor/update_filter.go
+++ b/ifacemonitor/update_filter.go
@@ -20,7 +20,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -101,7 +100,7 @@ mainLoop:
 					Update:  linkUpd,
 				})
 		case routeUpd := <-routeInC:
-			logrus.WithField("route", spew.Sdump(routeUpd)).Debug("Route update")
+			logrus.WithField("route", routeUpd).Debug("Route update")
 			if routeUpd.Route.Type&unix.RTN_LOCAL == 0 {
 				logrus.WithField("route", routeUpd).Debug("Ignoring non-local route.")
 				continue


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

This makes Felix aware of local IPs that are only programmed into the local routing table but not actually programmed as an address on an interface.  This is an unusual corner case but there's at least one cloud (GCP) that programs additional local IPs into the local routing table.  In GCP's case this happens when you point a load balancer at the node.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix now derives its list of interface addresses from the local routing table instead of the interface address list.  This picks up IPs that have been added only to the local routing table, such as load balancer external IPs in GCE.
```
