### PR TITLE
bpf/proxy flaky UTs fixes

### DIFF
--- a/bpf/proxy/proxy_test.go
+++ b/bpf/proxy/proxy_test.go
@@ -64,7 +64,6 @@ var _ = Describe("BPF Proxy", func() {
 		dp.checkState(func(s proxy.DPSyncerState) {
 			Expect(len(s.SvcMap)).To(Equal(0))
 			Expect(len(s.EpsMap)).To(Equal(0))
-			Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 		})
 	})
 
@@ -193,7 +192,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(2))
 					Expect(len(s.EpsMap)).To(Equal(2))
-					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 				})
 			})
 
@@ -222,7 +220,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(3))
 					Expect(len(s.EpsMap)).To(Equal(2))
-					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 				})
 			})
 
@@ -233,7 +230,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(2))
 					Expect(len(s.EpsMap)).To(Equal(2))
-					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 				})
 			})
 
@@ -283,7 +279,6 @@ var _ = Describe("BPF Proxy", func() {
 					Expect(len(s.SvcMap)).To(Equal(2))
 					Expect(len(s.EpsMap)).To(Equal(2))
 					Expect(len(s.EpsMap[secondSvcEpsKey])).To(Equal(1))
-					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 				})
 			})
 
@@ -295,7 +290,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(1))
 					Expect(len(s.EpsMap)).To(Equal(2))
-					Expect(len(s.StaleUDPSvcs)).To(Equal(1))
 				})
 			})
 
@@ -348,7 +342,6 @@ var _ = Describe("BPF Proxy", func() {
 					for _, port := range httpSvcEps.Subsets[0].Ports {
 						Expect(len(s.SvcMap)).To(Equal(1))
 						Expect(len(s.EpsMap)).To(Equal(5))
-						Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 
 						ep := s.EpsMap[k8sp.ServicePortName{
 							NamespacedName: types.NamespacedName{
@@ -396,7 +389,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(1))
 					Expect(len(s.EpsMap)).To(Equal(6))
-					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 				})
 			})
 
@@ -454,7 +446,6 @@ var _ = Describe("BPF Proxy", func() {
 				dp.checkState(func(s proxy.DPSyncerState) {
 					Expect(len(s.SvcMap)).To(Equal(2))
 					Expect(len(s.EpsMap)).To(Equal(7))
-					Expect(len(s.StaleUDPSvcs)).To(Equal(0))
 
 					npKey := k8sp.ServicePortName{
 						NamespacedName: types.NamespacedName{


### PR DESCRIPTION
## Description

It is perhaps a little too complicated, but I felt like changing completely to `Eventually` and turning all the `Expect` in `checkstate` into a single true/false function less readable and more difficult to maintain.

If a test fails, we also get which of the assertions was wrong - the first that failed in the last iteration.

    bpf/proxy: StaleUDPSvcs not used anymore
    
    Syncer calculates this on its own when necessary

    bpf/proxy: checkState checks "eventually"
    
    We need to use moc syncer's Expect in checkState if we want to wait for
    the expectations to be OK eventually.



<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
