### PR TITLE
Collect race detector reports during FV

### DIFF
--- a/.semaphore/collect-artifacts
+++ b/.semaphore/collect-artifacts
@@ -32,5 +32,8 @@ for file in /tmp/core_felix* ; do
     xz < "$file" > "$out_file"
   fi
 done
-xz < fv/data-races.log > artifacts/data-races.log
+if [ -s fv/data-races.log ]; then
+  # Only save the log if it's non-empty.
+  xz < fv/data-races.log > artifacts/data-races.log.xz
+fi
 tar -cJf artifacts/binaries.tar.xz bin/calico-felix-amd64 bin/calico-bpf bin/test-*

--- a/.semaphore/collect-artifacts
+++ b/.semaphore/collect-artifacts
@@ -32,4 +32,5 @@ for file in /tmp/core_felix* ; do
     xz < "$file" > "$out_file"
   fi
 done
+xz < fv/data-races.log > artifacts/data-races.log
 tar -cJf artifacts/binaries.tar.xz bin/calico-felix-amd64 bin/calico-bpf bin/test-*

--- a/.semaphore/publish-artifacts
+++ b/.semaphore/publish-artifacts
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2020 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# No set -e so that we continue to collect artifacts even if some fail.
+set -x
+
+my_dir="$(dirname "$0")"
+repo_dir="$my_dir/.."
+
+cd "$repo_dir/artifacts" || exit 1
+
+for file in *; do
+  artifact push --expire-in 4w job "$file"
+done

--- a/.semaphore/publish-artifacts
+++ b/.semaphore/publish-artifacts
@@ -17,8 +17,8 @@
 # No set -e so that we continue to collect artifacts even if some fail.
 set -x
 
-my_dir="$(dirname "$0")"
-repo_dir="$my_dir/.."
+my_dir=$(dirname "$0")
+repo_dir=$my_dir/..
 
 cd "$repo_dir/artifacts" || exit 1
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -65,7 +65,7 @@ blocks:
       always:
         commands:
         - ./.semaphore/collect-artifacts
-        - artifact push --expire-in 4w job artifacts
+        - ./.semaphore/publish-artifacts
 - name: BPF UT/FV tests on new kernel
   dependencies: []
   task:
@@ -94,7 +94,7 @@ blocks:
         commands:
         - ./.semaphore/on-test-vm ${REPO_NAME}/.semaphore/collect-artifacts
         - gcloud --quiet compute scp "--zone=${ZONE}" "ubuntu@${VM_NAME}:${REPO_NAME}/artifacts" ./ --recurse
