### PR TITLE
Add BPF dataplane support for Wireguard

### DIFF
--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -106,11 +106,12 @@ struct bpf_map_def_extended {
 };
 
 /* These constants must be kept in sync with the calculate-flags script. */
-#define CALI_TC_HOST_EP	(1<<0)
-#define CALI_TC_INGRESS	(1<<1)
-#define CALI_TC_TUNNEL	(1<<2)
-#define CALI_CGROUP	(1<<3)
-#define CALI_TC_DSR	(1<<4)
+#define CALI_TC_HOST_EP		(1<<0)
+#define CALI_TC_INGRESS		(1<<1)
+#define CALI_TC_TUNNEL		(1<<2)
+#define CALI_CGROUP		(1<<3)
+#define CALI_TC_DSR		(1<<4)
+#define CALI_TC_WIREGUARD	(1<<5)
 
 #ifndef CALI_COMPILE_FLAGS
 #define CALI_COMPILE_FLAGS 0
@@ -119,9 +120,10 @@ struct bpf_map_def_extended {
 #define CALI_F_INGRESS ((CALI_COMPILE_FLAGS) & CALI_TC_INGRESS)
 #define CALI_F_EGRESS  (!CALI_F_INGRESS)
 
-#define CALI_F_HEP     ((CALI_COMPILE_FLAGS) & CALI_TC_HOST_EP)
-#define CALI_F_WEP     (!CALI_F_HEP)
-#define CALI_F_TUNNEL  ((CALI_COMPILE_FLAGS) & CALI_TC_TUNNEL)
+#define CALI_F_HEP     	 ((CALI_COMPILE_FLAGS) & CALI_TC_HOST_EP)
+#define CALI_F_WEP     	 (!CALI_F_HEP)
+#define CALI_F_TUNNEL  	 ((CALI_COMPILE_FLAGS) & CALI_TC_TUNNEL)
+#define CALI_F_WIREGUARD ((CALI_COMPILE_FLAGS) & CALI_TC_WIREGUARD)
 
 #define CALI_F_FROM_HEP (CALI_F_HEP && CALI_F_INGRESS)
 #define CALI_F_TO_HEP   (CALI_F_HEP && !CALI_F_INGRESS)
@@ -133,6 +135,7 @@ struct bpf_map_def_extended {
 #define CALI_F_FROM_HOST     (!CALI_F_TO_HOST)
 #define CALI_F_L3            (CALI_F_TO_HEP && CALI_F_TUNNEL)
 #define CALI_F_IPIP_ENCAPPED (CALI_F_INGRESS && CALI_F_TUNNEL)
+#define CALI_F_WG_INGRESS    (CALI_F_INGRESS && CALI_F_WIREGUARD)
 
 #define CALI_F_CGROUP	(((CALI_COMPILE_FLAGS) & CALI_CGROUP) != 0)
 #define CALI_F_DSR	(CALI_COMPILE_FLAGS & CALI_TC_DSR)

--- a/bpf-gpl/calculate-flags
+++ b/bpf-gpl/calculate-flags
@@ -61,6 +61,7 @@ flags=0
 ((CALI_TC_TUNNEL = 1 << 2))
 ((CALI_CGROUP = 1 << 3))
 ((CALI_TC_DSR = 1 << 4))
+((CALI_TC_WIREGUARD = 1 << 5))
 
 if [[ "${filename}" =~ .*hep.* ]]; then
   # Host endpoint.
@@ -72,6 +73,11 @@ elif [[ "${filename}" =~ .*tnl.* ]]; then
   ((flags |= CALI_TC_TUNNEL | CALI_TC_HOST_EP))
   args+=("-DCALI_DEBUG_ALLOW_ALL" "-DCALI_LOG_PFX=CALICOLO")
   ep_type="tunnel"
+elif [[ "${filename}" =~ .*wg.* ]]; then
+  # Wireguard.
+  ((flags |= CALI_TC_WIREGUARD | CALI_TC_HOST_EP))
+  args+=("-DCALI_DEBUG_ALLOW_ALL" "-DCALI_LOG_PFX=CALICOLO")
+  ep_type="wireguard"
 elif [[ "${filename}" =~ .*connect.* ]]; then
   # Connect-time load balancer (CGROUP attached).
   ((flags |= CALI_CGROUP))

--- a/bpf-gpl/list-objs
+++ b/bpf-gpl/list-objs
@@ -34,7 +34,7 @@ for log_level in debug info no_log; do
       # The workload-to-host drop setting only applies to the from-workload hook.
       ep_types="wep"
     else
-      ep_types="wep hep tnl"
+      ep_types="wep hep tnl wg"
     fi
     for fib in "" "fib_"; do
       for ep_type in $ep_types; do

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -46,7 +46,7 @@ static CALI_BPF_INLINE bool skb_too_short(struct __sk_buff *skb)
 {
 	if (CALI_F_IPIP_ENCAPPED) {
 		return skb_shorter(skb, ETH_IPV4_UDP_SIZE + sizeof(struct iphdr));
-	} else if (CALI_F_L3) {
+	} else if (CALI_F_L3 | CALI_F_WIREGUARD) {
 		return skb_shorter(skb, IPV4_UDP_SIZE);
 	} else {
 		return skb_shorter(skb, ETH_IPV4_UDP_SIZE);
@@ -59,8 +59,9 @@ static CALI_BPF_INLINE long skb_iphdr_offset(struct __sk_buff *skb)
 	if (CALI_F_IPIP_ENCAPPED) {
 		// Ingress on an IPIP tunnel: skb is [ether|outer IP|inner IP|payload]
 		return sizeof(struct ethhdr) + sizeof(struct iphdr);
-	} else if (CALI_F_L3) {
-		// Egress on an IPIP tunnel: skb is [inner IP|payload]
+	} else if (CALI_F_L3 | CALI_F_WIREGUARD) {
+		// Egress on an IPIP tunnel, or Wireguard both directions:
+		// skb is [inner IP|payload]
 		return 0;
 	} else {
 		// Normal L2 interface: skb is [ether|IP|payload]

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -211,6 +211,14 @@ static CALI_BPF_INLINE int forward_or_drop(struct __sk_buff *skb,
 #if FIB_ENABLED
 	// Try a short-circuit FIB lookup.
 	if (fwd_fib(fwd)) {
+		if (CALI_F_WG_INGRESS) {
+			// Don't try redirect from Wireguard ingress, because it doesn't work.
+			// Wireguard SKBs are L3 and we think we need to add on an Ethernet header
+			// before redirecting to a local cali* veth, so that the veth doesn't drop
+			// the packet.
+			goto cancel_fib;
+		}
+
 		/* XXX we might include the tot_len in the fwd, set it once when
 		 * we get the ip_header the first time and only adjust the value
 		 * when we modify the packet - to avoid geting the header here

--- a/bpf/tc/attach.go
+++ b/bpf/tc/attach.go
@@ -215,7 +215,7 @@ func (ap AttachPoint) ProgramName() string {
 	return SectionName(ap.Type, ap.ToOrFrom)
 }
 
-// FileName returnthe file the AttachPoint will load the program from
+// FileName return the file the AttachPoint will load the program from
 func (ap AttachPoint) FileName() string {
 	return ProgFilename(ap.Type, ap.ToOrFrom, ap.ToHostDrop, ap.FIB, ap.DSR, ap.LogLevel)
 }

--- a/bpf/tc/compiler.go
+++ b/bpf/tc/compiler.go
@@ -42,9 +42,10 @@ const (
 type EndpointType string
 
 const (
-	EpTypeWorkload EndpointType = "workload"
-	EpTypeHost     EndpointType = "host"
-	EpTypeTunnel   EndpointType = "tunnel"
+	EpTypeWorkload  EndpointType = "workload"
+	EpTypeHost      EndpointType = "host"
+	EpTypeTunnel    EndpointType = "tunnel"
+	EpTypeWireguard EndpointType = "wireguard"
 )
 
 func SectionName(endpointType EndpointType, fromOrTo ToOrFromEp) string {
@@ -87,6 +88,8 @@ func ProgFilename(epType EndpointType, toOrFrom ToOrFromEp, epToHostDrop, fib, d
 		epTypeShort = "hep"
 	case EpTypeTunnel:
 		epTypeShort = "tnl"
+	case EpTypeWireguard:
+		epTypeShort = "wg"
 	}
 	oFileName := fmt.Sprintf("%v_%v_%s%s%s%v.o",
 		toOrFrom, epTypeShort, hostDropPart, fibPart, dsrPart, logLevel)

--- a/bpf/tc/compiler.go
+++ b/bpf/tc/compiler.go
@@ -32,13 +32,6 @@ const (
 	HookEgress  Hook = "egress"
 )
 
-const (
-	CompileFlagHostEp  = 1
-	CompileFlagIngress = 2
-	CompileFlagTunnel  = 4
-	CompileFlagCgroup  = 8
-)
-
 type ToOrFromEp string
 
 const (
@@ -56,17 +49,6 @@ const (
 
 func SectionName(endpointType EndpointType, fromOrTo ToOrFromEp) string {
 	return fmt.Sprintf("calico_%s_%s_ep", fromOrTo, endpointType)
-}
-
-var sectionToFlags = map[string]int{}
-
-func init() {
-	sectionToFlags[SectionName(EpTypeWorkload, FromEp)] = 0
-	sectionToFlags[SectionName(EpTypeWorkload, ToEp)] = CompileFlagIngress
-	sectionToFlags[SectionName(EpTypeHost, FromEp)] = CompileFlagHostEp | CompileFlagIngress
-	sectionToFlags[SectionName(EpTypeHost, ToEp)] = CompileFlagHostEp
-	sectionToFlags[SectionName(EpTypeTunnel, FromEp)] = CompileFlagHostEp | CompileFlagIngress | CompileFlagTunnel
-	sectionToFlags[SectionName(EpTypeTunnel, ToEp)] = CompileFlagHostEp | CompileFlagTunnel
 }
 
 func ProgFilename(epType EndpointType, toOrFrom ToOrFromEp, epToHostDrop, fib, dsr bool, logLevel string) string {

--- a/config/config_params.go
+++ b/config/config_params.go
@@ -117,7 +117,7 @@ type Config struct {
 	BPFEnabled                         bool           `config:"bool;false"`
 	BPFDisableUnprivileged             bool           `config:"bool;true"`
 	BPFLogLevel                        string         `config:"oneof(off,info,debug);off;non-zero"`
-	BPFDataIfacePattern                *regexp.Regexp `config:"regexp;^(en.*|eth.*|tunl0$)"`
+	BPFDataIfacePattern                *regexp.Regexp `config:"regexp;^(en.*|eth.*|tunl0$|wireguard.cali$)"`
 	BPFConnectTimeLoadBalancingEnabled bool           `config:"bool;true"`
 	BPFExternalServiceMode             string         `config:"oneof(tunnel,dsr);tunnel;non-zero"`
 	BPFKubeProxyIptablesCleanupEnabled bool           `config:"bool;true"`

--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -614,6 +614,8 @@ func (m *bpfEndpointManager) attachDataIfaceProgram(ifaceName string, polDirecti
 	epType := tc.EpTypeHost
 	if ifaceName == "tunl0" {
 		epType = tc.EpTypeTunnel
+	} else if ifaceName == "wireguard.cali" {
+		epType = tc.EpTypeWireguard
 	}
 	ap := m.calculateTCAttachPoint(epType, polDirection, ifaceName)
 	ap.HostIP = m.hostIP


### PR DESCRIPTION
We need a new BPF program variant for Wireguard interfaces, because a
Wireguard device sees an SKB with the IP header at offset 0, in both
directions.  (aka It's an L3 device.)

For now we prevent direct redirect from the Wireguard ingress problem,
because that would need adding back an Ethernet header.  There will be
follow-on work to try to do that.


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
