### PR TITLE
Only program iptables chains that are referenced.

### DIFF
--- a/dataplane/linux/policy_mgr.go
+++ b/dataplane/linux/policy_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017, 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017, 2019-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,6 +81,9 @@ func (m *policyManager) OnUpdate(msg interface{}) {
 	case *proto.ActivePolicyUpdate:
 		log.WithField("id", msg.Id).Debug("Updating policy chains")
 		chains := m.ruleRenderer.PolicyToIptablesChains(msg.Id, msg.Policy, m.ipVersion)
+		// We can't easily tell whether the policy is in use in a particular table, and, if the policy
+		// type gets changed it may move between tables.  Hence, we put the policy into all tables.
+		// The iptables layer will avoid programming it if it is not actually used.
 		m.rawTable.UpdateChains(chains)
 		m.mangleTable.UpdateChains(chains)
 		m.filterTable.UpdateChains(chains)
@@ -89,6 +92,7 @@ func (m *policyManager) OnUpdate(msg interface{}) {
 		log.WithField("id", msg.Id).Debug("Removing policy chains")
 		inName := rules.PolicyChainName(rules.PolicyInboundPfx, msg.Id)
 		outName := rules.PolicyChainName(rules.PolicyOutboundPfx, msg.Id)
+		// As above, we need to clean up in all the tables.
 		m.filterTable.RemoveChainByName(inName)
 		m.filterTable.RemoveChainByName(outName)
 		m.mangleTable.RemoveChainByName(inName)

--- a/iptables/actions.go
+++ b/iptables/actions.go
@@ -21,7 +21,7 @@ type Action interface {
 }
 
 type Referrer interface {
-	ReferredToChain() string
+	ReferencedChain() string
 }
 
 type GotoAction struct {
@@ -37,11 +37,11 @@ func (g GotoAction) String() string {
 	return "Goto->" + g.Target
 }
 
-func (g GotoAction) ReferredToChain() string {
+func (g GotoAction) ReferencedChain() string {
 	return g.Target
 }
 
-var _ Referrer = (*GotoAction)(nil)
+var _ Referrer = GotoAction{}
 
 type JumpAction struct {
 	Target   string
@@ -56,11 +56,11 @@ func (g JumpAction) String() string {
 	return "Jump->" + g.Target
 }
 
-func (g JumpAction) ReferredToChain() string {
+func (g JumpAction) ReferencedChain() string {
 	return g.Target
 }
 
-var _ Referrer = (*JumpAction)(nil)
+var _ Referrer = JumpAction{}
 
 type ReturnAction struct {
 	TypeReturn struct{}

--- a/iptables/actions.go
+++ b/iptables/actions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018,2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,10 @@ type Action interface {
 	ToFragment(features *Features) string
 }
 
+type Referrer interface {
+	ReferredToChain() string
+}
+
 type GotoAction struct {
 	Target   string
 	TypeGoto struct{}
@@ -33,6 +37,12 @@ func (g GotoAction) String() string {
 	return "Goto->" + g.Target
 }
 
+func (g GotoAction) ReferredToChain() string {
+	return g.Target
+}
+
+var _ Referrer = (*GotoAction)(nil)
+
 type JumpAction struct {
 	Target   string
 	TypeJump struct{}
@@ -45,6 +55,12 @@ func (g JumpAction) ToFragment(features *Features) string {
 func (g JumpAction) String() string {
 	return "Jump->" + g.Target
 }
+
+func (g JumpAction) ReferredToChain() string {
+	return g.Target
+}
+
+var _ Referrer = (*JumpAction)(nil)
 
 type ReturnAction struct {
 	TypeReturn struct{}

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -197,7 +197,7 @@ type Table struct {
 	// as needed).
 	chainNameToChain map[string]*Chain
 	// chainRefCounts counts the number of chains that refer to a given chain.  Transitive
-	// reachabilty isn't tracked but testing whether a chain is referenced does allow us to
+	// reachability isn't tracked but testing whether a chain is referenced does allow us to
 	// avoid programming unreferenced leaf chains (for example, policies that aren't used in
 	// this table).
 	chainRefCounts map[string]int
@@ -518,7 +518,7 @@ func (t *Table) RemoveChainByName(name string) {
 func (t *Table) increfReferredChains(rules []Rule) {
 	for _, r := range rules {
 		if ref, ok := r.Action.(Referrer); ok {
-			t.increfChain(ref.ReferredToChain())
+			t.increfChain(ref.ReferencedChain())
 		}
 	}
 }
@@ -528,7 +528,7 @@ func (t *Table) increfReferredChains(rules []Rule) {
 func (t *Table) decrefReferredChains(rules []Rule) {
 	for _, r := range rules {
 		if ref, ok := r.Action.(Referrer); ok {
-			t.decrefChain(ref.ReferredToChain())
+			t.decrefChain(ref.ReferencedChain())
 		}
 	}
 }

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -196,7 +196,12 @@ type Table struct {
 	// "--match foo --jump DROP" (i.e. omitting the action and chain name, which are calculated
 	// as needed).
 	chainNameToChain map[string]*Chain
-	dirtyChains      set.Set
+	// chainRefCounts counts the number of chains that refer to a given chain.  Transitive
+	// reachabilty isn't tracked but testing whether a chain is referenced does allow us to
+	// avoid programming unreferenced leaf chains (for example, policies that aren't used in
+	// this table).
+	chainRefCounts map[string]int
+	dirtyChains    set.Set
 
 	inSyncWithDataPlane bool
 
@@ -321,9 +326,12 @@ func NewTable(
 	// clean up any chains that we hooked on a previous run.
 	inserts := map[string][]Rule{}
 	dirtyInserts := set.New()
+	refcounts := map[string]int{}
 	for _, kernelChain := range tableToKernelChains[name] {
 		inserts[kernelChain] = []Rule{}
 		dirtyInserts.Add(kernelChain)
+		// Kernel chains are referred to by definition.
+		refcounts[kernelChain] += 1
 	}
 
 	var insertMode string
@@ -369,6 +377,7 @@ func NewTable(
 		chainToInsertedRules:   inserts,
 		dirtyInserts:           dirtyInserts,
 		chainNameToChain:       map[string]*Chain{},
+		chainRefCounts:         refcounts,
 		dirtyChains:            set.New(),
 		chainToDataplaneHashes: map[string][]string{},
 		chainToFullRules:       map[string][]string{},
@@ -437,6 +446,11 @@ func (t *Table) SetRuleInsertions(chainName string, rules []Rule) {
 	t.gaugeNumRules.Add(float64(numRulesDelta))
 	t.dirtyInserts.Add(chainName)
 
+	// Incref any newly-referenced chains, then decref the old ones.  By incrementing first we
+	// avoid marking a still-referenced chain as dirty.
+	t.increfReferredChains(rules)
+	t.decrefReferredChains(oldRules)
+
 	// Defensive: make sure we re-read the dataplane state before we make updates.  While the
 	// code was originally designed not to need this, we found that other users of
 	// iptables-restore can still clobber out updates so it's safest to re-read the state before
@@ -453,13 +467,20 @@ func (t *Table) UpdateChains(chains []*Chain) {
 func (t *Table) UpdateChain(chain *Chain) {
 	t.logCxt.WithField("chainName", chain.Name).Info("Queueing update of chain.")
 	oldNumRules := 0
+
+	// Incref any newly-referenced chains, then decref the old ones.  By incrementing first we
+	// avoid marking a still-referenced chain as dirty.
+	t.increfReferredChains(chain.Rules)
 	if oldChain := t.chainNameToChain[chain.Name]; oldChain != nil {
 		oldNumRules = len(oldChain.Rules)
+		t.decrefReferredChains(oldChain.Rules)
 	}
 	t.chainNameToChain[chain.Name] = chain
 	numRulesDelta := len(chain.Rules) - oldNumRules
 	t.gaugeNumRules.Add(float64(numRulesDelta))
-	t.dirtyChains.Add(chain.Name)
+	if t.chainRefCounts[chain.Name] > 0 {
+		t.dirtyChains.Add(chain.Name)
+	}
 
 	// Defensive: make sure we re-read the dataplane state before we make updates.  While the
 	// code was originally designed not to need this, we found that other users of
@@ -475,11 +496,14 @@ func (t *Table) RemoveChains(chains []*Chain) {
 }
 
 func (t *Table) RemoveChainByName(name string) {
-	t.logCxt.WithField("chainName", name).Info("Queing deletion of chain.")
+	t.logCxt.WithField("chainName", name).Info("Queuing deletion of chain.")
 	if oldChain, known := t.chainNameToChain[name]; known {
 		t.gaugeNumRules.Sub(float64(len(oldChain.Rules)))
 		delete(t.chainNameToChain, name)
-		t.dirtyChains.Add(name)
+		if t.chainRefCounts[name] > 0 {
+			t.dirtyChains.Add(name)
+		}
+		t.decrefReferredChains(oldChain.Rules)
 	}
 
 	// Defensive: make sure we re-read the dataplane state before we make updates.  While the
@@ -487,6 +511,49 @@ func (t *Table) RemoveChainByName(name string) {
 	// iptables-restore can still clobber out updates so it's safest to re-read the state before
 	// each write.
 	t.InvalidateDataplaneCache("chain removal")
+}
+
+// increfReferredChains finds all the chains that the given rules refer to  (i.e. have jumps/gotos to) and
+// increments their refcount.
+func (t *Table) increfReferredChains(rules []Rule) {
+	for _, r := range rules {
+		if ref, ok := r.Action.(Referrer); ok {
+			t.increfChain(ref.ReferredToChain())
+		}
+	}
+}
+
+// decrefReferredChains finds all the chains that the given rules refer to (i.e. have jumps/gotos to) and
+// decrements their refcount.
+func (t *Table) decrefReferredChains(rules []Rule) {
+	for _, r := range rules {
+		if ref, ok := r.Action.(Referrer); ok {
+			t.decrefChain(ref.ReferredToChain())
+		}
+	}
+}
+
+// increfChain increments the refcount of the given chain; if the refcount transitions from 0,
+// marks the chain dirty so it will be programmed.
+func (t *Table) increfChain(chainName string) {
+	log.WithField("chainName", chainName).Debug("Incref chain")
+	t.chainRefCounts[chainName] += 1
+	if t.chainRefCounts[chainName] == 1 {
+		log.WithField("chainName", chainName).Info("Chain became referenced, marking it for programming")
+		t.dirtyChains.Add(chainName)
+	}
+}
+
+// decrefChain decrements the refcount of the given chain; if the refcount transitions to 0,
+// marks the chain dirty so it will be cleaned up.
+func (t *Table) decrefChain(chainName string) {
+	log.WithField("chainName", chainName).Debug("Decref chain")
+	t.chainRefCounts[chainName] -= 1
+	if t.chainRefCounts[chainName] == 0 {
+		log.WithField("chainName", chainName).Info("Chain no longer referenced, marking it for removal")
+		delete(t.chainRefCounts, chainName)
+		t.dirtyChains.Add(chainName)
+	}
 }
 
 func (t *Table) loadDataplaneState() {
@@ -886,7 +953,7 @@ func (t *Table) Apply() (rescheduleAfter time.Duration) {
 		break
 	}
 
-	t.gaugeNumChains.Set(float64(len(t.chainNameToChain)))
+	t.gaugeNumChains.Set(float64(len(t.chainRefCounts)))
 
 	// Check whether we need to be rescheduled and how soon.
 	if t.refreshInterval > 0 {
@@ -927,7 +994,7 @@ func (t *Table) applyUpdates() error {
 			// iptables-nft-restore <v1.8.3 has a bug (https://bugzilla.netfilter.org/show_bug.cgi?id=1348)
 			// where only the first replace command sets the rule index.  Work around that by refreshing the
 			// whole chain using a flush.
-			chain := t.chainNameToChain[chainName]
+			chain, _ := t.desiredStateOfChain(chainName)
 			currentHashes := chain.RuleHashes(features)
 			previousHashes := t.chainToDataplaneHashes[chainName]
 			t.logCxt.WithFields(log.Fields{
@@ -940,7 +1007,7 @@ func (t *Table) applyUpdates() error {
 				return set.RemoveItem
 			}
 			chainNeedsToBeFlushed = true
-		} else if _, ok := t.chainNameToChain[chainName]; !ok {
+		} else if _, present := t.desiredStateOfChain(chainName); !present {
 			// About to delete this chain, flush it first to sever dependencies.
 			chainNeedsToBeFlushed = true
 		} else if _, ok := t.chainToDataplaneHashes[chainName]; !ok {
@@ -957,7 +1024,7 @@ func (t *Table) applyUpdates() error {
 	newHashes := map[string][]string{}
 	t.dirtyChains.Iter(func(item interface{}) error {
 		chainName := item.(string)
-		if chain, ok := t.chainNameToChain[chainName]; ok {
+		if chain, ok := t.desiredStateOfChain(chainName); ok {
 			// Chain update or creation.  Scan the chain against its previous hashes
 			// and replace/append/delete as appropriate.
 			var previousHashes []string
@@ -1087,7 +1154,7 @@ func (t *Table) applyUpdates() error {
 
 		t.dirtyChains.Iter(func(item interface{}) error {
 			chainName := item.(string)
-			if _, ok := t.chainNameToChain[chainName]; !ok {
+			if _, ok := t.desiredStateOfChain(chainName); !ok {
 				// Chain deletion
 				buf.WriteForwardReference(chainName)
 			}
@@ -1102,7 +1169,7 @@ func (t *Table) applyUpdates() error {
 	// references.
 	t.dirtyChains.Iter(func(item interface{}) error {
 		chainName := item.(string)
-		if _, ok := t.chainNameToChain[chainName]; !ok {
+		if _, ok := t.desiredStateOfChain(chainName); !ok {
 			// Chain deletion
 			buf.WriteLine(fmt.Sprintf("--delete-chain %s", chainName))
 			newHashes[chainName] = nil
@@ -1195,6 +1262,16 @@ func (t *Table) applyUpdates() error {
 	t.chainToFullRules = newChainToFullRules
 
 	return nil
+}
+
+// desiredStateOfChain returns the given chain, if and only if it exists in the cache and it is referenced by some
+// other chain.  If the chain doesn't exist or it is not referenced, returns nil and false.
+func (t *Table) desiredStateOfChain(chainName string) (chain *Chain, present bool) {
+	if t.chainRefCounts[chainName] == 0 {
+		return
+	}
+	chain, present = t.chainNameToChain[chainName]
+	return
 }
 
 func (t *Table) commentFrag(hash string) string {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
This avoids programming policy chains that are not in use in the particular table. Should significantly reduce iptables use and contention when updating large policies.

When Felix was first designed we were able to run itpables-restore in parallel to mitigate the slowness of programming policies multiple times.  However, the ability to run in parallel was removed once iptables-restore adopted the xtables lock with no way to disable it.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix now only programs policies into the iptables tables where they are in use.  This significantly reduces iptables use and contention when updating policies on a system with lots of iptables rules.
```
