### PR TITLE
bpf: EndpointSlices support for kube-proxy

### DIFF
--- a/bpf/proxy/options.go
+++ b/bpf/proxy/options.go
@@ -50,3 +50,12 @@ func WithMinSyncPeriod(min time.Duration) Option {
 func WithImmediateSync() Option {
 	return WithMinSyncPeriod(0)
 }
+
+// WithEndpointsSlices enables using EndpointSlices
+func WithEndpointsSlices() Option {
+	return makeOption(func(p *proxy) error {
+		p.endpointSlicesEnabled = true
+		log.Infof("proxy.WithEndpointsSlices()")
+		return nil
+	})
+}

--- a/bpf/proxy/proxy_test.go
+++ b/bpf/proxy/proxy_test.go
@@ -122,6 +122,7 @@ var _ = Describe("BPF Proxy", func() {
 				{
 					Protocol: v1.ProtocolUDP,
 					Port:     1221,
+					Name:     "1221",
 				},
 			},
 		},

--- a/bpf/proxy/proxy_test.go
+++ b/bpf/proxy/proxy_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
@@ -101,6 +102,7 @@ var _ = Describe("BPF Proxy", func() {
 				Ports: []v1.EndpointPort{
 					{
 						Port: 1234,
+						Name: "1234",
 					},
 				},
 			},
@@ -141,16 +143,23 @@ var _ = Describe("BPF Proxy", func() {
 				Ports: []v1.EndpointPort{
 					{
 						Port: 1221,
+						Name: "1221",
 					},
 				},
 			},
 		},
 	}
 
-	Describe("with k8s client", func() {
+	proxyTransitionsTest := func(endpointSlicesEnabled bool) {
 		var p proxy.Proxy
 		var dp *mockSyncer
-		k8s := fake.NewSimpleClientset(testSvc, testSvcEps, secondSvc, secondSvcEps)
+		var k8s *fake.Clientset
+
+		if endpointSlicesEnabled {
+			k8s = fake.NewSimpleClientset(testSvc, epsToSlice(testSvcEps), secondSvc, epsToSlice(secondSvcEps))
+		} else {
+			k8s = fake.NewSimpleClientset(testSvc, testSvcEps, secondSvc, secondSvcEps)
+		}
 
 		BeforeEach(func() {
 			By("creating proxy with fake client and mock syncer", func() {
@@ -159,7 +168,12 @@ var _ = Describe("BPF Proxy", func() {
 				syncStop = make(chan struct{})
 				dp = newMockSyncer(syncStop)
 
-				p, err = proxy.New(k8s, dp, "testnode", proxy.WithMinSyncPeriod(200*time.Millisecond))
+				opts := []proxy.Option{proxy.WithMinSyncPeriod(200 * time.Millisecond)}
+				if endpointSlicesEnabled {
+					opts = append(opts, proxy.WithEndpointsSlices())
+				}
+
+				p, err = proxy.New(k8s, dp, "testnode", opts...)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -225,33 +239,43 @@ var _ = Describe("BPF Proxy", func() {
 			})
 
 			By("deleting an endpoint of the second-service", func() {
-				err := k8s.Tracker().Update(v1.SchemeGroupVersion.WithResource("endpoints"),
-					&v1.Endpoints{
-						TypeMeta:   typeMetaV1("Endpoints"),
-						ObjectMeta: objectMeataV1("second-service"),
-						Subsets: []v1.EndpointSubset{
-							{
-								Addresses: []v1.EndpointAddress{
-									{
-										IP: "10.1.2.11",
-									},
+				eps := &v1.Endpoints{
+					TypeMeta:   typeMetaV1("Endpoints"),
+					ObjectMeta: objectMeataV1("second-service"),
+					Subsets: []v1.EndpointSubset{
+						{
+							Addresses: []v1.EndpointAddress{
+								{
+									IP: "10.1.2.11",
 								},
-								Ports: []v1.EndpointPort{
-									{
-										Port: 1221,
-									},
+							},
+							Ports: []v1.EndpointPort{
+								{
+									Port: 1221,
+									Name: "1221",
 								},
 							},
 						},
 					},
-					"default")
-				Expect(err).NotTo(HaveOccurred())
+				}
+
+				if endpointSlicesEnabled {
+					slice := epsToSlice(eps)
+					err := k8s.Tracker().Update(discovery.SchemeGroupVersion.WithResource("endpointslices"),
+						slice, "default")
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					err := k8s.Tracker().Update(v1.SchemeGroupVersion.WithResource("endpoints"),
+						eps, "default")
+					Expect(err).NotTo(HaveOccurred())
+				}
 
 				secondSvcEpsKey := k8sp.ServicePortName{
 					NamespacedName: types.NamespacedName{
 						Namespace: secondSvcEps.ObjectMeta.Namespace,
 						Name:      secondSvcEps.ObjectMeta.Name,
 					},
+					Port: eps.Subsets[0].Ports[0].Name,
 				}
 
 				dp.checkState(func(s proxy.DPSyncerState) {
@@ -310,8 +334,13 @@ var _ = Describe("BPF Proxy", func() {
 					},
 				}
 
-				err := k8s.Tracker().Add(httpSvcEps)
-				Expect(err).NotTo(HaveOccurred())
+				if endpointSlicesEnabled {
+					err := k8s.Tracker().Add(epsToSlice(httpSvcEps))
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					err := k8s.Tracker().Add(httpSvcEps)
+					Expect(err).NotTo(HaveOccurred())
+				}
 
 				dp.checkState(func(s proxy.DPSyncerState) {
 					for _, port := range httpSvcEps.Subsets[0].Ports {
@@ -335,26 +364,32 @@ var _ = Describe("BPF Proxy", func() {
 			})
 
 			By("including endpoints without service", func() {
-				err := k8s.Tracker().Add(
-					&v1.Endpoints{
-						TypeMeta:   typeMetaV1("Endpoints"),
-						ObjectMeta: objectMeataV1("noservice"),
-						Subsets: []v1.EndpointSubset{
-							{
-								Addresses: []v1.EndpointAddress{
-									{
-										IP: "10.1.2.244",
-									},
+				eps := &v1.Endpoints{
+					TypeMeta:   typeMetaV1("Endpoints"),
+					ObjectMeta: objectMeataV1("noservice"),
+					Subsets: []v1.EndpointSubset{
+						{
+							Addresses: []v1.EndpointAddress{
+								{
+									IP: "10.1.2.244",
 								},
-								Ports: []v1.EndpointPort{
-									{
-										Port: 666,
-									},
+							},
+							Ports: []v1.EndpointPort{
+								{
+									Port: 666,
 								},
 							},
 						},
-					})
-				Expect(err).NotTo(HaveOccurred())
+					},
+				}
+
+				if endpointSlicesEnabled {
+					err := k8s.Tracker().Add(epsToSlice(eps))
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					err := k8s.Tracker().Add(eps)
+					Expect(err).NotTo(HaveOccurred())
+				}
 
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(1))
@@ -407,8 +442,13 @@ var _ = Describe("BPF Proxy", func() {
 				Expect(err).NotTo(HaveOccurred())
 				dp.checkState(func(s proxy.DPSyncerState) { /* just consume the event */ })
 
-				err = k8s.Tracker().Add(nodeportEps)
-				Expect(err).NotTo(HaveOccurred())
+				if endpointSlicesEnabled {
+					err := k8s.Tracker().Add(epsToSlice(nodeportEps))
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					err := k8s.Tracker().Add(nodeportEps)
+					Expect(err).NotTo(HaveOccurred())
+				}
 
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(2))
@@ -428,6 +468,16 @@ var _ = Describe("BPF Proxy", func() {
 					Expect(s.SvcMap[npKey].NodePort()).To(Equal(int(nodeport.Spec.Ports[0].NodePort)))
 				})
 			})
+		})
+	}
+
+	Describe("with k8s client", func() {
+		Context("with Endpoints", func() {
+			proxyTransitionsTest(false)
+		})
+
+		Context("with EndpointSlices", func() {
+			proxyTransitionsTest(true)
 		})
 	})
 
@@ -569,4 +619,54 @@ func objectMeataV1(name string) metav1.ObjectMeta {
 
 func strPtr(s string) *string {
 	return &s
+}
+
+func epsToSlice(eps *v1.Endpoints) *discovery.EndpointSlice {
+	addrType := discovery.AddressTypeIP
+
+	slice := &discovery.EndpointSlice{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "EndpointSlice",
+			APIVersion: "discovery.k8s.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      eps.ObjectMeta.Name,
+			Namespace: eps.ObjectMeta.Namespace,
+			Labels: map[string]string{
+				"kubernetes.io/service-name": eps.ObjectMeta.Name,
+			},
+		},
+		AddressType: &addrType,
+	}
+
+	for i, subset := range eps.Subsets {
+		for _, addr := range subset.Addresses {
+			slice.Endpoints = append(slice.Endpoints, discovery.Endpoint{
+				Addresses: []string{addr.IP},
+				Hostname:  addr.NodeName,
+			})
+		}
+
+		for j, p := range subset.Ports {
+			port := p
+			ep := discovery.EndpointPort{
+				Port: &port.Port,
+			}
+
+			if port.Name != "" {
+				ep.Name = &port.Name
+			} else {
+				name := fmt.Sprintf("port-%d-%d-%d", i, j, port.Port)
+				ep.Name = &name
+			}
+
+			if port.Protocol != "" {
+				ep.Protocol = &port.Protocol
+			}
+
+			slice.Ports = append(slice.Ports, ep)
+		}
+	}
+
+	return slice
 }

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -122,6 +122,7 @@ type Config struct {
 	BPFExternalServiceMode             string         `config:"oneof(tunnel,dsr);tunnel;non-zero"`
 	BPFKubeProxyIptablesCleanupEnabled bool           `config:"bool;true"`
 	BPFKubeProxyMinSyncPeriod          time.Duration  `config:"seconds;1"`
+	BPFKubeProxyEndpointSlicesEnabled  bool           `config:"bool;false"`
 
 	// DebugBPFCgroupV2 controls the cgroup v2 path that we apply the connect-time load balancer to.  Most distros
 	// are configured for cgroup v1, which prevents all but hte root cgroup v2 from working so this is only useful

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -234,6 +234,7 @@ func StartDataplaneDriver(configParams *config.Config,
 			BPFCgroupV2:                        configParams.DebugBPFCgroupV2,
 			BPFMapRepin:                        configParams.DebugBPFMapRepinEnabled,
 			KubeProxyMinSyncPeriod:             configParams.BPFKubeProxyMinSyncPeriod,
+			KubeProxyEndpointSlicesEnabled:     configParams.BPFKubeProxyEndpointSlicesEnabled,
 			XDPEnabled:                         configParams.XDPEnabled,
 			XDPAllowGeneric:                    configParams.GenericXDPEnabled,
 			BPFConntrackTimeouts:               conntrack.DefaultTimeouts(), // FIXME make timeouts configurable

--- a/go.mod
+++ b/go.mod
@@ -23,9 +23,9 @@ require (
 	github.com/onsi/gomega v1.7.0
 	github.com/pkg/errors v0.8.1
 	github.com/pquerna/ffjson v0.0.0-20190813045741-dac163c6c0a9 // indirect
-	github.com/projectcalico/libcalico-go v1.7.2-0.20200522134408-df181482b303
+	github.com/projectcalico/libcalico-go v1.7.2-0.20200527172159-35eb09f7909c
 	github.com/projectcalico/pod2daemon v0.0.0-20191223184832-a0e1c4693271
-	github.com/projectcalico/typha v0.7.3-0.20200523040929-7115ed00b715
+	github.com/projectcalico/typha v0.7.3-0.20200527211152-a1bf881f9cc4
 	github.com/prometheus/client_golang v0.9.2
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -418,6 +418,8 @@ github.com/projectcalico/libcalico-go v1.7.2-0.20200515163405-fc50f8064a53 h1:29
 github.com/projectcalico/libcalico-go v1.7.2-0.20200515163405-fc50f8064a53/go.mod h1:P4D/eq0J3r5BMLmyyFD6TVNWKP2UzNUUT+atwSlqY4Y=
 github.com/projectcalico/libcalico-go v1.7.2-0.20200522134408-df181482b303 h1:YWtdxawov6gquk7MkaotzQchQ/9VrIv46V0NNcwW0DE=
 github.com/projectcalico/libcalico-go v1.7.2-0.20200522134408-df181482b303/go.mod h1:P4D/eq0J3r5BMLmyyFD6TVNWKP2UzNUUT+atwSlqY4Y=
+github.com/projectcalico/libcalico-go v1.7.2-0.20200527172159-35eb09f7909c h1:LvngU7vcoUjjQ9BcqHFPVqoExc5z4F6BFKsGYeQZGiQ=
+github.com/projectcalico/libcalico-go v1.7.2-0.20200527172159-35eb09f7909c/go.mod h1:P4D/eq0J3r5BMLmyyFD6TVNWKP2UzNUUT+atwSlqY4Y=
 github.com/projectcalico/logrus v0.0.0-20180701205716-fc9bbf2f5799 h1:9jp4YoHqZvEKDW3Z9464x/whSRCWEinIo4/JifaKR+g=
 github.com/projectcalico/logrus v0.0.0-20180701205716-fc9bbf2f5799/go.mod h1:DfgrchabbtEO9wjOz5lVae+XRvjFKKWEA9GTMme6A8g=
 github.com/projectcalico/pod2daemon v0.0.0-20191223184832-a0e1c4693271 h1:AOFOckD83tAIMQob6I1FpzSVs+Rn5Td701Q3/aQFqe8=
@@ -430,6 +432,8 @@ github.com/projectcalico/typha v0.7.3-0.20200516040706-0ded08b5264f h1:61oxtoiBw
 github.com/projectcalico/typha v0.7.3-0.20200516040706-0ded08b5264f/go.mod h1:naIdt9P7D6SeL7sfAhoJmbt4oELI7Y/q8uf5uk6ae3s=
 github.com/projectcalico/typha v0.7.3-0.20200523040929-7115ed00b715 h1:7CApow6BhNL+2HY/E1h3ThXT+2hmC/0B5xVSu5NaDBo=
 github.com/projectcalico/typha v0.7.3-0.20200523040929-7115ed00b715/go.mod h1:zgvJFgzB4evtL0Pfy91z/MwQ0O5BD+o1V6hhE8iiy4U=
+github.com/projectcalico/typha v0.7.3-0.20200527211152-a1bf881f9cc4 h1:j/1Qd7cdpSd1iR21UIREvsygqqgH2K9/D3efW/Xq7Nc=
+github.com/projectcalico/typha v0.7.3-0.20200527211152-a1bf881f9cc4/go.mod h1:GsholfXQWXxv8RHdqFLoq41GUjTF+WYM0VZwF/+TgAI=
 github.com/prometheus/client_golang v0.0.0-20171005112915-5cec1d0429b0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2 h1:awm861/B8OKDd2I/6o1dy3ra4BamzKhYOiGItCeZ740=


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Add support for using Kubernetes' new EndpointSlices feature, which provides a more efficient alternative to Endpoints.

Code mostly inherited from upstream.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, Calico now supports Kubernetes EndpointSlices as a more efficient alternative to Endpoints.  Controlled by the Felix configuration parameter `BPFKubeProxyEndpointSlicesEnabled`.
```
