### PR TITLE
BPF proxy startup fix

### DIFF
--- a/bpf/proxy/lb_src_range_test.go
+++ b/bpf/proxy/lb_src_range_test.go
@@ -187,7 +187,7 @@ var _ = Describe("BPF Load Balancer source range", func() {
 			s.Stop()
 		}))
 
-		By("Recreate the service with stale entries", makestep(func() {
+		By("Remove stale src range entries after syncer restarts", makestep(func() {
 			state.SvcMap[svcKey] = proxy.NewK8sServicePort(
 				net.IPv4(10, 0, 0, 2),
 				2222,
@@ -201,7 +201,7 @@ var _ = Describe("BPF Load Balancer source range", func() {
 			Expect(svcs.m).To(HaveLen(3))
 		}))
 
-		By("Recreate the service with stale entries and no lb source IPs", makestep(func() {
+		By("Remove all stale src ranges after syncer restarts", makestep(func() {
 			state.SvcMap[svcKey] = proxy.NewK8sServicePort(
 				net.IPv4(10, 0, 0, 2),
 				2222,

--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -304,6 +304,9 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 			continue
 		}
 
+		if count > 0 {
+			s.prevEpsMap[svckey.sname] = make([]k8sp.Endpoint, 0, count)
+		}
 		for i := 0; i < count; i++ {
 			epk := nat.NewNATBackendKey(id, uint32(i))
 			ep, ok := s.origEps[epk]

--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -221,7 +221,7 @@ func (s *Syncer) loadOrigs() error {
 	return nil
 }
 
-func (s *Syncer) startupSync(state DPSyncerState) error {
+func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 	for svck, svcv := range s.origSvcs {
 		svckey := s.matchBpfSvc(svck, state.SvcMap)
 		if svckey == nil {
@@ -264,6 +264,10 @@ func (s *Syncer) startupSync(state DPSyncerState) error {
 		}
 	}
 
+	return nil
+}
+
+func (s *Syncer) startupRemoveStale() error {
 	for k := range s.origSvcs {
 		log.Debugf("removing stale %s", k)
 		if err := s.bpfSvcs.Delete(k[:]); err != nil {
@@ -279,6 +283,14 @@ func (s *Syncer) startupSync(state DPSyncerState) error {
 	}
 
 	return nil
+}
+
+func (s *Syncer) startupSync(state DPSyncerState) error {
+	if err := s.startupBuildPrev(state); err != nil {
+		return err
+	}
+
+	return s.startupRemoveStale()
 }
 
 func (s *Syncer) cleanupDerived(id uint32) error {

--- a/bpf/proxy/syncer_bench_test.go
+++ b/bpf/proxy/syncer_bench_test.go
@@ -15,6 +15,8 @@
 // We keep the benchmarks in the proxy package to be able to bench unexported
 // partial functionality.
 
+// +build benchmark
+
 package proxy
 
 import (

--- a/bpf/proxy/syncer_bench_test.go
+++ b/bpf/proxy/syncer_bench_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// We keep the benchmarks in the proxy package to be able to bench unexported
+// partial functionality.
+
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sp "k8s.io/kubernetes/pkg/proxy"
+
+	"github.com/projectcalico/felix/bpf/nat"
+)
+
+func makeState(svcCnt, epCnt int) DPSyncerState {
+	state := DPSyncerState{
+		SvcMap: make(k8sp.ServiceMap, svcCnt),
+		EpsMap: make(k8sp.EndpointsMap, epCnt),
+	}
+
+	for i := 0; i < svcCnt; i++ {
+		sk := k8sp.ServicePortName{
+			NamespacedName: types.NamespacedName{
+				Namespace: "default",
+				Name:      fmt.Sprintf("bench-svc-%d", i),
+			},
+		}
+		state.SvcMap[sk] = NewK8sServicePort(
+			net.IPv4(10, byte((i&0xff0000)>>16), byte((i&0xff00)>>8), byte(i&0xff)),
+			1234,
+			v1.ProtocolTCP,
+		)
+
+		eps := make([]k8sp.Endpoint, epCnt)
+		for j := 0; j < epCnt; j++ {
+			eps[j] = &k8sp.BaseEndpointInfo{Endpoint: fmt.Sprintf("11.1.1.1:%d", j+1)}
+		}
+		state.EpsMap[sk] = eps
+	}
+
+	return state
+}
+
+func stateToBPFMaps(state DPSyncerState) (nat.MapMem, nat.BackendMapMem) {
+	fe := make(nat.MapMem, len(state.SvcMap))
+	be := make(nat.BackendMapMem, len(state.SvcMap)*10)
+
+	id := uint32(1)
+	for sk, sv := range state.SvcMap {
+		fk := nat.NewNATKey(sv.ClusterIP(), uint16(sv.Port()), ProtoV1ToIntPanic(sv.Protocol()))
+
+		eps := state.EpsMap[sk]
+
+		fe[fk] = nat.NewNATValue(id, uint32(len(eps)), 0, 0)
+
+		for i, ep := range eps {
+			port, _ := ep.Port()
+			be[nat.NewNATBackendKey(id, uint32(i))] = nat.NewNATBackendValue(net.ParseIP(ep.IP()), uint16(port))
+		}
+
+		id++
+	}
+
+	return fe, be
+}
+
+func benchmarkStartupSync(b *testing.B, svcCnt, epCnt int) {
+	state := makeState(svcCnt, epCnt)
+
+	b.Run(fmt.Sprintf("Services %d Endpoints %d", svcCnt, epCnt), func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			b.StopTimer()
+			origSvcs, origEps := stateToBPFMaps(state)
+			s := &Syncer{
+				prevSvcMap: make(map[svcKey]svcInfo),
+				prevEpsMap: make(k8sp.EndpointsMap),
+				origSvcs:   origSvcs,
+				origEps:    origEps,
+			}
+
+			b.StartTimer()
+			s.startupBuildPrev(state)
+		}
+	})
+}
+
+func BenchmarkStartupSync(b *testing.B) {
+	logrus.SetLevel(logrus.InfoLevel)
+
+	benchmarkStartupSync(b, 10, 1)
+	benchmarkStartupSync(b, 10, 10)
+	benchmarkStartupSync(b, 100, 1)
+	benchmarkStartupSync(b, 100, 10)
+	benchmarkStartupSync(b, 1000, 10)
+	benchmarkStartupSync(b, 1000, 100)
+	benchmarkStartupSync(b, 10000, 1)
+	benchmarkStartupSync(b, 10000, 10)
+	benchmarkStartupSync(b, 10000, 100)
+}


### PR DESCRIPTION
## Description

From O(n^2) towards O(n)

before:

```
BenchmarkStartupSync/Services_10_Endpoints_1-12         	   63256	     18718 ns/op	    8357 B/op	     236 allocs/op
BenchmarkStartupSync/Services_10_Endpoints_10-12        	   22261	     54462 ns/op	   18195 B/op	     545 allocs/op
BenchmarkStartupSync/Services_100_Endpoints_1-12        	    1756	    737219 ns/op	  237768 B/op	   11326 allocs/op
BenchmarkStartupSync/Services_100_Endpoints_10-12       	    1060	   1271850 ns/op	  336121 B/op	   14413 allocs/op
BenchmarkStartupSync/Services_1000_Endpoints_10-12      	      18	  63691920 ns/op	17817078 B/op	 1040328 allocs/op
BenchmarkStartupSync/Services_1000_Endpoints_100-12     	      12	  92424672 ns/op	26530761 B/op	 1319624 allocs/op
BenchmarkStartupSync/Services_10000_Endpoints_1-12      	       1	6289452353 ns/op	1605454416 B/op	100324524 allocs/op
BenchmarkStartupSync/Services_10000_Endpoints_10-12     	       1	6325168548 ns/op	1607597344 B/op	100173814 allocs/op
BenchmarkStartupSync/Services_10000_Endpoints_100-12    	       1	7681977134 ns/op	1720611008 B/op	104589689 allocs/op
```

after:

```
BenchmarkStartupSync/Services_10_Endpoints_1-12         	   74241	     16182 ns/op	    9576 B/op	     168 allocs/op
BenchmarkStartupSync/Services_10_Endpoints_10-12        	   23649	     47887 ns/op	   19417 B/op	     478 allocs/op
BenchmarkStartupSync/Services_100_Endpoints_1-12        	    7606	    152907 ns/op	  102965 B/op	    1624 allocs/op
BenchmarkStartupSync/Services_100_Endpoints_10-12       	    2353	    577624 ns/op	  202049 B/op	    4724 allocs/op
BenchmarkStartupSync/Services_1000_Endpoints_10-12      	     234	   5063275 ns/op	 2443199 B/op	   47079 allocs/op
BenchmarkStartupSync/Services_1000_Endpoints_100-12     	      36	  31615645 ns/op	11065896 B/op	  321077 allocs/op
BenchmarkStartupSync/Services_10000_Endpoints_1-12      	      64	  18008992 ns/op	11967414 B/op	  160594 allocs/op
BenchmarkStartupSync/Services_10000_Endpoints_10-12     	      22	  55656731 ns/op	21884698 B/op	  470594 allocs/op
BenchmarkStartupSync/Services_10000_Endpoints_100-12    	       3	 354862182 ns/op	108117866 B/op	 3210587 allocs/op
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, Felix now uses a more efficient algorithm to resync the Kubernetes sevices with the dataplane.  This speeds up the initial sync (especially with large numbers of services).
```
