### PR TITLE
Allow tc to run in parallel again.

### DIFF
--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -47,7 +47,7 @@ import (
 
 type epIface struct {
 	ifacemonitor.State
-	jumpMapFD map[PolDirection]bpf.MapFD
+	jumpMapFDs map[PolDirection]bpf.MapFD
 }
 
 type bpfEndpointManager struct {
@@ -55,6 +55,8 @@ type bpfEndpointManager struct {
 	wlEps    map[proto.WorkloadEndpointID]*proto.WorkloadEndpoint
 	policies map[proto.PolicyID]*proto.Policy
 	profiles map[proto.ProfileID]*proto.Profile
+
+	ifacesLock sync.Mutex
 	ifaces   map[string]epIface
 
 	// Indexes
@@ -144,9 +146,13 @@ func (m *bpfEndpointManager) OnUpdate(msg interface{}) {
 			ip := net.ParseIP(msg.Ipv4Addr)
 			if ip != nil {
 				m.hostIP = ip
+				// Should be safe without the lock since there shouldn't be any active background threads
+				// but taking it now makes us robust to refactoring.
+				m.ifacesLock.Lock()
 				for iface := range m.ifaces {
 					m.dirtyIfaces.Add(iface)
 				}
+				m.ifacesLock.Unlock()
 			} else {
 				log.WithField("HostMetadataUpdate", msg).Warn("Cannot parse IP, no change applied")
 			}
@@ -155,10 +161,15 @@ func (m *bpfEndpointManager) OnUpdate(msg interface{}) {
 }
 
 func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceUpdate) {
+	// Should be safe without the lock since there shouldn't be any active background threads
+	// but taking it now makes us robust to refactoring.
+	m.ifacesLock.Lock()
+	defer m.ifacesLock.Unlock()
+
 	if update.State == ifacemonitor.StateUnknown {
 		log.WithField("iface", update.Name).Debug("Interface no longer present.")
 		if iface, ok := m.ifaces[update.Name]; ok {
-			for _, fd := range iface.jumpMapFD {
+			for _, fd := range iface.jumpMapFDs {
 				_ = fd.Close()
 			}
 			delete(m.ifaces, update.Name)
@@ -380,7 +391,7 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 				"Ignoring interface that doesn't match the host data interface regex")
 			return set.RemoveItem
 		}
-		if m.ifaces[iface].State != ifacemonitor.StateUp {
+		if m.getIfaceState(iface) != ifacemonitor.StateUp {
 			log.WithField("iface", iface).Debug("Ignoring interface that is down")
 			return set.RemoveItem
 		}
@@ -524,26 +535,45 @@ func (m *bpfEndpointManager) attachWorkloadProgram(endpoint *proto.WorkloadEndpo
 	}
 	rules := m.extractRules(tier, endpoint.ProfileIds, polDirection)
 
-	iface := m.ifaces[endpoint.Name]
-	if iface.jumpMapFD[polDirection] == 0 {
+	jumpMapFD := m.getJumpMapFD(endpoint.Name, polDirection)
+	if jumpMapFD == 0 {
 		// We don't have a program attached to this interface yet, attach one now.
 		err := ap.AttachProgram()
 		if err != nil {
 			return err
 		}
 
-		jumpMapFD, err := FindJumpMap(ap)
+		jumpMapFD, err = FindJumpMap(ap)
 		if err != nil {
 			return errors.Wrap(err, "failed to look up jump map")
 		}
-		if iface.jumpMapFD == nil {
-			iface.jumpMapFD = map[PolDirection]bpf.MapFD{}
-		}
-		iface.jumpMapFD[polDirection] = jumpMapFD
-		m.ifaces[endpoint.Name] = iface
+		m.setJumpMapFD(endpoint.Name, polDirection, jumpMapFD)
 	}
 
-	return m.updatePolicyProgram(iface.jumpMapFD[polDirection], rules)
+	return m.updatePolicyProgram(jumpMapFD, rules)
+}
+
+func (m *bpfEndpointManager) getJumpMapFD(ifaceName string, direction PolDirection) bpf.MapFD {
+	m.ifacesLock.Lock()
+	defer m.ifacesLock.Unlock()
+	return m.ifaces[ifaceName].jumpMapFDs[direction]
+}
+
+func (m *bpfEndpointManager) setJumpMapFD(name string, direction PolDirection, fd bpf.MapFD) {
+	m.ifacesLock.Lock()
+	defer m.ifacesLock.Unlock()
+	iface := m.ifaces[name]
+	if iface.jumpMapFDs == nil {
+		iface.jumpMapFDs = map[PolDirection]bpf.MapFD{}
+	}
+	iface.jumpMapFDs[direction] = fd
+	m.ifaces[name] = iface
+}
+
+func (m *bpfEndpointManager) getIfaceState(iface string) ifacemonitor.State {
+	m.ifacesLock.Lock()
+	defer m.ifacesLock.Unlock()
+	return m.ifaces[iface].State
 }
 
 func (m *bpfEndpointManager) updatePolicyProgram(jumpMapFD bpf.MapFD, rules [][][]*proto.Rule) error {
@@ -712,3 +742,4 @@ func (m *bpfEndpointManager) extractRules(tier *proto.TierInfo, profileNames []s
 	allRules = append(allRules, profs)
 	return allRules
 }
+


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
TC based object-pinned map names on the hash of the object file but we really want one map per attached instance of the program.  

- Add a UUID to each binary to avoid hash clashes.
- Use RWMutex to allow attach to run in parallel.
- Remove map repinning logic.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, Felix now attaches programs in parallel for improved performance.
```
