### PR TITLE
Drop packets to unknown WEPs

### DIFF
--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -169,7 +169,7 @@ enum calico_skb_mark {
 	CALI_SKB_MARK_BYPASS_FWD             = CALI_SKB_MARK_BYPASS  | 0x00300000,
 	CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP   = CALI_SKB_MARK_BYPASS  | 0x00500000,
 	CALI_SKB_MARK_SKIP_RPF               = CALI_SKB_MARK_BYPASS  | 0x00400000,
-	CALI_SKB_MARK_NAT_OUT                = CALI_SKB_MARK_SEEN  | 0x00800000,
+	CALI_SKB_MARK_NAT_OUT                = CALI_SKB_MARK_BYPASS  | 0x00800000,
 };
 
 #define ip_is_dnf(ip) ((ip)->frag_off & host_to_be16(0x4000))

--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -161,13 +161,15 @@ static CALI_BPF_INLINE void __compile_asserts(void) {
 
 enum calico_skb_mark {
 	// TODO allocate marks from the mark pool.
-	CALI_SKB_MARK_SEEN                   = 0xc1000000,
-	CALI_SKB_MARK_SEEN_MASK              = 0xff000000,
-	CALI_SKB_MARK_BYPASS                 = CALI_SKB_MARK_SEEN | 0x2000000,
-	CALI_SKB_MARK_BYPASS_FWD             = CALI_SKB_MARK_BYPASS | 0x300000,
-	CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP   = CALI_SKB_MARK_BYPASS | 0x500000,
-	CALI_SKB_MARK_SKIP_RPF               = CALI_SKB_MARK_BYPASS | 0x400000,
-	CALI_SKB_MARK_NAT_OUT                = CALI_SKB_MARK_SEEN | 0x800000,
+	CALI_MARK_CALICO                     = 0xc0000000,
+	CALI_MARK_CALICO_MASK                = 0xf0000000,
+	CALI_SKB_MARK_SEEN                   = CALI_MARK_CALICO      | 0x01000000,
+	CALI_SKB_MARK_SEEN_MASK              = CALI_MARK_CALICO_MASK | CALI_SKB_MARK_SEEN,
+	CALI_SKB_MARK_BYPASS                 = CALI_SKB_MARK_SEEN    | 0x02000000,
+	CALI_SKB_MARK_BYPASS_FWD             = CALI_SKB_MARK_BYPASS  | 0x00300000,
+	CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP   = CALI_SKB_MARK_BYPASS  | 0x00500000,
+	CALI_SKB_MARK_SKIP_RPF               = CALI_SKB_MARK_BYPASS  | 0x00400000,
+	CALI_SKB_MARK_NAT_OUT                = CALI_SKB_MARK_SEEN  | 0x00800000,
 };
 
 #define ip_is_dnf(ip) ((ip)->frag_off & host_to_be16(0x4000))

--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -161,13 +161,13 @@ static CALI_BPF_INLINE void __compile_asserts(void) {
 
 enum calico_skb_mark {
 	// TODO allocate marks from the mark pool.
-	CALI_SKB_MARK_SEEN                   = 0xca100000,
-	CALI_SKB_MARK_SEEN_MASK              = 0xfff00000,
-	CALI_SKB_MARK_BYPASS                 = CALI_SKB_MARK_SEEN | 0x10000,
-	CALI_SKB_MARK_BYPASS_FWD             = CALI_SKB_MARK_SEEN | 0x30000,
-	CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP   = CALI_SKB_MARK_SEEN | 0x50000,
-	CALI_SKB_MARK_SKIP_RPF               = CALI_SKB_MARK_SEEN | 0x40000,
-	CALI_SKB_MARK_NAT_OUT                = CALI_SKB_MARK_SEEN | 0x80000,
+	CALI_SKB_MARK_SEEN                   = 0xc1000000,
+	CALI_SKB_MARK_SEEN_MASK              = 0xff000000,
+	CALI_SKB_MARK_BYPASS                 = CALI_SKB_MARK_SEEN | 0x2000000,
+	CALI_SKB_MARK_BYPASS_FWD             = CALI_SKB_MARK_BYPASS | 0x300000,
+	CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP   = CALI_SKB_MARK_BYPASS | 0x500000,
+	CALI_SKB_MARK_SKIP_RPF               = CALI_SKB_MARK_BYPASS | 0x400000,
+	CALI_SKB_MARK_NAT_OUT                = CALI_SKB_MARK_SEEN | 0x800000,
 };
 
 #define ip_is_dnf(ip) ((ip)->frag_off & host_to_be16(0x4000))

--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -167,6 +167,7 @@ static CALI_BPF_INLINE int calico_ct_v4_create_tracking(struct ct_ctx *ctx,
 		syn = ctx->tcp->syn;
 	}
 
+	CALI_DEBUG("CT-ALL packet mark is: 0x%x\n", ctx->skb->mark);
 	if ((ctx->skb->mark & CALI_SKB_MARK_SEEN_MASK) == CALI_SKB_MARK_SEEN) {
 		/* Packet already marked as being from another workload, which will
 		 * have created a conntrack entry.  Look that one up instead of

--- a/bpf-gpl/list-ut-objs
+++ b/bpf-gpl/list-ut-objs
@@ -22,17 +22,27 @@
 #
 # WARNING: should be kept in sync with the combinations used in tests, in particular bpf_prog_test.go.
 
-
 emit_filename() {
   echo "bin/test_${from_or_to}_${ep_type}_fib_${log_level}_skb${skb}${dsr}.o"
 }
+
+((mark_calico = 0xc0000000))
+((mark_seen = mark_calico | 0x1000000))
+((mark_seen_bypass = mark_seen | 0x2000000))
+((mark_seen_bypass_src_fixup = mark_seen_bypass | 0x500000))
+((mark_seen_bypass_forward = mark_seen_bypass | 0x300000))
+((mark_seen_bypass_skip_rpf = mark_seen_bypass | 0x400000))
 
 log_level=debug
 ep_types="wep hep"
 for ep_type in $ep_types; do
   directions="from to"
   for from_or_to in $directions; do
-    for skb in "0x0" "0xca100000" "0xca130000" "0xca140000" "0xca150000"; do
+    for skb in "0x0" \
+      $(printf 0x%x $mark_seen) \
+      $(printf 0x%x $mark_seen_bypass_src_fixup) \
+      $(printf 0x%x $mark_seen_bypass_skip_rpf) \
+      $(printf 0x%x $mark_seen_bypass_forward); do
       for dsr in "" "_dsr"; do
         if [ "${dsr}" = "_dsr" ]; then
           if [ "${ep_type}" = "hep" ]; then

--- a/bpf/bpf_syscall.go
+++ b/bpf/bpf_syscall.go
@@ -209,7 +209,7 @@ func LoadBPFProgramFromInsns(insns asm.Insns, license string) (ProgFD, error) {
 			log.Warn("Retry succeeded.")
 			return fd, nil
 		}
-		if err2 == unix.ENOSPC &&  logSize < maxLogSize {
+		if err2 == unix.ENOSPC && logSize < maxLogSize {
 			// Log buffer was too small.
 			log.Warn("Diagnostics buffer was too small, trying again with a larger buffer.")
 			logSize *= 2
@@ -237,7 +237,7 @@ func tryLoadBPFProgramFromInsns(insns asm.Insns, license string, logSize uint) (
 		defer C.free(logBuf)
 	}
 
-	C.bpf_attr_setup_load_prog(bpfAttr, unix.BPF_PROG_TYPE_SCHED_CLS, C.uint(len(insns)), cInsnBytes, cLicense,(C.uint)(logLevel), (C.uint)(logSize), logBuf)
+	C.bpf_attr_setup_load_prog(bpfAttr, unix.BPF_PROG_TYPE_SCHED_CLS, C.uint(len(insns)), cInsnBytes, cLicense, (C.uint)(logLevel), (C.uint)(logSize), logBuf)
 	fd, _, errno := unix.Syscall(unix.SYS_BPF, unix.BPF_PROG_LOAD, uintptr(unsafe.Pointer(bpfAttr)), C.sizeof_union_bpf_attr)
 
 	if errno != 0 && errno != unix.ENOSPC /* log buffer too small */ {

--- a/bpf/tc/tc_defs.go
+++ b/bpf/tc/tc_defs.go
@@ -15,15 +15,16 @@
 package tc
 
 const (
-	MarkSeen                        = 0xca100000
-	MarkSeenMask                    = 0xfff00000
-	MarkSeenAndFlagsMask            = 0xfffe0000
-	MarkSeenBypass                  = MarkSeen | 0x10000
-	MarkSeenBypassMask              = 0xffff0000
-	MarkSeenBypassForward           = MarkSeen | 0x30000
-	MarkSeenBypassForwadSourceFixup = MarkSeen | 0x50000
-	MarkSeenBypassSkipRPF           = MarkSeen | 0x40000
-	MarkSeenBypassSkipRPFMask       = 0xffff0000
-	MarkSeenNATOutgoing             = MarkSeen | 0x80000
-	MarkSeenNATOutgoingMask         = 0xfff80000
+	MarkCalico                       = 0xc0000000
+	MarkCalicoMask                   = 0xf0000000
+	MarkSeen                         = MarkCalico | 0x1000000
+	MarkSeenMask                     = MarkCalicoMask | MarkSeen
+	MarkSeenBypass                   = MarkSeen | 0x2000000
+	MarkSeenBypassMask               = MarkSeenMask | MarkSeenBypass
+	MarkSeenBypassForward            = MarkSeenBypass | 0x300000
+	MarkSeenBypassForwardSourceFixup = MarkSeenBypass | 0x500000
+	MarkSeenBypassSkipRPF            = MarkSeenBypass | 0x400000
+	MarkSeenBypassSkipRPFMask        = MarkSeenBypassMask | 0xf00000
+	MarkSeenNATOutgoing              = MarkSeen | 0x800000
+	MarkSeenNATOutgoingMask          = MarkSeenMask | MarkSeenNATOutgoing
 )

--- a/bpf/tc/tc_defs.go
+++ b/bpf/tc/tc_defs.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tc
+
+const (
+	MarkSeen                        = 0xca100000
+	MarkSeenMask                    = 0xfff00000
+	MarkSeenAndFlagsMask            = 0xfffe0000
+	MarkSeenBypass                  = MarkSeen | 0x10000
+	MarkSeenBypassMask              = 0xffff0000
+	MarkSeenBypassForward           = MarkSeen | 0x30000
+	MarkSeenBypassForwadSourceFixup = MarkSeen | 0x50000
+	MarkSeenBypassSkipRPF           = MarkSeen | 0x40000
+	MarkSeenBypassSkipRPFMask       = 0xffff0000
+	MarkSeenNATOutgoing             = MarkSeen | 0x80000
+	MarkSeenNATOutgoingMask         = 0xfff80000
+)

--- a/bpf/tc/tc_defs.go
+++ b/bpf/tc/tc_defs.go
@@ -17,14 +17,14 @@ package tc
 const (
 	MarkCalico                       = 0xc0000000
 	MarkCalicoMask                   = 0xf0000000
-	MarkSeen                         = MarkCalico | 0x1000000
+	MarkSeen                         = MarkCalico | 0x01000000
 	MarkSeenMask                     = MarkCalicoMask | MarkSeen
-	MarkSeenBypass                   = MarkSeen | 0x2000000
+	MarkSeenBypass                   = MarkSeen | 0x02000000
 	MarkSeenBypassMask               = MarkSeenMask | MarkSeenBypass
-	MarkSeenBypassForward            = MarkSeenBypass | 0x300000
-	MarkSeenBypassForwardSourceFixup = MarkSeenBypass | 0x500000
-	MarkSeenBypassSkipRPF            = MarkSeenBypass | 0x400000
-	MarkSeenBypassSkipRPFMask        = MarkSeenBypassMask | 0xf00000
-	MarkSeenNATOutgoing              = MarkSeen | 0x800000
+	MarkSeenBypassForward            = MarkSeenBypass | 0x00300000
+	MarkSeenBypassForwardSourceFixup = MarkSeenBypass | 0x00500000
+	MarkSeenBypassSkipRPF            = MarkSeenBypass | 0x00400000
+	MarkSeenBypassSkipRPFMask        = MarkSeenBypassMask | 0x00f00000
+	MarkSeenNATOutgoing              = MarkSeen | 0x00800000
 	MarkSeenNATOutgoingMask          = MarkSeenMask | MarkSeenNATOutgoing
 )

--- a/bpf/tc/tc_defs.go
+++ b/bpf/tc/tc_defs.go
@@ -25,6 +25,6 @@ const (
 	MarkSeenBypassForwardSourceFixup = MarkSeenBypass | 0x00500000
 	MarkSeenBypassSkipRPF            = MarkSeenBypass | 0x00400000
 	MarkSeenBypassSkipRPFMask        = MarkSeenBypassMask | 0x00f00000
-	MarkSeenNATOutgoing              = MarkSeen | 0x00800000
-	MarkSeenNATOutgoingMask          = MarkSeenMask | MarkSeenNATOutgoing
+	MarkSeenNATOutgoing              = MarkSeenBypass | 0x00800000
+	MarkSeenNATOutgoingMask          = MarkSeenBypassMask | MarkSeenNATOutgoing
 )

--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/projectcalico/felix/bpf"
+	"github.com/projectcalico/felix/bpf/tc"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
@@ -107,7 +108,7 @@ func TestNATPodPodXNode(t *testing.T) {
 	})
 
 	// Leaving node 1
-	skbMark = 0xca100000 // CALI_SKB_MARK_SEEN
+	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 
 	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(natedPkt)
@@ -143,7 +144,7 @@ func TestNATPodPodXNode(t *testing.T) {
 	})
 
 	// Arriving at workload at node 2
-	skbMark = 0xca100000 // CALI_SKB_MARK_SEEN
+	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(natedPkt)
 		Expect(err).NotTo(HaveOccurred())
@@ -175,7 +176,7 @@ func TestNATPodPodXNode(t *testing.T) {
 	})
 
 	// Response leaving node 2
-	skbMark = 0xca100000 // CALI_SKB_MARK_SEEN
+	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(respPkt)
 		Expect(err).NotTo(HaveOccurred())
@@ -211,7 +212,7 @@ func TestNATPodPodXNode(t *testing.T) {
 	dumpCTMap(ctMap)
 
 	// Response arriving at workload at node 1
-	skbMark = 0xca100000 // CALI_SKB_MARK_SEEN
+	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		pktExp := gopacket.NewPacket(respPkt, layers.LayerTypeEthernet, gopacket.Default)
 		ipv4L := pktExp.Layer(layers.LayerTypeIPv4)
@@ -369,7 +370,7 @@ func TestNATNodePort(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
-	skbMark = 0xca100000 | 0x50000 // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
+	skbMark = tc.MarkSeenBypassForwadSourceFixup // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
 	// Leaving node 1
 	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(encapedPkt)
@@ -477,7 +478,7 @@ func TestNATNodePort(t *testing.T) {
 
 	hostIP = net.IPv4(0, 0, 0, 0) // workloads do not have it set
 
-	skbMark = 0xca140000 // CALI_SKB_MARK_SKIP_RPF
+	skbMark = tc.MarkSeenBypassSkipRPF // CALI_SKB_MARK_SKIP_RPF
 
 	// Arriving at workload at node 2
 	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
@@ -536,7 +537,7 @@ func TestNATNodePort(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
-	skbMark = 0xca100000 | 0x50000 // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
+	skbMark = tc.MarkSeenBypassForwadSourceFixup // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
 
 	hostIP = node2ip
 
@@ -614,7 +615,7 @@ func TestNATNodePort(t *testing.T) {
 		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
 	})
 
-	skbMark = 0xca100000 | 0x30000 // CALI_SKB_MARK_BYPASS_FWD
+	skbMark = tc.MarkSeenBypassForward // CALI_SKB_MARK_BYPASS_FWD
 
 	// Response leaving to original source
 	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
@@ -762,7 +763,7 @@ func TestNATNodePortNoFWD(t *testing.T) {
 
 	hostIP = net.IPv4(0, 0, 0, 0) // workloads do not have it set
 
-	skbMark = 0xca100000 // CALI_SKB_MARK_SEEN
+	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 
 	// Arriving at workload
 	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
@@ -792,7 +793,7 @@ func TestNATNodePortNoFWD(t *testing.T) {
 		Expect(res.dataOut).To(Equal(respPkt))
 	})
 
-	skbMark = 0xca100000 // CALI_SKB_MARK_SEEN
+	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 
 	// Response leaving to original source
 	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
@@ -938,7 +939,7 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
-	skbMark = 0xca100000 | 0x50000 // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
+	skbMark = tc.MarkSeenBypassForwadSourceFixup // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
 
 	hostIP = node1ip
 	var encapedGoPkt gopacket.Packet
@@ -1001,7 +1002,7 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
-	skbMark = 0xca100000 | 0x30000 // CALI_SKB_MARK_BYPASS_FWD
+	skbMark = tc.MarkSeenBypassForward // CALI_SKB_MARK_BYPASS_FWD
 
 	// Response leaving to original source
 	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {

--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -504,9 +504,10 @@ func TestNATNodePort(t *testing.T) {
 		ctKey = ctr.ReverseNATKey()
 		Expect(ct).Should(HaveKey(ctKey))
 		ctr = ct[ctKey]
-		Expect(ctr.Type()).To(Equal(conntrack.TypeNATReverse))
+		Expect(ctr.Type()).To(Equal(conntrack.TypeNATReverse),
+			fmt.Sprintf("Expected reverse conntrack entry but got %v", ctr))
 
-		// Whitlisted source side
+		// Whitelisted source side
 		Expect(ctr.Data().A2B.Whitelisted).To(BeTrue())
 		// Whitelisted destination side as well
 		Expect(ctr.Data().B2A.Whitelisted).To(BeTrue())

--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -370,7 +370,7 @@ func TestNATNodePort(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
-	skbMark = tc.MarkSeenBypassForwadSourceFixup // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
+	skbMark = tc.MarkSeenBypassForwardSourceFixup // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
 	// Leaving node 1
 	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(encapedPkt)
@@ -537,7 +537,7 @@ func TestNATNodePort(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
-	skbMark = tc.MarkSeenBypassForwadSourceFixup // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
+	skbMark = tc.MarkSeenBypassForwardSourceFixup // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
 
 	hostIP = node2ip
 
@@ -939,7 +939,7 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
-	skbMark = tc.MarkSeenBypassForwadSourceFixup // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
+	skbMark = tc.MarkSeenBypassForwardSourceFixup // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
 
 	hostIP = node1ip
 	var encapedGoPkt gopacket.Packet

--- a/bpf/ut/pol_prog_test.go
+++ b/bpf/ut/pol_prog_test.go
@@ -138,7 +138,7 @@ func TestLoadGarbageProgram(t *testing.T) {
 	var insns asm.Insns
 	for i := 0; i < 256; i++ {
 		i := uint8(i)
-		insns = append(insns, asm.Insn{i,i,i,i,i,i,i,i})
+		insns = append(insns, asm.Insn{i, i, i, i, i, i, i, i})
 	}
 
 	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0")

--- a/bpf/ut/whitelist_test.go
+++ b/bpf/ut/whitelist_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projectcalico/felix/bpf"
 	"github.com/projectcalico/felix/bpf/conntrack"
 	"github.com/projectcalico/felix/bpf/routes"
+	"github.com/projectcalico/felix/bpf/tc"
 )
 
 // Usually a packet passes through 2 programs, HEP->WEP, WEP->HEP or WEP->WEP. These test
@@ -79,7 +80,7 @@ func TestWhitelistFromWorkloadExitHost(t *testing.T) {
 	})
 
 	// Leaving node 1
-	skbMark = 0xca100000 // CALI_SKB_MARK_SEEN
+	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 
 	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
@@ -147,7 +148,7 @@ func TestWhitelistEnterHostToWorkload(t *testing.T) {
 		Expect(ctr.Data().B2A.Whitelisted).NotTo(BeTrue())
 	})
 
-	skbMark = 0xca100000 // CALI_SKB_MARK_SEEN
+	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 
 	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
@@ -215,7 +216,7 @@ func TestWhitelistWorkloadToWorkload(t *testing.T) {
 		Expect(ctr.Data().B2A.Whitelisted).NotTo(BeTrue())
 	})
 
-	skbMark = 0xca100000 // CALI_SKB_MARK_SEEN
+	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 
 	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)

--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -506,7 +506,7 @@ func (m *bpfEndpointManager) applyProgramsToDirtyWorkloadEndpoints() {
 		err := errs[wlID]
 		if err == nil {
 			log.WithField("id", wlID).Info("Applied policy to workload")
-			if _, ok := m.happyWEPs[wlID]; !ok {
+			if _, ok := m.happyWEPs[wlID]; !ok && m.allWEPs[wlID] != nil {
 				log.WithField("id", wlID).Info("Adding workload interface to iptables allow list.")
 				m.happyWEPsDirty = true
 			}

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -518,6 +518,8 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			config.BPFNodePortDSREnabled,
 			ipSetsMap,
 			stateMap,
+			ruleRenderer,
+			filterTableV4,
 		))
 
 		// Pre-create the NAT maps so that later operations can assume access.
@@ -887,48 +889,70 @@ func (d *InternalDataplane) doStaticDataplaneConfig() {
 }
 
 func (d *InternalDataplane) setUpIptablesBPF() {
-	// TODO have raw table mark for notrack
-	// TODO Any BPF SNAT we need to do
+	// TODO Make make bits configurable.
 
 	for _, t := range d.iptablesFilterTables {
 		fwdRules := []iptables.Rule{
 			{
-				// TODO Make "from workload" mark configurable
-				Match:  iptables.Match().MarkMatchesWithMask(0xca100000, 0xfff00000),
-				Action: iptables.AcceptAction{},
+				// Bypass is a strong signal from the BPF program, it means that the flow is approved
+				// by the program at both ingress and egress.
+				Comment: []string{"Pre-approved by BPF programs."},
+				Match:   iptables.Match().MarkMatchesWithMask(tc.MarkSeenBypass, tc.MarkSeenBypassMask),
+				Action:  iptables.AcceptAction{},
 			},
 		}
+
 		var inputRules []iptables.Rule
 		for _, prefix := range d.config.RulesConfig.WorkloadIfacePrefixes {
 			fwdRules = append(fwdRules,
 				iptables.Rule{
-					Match:   iptables.Match().InInterface(prefix + "+"),
+					Match:   iptables.Match().InInterface(prefix+"+").NotMarkMatchesWithMask(tc.MarkSeen, tc.MarkSeenMask),
 					Action:  iptables.DropAction{},
-					Comment: []string{"From workload without BPF ACCEPT mark"},
+					Comment: []string{"From workload without BPF seen mark"},
+				}, iptables.Rule{
+					Match:   iptables.Match().InInterface(prefix + "+"),
+					Action:  iptables.AcceptAction{},
+					Comment: []string{"From workload without BPF seen mark"},
 				})
 
 			if d.config.RulesConfig.EndpointToHostAction == "ACCEPT" {
 				// Only need to worry about ACCEPT here.  Drop gets compiled into the BPF program and
 				// RETURN would be a no-op since there's nothing to RETURN from.
 				inputRules = append(inputRules, iptables.Rule{
-					Match:  iptables.Match().InInterface(prefix+"+").MarkMatchesWithMask(tc.MarkSeen, tc.MarkSeenAndFlagsMask),
+					Match:  iptables.Match().InInterface(prefix+"+").MarkMatchesWithMask(tc.MarkSeen, tc.MarkSeenMask),
 					Action: iptables.AcceptAction{},
 				})
 			}
 			// Catch any workload to host packets that haven't been through the BPF program.
 			inputRules = append(inputRules, iptables.Rule{
-				Match:  iptables.Match().InInterface(prefix+"+").NotMarkMatchesWithMask(tc.MarkSeen, tc.MarkSeenMask),
+				Match:  iptables.Match().InInterface(prefix + "+"),
 				Action: iptables.DropAction{},
 			})
 		}
-		for _, prefix := range d.config.RulesConfig.WorkloadIfacePrefixes {
-			// Make sure iptables rules don't drop packets that we're about to process through BPF.
-			fwdRules = append(fwdRules, iptables.Rule{
-				Match:   iptables.Match().OutInterface(prefix + "+"),
-				Action:  iptables.AcceptAction{},
-				Comment: []string{"To workload, BPF will handle."},
-			})
+
+		if t.IPVersion == 6 {
+			for _, prefix := range d.config.RulesConfig.WorkloadIfacePrefixes {
+				// In BPF mode, we don't support IPv6 yet.  Drop it.
+				fwdRules = append(fwdRules, iptables.Rule{
+					Match:   iptables.Match().OutInterface(prefix + "+"),
+					Action:  iptables.DropAction{},
+					Comment: []string{"To workload, drop IPv6."},
+				})
+			}
+		} else {
+			// The packet may be about to go to a local workload.  However, the local workload may not have a BPF
+			// program attached (yet).  To catch that case, we send the packet through a dispatch chain.  We only
+			// add interfaces to the dispatch chain if the BPF program is in place.
+			for _, prefix := range d.config.RulesConfig.WorkloadIfacePrefixes {
+				// Make sure iptables rules don't drop packets that we're about to process through BPF.
+				fwdRules = append(fwdRules, iptables.Rule{
+					Match:   iptables.Match().OutInterface(prefix + "+"),
+					Action:  iptables.JumpAction{Target: rules.ChainToWorkloadDispatch},
+					Comment: []string{"To workload, check workload is known."},
+				})
+			}
 		}
+
 		t.InsertOrAppendRules("INPUT", inputRules)
 		t.InsertOrAppendRules("FORWARD", fwdRules)
 	}

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -905,15 +905,13 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 		var inputRules []iptables.Rule
 		for _, prefix := range d.config.RulesConfig.WorkloadIfacePrefixes {
 			fwdRules = append(fwdRules,
+				// Drop packets that have come from a workload but have not been through our BPF program.
 				iptables.Rule{
 					Match:   iptables.Match().InInterface(prefix+"+").NotMarkMatchesWithMask(tc.MarkSeen, tc.MarkSeenMask),
 					Action:  iptables.DropAction{},
 					Comment: []string{"From workload without BPF seen mark"},
-				}, iptables.Rule{
-					Match:   iptables.Match().InInterface(prefix + "+"),
-					Action:  iptables.AcceptAction{},
-					Comment: []string{"From workload without BPF seen mark"},
-				})
+				},
+			)
 
 			if d.config.RulesConfig.EndpointToHostAction == "ACCEPT" {
 				// Only need to worry about ACCEPT here.  Drop gets compiled into the BPF program and
@@ -925,7 +923,7 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 			}
 			// Catch any workload to host packets that haven't been through the BPF program.
 			inputRules = append(inputRules, iptables.Rule{
-				Match:  iptables.Match().InInterface(prefix + "+"),
+				Match:  iptables.Match().InInterface(prefix + "+").NotMarkMatchesWithMask(tc.MarkSeen, tc.MarkSeenMask),
 				Action: iptables.DropAction{},
 			})
 		}
@@ -945,11 +943,27 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 			// add interfaces to the dispatch chain if the BPF program is in place.
 			for _, prefix := range d.config.RulesConfig.WorkloadIfacePrefixes {
 				// Make sure iptables rules don't drop packets that we're about to process through BPF.
-				fwdRules = append(fwdRules, iptables.Rule{
-					Match:   iptables.Match().OutInterface(prefix + "+"),
-					Action:  iptables.JumpAction{Target: rules.ChainToWorkloadDispatch},
-					Comment: []string{"To workload, check workload is known."},
-				})
+				fwdRules = append(fwdRules,
+					iptables.Rule{
+						Match:   iptables.Match().OutInterface(prefix + "+"),
+						Action:  iptables.JumpAction{Target: rules.ChainToWorkloadDispatch},
+						Comment: []string{"To workload, check workload is known."},
+					},
+				)
+			}
+			// Need a final rule to accept traffic that is from a workload and going somewhere else.
+			// Otherwise, if iptables has a DROP policy on the forward chain, the packet will get dropped.
+			// This rule must come after the to-workload jump rules above to ensure that we don't accept too
+			// early before the destination is checked.
+			for _, prefix := range d.config.RulesConfig.WorkloadIfacePrefixes {
+				// Make sure iptables rules don't drop packets that we're about to process through BPF.
+				fwdRules = append(fwdRules,
+					iptables.Rule{
+						Match:   iptables.Match().InInterface(prefix + "+"),
+						Action:  iptables.AcceptAction{},
+						Comment: []string{"To workload, mark has already been verified."},
+					},
+				)
 			}
 		}
 

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -2282,6 +2282,7 @@ func dumpNATmaps(felixes []*infrastructure.Felix) ([]nat.MapMem, []nat.BackendMa
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
+			defer GinkgoRecover()
 			bpfsvcs[i], bpfeps[i] = dumpNATMaps(felixes[i])
 		}(i)
 	}

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -626,18 +626,18 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							_, err = w[1][0].RunCmd("/pktgen", w[1][0].IP, dpOnlyWorkload.IP, "udp",
 								"--port-src", "30444", "--port-dst", "8057")
 							Expect(err).NotTo(HaveOccurred())
-							time.Sleep(100*(time.Millisecond))
+							time.Sleep(100 * (time.Millisecond))
 						}
 					}()
 					defer wg.Wait()
 
-					Consistently(tcpdump.MatchCountFn("UDP-8057"), "5s").Should(
+					Consistently(tcpdump.MatchCountFn("UDP-8057"), "5s", "200ms").Should(
 						BeNumerically("==", 0),
 						"Traffic to the workload should be blocked before datastore is configured")
 
 					dpOnlyWorkload.ConfigureInDatastore(infra)
 
-					Eventually(tcpdump.MatchCountFn("UDP-8057"), "5s").Should(
+					Eventually(tcpdump.MatchCountFn("UDP-8057"), "5s", "200ms").Should(
 						BeNumerically(">", 0),
 						"Traffic to the workload should be allowed after datastore is configured")
 				})

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -635,7 +635,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						BeNumerically("==", 0),
 						"Traffic to the workload should be blocked before datastore is configured")
 
