### PR TITLE
Remove FORCE_WIREGUARD_FV

### DIFF
--- a/.semaphore/cleanup.yml
+++ b/.semaphore/cleanup.yml
@@ -20,7 +20,7 @@ blocks:
       - export VM_PREFIX=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}
       - echo VM_PREFIX=${VM_PREFIX}
     jobs:
-    - name: Clean up GCE insances
+    - name: Clean up GCE instances
       commands:
       - ./.semaphore/clean-up-vms ${VM_PREFIX}
     secrets:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -86,7 +86,7 @@ blocks:
     - name: UT on newer kernel
       commands:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} ut-bpf
-      - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-wireguard FORCE_WIREGUARD_FV="1"
+      - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-wireguard
     - name: FV on newer kernel
       commands:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-bpf GINKGO_FOCUS=BPF-SAFE FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT} FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -83,7 +83,7 @@ blocks:
       - mkdir artifacts
       - ./.semaphore/create-test-vm ${VM_NAME}
     jobs:
-    - name: UT on newer kernel
+    - name: UT and Wireguard FV on newer kernel
       commands:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} ut-bpf
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-wireguard

--- a/Makefile
+++ b/Makefile
@@ -427,18 +427,9 @@ fv-bpf:
 	$(MAKE) fv FELIX_FV_ENABLE_BPF=true
 
 KO_DIR := "/lib/modules/$(shell uname -r)/"
-WIREGUARD_KO_PATH := $(shell find $(KO_DIR) -name "wireguard.ko")
 fv-wireguard:
-ifndef FORCE_WIREGUARD_FV
-	@if test -z $(WIREGUARD_KO_PATH); then \
-		echo "WireGuard not available."; \
-		exit 1; \
-	else \
-		$(MAKE) fv FELIX_FV_WIREGUARD_AVAILABLE=true GINKGO_FOCUS="WireGuard-Supported"; \
-	fi
-else
+	test "`find $(KO_DIR) -name wireguard.ko`" || ( echo "WireGuard not available."; exit 1 )
 	$(MAKE) fv FELIX_FV_WIREGUARD_AVAILABLE=true GINKGO_FOCUS="WireGuard-Supported"
-endif
 
 ###############################################################################
 # K8SFV Tests


### PR DESCRIPTION
We shouldn't ever force wireguard if it's not available.  This is a
step towards simplifying the FV invocation logic so that we can
compose Wireguard and BPF testing.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
