### PR TITLE
Rate limit jump map cleanup

### DIFF
--- a/fv/apply_on_forward_test.go
+++ b/fv/apply_on_forward_test.go
@@ -62,7 +62,7 @@ var _ = infrastructure.DatastoreDescribe("apply on forward tests; with 2 nodes",
 			wIP := fmt.Sprintf("10.65.%d.2", ii)
 			wName := fmt.Sprintf("w%d", ii)
 			w[ii] = workload.Run(felixes[ii], wName, "default", wIP, "8055", "tcp")
-			w[ii].ConfigureInDatastore(infra)
+			w[ii].ConfigureInInfra(infra)
 
 			hostW[ii] = workload.Run(felixes[ii], fmt.Sprintf("host%d", ii), "", felixes[ii].IP, "8055", "tcp")
 		}

--- a/fv/host_port_test.go
+++ b/fv/host_port_test.go
@@ -100,7 +100,7 @@ var _ = infrastructure.DatastoreDescribe("host-port tests", []apiconfig.Datastor
 
 	It("with a local workload, port should be reachable", func() {
 		w := workload.Run(felix, "w", "default", "10.65.0.2", "8055", "tcp")
-		w.ConfigureInDatastore(infra)
+		w.ConfigureInInfra(infra)
 		Eventually(metricsPortReachable, "10s", "1s").Should(BeTrue(), "Not reachable with workload running")
 		w.Stop()
 		Eventually(metricsPortReachable, "10s", "1s").Should(BeTrue(), "With workload stopped, not reachable")

--- a/fv/hostendpoints_test.go
+++ b/fv/hostendpoints_test.go
@@ -67,7 +67,7 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 			wIP := fmt.Sprintf("10.65.%d.2", ii)
 			wName := fmt.Sprintf("w%d", ii)
 			w[ii] = workload.Run(felixes[ii], wName, "default", wIP, "8055", "tcp")
-			w[ii].ConfigureInDatastore(infra)
+			w[ii].ConfigureInInfra(infra)
 
 			hostW[ii] = workload.Run(felixes[ii], fmt.Sprintf("host%d", ii), "", felixes[ii].IP, "8055", "tcp")
 		}

--- a/fv/infrastructure/infra_etcd.go
+++ b/fv/infrastructure/infra_etcd.go
@@ -135,6 +135,11 @@ func (eds *EtcdDatastoreInfra) AddWorkload(wep *api.WorkloadEndpoint) (*api.Work
 	return eds.GetCalicoClient().WorkloadEndpoints().Create(utils.Ctx, wep, utils.NoOptions)
 }
 
+func (eds *EtcdDatastoreInfra) RemoveWorkload(ns string, name string) error {
+	_, err := eds.GetCalicoClient().WorkloadEndpoints().Delete(utils.Ctx, ns, name, options.DeleteOptions{})
+	return err
+}
+
 func (eds *EtcdDatastoreInfra) AddAllowToDatastore(selector string) error {
 	// Create a policy to allow egress from the host so that we don't cut off Felix's datastore connection
 	// when we enable the host endpoint.

--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -554,6 +554,15 @@ func (kds *K8sDatastoreInfra) ensureNamespace(name string) {
 	}
 }
 
+func (kds *K8sDatastoreInfra) RemoveWorkload(ns, name string) error {
+	wepIDs, err := names.ParseWorkloadEndpointName(name)
+	if err != nil {
+		return err
+	}
+	err = kds.K8sClient.CoreV1().Pods(ns).Delete(wepIDs.Pod, DeleteImmediately)
+	return err
+}
+
 func (kds *K8sDatastoreInfra) AddWorkload(wep *api.WorkloadEndpoint) (*api.WorkloadEndpoint, error) {
 	podIP := wep.Spec.IPNetworks[0]
 	if strings.Contains(podIP, "/") {

--- a/fv/infrastructure/infrastructure.go
+++ b/fv/infrastructure/infrastructure.go
@@ -63,6 +63,8 @@ type DatastoreInfra interface {
 	// *api.WorkloadEndpoint will be returned, otherwise an error will be
 	// returned.
 	AddWorkload(wep *api.WorkloadEndpoint) (*api.WorkloadEndpoint, error)
+	// RemoveWorkload reverses the effect of AddWorkload.
+	RemoveWorkload(ns string, name string) error
 	// AddDefaultAllow will ensure that the datastore is configured so that
 	// the default profile/namespace will allow traffic. Returns the name of the
 	// default profile.

--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -79,7 +79,7 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 			wIP := fmt.Sprintf("10.65.%d.2", ii)
 			wName := fmt.Sprintf("w%d", ii)
 			w[ii] = workload.Run(felixes[ii], wName, "default", wIP, "8055", "tcp")
-			w[ii].ConfigureInDatastore(infra)
+			w[ii].ConfigureInInfra(infra)
 
 			hostW[ii] = workload.Run(felixes[ii], fmt.Sprintf("host%d", ii), "", felixes[ii].IP, "8055", "tcp")
 		}

--- a/fv/pre_dnat_test.go
+++ b/fv/pre_dnat_test.go
@@ -71,7 +71,7 @@ var _ = infrastructure.DatastoreDescribe("pre-dnat with initialized Felix, 2 wor
 		for ii := range w {
 			iiStr := strconv.Itoa(ii)
 			w[ii] = workload.Run(felix, "w"+iiStr, "default", "10.65.0.1"+iiStr, "8055", "tcp")
-			w[ii].ConfigureInDatastore(infra)
+			w[ii].ConfigureInInfra(infra)
 		}
 
 		// We will use this container to model an external client trying to connect into

--- a/fv/sockmap_test.go
+++ b/fv/sockmap_test.go
@@ -253,7 +253,7 @@ var _ = infrastructure.DatastoreDescribe("[SOCKMAP] with Felix using sockmap", [
 			ip,
 			fmt.Sprintf("%d", port),
 			"tcp")
-		host.ConfigureInDatastore(infra)
+		host.ConfigureInInfra(infra)
 		unlockAtEnd = false
 	})
 

--- a/fv/spoof_test.go
+++ b/fv/spoof_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Spoof tests", func() {
 				wIP := fmt.Sprintf("10.65.%d.2", ii)
 				wName := fmt.Sprintf("w%d", ii)
 				w[ii] = workload.Run(felixes[ii], wName, "default", wIP, "8055", "tcp")
-				w[ii].ConfigureInDatastore(infra)
+				w[ii].ConfigureInInfra(infra)
 			}
 		})
 
@@ -142,7 +142,7 @@ var _ = Describe("Spoof tests", func() {
 				wIP := fmt.Sprintf("fdc6:3dbc:e983:cbc%x::1", ii)
 				wName := fmt.Sprintf("w%d", ii)
 				w[ii] = workload.Run(felixes[0], wName, "default", wIP, "8055", "tcp")
-				w[ii].ConfigureInDatastore(infra)
+				w[ii].ConfigureInInfra(infra)
 			}
 		})
 