-					dpOnlyWorkload.ConfigureInDatastore(infra)
+					dpOnlyWorkload.ConfigureInInfra(infra)
 
 					Eventually(tcpdump.MatchCountFn("UDP-8057"), "5s", "200ms").Should(
 						BeNumerically(">", 0),

--- a/fv/tcpdump/tcpdump.go
+++ b/fv/tcpdump/tcpdump.go
@@ -125,6 +125,12 @@ func (t *TCPDump) MatchCount(name string) int {
 	return c
 }
 
+func (t *TCPDump) MatchCountFn(name string) func() int {
+	return func() int {
+		return t.MatchCount(name)
+	}
+}
+
 func (t *TCPDump) ResetCount(name string) {
 	t.lock.Lock()
 	defer t.lock.Unlock()

--- a/rules/dispatch.go
+++ b/rules/dispatch.go
@@ -43,21 +43,58 @@ func (r *DefaultRuleRenderer) WorkloadDispatchChains(
 			Comment: []string{"Unknown interface"},
 		},
 	}
-	result := []*Chain{}
-	result = append(result,
-		// Assemble a from-workload and to-workload dispatch chain.
-		r.interfaceNameDispatchChains(
-			names,
-			WorkloadFromEndpointPfx,
-			WorkloadToEndpointPfx,
-			ChainFromWorkloadDispatch,
-			ChainToWorkloadDispatch,
-			endRules,
-			endRules,
-		)...,
+	return r.interfaceNameDispatchChains(
+		names,
+		WorkloadFromEndpointPfx,
+		WorkloadToEndpointPfx,
+		ChainFromWorkloadDispatch,
+		ChainToWorkloadDispatch,
+		endRules,
+		endRules,
 	)
+}
 
-	return result
+func (r *DefaultRuleRenderer) WorkloadInterfaceAllowChains(
+	endpoints map[proto.WorkloadEndpointID]*proto.WorkloadEndpoint,
+) []*Chain {
+	// Extract endpoint names.
+	log.WithField("numEndpoints", len(endpoints)).Debug("Rendering workload interface allow chain")
+	names := make([]string, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		names = append(names, endpoint.Name)
+	}
+
+	// If workload endpoint is unknown, drop.
+	endRules := []Rule{
+		{
+			Match:   Match(),
+			Action:  DropAction{},
+			Comment: []string{"Unknown interface"},
+		},
+	}
+
+	// Since there can be >100 endpoints, putting them in a single list adds some latency to
+	// endpoints that are later in the chain.  To reduce that impact, we build a shallow tree of
+	// chains based on the prefixes of the chains.
+	commonPrefix, prefixes, prefixToNames := r.sortAndDivideEndpointNamesToPrefixTree(names)
+	var chains []*Chain
+	// Build to endpoint chains.
+	toChildChains, toRootChain, _ := r.buildSingleDispatchChains(
+		ChainToWorkloadDispatch,
+		commonPrefix,
+		prefixes,
+		prefixToNames,
+		WorkloadPfxSpecialAllow,
+		func(name string) MatchCriteria { return Match().OutInterface(name) },
+		func(pfx, name string) Action {
+			return AcceptAction{}
+		},
+		endRules,
+	)
+	chains = append(chains, toChildChains...)
+	chains = append(chains, toRootChain)
+
+	return chains
 }
 
 // In some scenario, e.g. packet goes to an kubernetes ipvs service ip. Traffic goes through input/output filter chain

--- a/rules/nat.go
+++ b/rules/nat.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/projectcalico/felix/bpf/tc"
 	"github.com/projectcalico/felix/iptables"
 )
 
