### PR TITLE
bpf: HOST_IP represents the same node ip on all host ifaces

### DIFF
--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -1016,7 +1016,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 				goto icmp_too_big;
 			}
 			state->ip_src = HOST_IP;
-			seen_mark = CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP;
+			seen_mark = CALI_SKB_MARK_SKIP_RPF;
 
 			/* We cannot enforce RPF check on encapped traffic, do FIB if you can */
 			fib = true;

--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -612,12 +612,7 @@ func (m *bpfEndpointManager) attachDataIfaceProgram(ifaceName string, polDirecti
 		epType = tc.EpTypeTunnel
 	}
 	ap := m.calculateTCAttachPoint(epType, polDirection, ifaceName)
-	if ifaceName == "tunl0" {
-		log.Debug("No IP for tunl0, perhaps IPIP is disabled?")
-		ap.IP = calicoRouterIP // Use the router IP to avoid spammy errors.
-	} else {
-		ap.IP = m.hostIP
-	}
+	ap.IP = m.hostIP
 	ap.TunnelMTU = uint16(m.vxlanMTU)
 	return ap.AttachProgram()
 }

--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"os/exec"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -48,7 +47,6 @@ import (
 
 type epIface struct {
 	ifacemonitor.State
-	addrs []net.IP
 }
 
 type bpfEndpointManager struct {
@@ -66,6 +64,8 @@ type bpfEndpointManager struct {
 	dirtyIfaces    set.Set
 
 	bpfLogLevel      string
+	hostname         string
+	hostIP           net.IP
 	fibLookupEnabled bool
 	dataIfaceRegex   *regexp.Regexp
 	ipSetIDAlloc     *idalloc.IDAllocator
@@ -79,6 +79,7 @@ type bpfEndpointManager struct {
 
 func newBPFEndpointManager(
 	bpfLogLevel string,
+	hostname string,
 	fibLookupEnabled bool,
 	epToHostDrop bool,
 	dataIfaceRegex *regexp.Regexp,
@@ -98,6 +99,7 @@ func newBPFEndpointManager(
 		dirtyWorkloads:      set.New(),
 		dirtyIfaces:         set.New(),
 		bpfLogLevel:         bpfLogLevel,
+		hostname:            hostname,
 		fibLookupEnabled:    fibLookupEnabled,
 		dataIfaceRegex:      dataIfaceRegex,
 		ipSetIDAlloc:        ipSetIDAlloc,
@@ -116,8 +118,6 @@ func (m *bpfEndpointManager) OnUpdate(msg interface{}) {
 	// Interface updates.
 	case *ifaceUpdate:
 		m.onInterfaceUpdate(msg)
-	case *ifaceAddrsUpdate:
-		m.onInterfaceAddrsUpdate(msg)
 
 	// Updates from the datamodel:
 
@@ -136,6 +136,20 @@ func (m *bpfEndpointManager) OnUpdate(msg interface{}) {
 		m.onProfileUpdate(msg)
 	case *proto.ActiveProfileRemove:
 		m.onProfileRemove(msg)
+
+	case *proto.HostMetadataUpdate:
+		if msg.Hostname == m.hostname {
+			log.WithField("HostMetadataUpdate", msg).Info("Host IP changed")
+			ip := net.ParseIP(msg.Ipv4Addr)
+			if ip != nil {
+				m.hostIP = ip
+				for iface := range m.ifaces {
+					m.dirtyIfaces.Add(iface)
+				}
+			} else {
+				log.WithField("HostMetadataUpdate", msg).Warn("Cannot parse IP, no change applied")
+			}
+		}
 	}
 }
 
@@ -158,56 +172,6 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceUpdate) {
 			m.dirtyIfaces.Add(update.Name)
 		}
 	}
-}
-
-func (m *bpfEndpointManager) onInterfaceAddrsUpdate(update *ifaceAddrsUpdate) {
-	if update == nil || update.Addrs == nil {
-		return
-	}
-
-	var addrs []net.IP
-	update.Addrs.Iter(func(s interface{}) error {
-		str, ok := s.(string)
-		if !ok {
-			log.WithField("addr", s).Errorf("wrong type %T", s)
-			return nil
-		}
-		ip := net.ParseIP(str)
-		if ip == nil {
-			return nil
-		}
-		ip = ip.To4()
-		if ip == nil {
-			return nil
-		}
-		addrs = append(addrs, ip)
-		return nil
-	})
-
-	// Sort the slice for determinism and to make comparison easier.
-	sort.Slice(addrs, func(i, j int) bool {
-		return bytes.Compare(addrs[i], addrs[j]) < 0
-	})
-
-	iface := m.ifaces[update.Name]
-	changed := len(addrs) != len(iface.addrs)
-	if !changed {
-		for i := range addrs {
-			if !addrs[i].Equal(iface.addrs[i]) {
-				changed = true
-				break
-			}
-		}
-	}
-	if !changed {
-		log.WithField("iface", update.Name).Debug("No-op IPs update.")
-		return
-	}
-	iface.addrs = addrs
-	m.ifaces[update.Name] = iface
-	m.dirtyIfaces.Add(update.Name)
-	log.WithField("iface", update.Name).WithField("addrs", addrs).WithField("State", iface.State).
-		Debugf("onInterfaceAddrsUpdate")
 }
 
 // onWorkloadEndpointUpdate adds/updates the workload in the cache along with the index from active policy to
@@ -648,12 +612,11 @@ func (m *bpfEndpointManager) attachDataIfaceProgram(ifaceName string, polDirecti
 		epType = tc.EpTypeTunnel
 	}
 	ap := m.calculateTCAttachPoint(epType, polDirection, ifaceName)
-	iface := m.ifaces[ifaceName]
-	if len(iface.addrs) > 0 {
-		ap.IP = iface.addrs[0]
-	} else if ifaceName == "tunl0" {
+	if ifaceName == "tunl0" {
 		log.Debug("No IP for tunl0, perhaps IPIP is disabled?")
 		ap.IP = calicoRouterIP // Use the router IP to avoid spammy errors.
+	} else {
+		ap.IP = m.hostIP
 	}
 	ap.TunnelMTU = uint16(m.vxlanMTU)
 	return ap.AttachProgram()

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -507,6 +507,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		}
 		dp.RegisterManager(newBPFEndpointManager(
 			config.BPFLogLevel,
+			config.Hostname,
 			fibLookupEnabled,
 			config.RulesConfig.EndpointToHostAction == "DROP",
 			config.BPFDataIfacePattern,

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -1351,6 +1351,12 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 									// Add a route to felix[1] to be able to reach the nodeport
 									_, err = eth20.RunCmd("ip", "route", "add", felixes[1].IP+"/32", "via", "10.0.0.20")
 									Expect(err).NotTo(HaveOccurred())
+									// This multi-NIC scenario works only if the kernel's RPF check
+									// is not strict so we need to override it for the test and must
+									// be set properly when product is deployed. We reply on
+									// iptables to do require check for us.
+									felixes[1].Exec("sysctl", "-w", "net.ipv4.conf.eth0.rp_filter=2")
+									felixes[1].Exec("sysctl", "-w", "net.ipv4.conf.eth20.rp_filter=2")
 								})
 
 								By("setting up routes to .20 net on dest node to trigger RPF check", func() {


### PR DESCRIPTION
Instead of having the iface ip hardwired in the attached tc program, we
hardwire the single node IP that is used to pass packets within the
cluster (the NP vxlan tunnel) and to respond with ICMP errors.

This allows, for instance, for scenarious with multiple NICs that share
the same IP, but the IP is not assinged to any of them, but is
represented by local routes.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->
```
In BPF mode, Calico now uses the node IP for generated encap packets.
```
