### PR TITLE
Avoid programming every policy to every iptables table.

### DIFF
--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -346,14 +346,14 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	}
 
 	mangleTableV4 := iptables.NewTable(
-		"mangle",
+		iptables.TableMangle,
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
 		featureDetector,
 		iptablesOptions)
 	natTableV4 := iptables.NewTable(
-		"nat",
+		iptables.TableNAT,
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
@@ -361,14 +361,14 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		iptablesNATOptions,
 	)
 	rawTableV4 := iptables.NewTable(
-		"raw",
+		iptables.TableRaw,
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
 		featureDetector,
 		iptablesOptions)
 	filterTableV4 := iptables.NewTable(
-		"filter",
+		iptables.TableFilter,
 		4,
 		rules.RuleHashPrefix,
 		iptablesLock,
@@ -620,7 +620,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 
 	if config.IPv6Enabled {
 		mangleTableV6 := iptables.NewTable(
-			"mangle",
+			iptables.TableMangle,
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,
@@ -628,7 +628,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			iptablesOptions,
 		)
 		natTableV6 := iptables.NewTable(
-			"nat",
+			iptables.TableNAT,
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,
@@ -636,7 +636,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			iptablesNATOptions,
 		)
 		rawTableV6 := iptables.NewTable(
-			"raw",
+			iptables.TableRaw,
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,
@@ -644,7 +644,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			iptablesOptions,
 		)
 		filterTableV6 := iptables.NewTable(
-			"filter",
+			iptables.TableFilter,
 			6,
 			rules.RuleHashPrefix,
 			iptablesLock,

--- a/dataplane/linux/policy_mgr.go
+++ b/dataplane/linux/policy_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017, 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017, 2019-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,16 +49,30 @@ func (c *policyManagerCallbacks) InvokeRemovePolicy(policyID proto.PolicyID) {
 	c.removePolicy.Invoke(policyID)
 }
 
-// policyManager simply renders policy/profile updates into iptables.Chain objects and sends
-// them to the dataplane layer.
+// policyManager does refcounting per policy and iptables table and programs the policy's chains
+// into the tables where it is referenced by an endpoint.
+//
+// Workload endpoint policy always goes in the filter chain only. Host endpoint policy varies by type.
+// Profiles only go in the filter table so they are passed through without refcounting.
 type policyManager struct {
-	rawTable     iptablesTable
-	mangleTable  iptablesTable
-	filterTable  iptablesTable
+	tables map[iptables.TableName]iptablesTable
+
 	ruleRenderer policyRenderer
 	ipVersion    uint8
 	callbacks    policyManagerCallbacks
+
+	// Caches of endpoints so that we can decref the correct policies when an endpoint is
+	// removed or updated.
+
+	wepsByID map[proto.WorkloadEndpointID]*proto.WorkloadEndpoint
+	hepsByID map[proto.HostEndpointID]*proto.HostEndpoint
+
+	// policyRefCounts stores a map of refcounts per policy.  perTableRefcounts holds a value per table
+	policyRefCounts map[proto.PolicyID]perTableRefcounts
+	policiesByID    map[proto.PolicyID]*proto.Policy
 }
+
+type perTableRefcounts map[iptables.TableName]int
 
 type policyRenderer interface {
 	PolicyToIptablesChains(policyID *proto.PolicyID, policy *proto.Policy, ipVersion uint8) []*iptables.Chain
@@ -67,49 +81,204 @@ type policyRenderer interface {
 
 func newPolicyManager(rawTable, mangleTable, filterTable iptablesTable, ruleRenderer policyRenderer, ipVersion uint8, callbacks *callbacks) *policyManager {
 	return &policyManager{
-		rawTable:     rawTable,
-		mangleTable:  mangleTable,
-		filterTable:  filterTable,
+		tables: map[iptables.TableName]iptablesTable{
+			iptables.TableRaw:    rawTable,
+			iptables.TableMangle: mangleTable,
+			iptables.TableFilter: filterTable,
+		},
 		ruleRenderer: ruleRenderer,
 		ipVersion:    ipVersion,
 		callbacks:    newPolicyManagerCallbacks(callbacks, ipVersion),
+
+		wepsByID: map[proto.WorkloadEndpointID]*proto.WorkloadEndpoint{},
+		hepsByID: map[proto.HostEndpointID]*proto.HostEndpoint{},
+
+		policyRefCounts: map[proto.PolicyID]perTableRefcounts{},
+		policiesByID:    map[proto.PolicyID]*proto.Policy{},
 	}
 }
 
 func (m *policyManager) OnUpdate(msg interface{}) {
 	switch msg := msg.(type) {
+	case *proto.WorkloadEndpointUpdate:
+		m.onWorkloadEndpointUpdate(msg)
+	case *proto.WorkloadEndpointRemove:
+		m.onWorkloadEndpointRemove(msg)
+	case *proto.HostEndpointUpdate:
+		m.onHostEndpointUpdate(msg)
+	case *proto.HostEndpointRemove:
+		m.onHostEndpointRemove(msg)
+
 	case *proto.ActivePolicyUpdate:
-		log.WithField("id", msg.Id).Debug("Updating policy chains")
-		chains := m.ruleRenderer.PolicyToIptablesChains(msg.Id, msg.Policy, m.ipVersion)
-		m.rawTable.UpdateChains(chains)
-		m.mangleTable.UpdateChains(chains)
-		m.filterTable.UpdateChains(chains)
-		m.callbacks.InvokeUpdatePolicy(*msg.Id, msg.Policy)
+		m.onPolicyUpdate(msg)
 	case *proto.ActivePolicyRemove:
-		log.WithField("id", msg.Id).Debug("Removing policy chains")
-		inName := rules.PolicyChainName(rules.PolicyInboundPfx, msg.Id)
-		outName := rules.PolicyChainName(rules.PolicyOutboundPfx, msg.Id)
-		m.filterTable.RemoveChainByName(inName)
-		m.filterTable.RemoveChainByName(outName)
-		m.mangleTable.RemoveChainByName(inName)
-		m.mangleTable.RemoveChainByName(outName)
-		m.rawTable.RemoveChainByName(inName)
-		m.rawTable.RemoveChainByName(outName)
-		m.callbacks.InvokeRemovePolicy(*msg.Id)
+		m.onPolicyRemove(msg)
 	case *proto.ActiveProfileUpdate:
-		log.WithField("id", msg.Id).Debug("Updating profile chains")
-		chains := m.ruleRenderer.ProfileToIptablesChains(msg.Id, msg.Profile, m.ipVersion)
-		m.filterTable.UpdateChains(chains)
+		m.onProfileUpdate(msg)
 	case *proto.ActiveProfileRemove:
-		log.WithField("id", msg.Id).Debug("Removing profile chains")
-		inName := rules.ProfileChainName(rules.ProfileInboundPfx, msg.Id)
-		outName := rules.ProfileChainName(rules.ProfileOutboundPfx, msg.Id)
-		m.filterTable.RemoveChainByName(inName)
-		m.filterTable.RemoveChainByName(outName)
+		m.onProfileRemove(msg)
 	}
+}
+
+func (m *policyManager) onWorkloadEndpointUpdate(msg *proto.WorkloadEndpointUpdate) {
+	id := *msg.Id
+
+	// Incref the new endpoint first, triggering and new policies to be programmed.
+	newWep := msg.Endpoint
+	m.increfTier(newWep.Tiers, iptables.TableFilter) // Workload policy lives only in filter.
+
+	// Decref the old endpoint.  Any policies that are not also in the new wep will
+	// hit 0 and be removed.
+	m.removeWep(id)
+
+	// Store off the new wep.
+	m.wepsByID[id] = newWep
+}
+
+func (m *policyManager) onWorkloadEndpointRemove(msg *proto.WorkloadEndpointRemove) {
+	m.removeWep(*msg.Id)
+}
+
+func (m *policyManager) removeWep(id proto.WorkloadEndpointID) {
+	if oldWep := m.wepsByID[id]; oldWep != nil {
+		tier := oldWep.Tiers
+		m.decrefTier(tier, iptables.TableFilter)
+		delete(m.wepsByID, id)
+	}
+}
+
+func (m *policyManager) onHostEndpointUpdate(msg *proto.HostEndpointUpdate) {
+	id := *msg.Id
+
+	// Incref the new endpoint first, triggering and new policies to be programmed.
+	newHep := msg.Endpoint
+	m.increfTier(newHep.Tiers, iptables.TableFilter)
+	m.increfTier(newHep.ForwardTiers, iptables.TableFilter)
+	m.increfTier(newHep.PreDnatTiers, iptables.TableMangle)
+	m.increfTier(newHep.UntrackedTiers, iptables.TableRaw)
+
+	// Decref the old endpoint.  Any policies that are not also in the new hep will
+	// hit 0 and be removed.
+	m.removeHep(id)
+
+	// Store off the new hep.
+	m.hepsByID[id] = newHep
+}
+
+func (m *policyManager) onHostEndpointRemove(msg *proto.HostEndpointRemove) {
+	m.removeHep(*msg.Id)
+}
+
+func (m *policyManager) removeHep(id proto.HostEndpointID) {
+	if oldHep := m.hepsByID[id]; oldHep != nil {
+		m.decrefTier(oldHep.Tiers, iptables.TableFilter)
+		m.decrefTier(oldHep.ForwardTiers, iptables.TableFilter)
+		m.decrefTier(oldHep.PreDnatTiers, iptables.TableMangle)
+		m.decrefTier(oldHep.UntrackedTiers, iptables.TableRaw)
+
+		delete(m.hepsByID, id)
+	}
+}
+
+func (m *policyManager) onPolicyUpdate(msg *proto.ActivePolicyUpdate) {
+	id := *msg.Id
+	log.WithField("id", id).Debug("Updating policy chains")
+	m.policiesByID[id] = msg.Policy
+	refCounts := m.policyRefCounts[id]
+	for table := range refCounts {
+		m.programPolicy(id, table)
+	}
+	m.callbacks.InvokeUpdatePolicy(id, msg.Policy)
+}
+
+func (m *policyManager) onPolicyRemove(msg *proto.ActivePolicyRemove) {
+	log.WithField("id", msg.Id).Debug("Removing policy chains")
+	id := *msg.Id
+	if _, ok := m.policyRefCounts[id]; ok {
+		log.WithField("id", id).Panic("Policy removed while still referenced")
+	}
+	delete(m.policiesByID, id)
+	m.callbacks.InvokeRemovePolicy(id)
+}
+
+func (m *policyManager) onProfileUpdate(msg *proto.ActiveProfileUpdate) {
+	log.WithField("id", msg.Id).Debug("Updating profile chains")
+	chains := m.ruleRenderer.ProfileToIptablesChains(msg.Id, msg.Profile, m.ipVersion)
+	m.tables[iptables.TableFilter].UpdateChains(chains)
+}
+
+func (m *policyManager) onProfileRemove(msg *proto.ActiveProfileRemove) {
+	log.WithField("id", msg.Id).Debug("Removing profile chains")
+	inName := rules.ProfileChainName(rules.ProfileInboundPfx, msg.Id)
+	outName := rules.ProfileChainName(rules.ProfileOutboundPfx, msg.Id)
+	m.tables[iptables.TableFilter].RemoveChainByName(inName)
+	m.tables[iptables.TableFilter].RemoveChainByName(outName)
 }
 
 func (m *policyManager) CompleteDeferredWork() error {
 	// Nothing to do, we don't defer any work.
 	return nil
+}
+
+func (m *policyManager) programPolicy(id proto.PolicyID, table iptables.TableName) {
+	policy := m.policiesByID[id]
+	chains := m.ruleRenderer.PolicyToIptablesChains(&id, policy, m.ipVersion)
+	m.tables[table].UpdateChains(chains)
+}
+
+func (m *policyManager) removePolicy(id proto.PolicyID, table iptables.TableName) {
+	inName := rules.PolicyChainName(rules.PolicyInboundPfx, &id)
+	outName := rules.PolicyChainName(rules.PolicyOutboundPfx, &id)
+	m.tables[table].RemoveChainByName(inName)
+	m.tables[table].RemoveChainByName(outName)
+}
+
+func (m *policyManager) increfTier(tier []*proto.TierInfo, table iptables.TableName) {
+	if len(tier) > 0 {
+		for _, pols := range [][]string{tier[0].IngressPolicies, tier[0].EgressPolicies} {
+			for _, p := range pols {
+				m.increfPolicy(proto.PolicyID{
+					Tier: tier[0].Name,
+					Name: p,
+				}, table)
+			}
+		}
+	}
+}
+
+func (m *policyManager) decrefTier(tier []*proto.TierInfo, table iptables.TableName) {
+	if len(tier) > 0 {
+		for _, pols := range [][]string{tier[0].IngressPolicies, tier[0].EgressPolicies} {
+			for _, p := range pols {
+				m.decrefPolicy(proto.PolicyID{
+					Tier: tier[0].Name,
+					Name: p,
+				}, table)
+			}
+		}
+	}
+}
+
+func (m *policyManager) increfPolicy(id proto.PolicyID, table iptables.TableName) {
+	refCounts := m.policyRefCounts[id]
+	if refCounts == nil {
+		refCounts = make(perTableRefcounts)
+	}
+	if refCounts[table] == 0 {
+		m.programPolicy(id, table)
+	}
+	refCounts[table]++
+	m.policyRefCounts[id] = refCounts
+}
+
+func (m *policyManager) decrefPolicy(id proto.PolicyID, table iptables.TableName) {
+	refCounts := m.policyRefCounts[id]
+	refCounts[table]--
+	if refCounts[table] == 0 {
+		m.removePolicy(id, table)
+		delete(refCounts, table)
+	}
+	if len(refCounts) == 0 {
+		delete(m.policyRefCounts, id)
+	}
 }

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -1664,12 +1664,12 @@ func dumpBPFMap(felix *infrastructure.Felix, m bpf.Map, iter bpf.MapIter) {
 		return felix.FileExists(m.Path())
 	}).Should(BeTrue(), fmt.Sprintf("dumpBPFMap: map %s didn't show up inside container", m.Path()))
 	cmd, err := bpf.DumpMapCmd(m)
-	Expect(err).NotTo(HaveOccurred(), "Failed to get BPF map dump command: " + m.Path())
+	Expect(err).NotTo(HaveOccurred(), "Failed to get BPF map dump command: "+m.Path())
 	log.WithField("cmd", cmd).Debug("dumpBPFMap")
 	out, err := felix.ExecOutput(cmd...)
-	Expect(err).NotTo(HaveOccurred(), "Failed to get dump BPF map: " + m.Path())
+	Expect(err).NotTo(HaveOccurred(), "Failed to get dump BPF map: "+m.Path())
 	err = bpf.IterMapCmdOutput([]byte(out), iter)
-	Expect(err).NotTo(HaveOccurred(), "Failed to parse BPF map dump: " + m.Path())
+	Expect(err).NotTo(HaveOccurred(), "Failed to parse BPF map dump: "+m.Path())
 }
 
 func dumpNATMap(felix *infrastructure.Felix) nat.MapMem {

--- a/iptables/restore_buffer.go
+++ b/iptables/restore_buffer.go
@@ -39,7 +39,7 @@ import (
 // and EndTransaction() calls.
 type RestoreInputBuilder struct {
 	buf              bytes.Buffer
-	currentTableName string
+	currentTableName TableName
 	txnOpenerWritten bool
 	NumLinesWritten  counter
 }
@@ -58,7 +58,7 @@ func (b *RestoreInputBuilder) Reset() {
 
 // StartTransaction opens a new transaction context for the named table.
 // Panics if there is already a transaction in progress.
-func (b *RestoreInputBuilder) StartTransaction(tableName string) {
+func (b *RestoreInputBuilder) StartTransaction(tableName TableName) {
 	if b.currentTableName != "" {
 		log.Panic("StartTransaction() called without ending previous transaction.")
 	}

--- a/iptables/rules_test.go
+++ b/iptables/rules_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ var _ = Describe("Hash extraction tests", func() {
 			return NewRealCmd("echo", "iptables v1.4.7")
 		}
 		table = NewTable(
-			"filter",
+			TableFilter,
 			4,
 			"cali:",
 			&sync.Mutex{},

--- a/iptables/table_test.go
+++ b/iptables/table_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ var _ = Describe("Table with an empty dataplane (legacy)", func() {
 		featureDetector.NewCmd = dataplane.newCmd
 		featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 		table := NewTable(
-			"filter",
+			TableFilter,
 			4,
 			rules.RuleHashPrefix,
 			iptLock,
@@ -86,7 +86,7 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 		featureDetector.NewCmd = dataplane.newCmd
 		featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 		table = NewTable(
-			"filter",
+			TableFilter,
 			4,
 			rules.RuleHashPrefix,
 			iptLock,
@@ -160,7 +160,7 @@ func describeEmptyDataplaneTests(dataplaneMode string) {
 	It("should police the insert mode", func() {
 		Expect(func() {
 			NewTable(
-				"filter",
+				TableFilter,
 				4,
 				rules.RuleHashPrefix,
 				&mockMutex{},
@@ -727,7 +727,7 @@ func describePostUpdateCheckTests(enableRefresh bool, dataplaneMode string) {
 		featureDetector.NewCmd = dataplane.newCmd
 		featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 		table = NewTable(
-			"filter",
+			TableFilter,
 			4,
 			rules.RuleHashPrefix,
 			&mockMutex{},
@@ -930,7 +930,7 @@ func describeDirtyDataplaneTests(appendMode bool, dataplaneMode string) {
 		featureDetector.NewCmd = dataplane.newCmd
 		featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 		table = NewTable(
-			"filter",
+			TableFilter,
 			4,
 			rules.RuleHashPrefix,
 			&mockMutex{},
@@ -1327,7 +1327,7 @@ func describeInsertAndNonCalicoChainTests(dataplaneMode string) {
 		featureDetector.NewCmd = dataplane.newCmd
 		featureDetector.GetKernelVersionReader = dataplane.getKernelVersionReader
 		table = NewTable(
-			"filter",
+			TableFilter,
 			6,
 			rules.RuleHashPrefix,
 			iptLock,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Reduces the amount of time spent in iptables by a factor of 3 when updating policies since, in practice each policy can only ever be in one table at a time.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In iptables mode, Felix now programs policy only to those iptables tables where it is needed.  This can give a 3x reduction in dataplane apply times with lots of policies in use.
```