@@ -30,7 +31,7 @@ func (r *DefaultRuleRenderer) MakeNatOutgoingRule(protocol string, action iptabl
 }
 
 func (r *DefaultRuleRenderer) makeNATOutgoingRuleBPF(version uint8, protocol string, action iptables.Action) iptables.Rule {
-	match := iptables.Match().MarkMatchesWithMask(0xca180000, 0xfff80000)
+	match := iptables.Match().MarkMatchesWithMask(tc.MarkSeenNATOutgoing, tc.MarkSeenNATOutgoingMask)
 
 	if protocol != "" {
 		match = match.Protocol(protocol)

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -84,6 +84,7 @@ const (
 	ChainForwardEndpointMark = ChainNamePrefix + "forward-endpoint-mark"
 
 	WorkloadToEndpointPfx   = ChainNamePrefix + "tw-"
+	WorkloadPfxSpecialAllow = "ALLOW"
 	WorkloadFromEndpointPfx = ChainNamePrefix + "fw-"
 
 	SetEndPointMarkPfx = ChainNamePrefix + "sm-"
@@ -171,6 +172,8 @@ type RuleRenderer interface {
 		egressPolicies []string,
 		profileIDs []string,
 	) []*iptables.Chain
+
+	WorkloadInterfaceAllowChains(endpoints map[proto.WorkloadEndpointID]*proto.WorkloadEndpoint) []*iptables.Chain
 
 	EndpointMarkDispatchChains(
 		epMarkMapper EndpointMarkMapper,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

* Add an iptables chain that accepts traffic to known workloads.
* Refactor the mark bits to use fewer bytes and to give a clean bit flag for "bypass".
* Rearrange the base iptables rules to:

  * Check the bypass bit first and immediately accept.
  * Check for missing marks (i.e. missing programs).
  * Jump to the new chain.

## Todos
- [x] Ensure only packets that are approved at both ends get bypass (might already be true)
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, traffic to unknown workload interfaces is now blocked (as long as Felix was running long enough to insert its policing rules).
```
