### PR TITLE
bpf: clean conntrack of stale UDP services

### DIFF
--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -98,11 +98,11 @@ struct calico_ct_value {
 			struct calico_ct_leg b_to_a; // 36
 
 			// CALI_CT_TYPE_NAT_REV
-			__u32 orig_ip;                     // 44
-			__u16 orig_port;                   // 48
-			__u8 pad1[2];                      // 50
-			__u32 tun_ip;                      // 52
-			__u32 pad3;                        // 56
+			__u32 orig_ip;                     // 48
+			__u16 orig_port;                   // 52
+			__u8 pad1[2];                      // 54
+			__u32 tun_ip;                      // 56
+			__u32 pad3;                        // 60
 		};
 
 		// CALI_CT_TYPE_NAT_FWD; key for the CALI_CT_TYPE_NAT_REV entry.

--- a/bpf/conntrack/map.go
+++ b/bpf/conntrack/map.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -67,8 +68,8 @@ func (k Key) String() string {
 func NewKey(proto uint8, ipA net.IP, portA uint16, ipB net.IP, portB uint16) Key {
 	var k Key
 	binary.LittleEndian.PutUint32(k[:4], uint32(proto))
-	copy(k[4:8], ipA)
-	copy(k[8:12], ipB)
+	copy(k[4:8], ipA.To4())
+	copy(k[8:12], ipB.To4())
 	binary.LittleEndian.PutUint16(k[12:14], portA)
 	binary.LittleEndian.PutUint16(k[14:16], portB)
 	return k
@@ -92,11 +93,11 @@ func NewKey(proto uint8, ipA net.IP, portA uint16, ipB net.IP, portB uint16) Key
 //      struct calico_ct_leg b_to_a; // 36
 //
 //      // CALI_CT_TYPE_NAT_REV only.
-//      __u32 orig_dst;                    // 44
-//      __u16 orig_port;                   // 48
-//      __u8 pad1[2];                      // 50
-//      __u32 tun_ip;                      // 52
-//      __u32 pad3;                        // 56
+//      __u32 orig_dst;                    // 48
+//      __u16 orig_port;                   // 52
+//      __u8 pad1[2];                      // 54
+//      __u32 tun_ip;                      // 56
+//      __u32 pad3;                        // 60
 //    };
 //
 //    // CALI_CT_TYPE_NAT_FWD; key for the CALI_CT_TYPE_NAT_REV entry.
@@ -124,6 +125,11 @@ func (e Value) Flags() uint8 {
 	return e[17]
 }
 
+// OrigIP returns the original destination IP, valid only if Type() is TypeNormal or TypeNATReverse
+func (e Value) OrigIP() net.IP {
+	return e[48:52]
+}
+
 const (
 	TypeNormal uint8 = iota
 	TypeNATForward
@@ -143,6 +149,61 @@ func (e Value) ReverseNATKey() Key {
 	return ret
 }
 
+// AsBytes returns the value as slice of bytes
+func (e Value) AsBytes() []byte {
+	return e[:]
+}
+
+func initValue(v *Value, created, lastSeen time.Duration, typ, flags uint8) {
+	binary.LittleEndian.PutUint64(v[:8], uint64(created))
+	binary.LittleEndian.PutUint64(v[8:16], uint64(lastSeen))
+	v[16] = typ
+	v[17] = flags
+}
+
+// NewValueNormal creates a new Value of type TypeNormal based on the given parameters
+func NewValueNormal(created, lastSeen time.Duration, flags uint8, legA, legB Leg) Value {
+	v := Value{}
+
+	initValue(&v, created, lastSeen, TypeNormal, flags)
+
+	copy(v[24:36], legA.AsBytes())
+	copy(v[36:48], legA.AsBytes())
+
+	return v
+}
+
+// NewValueNATForward creates a new Value of type TypeNATForward for the given
+// arguments and the reverse key
+func NewValueNATForward(created, lastSeen time.Duration, flags uint8, revKey Key) Value {
+	v := Value{}
+
+	initValue(&v, created, lastSeen, TypeNATForward, flags)
+
+	copy(v[24:24+conntrackKeySize], revKey.AsBytes())
+
+	return v
+}
+
+// NewValueNATReverse creates a new Value of type TypeNATReverse for the given
+// arguments and reverse parameters
+func NewValueNATReverse(created, lastSeen time.Duration, flags uint8, legA, legB Leg,
+	tunnelIP, origIP net.IP, origPort uint16) Value {
+	v := Value{}
+
+	initValue(&v, created, lastSeen, TypeNATReverse, flags)
+
+	copy(v[24:36], legA.AsBytes())
+	copy(v[36:48], legA.AsBytes())
+
+	copy(v[48:52], origIP.To4())
+	binary.LittleEndian.PutUint16(v[52:54], origPort)
+
+	copy(v[56:60], tunnelIP.To4())
+
+	return v
+}
+
 type Leg struct {
 	Seqno       uint32
 	SynSeen     bool
@@ -152,6 +213,32 @@ type Leg struct {
 	Whitelisted bool
 	Opener      bool
 	Ifindex     uint32
+}
+
+func setBit(bits *uint32, bit uint8, val bool) {
+	if val {
+		*bits |= (1 << bit)
+	}
+}
+
+// AsBytes returns Leg serialized as a slice of bytes
+func (leg Leg) AsBytes() []byte {
+	bytes := make([]byte, 12)
+
+	bits := uint32(0)
+
+	setBit(&bits, 0, leg.SynSeen)
+	setBit(&bits, 1, leg.AckSeen)
+	setBit(&bits, 2, leg.FinSeen)
+	setBit(&bits, 3, leg.RstSeen)
+	setBit(&bits, 4, leg.Whitelisted)
+	setBit(&bits, 5, leg.Opener)
+
+	binary.LittleEndian.PutUint32(bytes[0:4], leg.Seqno)
+	binary.LittleEndian.PutUint32(bytes[4:8], bits)
+	binary.LittleEndian.PutUint32(bytes[8:12], leg.Ifindex)
+
+	return bytes
 }
 
 func (leg Leg) Flags() uint32 {
@@ -341,4 +428,32 @@ func MapMemIter(m MapMem) bpf.MapIter {
 
 		m[key] = val
 	}
+}
+
+// BytesToKey turns a slice of bytes into a Key
+func BytesToKey(bytes []byte) Key {
+	var k Key
+
+	copy(k[:], bytes[:len(k)])
+
+	return k
+}
+
+// StringToKey turns a string into a Key
+func StringToKey(str string) Key {
+	return BytesToKey([]byte(str))
+}
+
+// BytesToValue turns a slice of bytes into a Key
+func BytesToValue(bytes []byte) Value {
+	var v Value
+
+	copy(v[:], bytes[:len(v)])
+
+	return v
+}
+
+// StringToValue turns a string into a Value
+func StringToValue(str string) Value {
+	return BytesToValue([]byte(str))
 }

--- a/bpf/mock/map.go
+++ b/bpf/mock/map.go
@@ -75,6 +75,11 @@ func (m Map) Delete(k []byte) error {
 	if len(k) != m.KeySize {
 		m.logCxt.Panicf("Key had wrong size (%d)", len(k))
 	}
+
+	if _, ok := m.Contents[string(k)]; !ok {
+		return unix.ENOENT
+	}
+
 	delete(m.Contents, string(k))
 	return nil
 }

--- a/bpf/proxy/kube-proxy.go
+++ b/bpf/proxy/kube-proxy.go
@@ -42,13 +42,14 @@ type KubeProxy struct {
 	frontendMap bpf.Map
 	backendMap  bpf.Map
 	affinityMap bpf.Map
+	ctMap       bpf.Map
 	rt          *RTCache
 	opts        []Option
 }
 
 // StartKubeProxy start a new kube-proxy if there was no error
 func StartKubeProxy(k8s kubernetes.Interface, hostname string,
-	frontendMap, backendMap, affinityMap bpf.Map, opts ...Option) (*KubeProxy, error) {
+	frontendMap, backendMap, affinityMap, ctMap bpf.Map, opts ...Option) (*KubeProxy, error) {
 
 	kp := &KubeProxy{
 		k8s:         k8s,
@@ -56,6 +57,7 @@ func StartKubeProxy(k8s kubernetes.Interface, hostname string,
 		frontendMap: frontendMap,
 		backendMap:  backendMap,
 		affinityMap: affinityMap,
+		ctMap:       ctMap,
 		opts:        opts,
 		rt:          NewRTCache(),
 
@@ -95,7 +97,7 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 	copy(withLocalNP, hostIPs)
 	withLocalNP = append(withLocalNP, podNPIP)
 
-	syncer, err := NewSyncer(withLocalNP, kp.frontendMap, kp.backendMap, kp.affinityMap, kp.rt)
+	syncer, err := NewSyncer(withLocalNP, kp.frontendMap, kp.backendMap, kp.affinityMap, kp.ctMap, kp.rt)
 	if err != nil {
 		return errors.WithMessage(err, "new bpf syncer")
 	}

--- a/bpf/proxy/kube-proxy_test.go
+++ b/bpf/proxy/kube-proxy_test.go
@@ -23,6 +23,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/projectcalico/felix/bpf/conntrack"
+	"github.com/projectcalico/felix/bpf/mock"
 	proxy "github.com/projectcalico/felix/bpf/proxy"
 )
 
@@ -72,7 +74,8 @@ var _ = Describe("BPF kube-proxy", func() {
 	front := newMockNATMap()
 	back := newMockNATBackendMap()
 	aff := newMockAffinityMap()
-	p, _ := proxy.StartKubeProxy(k8s, "test-node", front, back, aff, proxy.WithImmediateSync())
+	ct := mock.NewMockMap(conntrack.MapParams)
+	p, _ := proxy.StartKubeProxy(k8s, "test-node", front, back, aff, ct, proxy.WithImmediateSync())
 
 	AfterEach(func() {
 		p.Stop()

--- a/bpf/proxy/proxy.go
+++ b/bpf/proxy/proxy.go
@@ -52,7 +52,6 @@ type Proxy interface {
 type DPSyncerState struct {
 	SvcMap       k8sp.ServiceMap
 	EpsMap       k8sp.EndpointsMap
-	StaleUDPEps  []k8sp.ServiceEndpoint
 	StaleUDPSvcs sets.String
 }
 
@@ -106,6 +105,7 @@ type stoppableRunner interface {
 
 // New returns a new Proxy for the given k8s interface
 func New(k8s kubernetes.Interface, dp DPSyncer, hostname string, opts ...Option) (Proxy, error) {
+
 	if k8s == nil {
 		return nil, errors.Errorf("no k8s client")
 	}

--- a/bpf/proxy/proxy_test.go
+++ b/bpf/proxy/proxy_test.go
@@ -63,7 +63,6 @@ var _ = Describe("BPF Proxy", func() {
 		dp.checkState(func(s proxy.DPSyncerState) {
 			Expect(len(s.SvcMap)).To(Equal(0))
 			Expect(len(s.EpsMap)).To(Equal(0))
-			Expect(len(s.StaleUDPEps)).To(Equal(0))
 			Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 		})
 	})
@@ -193,7 +192,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(2))
 					Expect(len(s.EpsMap)).To(Equal(2))
-					Expect(len(s.StaleUDPEps)).To(Equal(0))
 					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 				})
 			})
@@ -223,7 +221,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(3))
 					Expect(len(s.EpsMap)).To(Equal(2))
-					Expect(len(s.StaleUDPEps)).To(Equal(0))
 					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 				})
 			})
@@ -235,7 +232,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(2))
 					Expect(len(s.EpsMap)).To(Equal(2))
-					Expect(len(s.StaleUDPEps)).To(Equal(0))
 					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 				})
 			})
