### PR TITLE
Changes to send ICMP port unreachable for requests to service wiith no backend

### DIFF
--- a/bpf-gpl/connect_balancer.c
+++ b/bpf-gpl/connect_balancer.c
@@ -41,10 +41,10 @@ static CALI_BPF_INLINE void do_nat_common(struct bpf_sock_addr *ctx, uint8_t pro
 	 * XXX same affinity, which (a) is sub-optimal and (b) leaks info between
 	 * XXX workloads.
 	 */
-	bool nat_lvl1_drop = 0;
+	int res = 0;
 	uint16_t dport_he = (uint16_t)(be32_to_host(ctx->user_port)>>16);
 	struct calico_nat_dest *nat_dest;
-	nat_dest = calico_v4_nat_lookup(0, ctx->user_ip4, proto, dport_he, &nat_lvl1_drop);
+	nat_dest = calico_v4_nat_lookup(0, ctx->user_ip4, proto, dport_he, &res);
 	if (!nat_dest) {
 		CALI_INFO("NAT miss.\n");
 		goto out;

--- a/bpf-gpl/icmp.h
+++ b/bpf-gpl/icmp.h
@@ -193,6 +193,13 @@ static CALI_BPF_INLINE int icmp_v4_ttl_exceeded(struct __sk_buff *skb)
 	return icmp_v4_reply(skb, ICMP_TIME_EXCEEDED, ICMP_EXC_TTL, 0);
 }
 
+static CALI_BPF_INLINE int icmp_v4_port_unreachable(struct __sk_buff *skb)
+{
+	if (skb_too_short(skb))
+		return -1;
+        return icmp_v4_reply(skb, ICMP_TIME_EXCEEDED, ICMP_EXC_TTL, 0);
+}
+
 static CALI_BPF_INLINE bool icmp_type_is_err(__u8 type)
 {
 	switch (type) {

--- a/bpf-gpl/nat.h
+++ b/bpf-gpl/nat.h
@@ -45,6 +45,11 @@
 #define VXLAN_ENCAP_SIZE	(sizeof(struct ethhdr) + sizeof(struct iphdr) + \
 				sizeof(struct udphdr) + sizeof(struct vxlanhdr))
 
+enum calico_nat_lookup_result {
+        NAT_FE_LOOKUP_ALLOW,
+        NAT_FE_LOOKUP_DROP,
+        NAT_NO_BACKEND,
+};
 
 struct calico_nat_v4 {
         uint32_t addr; // NBO
@@ -145,7 +150,7 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_v4_nat_lookup2(__be32 ip_s
 								     __u8 ip_proto,
 								     __u16 dport,
 								     bool from_tun,
-								     bool *drop)
+								     int *res)
 {
 	struct calico_nat_v4_key nat_key = {
 		.prefixlen = NAT_PREFIX_LEN_WITH_SRC_MATCH_IN_BITS,
@@ -222,7 +227,7 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_v4_nat_lookup2(__be32 ip_s
 	 * packet is dropped.
 	 */
 	if (nat_lv1_val->count == NAT_FE_DROP_COUNT) {
-		*drop = 1;
+		*res = NAT_FE_LOOKUP_DROP;
 		return NULL;
 	}
 	uint32_t count = from_tun ? nat_lv1_val->local : nat_lv1_val->count;
@@ -231,6 +236,7 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_v4_nat_lookup2(__be32 ip_s
 
 	if (count == 0) {
 		CALI_DEBUG("NAT: no backend\n");
+		*res = NAT_NO_BACKEND;
 		return NULL;
 	}
 
@@ -308,9 +314,9 @@ skip_affinity:
 }
 
 static CALI_BPF_INLINE struct calico_nat_dest* calico_v4_nat_lookup(__be32 ip_src, __be32 ip_dst,
-								    __u8 ip_proto, __u16 dport, bool *drop)
+								    __u8 ip_proto, __u16 dport, int *res)
 {
-	return calico_v4_nat_lookup2(ip_src, ip_dst, ip_proto, dport, false, drop);
+	return calico_v4_nat_lookup2(ip_src, ip_dst, ip_proto, dport, false, res);
 }
 
 struct vxlanhdr {


### PR DESCRIPTION
When we get a request to a service with no backends
1) From NAT find if there are valid backends
2) Send a ICMP port unreachable

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
