### PR TITLE
bpf: Map.Iter() uses bpf.GetMapNextKey syscall

### DIFF
--- a/bpf/bpf_syscall_stub.go
+++ b/bpf/bpf_syscall_stub.go
@@ -59,3 +59,7 @@ func GetMapInfo(fd MapFD) (*MapInfo, error) {
 func DeleteMapEntry(mapFD MapFD, k []byte, valueSize int) error {
 	panic("BPF syscall stub")
 }
+
+func GetMapNextKey(mapFD MapFD, k []byte, keySize int) ([]byte, error) {
+	panic("BPF syscall stub")
+}

--- a/bpf/conntrack/cleanup.go
+++ b/bpf/conntrack/cleanup.go
@@ -79,7 +79,8 @@ func (l *LivenessScanner) Scan() {
 			// Look up the reverse entry, where we do the book-keeping.
 			revEntryBytes, err := l.ctMap.Get(ctVal.ReverseNATKey().AsBytes())
 			if err != nil && bpf.IsNotExists(err) {
-				// Forward entry exists but no reverse entry (and the grace period has expired).
+				// Forward entry exists but no reverse entry. We might have come across the reverse
+				// entry first and removed it. It is useless on its own, so delete it now.
 				log.Info("Found a forward NAT conntrack entry with no reverse entry, removing...")
 				err := l.ctMap.Delete(k)
 				log.WithError(err).Debug("Deletion result")
@@ -99,11 +100,9 @@ func (l *LivenessScanner) Scan() {
 				if err != nil && !bpf.IsNotExists(err) {
 					log.WithError(err).Warn("Failed to delete expired conntrack forward-NAT entry.")
 				}
-				err = l.ctMap.Delete(ctVal.ReverseNATKey().AsBytes())
-				log.WithError(err).Debug("Deletion result")
-				if err != nil && !bpf.IsNotExists(err) {
-					log.WithError(err).Warn("Failed to delete expired conntrack reverse-NAT entry.")
-				}
+				// do not delete the reverse entry yet to avoid breaking the iterating
+				// over the map.  We must not delete other than the current key. We remove
+				// it once we come across it again.
 			}
 		case TypeNATReverse:
 			if reason, expired := l.EntryExpired(now, ctKey.Proto(), ctVal); expired {

--- a/bpf/conntrack/cleanup.go
+++ b/bpf/conntrack/cleanup.go
@@ -81,6 +81,11 @@ func (l *LivenessScanner) Scan() {
 			if err != nil && bpf.IsNotExists(err) {
 				// Forward entry exists but no reverse entry. We might have come across the reverse
 				// entry first and removed it. It is useless on its own, so delete it now.
+				//
+				// N.B. BPF code always creates REV entry before FWD entry, therefore if the REV
+				// entry does not exist now, we are not racing with the BPF code, we must have
+				// removed the entry or there is some external inconsistency. In either case, the
+				// FWD entry should be removed.
 				log.Info("Found a forward NAT conntrack entry with no reverse entry, removing...")
 				err := l.ctMap.Delete(k)
 				log.WithError(err).Debug("Deletion result")

--- a/bpf/mock/map.go
+++ b/bpf/mock/map.go
@@ -32,6 +32,11 @@ func (m Map) MapFD() bpf.MapFD {
 	panic("implement me")
 }
 
+func (m Map) Open() error {
+	m.logCxt.Info("Open called")
+	return nil
+}
+
 func (m Map) EnsureExists() error {
 	m.logCxt.Info("EnsureExists called")
 	return nil

--- a/bpf/nat/maps.go
+++ b/bpf/nat/maps.go
@@ -281,6 +281,10 @@ func (m MapMem) Equal(cmp MapMem) bool {
 func LoadFrontendMap(m bpf.Map) (MapMem, error) {
 	ret := make(MapMem)
 
+	if err := m.Open(); err != nil {
+		return nil, err
+	}
+
 	err := m.Iter(MapMemIter(ret))
 	if err != nil {
 		ret = nil
@@ -305,7 +309,7 @@ func MapMemIter(m MapMem) bpf.MapIter {
 	}
 }
 
-// NATBackendMapMem represents a NATBackend loaded into memory
+// BackendMapMem represents a NATBackend loaded into memory
 type BackendMapMem map[BackendKey]BackendValue
 
 // Equal compares keys and values of the NATBackendMapMem
@@ -327,6 +331,10 @@ func (m BackendMapMem) Equal(cmp BackendMapMem) bool {
 // LoadBackendMap loads the NATBackend map into a go map or returns an error
 func LoadBackendMap(m bpf.Map) (BackendMapMem, error) {
 	ret := make(BackendMapMem)
+
+	if err := m.Open(); err != nil {
+		return nil, err
+	}
 
 	err := m.Iter(BackendMapMemIter(ret))
 	if err != nil {

--- a/bpf/proxy/syncer_test.go
+++ b/bpf/proxy/syncer_test.go
@@ -807,7 +807,18 @@ var _ = Describe("BPF Syncer", func() {
 	})
 })
 
+type mockMapDummy struct{}
+
+func (m *mockMapDummy) Open() error {
+	return nil
+}
+
+func (m *mockMapDummy) EnsureExists() error {
+	return nil
+}
+
 type mockNATMap struct {
+	mockMapDummy
 	sync.Mutex
 	m map[nat.FrontendKey]nat.FrontendValue
 }
@@ -820,10 +831,6 @@ func newMockNATMap() *mockNATMap {
 	return &mockNATMap{
 		m: make(map[nat.FrontendKey]nat.FrontendValue),
 	}
-}
-
-func (m *mockNATMap) EnsureExists() error {
-	return nil
 }
 
 func (m *mockNATMap) GetName() string {
@@ -893,6 +900,7 @@ func (m *mockNATMap) Delete(k []byte) error {
 }
 
 type mockNATBackendMap struct {
+	mockMapDummy
 	sync.Mutex
 	m map[nat.BackendKey]nat.BackendValue
 }
@@ -905,10 +913,6 @@ func newMockNATBackendMap() *mockNATBackendMap {
 	return &mockNATBackendMap{
 		m: make(map[nat.BackendKey]nat.BackendValue),
 	}
-}
-
-func (m *mockNATBackendMap) EnsureExists() error {
-	return nil
 }
 
 func (m *mockNATBackendMap) GetName() string {
@@ -978,6 +982,7 @@ func (m *mockNATBackendMap) Delete(k []byte) error {
 }
 
 type mockAffinityMap struct {
+	mockMapDummy
 	sync.Mutex
 	m map[nat.AffinityKey]nat.AffinityValue
 }
@@ -986,10 +991,6 @@ func newMockAffinityMap() *mockAffinityMap {
 	return &mockAffinityMap{
 		m: make(map[nat.AffinityKey]nat.AffinityValue),
 	}
-}
-
-func (m *mockAffinityMap) EnsureExists() error {
-	return nil
 }
 
 func (m *mockAffinityMap) GetName() string {

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -45,6 +45,7 @@ import (
 	. "github.com/onsi/gomega/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 
 	"github.com/projectcalico/felix/bpf"
 	"github.com/projectcalico/felix/bpf/conntrack"
@@ -637,4 +638,51 @@ func testPacketUDPDefaultNP(destIP net.IP) (*layers.Ethernet, *layers.IPv4, gopa
 func resetBPFMaps() {
 	resetCTMap(ctMap)
 	resetRTMap(rtMap)
+}
+
+func TestMapIterWithDelete(t *testing.T) {
+	m := (&bpf.MapContext{}).NewPinnedMap(bpf.MapParameters{
+		Filename:   "/sys/fs/bpf/tc/globals/cali_tmap",
+		Type:       "hash",
+		KeySize:    8,
+		ValueSize:  8,
+		MaxEntries: 1000,
+		Name:       "cali_tmap",
+		Flags:      unix.BPF_F_NO_PREALLOC,
+	})
+
+	err := m.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+
+	for i := 0; i < 10; i++ {
+		var k, v [8]byte
+
+		binary.LittleEndian.PutUint64(k[:], uint64(i))
+		binary.LittleEndian.PutUint64(v[:], uint64(i*7))
+
+		err := m.Update(k[:], v[:])
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	out := make(map[uint64]uint64)
+
+	cnt := 0
+	err = m.Iter(func(K, V []byte) {
+		k := binary.LittleEndian.Uint64(K)
+		v := binary.LittleEndian.Uint64(V)
+
+		out[k] = v
+
+		err := m.Delete(K)
+		Expect(err).NotTo(HaveOccurred())
+		cnt++
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(cnt).To(Equal(10))
+
+	for i := 0; i < 10; i++ {
+		Expect(out).To(HaveKey(uint64(i)))
+		Expect(out[uint64(i)]).To(Equal(uint64(i * 7)))
+	}
 }

--- a/cmd/calico-bpf/commands/conntrack.go
+++ b/cmd/calico-bpf/commands/conntrack.go
@@ -77,7 +77,7 @@ func (cmd *conntrackDumpCmd) Args(c *cobra.Command, args []string) error {
 func (cmd *conntrackDumpCmd) Run(c *cobra.Command, _ []string) {
 	mc := &bpf.MapContext{}
 	ctMap := conntrack.Map(mc)
-	if err := ctMap.EnsureExists(); err != nil {
+	if err := ctMap.Open(); err != nil {
 		log.WithError(err).Error("Failed to access ConntrackMap")
 	}
 	err := ctMap.Iter(func(k, v []byte) {
@@ -193,7 +193,7 @@ func (cmd *conntrackRemoveCmd) Args(c *cobra.Command, args []string) error {
 func (cmd *conntrackRemoveCmd) Run(c *cobra.Command, _ []string) {
 	mc := &bpf.MapContext{}
 	ctMap := conntrack.Map(mc)
-	if err := ctMap.EnsureExists(); err != nil {
+	if err := ctMap.Open(); err != nil {
 		log.WithError(err).Error("Failed to access ConntrackMap")
 	}
 	var keysToRemove []conntrack.Key

--- a/cmd/calico-bpf/commands/ipsets.go
+++ b/cmd/calico-bpf/commands/ipsets.go
@@ -19,9 +19,9 @@ import (
 	"sort"
 
 	"github.com/projectcalico/felix/bpf"
-
 	"github.com/projectcalico/felix/bpf/ipsets"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -49,6 +49,11 @@ var ipsetsCmd = &cobra.Command{
 
 func dumpIPSets() error {
 	ipsetMap := ipsets.Map(&bpf.MapContext{})
+
+	if err := ipsetMap.Open(); err != nil {
+		return errors.WithMessage(err, "failed to open map")
+	}
+
 	membersBySet := map[uint64][]string{}
 	err := ipsetMap.Iter(func(k, v []byte) {
 		var entry ipsets.IPSetEntry

--- a/cmd/calico-bpf/commands/nat.go
+++ b/cmd/calico-bpf/commands/nat.go
@@ -197,7 +197,7 @@ func (cmd *natFrontend) ArgsSet(c *cobra.Command, args []string) error {
 
 func (cmd *natFrontend) RunSet(c *cobra.Command, _ []string) {
 	natMap := nat.FrontendMap(&bpf.MapContext{})
-	if err := natMap.EnsureExists(); err != nil {
+	if err := natMap.Open(); err != nil {
 		log.WithError(err).Error("Failed to access NATMap")
 	}
 	k := nat.NewNATKey(cmd.ip, cmd.port, cmd.proto)
@@ -243,7 +243,7 @@ func (cmd *natFrontend) ArgsDel(c *cobra.Command, args []string) error {
 
 func (cmd *natFrontend) RunDel(c *cobra.Command, _ []string) {
 	natMap := nat.FrontendMap(&bpf.MapContext{})
-	if err := natMap.EnsureExists(); err != nil {
+	if err := natMap.Open(); err != nil {
 		log.WithError(err).Error("Failed to access NATMap")
 	}
 	k := nat.NewNATKey(cmd.ip, cmd.port, cmd.proto)
@@ -329,7 +329,7 @@ func (cmd *natBackend) ArgsSet(c *cobra.Command, args []string) error {
 func (cmd *natBackend) RunSet(c *cobra.Command, _ []string) {
 	mc := &bpf.MapContext{}
 	m := nat.BackendMap(mc)
-	if err := m.EnsureExists(); err != nil {
+	if err := m.Open(); err != nil {
 		log.WithError(err).Error("Failed to access NATMap")
 	}
 	k := nat.NewNATBackendKey(cmd.id, cmd.idx)
@@ -376,7 +376,7 @@ func (cmd *natBackend) ArgsDel(c *cobra.Command, args []string) error {
 func (cmd *natBackend) RunDel(c *cobra.Command, _ []string) {
 	mc := &bpf.MapContext{}
 	m := nat.BackendMap(mc)
-	if err := m.EnsureExists(); err != nil {
+	if err := m.Open(); err != nil {
 		log.WithError(err).Error("Failed to access NATMap")
 	}
 	k := nat.NewNATBackendKey(cmd.id, cmd.idx)

--- a/cmd/calico-bpf/commands/routes.go
+++ b/cmd/calico-bpf/commands/routes.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projectcalico/felix/bpf/routes"
 	"github.com/projectcalico/felix/ip"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -51,6 +52,10 @@ var routesCmd = &cobra.Command{
 func dumpRoutes() error {
 	mc := &bpf.MapContext{}
 	routesMap := routes.Map(mc)
+
+	if err := routesMap.Open(); err != nil {
+		return errors.WithMessage(err, "failed to open map")
+	}
 
 	var dests []ip.CIDR
 	valueByDest := map[ip.CIDR]routes.Value{}

--- a/dataplane/linux/bpf_route_mgr.go
+++ b/dataplane/linux/bpf_route_mgr.go
@@ -122,6 +122,8 @@ func (m *bpfRouteManager) OnUpdate(msg interface{}) {
 }
 
 func (m *bpfRouteManager) CompleteDeferredWork() error {
+	m.ensureDataplaneInitialised()
+
 	startTime := time.Now()
 
 	// Step 1: calculate any updates to the _desired_ state of the BPF map.
@@ -275,7 +277,6 @@ func (m *bpfRouteManager) calculateRoute(cidr ip.V4CIDR) *routes.Value {
 }
 
 func (m *bpfRouteManager) applyUpdates() (numDels uint, numAdds uint) {
-	m.ensureDataplaneInitialised()
 
 	debug := log.GetLevel() >= log.DebugLevel
 


### PR DESCRIPTION
Iteration is delete-safe, that is, deleting the current key does not
break iterating over the map, no key will be skipped and no key is
visited more then once.

The above holds as long as there is no other concurrent user.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