@@ -286,7 +282,6 @@ var _ = Describe("BPF Proxy", func() {
 					Expect(len(s.SvcMap)).To(Equal(2))
 					Expect(len(s.EpsMap)).To(Equal(2))
 					Expect(len(s.EpsMap[secondSvcEpsKey])).To(Equal(1))
-					Expect(len(s.StaleUDPEps)).To(Equal(0))
 					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 				})
 			})
@@ -299,7 +294,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(1))
 					Expect(len(s.EpsMap)).To(Equal(2))
-					Expect(len(s.StaleUDPEps)).To(Equal(0))
 					Expect(len(s.StaleUDPSvcs)).To(Equal(1))
 				})
 			})
@@ -353,7 +347,6 @@ var _ = Describe("BPF Proxy", func() {
 					for _, port := range httpSvcEps.Subsets[0].Ports {
 						Expect(len(s.SvcMap)).To(Equal(1))
 						Expect(len(s.EpsMap)).To(Equal(5))
-						Expect(len(s.StaleUDPEps)).To(Equal(0))
 						Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 
 						ep := s.EpsMap[k8sp.ServicePortName{
@@ -402,7 +395,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(1))
 					Expect(len(s.EpsMap)).To(Equal(6))
-					Expect(len(s.StaleUDPEps)).To(Equal(0))
 					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 				})
 			})
@@ -461,7 +453,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(2))
 					Expect(len(s.EpsMap)).To(Equal(7))
-					Expect(len(s.StaleUDPEps)).To(Equal(0))
 					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 
 					npKey := k8sp.ServicePortName{

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -542,6 +542,12 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			log.WithError(err).Panic("Failed to create routes BPF map.")
 		}
 
+		ctMap := conntrack.Map(bpfMapContext)
+		err = ctMap.EnsureExists()
+		if err != nil {
+			log.WithError(err).Panic("Failed to create conntrack BPF map.")
+		}
+
 		bpfproxyOpts := []bpfproxy.Option{
 			bpfproxy.WithMinSyncPeriod(config.KubeProxyMinSyncPeriod),
 		}
@@ -558,6 +564,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				frontendMap,
 				backendMap,
 				backendAffinityMap,
+				ctMap,
 				bpfproxyOpts...,
 			)
 			if err != nil {


### PR DESCRIPTION
k8s tells us which UDP services do not exist anymore and we should clean
their conntrack entries.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
