### PR TITLE
Integrate Wireguard FVs into main FV runs, including BPF

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -83,10 +83,11 @@ blocks:
       - mkdir artifacts
       - ./.semaphore/create-test-vm ${VM_NAME}
     jobs:
-    - name: UT and Wireguard availability check on newer kernel
+    - name: UT and Wireguard non-BPF FV on newer kernel
       commands:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} ut-bpf
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} check-wireguard
+      - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv GINKGO_FOCUS=WireGuard-Supported
     - name: FV on newer kernel
       commands:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-bpf GINKGO_FOCUS=BPF-SAFE FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT} FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -83,10 +83,10 @@ blocks:
       - mkdir artifacts
       - ./.semaphore/create-test-vm ${VM_NAME}
     jobs:
-    - name: UT and Wireguard FV on newer kernel
+    - name: UT and Wireguard availability check on newer kernel
       commands:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} ut-bpf
-      - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-wireguard
+      - ./.semaphore/on-test-vm make --directory=${REPO_NAME} check-wireguard
     - name: FV on newer kernel
       commands:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-bpf GINKGO_FOCUS=BPF-SAFE FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT} FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,6 +61,7 @@ blocks:
     jobs:
     - name: FV Test matrix
       commands:
+      - "! make check-wireguard"
       - make fv FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}" FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT}
       parallelism: 5
     epilogue:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,6 +61,14 @@ blocks:
     jobs:
     - name: FV Test matrix
       commands:
+      # Check that Wireguard is NOT available on the normal Semaphore VM.  If it becomes
+      # available in future, then:
+      #
+      # 1. We should remove the `make fv GINKGO_FOCUS=WireGuard-Supported` that we're
+      # running on the newer kernel VMs (below), so as not to run those tests twice.
+      #
+      # 2. We should delete the WireGuard-Unsupported tests, or find another way to run
+      # them in CI, as they only do anything when WireGuard is NOT available.
       - "! make check-wireguard"
       - make fv FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}" FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT}
       parallelism: 5

--- a/Makefile
+++ b/Makefile
@@ -415,6 +415,7 @@ fv fv/latency.log fv/data-races.log: $(REMOTE_DEPS) image-test bin/iptables-lock
 	  GINKGO_FOCUS="$(GINKGO_FOCUS)" \
 	  FELIX_FV_ENABLE_BPF="$(FELIX_FV_ENABLE_BPF)" \
 	  FV_RACE_DETECTOR_ENABLED=$(FV_RACE_DETECTOR_ENABLED) \
+	  FELIX_FV_WIREGUARD_AVAILABLE=`./wireguard-available >/dev/null && echo true || echo false` \
 	  ./run-batches
 	@if [ -e fv/latency.log ]; then \
 	   echo; \
@@ -426,10 +427,8 @@ fv fv/latency.log fv/data-races.log: $(REMOTE_DEPS) image-test bin/iptables-lock
 fv-bpf:
 	$(MAKE) fv FELIX_FV_ENABLE_BPF=true
 
-KO_DIR := "/lib/modules/$(shell uname -r)/"
-fv-wireguard:
-	test "`find $(KO_DIR) -name wireguard.ko`" || ( echo "WireGuard not available."; exit 1 )
-	$(MAKE) fv FELIX_FV_WIREGUARD_AVAILABLE=true GINKGO_FOCUS="WireGuard-Supported"
+check-wireguard:
+	fv/wireguard-available || ( echo "WireGuard not available."; exit 1 )
 
 ###############################################################################
 # K8SFV Tests

--- a/fv/wireguard-available
+++ b/fv/wireguard-available
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Determine, for running FV tests, whether Wireguard is available in
+# the local Linux kernel.  Exit with success (0) if it is, failure
+# (non-zero) if not.
+
+mod_dir=/lib/modules/`uname -r`
+for f in `find $mod_dir -name wireguard.ko`; do
+    echo Found Wireguard module object at $f
+    exit 0
+done
+exit 1

--- a/fv/wireguard_test.go
+++ b/fv/wireguard_test.go
@@ -51,7 +51,7 @@ const (
 	fakeWireguardPubKey = "jlkVyQYooZYzI2wFfNhSZez5eWh44yfq1wKVjLvSXgY="
 )
 
-var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
 	const nodeCount = 2
 
 	var (
@@ -621,7 +621,7 @@ var _ = infrastructure.DatastoreDescribe("WireGuard-Unsupported", []apiconfig.Da
 	})
 })
 
-var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard 3 node cluster", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3 node cluster", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
 	const nodeCount = 3
 
 	var (

--- a/fv/wireguard_test.go
+++ b/fv/wireguard_test.go
@@ -51,7 +51,7 @@ const (
 	fakeWireguardPubKey = "jlkVyQYooZYzI2wFfNhSZez5eWh44yfq1wKVjLvSXgY="
 )
 
-var _ = infrastructure.DatastoreDescribe("WireGuard-Supported", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
 	const nodeCount = 2
 
 	var (
@@ -573,6 +573,11 @@ var _ = infrastructure.DatastoreDescribe("WireGuard-Unsupported", []apiconfig.Da
 	)
 
 	BeforeEach(func() {
+		// Run these tests only when the Host does not have Wireguard available.
+		if os.Getenv("FELIX_FV_WIREGUARD_AVAILABLE") == "true" {
+			Skip("Skipping Wireguard unsupported tests.")
+		}
+
 		// Setup a single node cluster.
 		const nodeCount = 1
 
@@ -616,7 +621,7 @@ var _ = infrastructure.DatastoreDescribe("WireGuard-Unsupported", []apiconfig.Da
 	})
 })
 
-var _ = infrastructure.DatastoreDescribe("WireGuard-Supported 3 node cluster", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard 3 node cluster", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
 	const nodeCount = 3
 
 	var (


### PR DESCRIPTION
- Wireguard is a feature like many others, so should be tested by the
  main FV run, instead of its own dedicated FV run.

- Create separate script for determining whether Wireguard is
  available, and use that to set `FELIX_FV_WIREGUARD_AVAILABLE` for all
  FV runs.

- To catch if we accidentally stop detecting Wireguard correctly, run
  `make check-wireguard` on the Semaphore setup where we expect
  Wireguard to be available.

- Wireguard is composable with BPF, and now works with BPF, so mark
  Wireguard tests as `_BPF-SAFE_`.

- Only run "WireGuard-Unsupported" tests when Wireguard is not
  available.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