-        - artifact push --expire-in 4w job artifacts
+        - ./.semaphore/publish-artifacts
         - gcloud --quiet compute instances delete ${VM_NAME} --zone=${ZONE}
     secrets:
     - name: google-service-account-for-gce

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -252,6 +252,7 @@ type Config struct {
 	DebugSimulateCalcGraphHangAfter time.Duration `config:"seconds;0"`
 	DebugSimulateDataplaneHangAfter time.Duration `config:"seconds;0"`
 	DebugPanicAfter                 time.Duration `config:"seconds;0"`
+	DebugSimulateDataRace           bool          `config:"bool;false"`
 
 	// Configure where Felix gets its routing information.
 	// - workloadIPs: use workload endpoints to construct routes.

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -283,6 +283,30 @@ type Config struct {
 	useNodeResourceUpdates bool
 }
 
+func (config *Config) Copy() *Config {
+	cp := *config
+
+	cp.internalOverrides = map[string]string{}
+	for k, v := range config.internalOverrides {
+		cp.internalOverrides[k] = v
+	}
+
+	cp.sourceToRawConfig = map[Source]map[string]string{}
+	for k, v := range config.sourceToRawConfig {
+		cp.sourceToRawConfig[k] = map[string]string{}
+		for k2, v2 := range v {
+			cp.sourceToRawConfig[k][k2] = v2
+		}
+	}
+
+	cp.rawValues = map[string]string{}
+	for k, v := range config.rawValues {
+		cp.rawValues[k] = v
+	}
+
+	return &cp
+}
+
 type ProtoPort struct {
 	Protocol string
 	Port     uint16

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -284,9 +284,13 @@ type Config struct {
 	useNodeResourceUpdates bool
 }
 
+// Copy makes a copy of the object.  Internal state is deep copied but config parameters are only shallow copied.
+// This saves work since updates to the copy will trigger the config params to be recalculated.
 func (config *Config) Copy() *Config {
+	// Start by shallow-copying the object.
 	cp := *config
 
+	// Copy the internal state over as a deep copy.
 	cp.internalOverrides = map[string]string{}
 	for k, v := range config.internalOverrides {
 		cp.internalOverrides[k] = v
@@ -338,8 +342,8 @@ func (config *Config) UpdateFrom(rawData map[string]string, source Source) (chan
 	return
 }
 
-func (c *Config) InterfacePrefixes() []string {
-	return strings.Split(c.InterfacePrefix, ",")
+func (config *Config) InterfacePrefixes() []string {
+	return strings.Split(config.InterfacePrefix, ",")
 }
 
 func (config *Config) OpenstackActive() bool {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -369,7 +369,11 @@ configRetry:
 	failureReportChan := make(chan string)
 	configChangedRestartCallback := func() { failureReportChan <- reasonConfigChanged }
 
-	dpDriver, dpDriverCmd = dp.StartDataplaneDriver(configParams.Copy(), healthAggregator, configChangedRestartCallback, k8sClientSet)
+	dpDriver, dpDriverCmd = dp.StartDataplaneDriver(
+		configParams.Copy(), // Copy to avoid concurrent access.
+		healthAggregator,
+		configChangedRestartCallback,
+		k8sClientSet)
 
 	// Initialise the glue logic that connects the calculation graph to/from the dataplane driver.
 	log.Info("Connect to the dataplane driver.")
@@ -380,7 +384,13 @@ configRetry:
 		// (Otherwise, we pass in a nil channel, which disables such updates.)
 		connToUsageRepUpdChan = make(chan map[string]string, 1)
 	}
-	dpConnector := newConnector(configParams.Copy(), connToUsageRepUpdChan, backendClient, v3Client, dpDriver, failureReportChan)
+	dpConnector := newConnector(
+		configParams.Copy(), // Copy to avoid concurrent access.
+		connToUsageRepUpdChan,
+		backendClient,
+		v3Client,
+		dpDriver,
+		failureReportChan)
 
 	// If enabled, create a server for the policy sync API.  This allows clients to connect to
 	// Felix over a socket and receive policy updates.
@@ -495,7 +505,7 @@ configRetry:
 	// do the dynamic calculation of ipset memberships and active policies
 	// etc.
 	asyncCalcGraph := calc.NewAsyncCalcGraph(
-		configParams.Copy(),
+		configParams.Copy(), // Copy to avoid concurrent access.
 		calcGraphClientChannels,
 		healthAggregator,
 	)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -352,11 +352,13 @@ configRetry:
 		"Successfully loaded configuration.")
 
 	if configParams.DebugPanicAfter > 0 {
-		go func(delay time.Duration) {
-			log.WithField("delay", delay).Warn("DebugPanicAfter is set, will panic after delay.")
-			time.Sleep(delay)
-			log.Panic("Panicking because config told me to!")
-		}(configParams.DebugPanicAfter)
+		log.WithField("delay", configParams.DebugPanicAfter).Warn("DebugPanicAfter is set, will panic after delay!")
+		go panicAfter(configParams.DebugPanicAfter)
+	}
+
+	if configParams.DebugSimulateDataRace {
+		log.Warn("DebugSimulateDataRace is set, will start some racing goroutines!")
+		simulateDataRace()
 	}
 
 	// Start up the dataplane driver.  This may be the internal go-based driver or an external

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -367,7 +367,7 @@ configRetry:
 	failureReportChan := make(chan string)
 	configChangedRestartCallback := func() { failureReportChan <- reasonConfigChanged }
 
-	dpDriver, dpDriverCmd = dp.StartDataplaneDriver(configParams, healthAggregator, configChangedRestartCallback, k8sClientSet)
+	dpDriver, dpDriverCmd = dp.StartDataplaneDriver(configParams.Copy(), healthAggregator, configChangedRestartCallback, k8sClientSet)
 
 	// Initialise the glue logic that connects the calculation graph to/from the dataplane driver.
 	log.Info("Connect to the dataplane driver.")
@@ -378,7 +378,7 @@ configRetry:
 		// (Otherwise, we pass in a nil channel, which disables such updates.)
 		connToUsageRepUpdChan = make(chan map[string]string, 1)
 	}
-	dpConnector := newConnector(configParams, connToUsageRepUpdChan, backendClient, v3Client, dpDriver, failureReportChan)
+	dpConnector := newConnector(configParams.Copy(), connToUsageRepUpdChan, backendClient, v3Client, dpDriver, failureReportChan)
 
 	// If enabled, create a server for the policy sync API.  This allows clients to connect to
 	// Felix over a socket and receive policy updates.
@@ -493,7 +493,7 @@ configRetry:
 	// do the dynamic calculation of ipset memberships and active policies
 	// etc.
 	asyncCalcGraph := calc.NewAsyncCalcGraph(
-		configParams,
+		configParams.Copy(),
 		calcGraphClientChannels,
 		healthAggregator,
 	)

--- a/daemon/debug.go
+++ b/daemon/debug.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func panicAfter(delay time.Duration) {
+	time.Sleep(delay)
+	log.Panic("Panicking because config told me to!")
+}
+
+func simulateDataRace() {
+	i := 0
+	for j := 0; j < 3; j++ {
+		go func() {
+			for {
+				k := i
+				time.Sleep(1 * time.Millisecond)
+				i = k + 1
+			}
+		}()
+	}
+}

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -769,7 +769,9 @@ func (d *InternalDataplane) routeTableSyncers() []routeTableSyncer {
 func (d *InternalDataplane) RegisterManager(mgr Manager) {
 	switch mgr := mgr.(type) {
 	case ManagerWithRouteTables:
-		log.WithField("manager", mgr).Debug("registering ManagerWithRouteTables")
+		// Used to log the whole manager out here but if we do that then we cause races if the manager has
+		// other threads or locks.
+		log.WithField("manager", reflect.TypeOf(mgr).Name()).Debug("registering ManagerWithRouteTables")
 		d.managersWithRouteTables = append(d.managersWithRouteTables, mgr)
 	}
 	d.allManagers = append(d.allManagers, mgr)

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -1336,7 +1336,8 @@ func (d *InternalDataplane) apply() {
 	for _, mgr := range d.allManagers {
 		err := mgr.CompleteDeferredWork()
 		if err != nil {
-			log.WithField("manager", mgr).WithError(err).Debug("couldn't complete deferred work for manager, will try again later")
+			log.WithField("manager", reflect.TypeOf(mgr).Name()).WithError(err).Debug(
+				"couldn't complete deferred work for manager, will try again later")
 			d.dataplaneNeedsSync = true
 		}
 		d.reportHealth()

--- a/fv/Dockerfile.test.amd64
+++ b/fv/Dockerfile.test.amd64
@@ -31,3 +31,4 @@ RUN apt-get update && apt-get install -y \
     tcpdump
 
 ADD test-connection test-workload pktgen  /
+ADD calico-felix-race-amd64 /code/calico-felix

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -319,6 +319,10 @@ func (c *Container) copyOutputToLog(streamName string, stream io.Reader, done *s
 	if err != nil {
 		log.WithError(err).Error("Failed to open data race log file.")
 	}
+	defer func() {
+		err := dataRaceFile.Close()
+		Expect(err).NotTo(HaveOccurred(), "Failed to write to data race log (close).")
+	}()
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -344,7 +344,8 @@ func (c *Container) copyOutputToLog(streamName string, stream io.Reader, done *s
 
 		// Capture data race warnings and log to file.
 		if strings.Contains(line, "WARNING: DATA RACE") {
-			_, err := fmt.Fprintf(dataRaceFile, "Detected data race while running test: %s\n", ginkgo.CurrentGinkgoTestDescription().FullTestText)
+			_, err := fmt.Fprintf(dataRaceFile, "Detected data race (in %s) while running test: %s\n",
+				c.Name, ginkgo.CurrentGinkgoTestDescription().FullTestText)
 			Expect(err).NotTo(HaveOccurred(), "Failed to write to data race log.")
 			foundDataRace = true
 		}

--- a/fv/fv_infra_test.go
+++ b/fv/fv_infra_test.go
@@ -197,5 +197,15 @@ var _ = infrastructure.DatastoreDescribe("Container self tests",
 				Expect(s.Size()).To(BeNumerically(">", 4096))
 			})
 		})
+
+		Describe("with DebugSimulateDataRace set", func() {
+			BeforeEach(func() {
+				options.ExtraEnvVars["FELIX_DebugSimulateDataRace"] = "true"
+			})
+
+			It("should detect a race", func() {
+				Eventually(felixes[0].DataRaces).ShouldNot(BeEmpty())
+			})
+		})
 	},
 )

--- a/fv/infrastructure/felix.go
+++ b/fv/infrastructure/felix.go
@@ -80,6 +80,7 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 	envVars := map[string]string{
 		// Enable core dumps.
 		"GOTRACEBACK": "crash",
+		"GORACE":      "history_size=2",
 		// Tell the wrapper to set the core file name pattern so we can find the dump.
 		"SET_CORE_PATTERN": "true",
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

- Update artifact collection to avoid extra directory.
- Watch for race detector warnings in the FV log and write them to a log file.
- Publish the log file as an artifact.
- Fix a couple of races:
  - The config object was used on the main thread but also passed to the calc graph in order to figure out if updates from the datastore resulted in a change of config.  This happened on another thread.  To fix I took a copy of the config.
  - Remove log statements that logged out the manager objects; the vxlan manager contains a mutex, which causes a race when it's logged out.

We don't yet fail when we get a race; I think it makes sense to monitor the output for a while before we start to fail on races.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix FV tests now run with Go's race detector enabled and a couple of low-impact data races have been fixed.
```
