### PR TITLE
bpf: Reduced allocations in map related syscalls

### DIFF
--- a/bpf/bpf_syscall.go
+++ b/bpf/bpf_syscall.go
@@ -30,6 +30,9 @@ import (
 // #include <linux/bpf.h>
 // #include <stdlib.h>
 // #include <string.h>
+// #include <errno.h>
+// #include <unistd.h>
+// #include <sys/syscall.h>
 //
 // union bpf_attr *bpf_attr_alloc() {
 //    union bpf_attr *attr = malloc(sizeof(union bpf_attr));
@@ -133,6 +136,18 @@ import (
 // __u32 bpf_attr_prog_run_duration(union bpf_attr *attr) {
 //    return attr->test.duration;
 // }
+//
+// int bpf_map_call(int cmd, __u32 map_fd, void *pointer_to_key, void *pointer_to_value, __u64 flags) {
+//    union bpf_attr attr = {};
+//
+//    attr.map_fd = map_fd;
+//    attr.key = (__u64)(unsigned long)pointer_to_key;
+//    attr.value = (__u64)(unsigned long)pointer_to_value;
+//    attr.flags = flags;
+//
+//    return syscall(SYS_bpf, cmd, &attr, sizeof(attr)) == 0 ? 0 : errno;
+// }
+//
 import "C"
 
 func SyscallSupport() bool {
@@ -292,26 +307,15 @@ func GetMapEntry(mapFD MapFD, k []byte, valueSize int) ([]byte, error) {
 		return nil, err
 	}
 
-	bpfAttr := C.bpf_attr_alloc()
-	defer C.free(unsafe.Pointer(bpfAttr))
+	val := make([]byte, valueSize)
 
-	// Have to make C-heap copies here because passing these to the syscalls is done via pointers in an
-	// intermediate struct.
-	cK := C.CBytes(k)
-	defer C.free(cK)
-	cV := C.malloc(C.size_t(valueSize))
-	defer C.free(cV)
-
-	C.bpf_attr_setup_map_elem(bpfAttr, C.uint(mapFD), cK, cV, unix.BPF_ANY)
-
-	_, _, errno := unix.Syscall(unix.SYS_BPF, unix.BPF_MAP_LOOKUP_ELEM, uintptr(unsafe.Pointer(bpfAttr)), C.sizeof_union_bpf_attr)
-
-	v := C.GoBytes(cV, C.int(valueSize))
-
+	errno := C.bpf_map_call(unix.BPF_MAP_LOOKUP_ELEM, C.uint(mapFD),
+		unsafe.Pointer(&k[0]), unsafe.Pointer(&val[0]), 0)
 	if errno != 0 {
-		return nil, errno
+		return nil, unix.Errno(errno)
 	}
-	return v, nil
+
+	return val, nil
 }
 
 func checkMapIfDebug(mapFD MapFD, keySize, valueSize int) error {
@@ -359,21 +363,12 @@ func DeleteMapEntry(mapFD MapFD, k []byte, valueSize int) error {
 		return err
 	}
 
-	bpfAttr := C.bpf_attr_alloc()
-	defer C.free(unsafe.Pointer(bpfAttr))
-
-	// Have to make C-heap copies here because passing these to the syscalls is done via pointers in an
-	// intermediate struct.
-	cK := C.CBytes(k)
-	defer C.free(cK)
-
-	C.bpf_attr_setup_map_elem_for_delete(bpfAttr, C.uint(mapFD), cK)
-
-	_, _, errno := unix.Syscall(unix.SYS_BPF, unix.BPF_MAP_DELETE_ELEM, uintptr(unsafe.Pointer(bpfAttr)), C.sizeof_union_bpf_attr)
-
+	errno := C.bpf_map_call(unix.BPF_MAP_DELETE_ELEM, C.uint(mapFD),
+		unsafe.Pointer(&k[0]), unsafe.Pointer(nil), 0)
 	if errno != 0 {
-		return errno
+		return unix.Errno(errno)
 	}
+
 	return nil
 }
 
@@ -383,39 +378,27 @@ func DeleteMapEntry(mapFD MapFD, k []byte, valueSize int) error {
 //
 // Start iterating by passing a nil key.
 func GetMapNextKey(mapFD MapFD, k []byte, keySize int) ([]byte, error) {
-	log.Debugf("MapNextKey(%v, %v, %v)", mapFD, k, keySize)
+	log.Debugf("GetMapNextKey(%v, %v, %v)", mapFD, k, keySize)
 
+	if log.GetLevel() >= log.DebugLevel && keySize == 0 && len(k) != keySize && len(k) != 0 {
+		log.WithField("keySize", keySize).WithField("keyLen", len(k)).Panic("keySize != len(k)")
+	}
 	err := checkMapIfDebug(mapFD, keySize, -1)
 	if err != nil {
 		return nil, err
 	}
 
-	bpfAttr := C.bpf_attr_alloc()
-	defer C.free(unsafe.Pointer(bpfAttr))
-
 	var cK unsafe.Pointer
-
-	// Have to make C-heap copies here because passing these to the syscalls is done via pointers in an
-	// intermediate struct.
-	//
-	// it is valid to pass a nil key to start the iteration
-	if k != nil {
-		cK = C.CBytes(k)
-		defer C.free(cK)
+	if len(k) > 0 {
+		cK = unsafe.Pointer(&k[0])
 	}
-	cV := C.malloc(C.size_t(keySize)) // value has the size of a key - it is the key!
-	defer C.free(cV)
 
-	C.bpf_attr_setup_map_get_next_key(bpfAttr, C.uint(mapFD), cK, cV, 0)
+	next := make([]byte, keySize)
 
-	_, _, errno := unix.Syscall(unix.SYS_BPF, unix.BPF_MAP_GET_NEXT_KEY,
-		uintptr(unsafe.Pointer(bpfAttr)), C.sizeof_union_bpf_attr)
-
-	v := C.GoBytes(cV, C.int(keySize))
-
+	errno := C.bpf_map_call(unix.BPF_MAP_GET_NEXT_KEY, C.uint(mapFD), cK, unsafe.Pointer(&next[0]), 0)
 	if errno != 0 {
-		return nil, errno
+		return nil, unix.Errno(errno)
 	}
 
-	return v, nil
+	return next, nil
 }

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -270,6 +270,7 @@ func cleanUpMaps() {
 		if m == stateMap || m == testStateMap || m == jumpMap {
 			continue // Can't clean up array maps
 		}
+		log.WithField("map", m.GetName()).Debug("Cleaning")
 		var allKeys [][]byte
 		err := m.Iter(func(k, v []byte) {
 			allKeys = append(allKeys, k)
@@ -645,6 +646,8 @@ func resetBPFMaps() {
 }
 
 func TestMapIterWithDelete(t *testing.T) {
+	RegisterTestingT(t)
+
 	m := (&bpf.MapContext{}).NewPinnedMap(bpf.MapParameters{
 		Filename:   "/sys/fs/bpf/tc/globals/cali_tmap",
 		Type:       "hash",


### PR DESCRIPTION
We use the slice buffer without allocating additional space.
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
