### PR TITLE
Only enable verifier log for post-failure retry

### DIFF
--- a/bpf/ut/pol_prog_test.go
+++ b/bpf/ut/pol_prog_test.go
@@ -132,6 +132,20 @@ func TestLoadKitchenSinkPolicy(t *testing.T) {
 	Expect(fd.Close()).NotTo(HaveOccurred())
 }
 
+func TestLoadGarbageProgram(t *testing.T) {
+	RegisterTestingT(t)
+
+	var insns asm.Insns
+	for i := 0; i < 256; i++ {
+		i := uint8(i)
+		insns = append(insns, asm.Insn{i,i,i,i,i,i,i,i})
+	}
+
+	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0")
+	Expect(err).To(HaveOccurred())
+	Expect(fd).To(BeZero())
+}
+
 const (
 	RCDrop            = 2
 	RCEpilogueReached = 123


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Also, size the log dynamically upto a limit.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, Felix now collects the BPF verifier log only on retry for increased performance and prevention of log buffer size issues.
```