--- a/fv/vxlan_test.go
+++ b/fv/vxlan_test.go
@@ -94,7 +94,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						Expect(err).NotTo(HaveOccurred())
 
 						w[ii] = workload.Run(felixes[ii], wName, "default", wIP, "8055", "tcp")
-						w[ii].ConfigureInDatastore(infra)
+						w[ii].ConfigureInInfra(infra)
 
 						hostW[ii] = workload.Run(felixes[ii], fmt.Sprintf("host%d", ii), "", felixes[ii].IP, "8055", "tcp")
 					}

--- a/fv/wireguard_test.go
+++ b/fv/wireguard_test.go
@@ -960,7 +960,7 @@ func createWorkloadWithAssignedIP(
 	Expect(err).NotTo(HaveOccurred())
 
 	wl := workload.Run(felix, wlName, "default", wlIP, "8055", "tcp")
-	wl.ConfigureInDatastore(*infra)
+	wl.ConfigureInInfra(*infra)
 
 	return wl
 }

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -69,8 +69,8 @@ func (w *Workload) Stop() {
 		Expect(err).NotTo(HaveOccurred(), "failed to run docker exec command to get workload pid")
 		pid := strings.TrimSpace(output)
 		w.C.Exec("kill", pid)
-		w.C.Exec("ip", "link", "del", w.InterfaceName)
-		w.C.Exec("ip", "netns", "del", w.NamespaceID())
+		_ = w.C.ExecMayFail("ip", "link", "del", w.InterfaceName)
+		_ = w.C.ExecMayFail("ip", "netns", "del", w.NamespaceID())
 		_, err = w.runCmd.Process.Wait()
 		if err != nil {
 			log.WithField("workload", w).Error("failed to wait for process")

--- a/ratelimited/runner.go
+++ b/ratelimited/runner.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ratelimited
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/timeshim"
+)
+
+func NewRunner(minInterval timeshim.Duration, f func(ctx context.Context), opts ...RunnerOpt) *Runner {
+	r := &Runner{
+		minInterval: minInterval,
+		callback:    f,
+		triggerC:    make(chan struct{}, 1),
+		time:        timeshim.RealTime(),
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+type RunnerOpt func(*Runner)
+
+func WithTimeShim(t timeshim.Interface) RunnerOpt {
+	return func(runner *Runner) {
+		runner.time = t
+	}
+}
+
+type Runner struct {
+	minInterval timeshim.Duration
+	callback    func(ctx context.Context)
+	triggerC    chan struct{}
+	time        timeshim.Interface
+}
+
+func (r *Runner) Start(ctx context.Context) {
+	go r.loop(ctx)
+}
+
+func (r *Runner) Trigger() {
+	select {
+	case r.triggerC <- struct{}{}:
+	default:
+		log.Debug("Already triggered")
+	}
+}
+
+func (r *Runner) loop(ctx context.Context) {
+	log.Info("Rate-limited Runner goroutine started")
+	triggered := true
+	var lastTriggerTime timeshim.Time
+	var timer timeshim.Timer
+	var timerC <-chan timeshim.Time
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("Context finished")
+			return
+		case <-r.triggerC:
+			log.Debug("Triggered.")
+			triggered = true
+		case <-timerC:
+			log.Debug("Timer popped.")
+			timerC = nil
+		}
+		sinceLastClean := r.time.Since(lastTriggerTime)
+		delayToNextClean := r.minInterval - sinceLastClean
+		if triggered && delayToNextClean <= 0 {
+			log.Debug("Executing callback.")
+			r.callback(ctx)
+			triggered = false
+			lastTriggerTime = r.time.Now()
+		} else if timerC == nil {
+			log.WithField("delay", delayToNextClean).Debug("Rate limited: starting timer.")
+			if timer == nil {
+				timer = r.time.NewTimer(delayToNextClean)
+			} else {
+				// We know we've received the last timer tick so the timer must be in the stopped state.
+				// Hence, it's safe to call Reset straight away.
+				timer.Reset(delayToNextClean)
+			}
+			timerC = timer.Chan()
+		}
+	}
+}

--- a/ratelimited/runner_test.go
+++ b/ratelimited/runner_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ratelimited
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/timeshim/mocktime"
+)
+
+func TestRunner(t *testing.T) {
+	RegisterTestingT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kicks := make(chan struct{})
+
+	mockTime := mocktime.New()
+	callback := func(ctx context.Context) {
+		kicks <- struct{}{}
+	}
+	runner := NewRunner(10*time.Second, callback, WithTimeShim(mockTime))
+	runner.Start(ctx)
+
+	t.Log("There should be no start-of day kick")
+	mockTime.IncrementTime(20 * time.Second)
+	Consistently(kicks).ShouldNot(Receive())
+
+	t.Log("First trigger should kick immediately but only once")
+	runner.Trigger()
+	Eventually(kicks).Should(Receive())
+
+	t.Log("Second trigger shouldn't kick after 9s")
+	runner.Trigger()
+	Consistently(kicks).ShouldNot(Receive()) // Needed to make sure runner's loop completes before increment.
+	mockTime.IncrementTime(9 * time.Second)
+	Consistently(kicks).ShouldNot(Receive())
+
+	t.Log("Second trigger should kick after 10s")
+	mockTime.IncrementTime(1 * time.Second)
+	Eventually(kicks).Should(Receive())
+
+	t.Log("Multiple triggers should only kick once")
+	runner.Trigger()
+	runner.Trigger()
+	Consistently(kicks).ShouldNot(Receive()) // Needed to make sure runner's loop completes.
+	runner.Trigger()
+	mockTime.IncrementTime(9 * time.Second)
+	Consistently(kicks).ShouldNot(Receive())
+	mockTime.IncrementTime(1 * time.Second)
+	Eventually(kicks).Should(Receive())
+
+	Expect(mockTime.HasTimers()).To(BeFalse(), "Should be no pending timers left")
+}
+
+func TestRunner_Trigger(t *testing.T) {
+	RegisterTestingT(t)
+	r := NewRunner(10*time.Second, func(ctx context.Context) {
+		panic("shouldn't be called")
+	})
+
+	t.Log("Trigger should not block even if loop is not running")
+	done := make(chan struct{})
+	go func() {
+		r.Trigger()
+		r.Trigger()
+		r.Trigger()
+		r.Trigger()
+		close(done)
+	}()
+	Eventually(done).Should(BeClosed())
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

* Add a generic rate-limited runner with UT.
* Do the cleanup from an instance of the rate-limited runner.
* Add FV to verify that cleanup happens as expected.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, Felix now rate-limits stale BPF map cleanup in order to save CPU.
```
