### PR TITLE
When logging a Typha connection failure, leave a hint to check firewall rules

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -480,7 +480,7 @@ configRetry:
 				time.Sleep(1 * time.Second)
 			}
 			if err != nil {
-				log.WithError(err).Fatal("Failed to connect to Typha")
+				log.WithError(err).Fatalf("Failed to connect to Typha at %s. Consider checking firewall rules.", typhaAddr)
 			} else {
 				log.Info("Connected to Typha after retries.")
 				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})


### PR DESCRIPTION

## Description

This updates the log line that is emitted when the connection to Typha fails, and adds a hint to look at firewall rules. I've encountered a situation where Typha was added to a deployment of calico but firewall rules to allow traffic to typha had not been added. There are obviously many other reasons Typha might not be reachable but this is bound to be a common one and the hint may be of help to a lot of users.

- type of fix: new feature
- testing: This log line does not appear to be covered by tests. Tests pass and the binary built with this modified log line shows it as expected when Typha is unreachable.
- affected components: daemon
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
