### PR TITLE
Adding support to detect RHEL with kernel version 4.18.0

### DIFF
--- a/bpf/bpf.go
+++ b/bpf/bpf.go
@@ -92,11 +92,8 @@ var (
 	// required features we use for XDP filtering
 	v4Dot16Dot0 = versionparse.MustParseVersion("4.16.0")
 	// v4Dot18Dot0 is the kernel version in RHEL that has all the
-	// required features for BPF dataplane
+	// required features for BPF dataplane, sidecar acceleration
 	v4Dot18Dot0 = versionparse.MustParseVersion("4.18.0")
-	// v4Dot20Dot0 is the first kernel version that has all the
-	// required features we use for sidecar acceleration
-	v4Dot20Dot0 = versionparse.MustParseVersion("4.20.0")
 	// v5Dot3Dot0 is the first kernel version that has all the
 	// required features we use for BPF dataplane mode
 	v5Dot3Dot0 = versionparse.MustParseVersion("5.3.0")

--- a/bpf/bpf.go
+++ b/bpf/bpf.go
@@ -37,7 +37,6 @@ import (
 	"strings"
 	"syscall"
 
-	version "github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
@@ -102,7 +101,7 @@ var (
 	v5Dot3Dot0 = versionparse.MustParseVersion("5.3.0")
 )
 
-var distToVersionMap = map[string]*version.Version{
+var distToVersionMap = map[string]*versionparse.Version{
 	"ubuntu":  v5Dot3Dot0,
 	"rhel":    v4Dot18Dot0,
 	"default": v5Dot3Dot0,
@@ -2169,7 +2168,7 @@ func (b *BPFLib) RemoveSockmapEndpointsMap() error {
 	return os.Remove(mapPath)
 }
 
-func isAtLeastKernel(v *version.Version) error {
+func isAtLeastKernel(v *versionparse.Version) error {
 	versionReader, err := versionparse.GetKernelVersionReader()
 	if err != nil {
 		return fmt.Errorf("failed to get kernel version reader: %v", err)
@@ -2180,7 +2179,7 @@ func isAtLeastKernel(v *version.Version) error {
 		return fmt.Errorf("failed to get kernel version: %v", err)
 	}
 
-	if versionparse.Compare(kernelVersion, v) < 0 {
+	if kernelVersion.Compare(v) < 0 {
 		return fmt.Errorf("kernel is too old (have: %v but want at least: %v)", kernelVersion, v)
 	}
 
@@ -2200,7 +2199,7 @@ func SupportsSockmap() error {
 	return nil
 }
 
-func GetMinKernelVersionForDistro(distName string) *version.Version {
+func GetMinKernelVersionForDistro(distName string) *versionparse.Version {
 	return distToVersionMap[distName]
 }
 

--- a/bpf/bpf.go
+++ b/bpf/bpf.go
@@ -93,7 +93,7 @@ var (
 	v4Dot16Dot0 = versionparse.MustParseVersion("4.16.0")
 	// v4Dot18Dot0 is the kernel version in RHEL that has all the
 	// required features for BPF dataplane, sidecar acceleration
-	v4Dot18Dot0 = versionparse.MustParseVersion("4.18.0")
+	v4Dot18Dot0 = versionparse.MustParseVersion("4.18.0-193")
 	// v5Dot3Dot0 is the first kernel version that has all the
 	// required features we use for BPF dataplane mode
 	v5Dot3Dot0 = versionparse.MustParseVersion("5.3.0")
@@ -2197,9 +2197,13 @@ func SupportsSockmap() error {
 	return nil
 }
 
+func GetExpectedVersionFromMap(distName string) *version.Version {
+	return distToVersionMap[distName]
+}
+
 func SupportsBPFDataplane() error {
 	distName := versionparse.GetDistributionName()
-	if err := isAtLeastKernel(distToVersionMap[distName]); err != nil {
+	if err := isAtLeastKernel(GetExpectedVersionFromMap(distName)); err != nil {
 		return err
 	}
 

--- a/bpf/bpf.go
+++ b/bpf/bpf.go
@@ -91,6 +91,9 @@ var (
 	// v4Dot16Dot0 is the first kernel version that has all the
 	// required features we use for XDP filtering
 	v4Dot16Dot0 = versionparse.MustParseVersion("4.16.0")
+	// v4Dot18Dot0 is the kernel version in RHEL that has all the
+	// required features for BPF dataplane
+	v4Dot18Dot0 = versionparse.MustParseVersion("4.18.0")
 	// v4Dot20Dot0 is the first kernel version that has all the
 	// required features we use for sidecar acceleration
 	v4Dot20Dot0 = versionparse.MustParseVersion("4.20.0")
@@ -98,6 +101,12 @@ var (
 	// required features we use for BPF dataplane mode
 	v5Dot3Dot0 = versionparse.MustParseVersion("5.3.0")
 )
+
+var distToVersionMap = map[string]*version.Version{
+	"ubuntu":  v5Dot3Dot0,
+	"rhel":    v4Dot18Dot0,
+	"default": v5Dot3Dot0,
+}
 
 func (m XDPMode) String() string {
 	switch m {
@@ -2179,7 +2188,7 @@ func isAtLeastKernel(v *version.Version) error {
 }
 
 func SupportsSockmap() error {
-	if err := isAtLeastKernel(v4Dot20Dot0); err != nil {
+	if err := isAtLeastKernel(v4Dot18Dot0); err != nil {
 		return err
 	}
 
@@ -2192,7 +2201,8 @@ func SupportsSockmap() error {
 }
 
 func SupportsBPFDataplane() error {
-	if err := isAtLeastKernel(v5Dot3Dot0); err != nil {
+	distName := versionparse.GetDistributionName()
+	if err := isAtLeastKernel(distToVersionMap[distName]); err != nil {
 		return err
 	}
 

--- a/bpf/bpf.go
+++ b/bpf/bpf.go
@@ -94,6 +94,9 @@ var (
 	// v4Dot18Dot0 is the kernel version in RHEL that has all the
 	// required features for BPF dataplane, sidecar acceleration
 	v4Dot18Dot0 = versionparse.MustParseVersion("4.18.0-193")
+	// v4Dot20Dot0 is the first kernel version that has all the
+	// required features we use for sidecar acceleration
+	v4Dot20Dot0 = versionparse.MustParseVersion("4.20.0")
 	// v5Dot3Dot0 is the first kernel version that has all the
 	// required features we use for BPF dataplane mode
 	v5Dot3Dot0 = versionparse.MustParseVersion("5.3.0")
@@ -2177,7 +2180,7 @@ func isAtLeastKernel(v *version.Version) error {
 		return fmt.Errorf("failed to get kernel version: %v", err)
 	}
 
-	if kernelVersion.Compare(v) < 0 {
+	if versionparse.Compare(kernelVersion, v) < 0 {
 		return fmt.Errorf("kernel is too old (have: %v but want at least: %v)", kernelVersion, v)
 	}
 
@@ -2185,7 +2188,7 @@ func isAtLeastKernel(v *version.Version) error {
 }
 
 func SupportsSockmap() error {
-	if err := isAtLeastKernel(v4Dot18Dot0); err != nil {
+	if err := isAtLeastKernel(v4Dot20Dot0); err != nil {
 		return err
 	}
 
@@ -2197,13 +2200,13 @@ func SupportsSockmap() error {
 	return nil
 }
 
-func GetExpectedVersionFromMap(distName string) *version.Version {
+func GetMinKernelVersionForDistro(distName string) *version.Version {
 	return distToVersionMap[distName]
 }
 
 func SupportsBPFDataplane() error {
 	distName := versionparse.GetDistributionName()
-	if err := isAtLeastKernel(GetExpectedVersionFromMap(distName)); err != nil {
+	if err := isAtLeastKernel(GetMinKernelVersionForDistro(distName)); err != nil {
 		return err
 	}
 

--- a/bpf/bpf_test.go
+++ b/bpf/bpf_test.go
@@ -30,6 +30,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/felix/labelindex"
+	"github.com/projectcalico/felix/versionparse"
 )
 
 const (
@@ -759,5 +760,48 @@ func TestIPv6NotSupported(t *testing.T) {
 	_, err := bpfDP.NewCIDRMap("myiface2", IPFamilyV6)
 	if err == nil {
 		t.Fatalf("creating an IPv6 blacklist should have failed")
+	}
+}
+
+func TestVersionParse(t *testing.T) {
+	t.Log("Test version parsing")
+	ubuntuVersionStr := "Linux version 5.3.0-39-generic (buildd@lcy01-amd64-016) (gcc version 9.3.0 (Ubuntu 9.3.0-10ubuntu2)) #43-Ubuntu SMP Fri Jun 19 10:28:31 UTC 2020"
+	rhelVersionStr := "Linux version 4.18.0-193.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com) (gcc version 8.3.1 20191121 (Red Hat 8.3.1-5) (GCC)) #1 SMP Fri Mar 27 14:35:58 UTC 2020"
+	fedVersionStr := "Linux version 5.3.0-193.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com) (gcc version 8.3.1 20191121 (Fedora 8.3.1-5) (GCC)) #1 SMP Fri Mar 27 14:35:58 UTC 2020"
+	distName := versionparse.GetDistFromString(ubuntuVersionStr)
+	if distName != "ubuntu" {
+		t.Fatalf("Parsing distribution name failed")
+	}
+	parsedVer, err := versionparse.GetVersionFromString(ubuntuVersionStr)
+	if err != nil {
+		t.Fatalf("Parsing kernel version failed")
+	}
+	expVer := GetExpectedVersionFromMap(distName)
+	if parsedVer.Compare(expVer) != 0 {
+		t.Fatalf("Parsed version not same as expected version")
+	}
+	distName = versionparse.GetDistFromString(rhelVersionStr)
+	if distName != "rhel" {
+		t.Fatalf("Parsing distribution name failed")
+	}
+	parsedVer, err = versionparse.GetVersionFromString(rhelVersionStr)
+	if err != nil {
+		t.Fatalf("Parsing kernel version failed")
+	}
+	expVer = GetExpectedVersionFromMap(distName)
+	if parsedVer.Compare(expVer) != 0 {
+		t.Fatalf("Parsed version not same as expected version")
+	}
+	distName = versionparse.GetDistFromString(fedVersionStr)
+	if distName != "default" {
+		t.Fatalf("Parsing distribution name failed")
+	}
+	parsedVer, err = versionparse.GetVersionFromString(fedVersionStr)
+	if err != nil {
+		t.Fatalf("Parsing kernel version failed")
+	}
+	expVer = GetExpectedVersionFromMap(distName)
+	if parsedVer.Compare(expVer) != 0 {
+		t.Fatalf("Parsed version not same as expected version")
 	}
 }

--- a/bpf/bpf_test.go
+++ b/bpf/bpf_test.go
@@ -777,7 +777,7 @@ func TestVersionParse(t *testing.T) {
 		t.Fatalf("Parsing kernel version failed")
 	}
 	expVer := GetMinKernelVersionForDistro(distName)
-	if versionparse.Compare(parsedVer, expVer) != 0 {
+	if parsedVer.Compare(expVer) != 0 {
 		t.Fatalf("Parsed version not same as expected version")
 	}
 
@@ -790,7 +790,7 @@ func TestVersionParse(t *testing.T) {
 		t.Fatalf("Parsing kernel version failed")
 	}
 	expVer = GetMinKernelVersionForDistro(distName)
-	if versionparse.Compare(parsedVer, expVer) != 0 {
+	if parsedVer.Compare(expVer) != 0 {
 		t.Fatalf("Parsed version not same as expected version")
 	}
 
@@ -803,34 +803,34 @@ func TestVersionParse(t *testing.T) {
 		t.Fatalf("Parsing kernel version failed")
 	}
 	expVer = GetMinKernelVersionForDistro(distName)
-	if versionparse.Compare(parsedVer, expVer) != 0 {
+	if parsedVer.Compare(expVer) != 0 {
 		t.Fatalf("Parsed version not same as expected version")
 	}
 
 	// Tests to verify the compare function in versionparse
 	ver1 := versionparse.MustParseVersion("4.18.0-193")
 	ver2 := versionparse.MustParseVersion("4.18.0-194")
-	if versionparse.Compare(ver1, ver2) != -1 {
+	if ver1.Compare(ver2) != -1 {
 		t.Fatalf("Comparing kernel versions 4.18.0-193 and 4.18.0-194 failed")
 	}
 	ver2 = versionparse.MustParseVersion("4.18.0-192")
-	if versionparse.Compare(ver1, ver2) != 1 {
+	if ver1.Compare(ver2) != 1 {
 		t.Fatalf("Comparing kernel versions 4.18.0-193 and 4.18.0-192 failed")
 	}
 	ver2 = versionparse.MustParseVersion("4.18.0-193")
-	if versionparse.Compare(ver1, ver2) != 0 {
+	if ver1.Compare(ver2) != 0 {
 		t.Fatalf("Comparing same kernel versions failed")
 	}
 	ver2 = versionparse.MustParseVersion("4.18.0")
-	if versionparse.Compare(ver1, ver2) != 1 {
+	if ver1.Compare(ver2) != 1 {
 		t.Fatalf("Comparing kernel versions 4.18.0-193 and 4.18.0 failed")
 	}
 	ver2 = versionparse.MustParseVersion("5.3.0")
-	if versionparse.Compare(ver1, ver2) != -1 {
+	if ver1.Compare(ver2) != -1 {
 		t.Fatalf("Comparing kernel versions 4.18.0-193 and 5.3.0 failed")
 	}
 	ver2 = versionparse.MustParseVersion("4.19.0")
-	if versionparse.Compare(ver1, ver2) != -1 {
+	if ver1.Compare(ver2) != -1 {
 		t.Fatalf("Comparing kernel versions 4.18.0-193 and 4.19.0 failed")
 	}
 }

--- a/bpf/bpf_test.go
+++ b/bpf/bpf_test.go
@@ -776,10 +776,11 @@ func TestVersionParse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parsing kernel version failed")
 	}
-	expVer := GetExpectedVersionFromMap(distName)
-	if parsedVer.Compare(expVer) != 0 {
+	expVer := GetMinKernelVersionForDistro(distName)
+	if versionparse.Compare(parsedVer, expVer) != 0 {
 		t.Fatalf("Parsed version not same as expected version")
 	}
+
 	distName = versionparse.GetDistFromString(rhelVersionStr)
 	if distName != "rhel" {
 		t.Fatalf("Parsing distribution name failed")
@@ -788,10 +789,11 @@ func TestVersionParse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parsing kernel version failed")
 	}
-	expVer = GetExpectedVersionFromMap(distName)
-	if parsedVer.Compare(expVer) != 0 {
+	expVer = GetMinKernelVersionForDistro(distName)
+	if versionparse.Compare(parsedVer, expVer) != 0 {
 		t.Fatalf("Parsed version not same as expected version")
 	}
+
 	distName = versionparse.GetDistFromString(fedVersionStr)
 	if distName != "default" {
 		t.Fatalf("Parsing distribution name failed")
@@ -800,8 +802,35 @@ func TestVersionParse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parsing kernel version failed")
 	}
-	expVer = GetExpectedVersionFromMap(distName)
-	if parsedVer.Compare(expVer) != 0 {
+	expVer = GetMinKernelVersionForDistro(distName)
+	if versionparse.Compare(parsedVer, expVer) != 0 {
 		t.Fatalf("Parsed version not same as expected version")
+	}
+
+	// Tests to verify the compare function in versionparse
+	ver1 := versionparse.MustParseVersion("4.18.0-193")
+	ver2 := versionparse.MustParseVersion("4.18.0-194")
+	if versionparse.Compare(ver1, ver2) != -1 {
+		t.Fatalf("Comparing kernel versions 4.18.0-193 and 4.18.0-194 failed")
+	}
+	ver2 = versionparse.MustParseVersion("4.18.0-192")
+	if versionparse.Compare(ver1, ver2) != 1 {
+		t.Fatalf("Comparing kernel versions 4.18.0-193 and 4.18.0-192 failed")
+	}
+	ver2 = versionparse.MustParseVersion("4.18.0-193")
+	if versionparse.Compare(ver1, ver2) != 0 {
+		t.Fatalf("Comparing same kernel versions failed")
+	}
+	ver2 = versionparse.MustParseVersion("4.18.0")
+	if versionparse.Compare(ver1, ver2) != 1 {
+		t.Fatalf("Comparing kernel versions 4.18.0-193 and 4.18.0 failed")
+	}
+	ver2 = versionparse.MustParseVersion("5.3.0")
+	if versionparse.Compare(ver1, ver2) != -1 {
+		t.Fatalf("Comparing kernel versions 4.18.0-193 and 5.3.0 failed")
+	}
+	ver2 = versionparse.MustParseVersion("4.19.0")
+	if versionparse.Compare(ver1, ver2) != -1 {
+		t.Fatalf("Comparing kernel versions 4.18.0-193 and 4.19.0 failed")
 	}
 }

--- a/fv/xdp_test.go
+++ b/fv/xdp_test.go
@@ -369,8 +369,8 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 				kernelVersion, err := versionparse.GetKernelVersion(versionReader)
 				Expect(err).NotTo(HaveOccurred())
 
-				if kernelVersion.Compare(versionparse.MustParseVersion("4.18.0-193")) < 0 {
-					Skip(fmt.Sprintf("Skipping TCP test on Linux %v (needs 4.18.0-193)", kernelVersion))
+				if kernelVersion.Compare(versionparse.MustParseVersion("4.19.0")) < 0 {
+					Skip(fmt.Sprintf("Skipping TCP test on Linux %v (needs 4.19)", kernelVersion))
 					return
 				}
 
@@ -494,8 +494,8 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 				kernelVersion, err := versionparse.GetKernelVersion(versionReader)
 				Expect(err).NotTo(HaveOccurred())
 
-				if kernelVersion.Compare(versionparse.MustParseVersion("4.18.0-193")) < 0 {
-					Skip(fmt.Sprintf("Skipping TCP test on Linux %v (needs 4.18.0-193)", kernelVersion))
+				if kernelVersion.Compare(versionparse.MustParseVersion("4.19.0")) < 0 {
+					Skip(fmt.Sprintf("Skipping TCP test on Linux %v (needs 4.19)", kernelVersion))
 					return
 				}
 

--- a/fv/xdp_test.go
+++ b/fv/xdp_test.go
@@ -369,7 +369,7 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 				kernelVersion, err := versionparse.GetKernelVersion(versionReader)
 				Expect(err).NotTo(HaveOccurred())
 
-				if kernelVersion.Compare(versionparse.MustParseVersion("4.19.0")) < 0 {
+				if kernelVersion.Compare(versionparse.MustParseVersion("4.18.0")) < 0 {
 					Skip(fmt.Sprintf("Skipping TCP test on Linux %v (needs 4.19)", kernelVersion))
 					return
 				}
@@ -494,7 +494,7 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 				kernelVersion, err := versionparse.GetKernelVersion(versionReader)
 				Expect(err).NotTo(HaveOccurred())
 
-				if kernelVersion.Compare(versionparse.MustParseVersion("4.19.0")) < 0 {
+				if kernelVersion.Compare(versionparse.MustParseVersion("4.18.0")) < 0 {
 					Skip(fmt.Sprintf("Skipping TCP test on Linux %v (needs 4.19)", kernelVersion))
 					return
 				}

--- a/fv/xdp_test.go
+++ b/fv/xdp_test.go
@@ -369,8 +369,8 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 				kernelVersion, err := versionparse.GetKernelVersion(versionReader)
 				Expect(err).NotTo(HaveOccurred())
 
-				if kernelVersion.Compare(versionparse.MustParseVersion("4.18.0")) < 0 {
-					Skip(fmt.Sprintf("Skipping TCP test on Linux %v (needs 4.19)", kernelVersion))
+				if kernelVersion.Compare(versionparse.MustParseVersion("4.18.0-193")) < 0 {
+					Skip(fmt.Sprintf("Skipping TCP test on Linux %v (needs 4.18.0-193)", kernelVersion))
 					return
 				}
 
@@ -494,8 +494,8 @@ var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.D
 				kernelVersion, err := versionparse.GetKernelVersion(versionReader)
 				Expect(err).NotTo(HaveOccurred())
 
-				if kernelVersion.Compare(versionparse.MustParseVersion("4.18.0")) < 0 {
-					Skip(fmt.Sprintf("Skipping TCP test on Linux %v (needs 4.19)", kernelVersion))
+				if kernelVersion.Compare(versionparse.MustParseVersion("4.18.0-193")) < 0 {
+					Skip(fmt.Sprintf("Skipping TCP test on Linux %v (needs 4.18.0-193)", kernelVersion))
 					return
 				}
 

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,9 @@ import (
 	"strings"
 	"sync"
 
-	version "github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/felix/versionparse"
+	version "github.com/projectcalico/felix/versionparse"
 )
 
 var (
@@ -33,17 +32,17 @@ var (
 
 	// iptables versions:
 	// v1Dot4Dot7 is the oldest version we've ever supported.
-	v1Dot4Dot7 = versionparse.MustParseVersion("1.4.7")
+	v1Dot4Dot7, _ = version.NewVersion("1.4.7")
 	// v1Dot6Dot0 added --random-fully to SNAT.
-	v1Dot6Dot0 = versionparse.MustParseVersion("1.6.0")
+	v1Dot6Dot0, _ = version.NewVersion("1.6.0")
 	// v1Dot6Dot2 added --random-fully to MASQUERADE and the xtables lock to iptables-restore.
-	v1Dot6Dot2 = versionparse.MustParseVersion("1.6.2")
+	v1Dot6Dot2, _ = version.NewVersion("1.6.2")
 
 	// Linux kernel versions:
 	// v3Dot10Dot0 is the oldest version we support at time of writing.
-	v3Dot10Dot0 = versionparse.MustParseVersion("3.10.0")
+	v3Dot10Dot0, _ = version.NewVersion("3.10.0")
 	// v3Dot14Dot0 added the random-fully feature on the iptables interface.
-	v3Dot14Dot0 = versionparse.MustParseVersion("3.14.0")
+	v3Dot14Dot0, _ = version.NewVersion("3.14.0")
 )
 
 type Features struct {
@@ -68,7 +67,7 @@ type FeatureDetector struct {
 
 func NewFeatureDetector() *FeatureDetector {
 	return &FeatureDetector{
-		GetKernelVersionReader: versionparse.GetKernelVersionReader,
+		GetKernelVersionReader: version.GetKernelVersionReader,
 		NewCmd:                 NewRealCmd,
 	}
 }
@@ -145,7 +144,7 @@ func (d *FeatureDetector) getKernelVersion() *version.Version {
 		log.WithError(err).Warn("Failed to get the kernel version reader, assuming old version with no optional features")
 		return v3Dot10Dot0
 	}
-	kernVersion, err := versionparse.GetKernelVersion(reader)
+	kernVersion, err := version.GetKernelVersion(reader)
 	if err != nil {
 		log.WithError(err).Warn("Failed to get kernel version, assuming old version with no optional features")
 		return v3Dot10Dot0

--- a/iptables/feature_detect.go
+++ b/iptables/feature_detect.go
@@ -24,7 +24,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	version "github.com/projectcalico/felix/versionparse"
+	"github.com/projectcalico/felix/versionparse"
 )
 
 var (
@@ -32,17 +32,17 @@ var (
 
 	// iptables versions:
 	// v1Dot4Dot7 is the oldest version we've ever supported.
-	v1Dot4Dot7, _ = version.NewVersion("1.4.7")
+	v1Dot4Dot7 = versionparse.MustParseVersion("1.4.7")
 	// v1Dot6Dot0 added --random-fully to SNAT.
-	v1Dot6Dot0, _ = version.NewVersion("1.6.0")
+	v1Dot6Dot0 = versionparse.MustParseVersion("1.6.0")
 	// v1Dot6Dot2 added --random-fully to MASQUERADE and the xtables lock to iptables-restore.
-	v1Dot6Dot2, _ = version.NewVersion("1.6.2")
+	v1Dot6Dot2 = versionparse.MustParseVersion("1.6.2")
 
 	// Linux kernel versions:
 	// v3Dot10Dot0 is the oldest version we support at time of writing.
-	v3Dot10Dot0, _ = version.NewVersion("3.10.0")
+	v3Dot10Dot0 = versionparse.MustParseVersion("3.10.0")
 	// v3Dot14Dot0 added the random-fully feature on the iptables interface.
-	v3Dot14Dot0, _ = version.NewVersion("3.14.0")
+	v3Dot14Dot0 = versionparse.MustParseVersion("3.14.0")
 )
 
 type Features struct {
@@ -67,7 +67,7 @@ type FeatureDetector struct {
 
 func NewFeatureDetector() *FeatureDetector {
 	return &FeatureDetector{
-		GetKernelVersionReader: version.GetKernelVersionReader,
+		GetKernelVersionReader: versionparse.GetKernelVersionReader,
 		NewCmd:                 NewRealCmd,
 	}
 }
@@ -113,7 +113,7 @@ func (d *FeatureDetector) refreshFeaturesLockHeld() {
 	}
 }
 
-func (d *FeatureDetector) getIptablesVersion() *version.Version {
+func (d *FeatureDetector) getIptablesVersion() *versionparse.Version {
 	cmd := d.NewCmd("iptables", "--version")
 	out, err := cmd.Output()
 	if err != nil {
@@ -128,7 +128,7 @@ func (d *FeatureDetector) getIptablesVersion() *version.Version {
 			"Failed to parse iptables version, assuming old version with no optional features")
 		return v1Dot4Dot7
 	}
-	parsedVersion, err := version.NewVersion(matches[1])
+	parsedVersion, err := versionparse.NewVersion(matches[1])
 	if err != nil {
 		log.WithField("rawVersion", s).WithError(err).Warn(
 			"Failed to parse iptables version, assuming old version with no optional features")
@@ -138,13 +138,13 @@ func (d *FeatureDetector) getIptablesVersion() *version.Version {
 	return parsedVersion
 }
 
-func (d *FeatureDetector) getKernelVersion() *version.Version {
+func (d *FeatureDetector) getKernelVersion() *versionparse.Version {
 	reader, err := d.GetKernelVersionReader()
 	if err != nil {
 		log.WithError(err).Warn("Failed to get the kernel version reader, assuming old version with no optional features")
 		return v3Dot10Dot0
 	}
-	kernVersion, err := version.GetKernelVersion(reader)
+	kernVersion, err := versionparse.GetKernelVersion(reader)
 	if err != nil {
 		log.WithError(err).Warn("Failed to get kernel version, assuming old version with no optional features")
 		return v3Dot10Dot0

--- a/versionparse/lib.go
+++ b/versionparse/lib.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"strings"
 
 	version "github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
@@ -63,4 +64,26 @@ func GetKernelVersion(reader io.Reader) (*version.Version, error) {
 	}
 	log.WithField("version", parsedVersion).Debug("Parsed kernel version")
 	return parsedVersion, nil
+}
+
+func GetDistributionName() string {
+	distName := "default"
+	reader, err := GetKernelVersionReader()
+	if err != nil {
+		log.WithError(err).Warn("Failed to get kernel version reader")
+		return distName
+	}
+	kernVersion, err := ioutil.ReadAll(reader)
+	if err != nil {
+		log.WithError(err).Warn("Failed to read kernel version from reader")
+		return distName
+	}
+	s := string(kernVersion)
+
+	if strings.Contains(s, "Ubuntu") {
+		distName = "ubuntu"
+	} else if strings.Contains(s, "Red Hat") {
+		distName = "rhel"
+	}
+	return distName
 }

--- a/versionparse/lib.go
+++ b/versionparse/lib.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	version "github.com/hashicorp/go-version"
@@ -39,6 +40,38 @@ func MustParseVersion(v string) *version.Version {
 	return ver
 }
 
+func convertVersionToIntSlice(ver *version.Version) []int {
+	intSlice := []int{0, 0, 0, 0}
+	sliceIndex := 0
+	for index, outer := range strings.Split(ver.String(), "-") {
+		if index == 0 {
+			for _, inner := range strings.Split(outer, ".") {
+				intSlice[sliceIndex], _ = strconv.Atoi(inner)
+				sliceIndex++
+			}
+		} else if index == 1 {
+			intSlice[sliceIndex], _ = strconv.Atoi(outer)
+		}
+	}
+	return intSlice
+}
+
+func Compare(version1, version2 *version.Version) int {
+	ver1Slice := convertVersionToIntSlice(version1)
+	ver2Slice := convertVersionToIntSlice(version2)
+	for index := range ver1Slice {
+		if ver1Slice[index] == ver2Slice[index] {
+			continue
+		}
+		if ver1Slice[index] < ver2Slice[index] {
+			return -1
+		}
+		if ver1Slice[index] > ver2Slice[index] {
+			return 1
+		}
+	}
+	return 0
+}
 func GetKernelVersionReader() (io.Reader, error) {
 	return os.Open("/proc/version")
 }

--- a/versionparse/lib.go
+++ b/versionparse/lib.go
@@ -28,6 +28,7 @@ import (
 
 var (
 	kernelVersionRegexp = regexp.MustCompile(`Linux version (\d+\.\d+\.\d+(?:-\d+)?)`)
+	splitRe             = regexp.MustCompile(`[\.-]`)
 )
 
 type Version struct {
@@ -83,7 +84,6 @@ func (v *Version) Compare(other *Version) int {
 }
 
 func convertVersionToIntSlice(s string) ([]int, error) {
-	var splitRe = regexp.MustCompile(`[\.-]`)
 	parts := splitRe.Split(s, 4)
 	intSlice := make([]int, len(parts))
 	for index, element := range parts {


### PR DESCRIPTION
## Description
Changes to detect RHEL with kernel version 4.18.0. To check if the kernel supports BPF, a new mapping between the linux distribution name and the kernel version supported is added. 
1) Read the distribution name and kernel version from /proc/version
2) Check if the read version is same as the expected one in the mapping table.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note



```release-note
In BPF mode, Felix now detects BPF support on Red Hat kernels with backports as well as generic kernels.
```
