### PR TITLE
Fix automatic disabling of BPF mode on older kernels

### DIFF
--- a/bpf/bpf.go
+++ b/bpf/bpf.go
@@ -2198,7 +2198,11 @@ func SupportsBPFDataplane() error {
 
 	// Test endianness
 	if nativeEndian != binary.LittleEndian {
-		return fmt.Errorf("this bpf library only supports little endian architectures")
+		return errors.New("this bpf library only supports little endian architectures")
+	}
+
+	if !SyscallSupport() {
+		return errors.New("BPF syscall support is not available on this platform")
 	}
 
 	return nil

--- a/config/config_params_test.go
+++ b/config/config_params_test.go
@@ -155,9 +155,27 @@ var _ = Describe("Config override empty", func() {
 			Expect(cp.BPFEnabled).To(BeFalse())
 
 			By("Ignoring a lower-priority config update")
-			changed, err = cp.UpdateFrom(map[string]string{"BPFEnabled": "true"}, EnvironmentVariable)
+			// Env vars get converted to lower-case before calling UpdateFrom.
+			changed, err = cp.UpdateFrom(map[string]string{"bpfenabled": "true"}, EnvironmentVariable)
 			Expect(changed).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
+			Expect(cp.BPFEnabled).To(BeFalse())
+		})
+	})
+
+	Describe("with env var set", func() {
+		BeforeEach(func() {
+			// Env vars get converted to lower-case before calling UpdateFrom.
+			changed, err := cp.UpdateFrom(map[string]string{"bpfenabled": "true"}, EnvironmentVariable)
+			Expect(changed).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cp.BPFEnabled).To(BeTrue())
+		})
+
+		It("should be overridable", func() {
+			changed, err := cp.OverrideParam("BPFEnabled", "false")
+			Expect(changed).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(cp.BPFEnabled).To(BeFalse())
 		})
 	})

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -359,11 +359,6 @@ configRetry:
 
 	// Start up the dataplane driver.  This may be the internal go-based driver or an external
 	// one.
-	if configParams.BPFEnabled && !bpf.SyscallSupport() {
-		log.Error("BPFEnabled is set but BPF mode is not supported on this platform.  Continuing with BPF disabled.")
-		configParams.BPFEnabled = false
-	}
-
 	var dpDriver dp.DataplaneDriver
 	var dpDriverCmd *exec.Cmd
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Previously, when processing env vars, we'd do a lookup for, say 'bpfenabled', when the map contained 'BPFEnabled'.  This would result in preferring the env var over an internal override.

Also, fix that we had two BPF supported checks in different places and combine them into one.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) Not needed
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix config inheritance so that the BPF kernel version check takes precedence  over environment variables.
```
