### PR TITLE
Squash spammy wireguard log.

### DIFF
--- a/wireguard/wireguard.go
+++ b/wireguard/wireguard.go
@@ -575,7 +575,7 @@ func (w *Wireguard) Apply() (err error) {
 
 	// If wireguard is not enabled, then short-circuit the processing - ensure config is deleted.
 	if !w.config.Enabled {
-		log.Info("Wireguard is not enabled")
+		log.Debug("Wireguard is not enabled, skipping sync")
 		if !w.inSyncWireguard {
 			log.Debug("Wireguard is not in-sync - verifying wireguard configuration is removed")
 			if err := w.ensureDisabled(netlinkClient); err != nil {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Log seems to be triggered every time the int dataplane runs apply().  I.e. every second or two.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix no longer logs "Wireguard disabled" in its dataplane resolution loop.
```
