### PR TITLE
Move GINKGO_FOCUS=BPF-SAFE to Makefile fv-bpf target

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -89,7 +89,7 @@ blocks:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-wireguard FORCE_WIREGUARD_FV="1"
     - name: FV on newer kernel
       commands:
-      - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-bpf GINKGO_FOCUS=BPF-SAFE FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT} FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}"
+      - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-bpf FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT} FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}"
       parallelism: 5
     epilogue:
       always:

--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,7 @@ fv fv/latency.log fv/data-races.log: $(REMOTE_DEPS) image-test bin/iptables-lock
 	fi
 
 fv-bpf:
-	$(MAKE) fv FELIX_FV_ENABLE_BPF=true
+	$(MAKE) fv FELIX_FV_ENABLE_BPF=true GINKGO_FOCUS=BPF-SAFE
 
 KO_DIR := "/lib/modules/$(shell uname -r)/"
 WIREGUARD_KO_PATH := $(shell find $(KO_DIR) -name "wireguard.ko")


### PR DESCRIPTION
GINKGO_FOCUS=BPF-SAFE is part of the definition of 'make fv-bpf', not
just of how we run under Semaphore

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
