### PR TITLE
Fix BPF endpoint manager handling of endpoint recreation

### DIFF
--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -44,38 +44,47 @@ import (
 
 const jumpMapCleanupInterval = 10 * time.Second
 
-type epIface struct {
-	ifacemonitor.State
-	jumpMapFDs map[PolDirection]bpf.MapFD
+type bpfInterface struct {
+	bpfInterfaceData
+	bpfInterfaceState
+}
+
+type bpfInterfaceData struct {
+	state      ifacemonitor.State
+	endpointID *proto.WorkloadEndpointID
+}
+
+type bpfInterfaceState struct {
+	jumpMapFDs [2]bpf.MapFD
 }
 
 type bpfEndpointManager struct {
-	// Caches.  Updated immediately for now.
+	// Main store of information about interfaces; indexed on interface name.
+	ifacesLock  sync.Mutex
+	nameToIface map[string]bpfInterface
+
 	allWEPs        map[proto.WorkloadEndpointID]*proto.WorkloadEndpoint
 	happyWEPs      map[proto.WorkloadEndpointID]*proto.WorkloadEndpoint
 	happyWEPsDirty bool
 	policies       map[proto.PolicyID]*proto.Policy
 	profiles       map[proto.ProfileID]*proto.Profile
 
-	ifacesLock sync.Mutex
-	ifaces     map[string]epIface
-
 	// Indexes
 	policiesToWorkloads map[proto.PolicyID]set.Set  /*proto.WorkloadEndpointID*/
 	profilesToWorkloads map[proto.ProfileID]set.Set /*proto.WorkloadEndpointID*/
 
-	dirtyWorkloads set.Set
-	dirtyIfaces    set.Set
+	dirtyIfaceNames set.Set
 
-	bpfLogLevel      string
-	hostname         string
-	hostIP           net.IP
-	fibLookupEnabled bool
-	dataIfaceRegex   *regexp.Regexp
-	ipSetIDAlloc     *idalloc.IDAllocator
-	epToHostDrop     bool
-	vxlanMTU         int
-	dsrEnabled       bool
+	bpfLogLevel        string
+	hostname           string
+	hostIP             net.IP
+	fibLookupEnabled   bool
+	dataIfaceRegex     *regexp.Regexp
+	workloadIfaceRegex *regexp.Regexp
+	ipSetIDAlloc       *idalloc.IDAllocator
+	epToHostDrop       bool
+	vxlanMTU           int
+	dsrEnabled         bool
 
 	ipSetMap            bpf.Map
 	stateMap            bpf.Map
@@ -96,6 +105,7 @@ func newBPFEndpointManager(
 	fibLookupEnabled bool,
 	epToHostDrop bool,
 	dataIfaceRegex *regexp.Regexp,
+	workloadIfaceRegex *regexp.Regexp,
 	ipSetIDAlloc *idalloc.IDAllocator,
 	vxlanMTU int,
 	dsrEnabled bool,
@@ -110,15 +120,15 @@ func newBPFEndpointManager(
 		happyWEPsDirty:      true,
 		policies:            map[proto.PolicyID]*proto.Policy{},
 		profiles:            map[proto.ProfileID]*proto.Profile{},
-		ifaces:              map[string]epIface{},
+		nameToIface:         map[string]bpfInterface{},
 		policiesToWorkloads: map[proto.PolicyID]set.Set{},
 		profilesToWorkloads: map[proto.ProfileID]set.Set{},
-		dirtyWorkloads:      set.New(),
-		dirtyIfaces:         set.New(),
+		dirtyIfaceNames:     set.New(),
 		bpfLogLevel:         bpfLogLevel,
 		hostname:            hostname,
 		fibLookupEnabled:    fibLookupEnabled,
 		dataIfaceRegex:      dataIfaceRegex,
+		workloadIfaceRegex:  workloadIfaceRegex,
 		ipSetIDAlloc:        ipSetIDAlloc,
 		epToHostDrop:        epToHostDrop,
 		vxlanMTU:            vxlanMTU,
@@ -132,6 +142,29 @@ func newBPFEndpointManager(
 			tc.CleanUpJumpMaps()
 		}),
 	}
+}
+
+func (m *bpfEndpointManager) withIface(ifaceName string, fn func(iface *bpfInterface) (forceDirty bool)) {
+	iface := m.nameToIface[ifaceName]
+	ifaceCopy := iface
+	dirty := fn(&iface)
+	logCtx := log.WithField("name", ifaceName)
+
+	var zeroIface bpfInterface
+	if iface == zeroIface {
+		logCtx.Debug("Interface info is now empty.")
+		delete(m.nameToIface, ifaceName)
+	}
+
+	dirty = dirty || iface.bpfInterfaceData != ifaceCopy.bpfInterfaceData
+
+	if !dirty {
+		return
+	}
+
+	logCtx.Debug("Marking iface dirty.")
+	m.dirtyIfaceNames.Add(ifaceName)
+	m.nameToIface[ifaceName] = iface
 }
 
 func (m *bpfEndpointManager) OnUpdate(msg interface{}) {
@@ -169,8 +202,8 @@ func (m *bpfEndpointManager) OnUpdate(msg interface{}) {
 				// Should be safe without the lock since there shouldn't be any active background threads
 				// but taking it now makes us robust to refactoring.
 				m.ifacesLock.Lock()
-				for iface := range m.ifaces {
-					m.dirtyIfaces.Add(iface)
+				for ifaceName := range m.nameToIface {
+					m.dirtyIfaceNames.Add(ifaceName)
 				}
 				m.ifacesLock.Unlock()
 			} else {
@@ -186,27 +219,15 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceUpdate) {
 	m.ifacesLock.Lock()
 	defer m.ifacesLock.Unlock()
 
-	if update.State == ifacemonitor.StateUnknown {
-		log.WithField("iface", update.Name).Debug("Interface no longer present.")
-		if iface, ok := m.ifaces[update.Name]; ok {
-			for _, fd := range iface.jumpMapFDs {
-				_ = fd.Close()
-			}
-			delete(m.ifaces, update.Name)
-			m.dirtyIfaces.Add(update.Name)
-		}
-	} else {
-		log.WithFields(log.Fields{
-			"name":  update.Name,
-			"state": update.State,
-		}).Debug("Interface state updated.")
-		iface := m.ifaces[update.Name]
-		if iface.State != update.State {
-			iface.State = update.State
-			m.ifaces[update.Name] = iface
-			m.dirtyIfaces.Add(update.Name)
-		}
+	if !m.isDataIface(update.Name) && !m.isWorkloadIface(update.Name) {
+		log.WithField("update", update).Debug("Ignoring interface that's neither data nor workload.")
+		return
 	}
+
+	m.withIface(update.Name, func(iface *bpfInterface) bool {
+		iface.state = update.State
+		return false
+	})
 }
 
 // onWorkloadEndpointUpdate adds/updates the workload in the cache along with the index from active policy to
@@ -214,10 +235,10 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceUpdate) {
 func (m *bpfEndpointManager) onWorkloadEndpointUpdate(msg *proto.WorkloadEndpointUpdate) {
 	log.WithField("wep", msg.Endpoint).Debug("Workload endpoint update")
 	wlID := *msg.Id
-	oldWL := m.allWEPs[wlID]
+	oldWEP := m.allWEPs[wlID]
 	wl := msg.Endpoint
-	if oldWL != nil {
-		for _, t := range oldWL.Tiers {
+	if oldWEP != nil {
+		for _, t := range oldWEP.Tiers {
 			for _, pol := range t.IngressPolicies {
 				polSet := m.policiesToWorkloads[proto.PolicyID{
 					Tier: t.Name,
@@ -240,7 +261,7 @@ func (m *bpfEndpointManager) onWorkloadEndpointUpdate(msg *proto.WorkloadEndpoin
 			}
 		}
 
-		for _, profName := range oldWL.ProfileIds {
+		for _, profName := range oldWEP.ProfileIds {
 			profID := proto.ProfileID{Name: profName}
 			profSet := m.profilesToWorkloads[profID]
 			if profSet == nil {
@@ -248,6 +269,11 @@ func (m *bpfEndpointManager) onWorkloadEndpointUpdate(msg *proto.WorkloadEndpoin
 			}
 			profSet.Discard(wlID)
 		}
+
+		m.withIface(oldWEP.Name, func(iface *bpfInterface) bool {
+			iface.endpointID = nil
+			return false
+		})
 	}
 	m.allWEPs[wlID] = msg.Endpoint
 	for _, t := range wl.Tiers {
@@ -281,15 +307,18 @@ func (m *bpfEndpointManager) onWorkloadEndpointUpdate(msg *proto.WorkloadEndpoin
 			profSet.Add(wlID)
 		}
 	}
-	m.dirtyWorkloads.Add(wlID)
+	m.withIface(wl.Name, func(iface *bpfInterface) bool {
+		iface.endpointID = &wlID
+		return true // Force interface to be marked dirty in case policies changed.
+	})
 }
 
 // onWorkloadEndpointRemove removes the workload from the cache and the index, which maps from policy to workload.
 func (m *bpfEndpointManager) onWorkloadEnpdointRemove(msg *proto.WorkloadEndpointRemove) {
 	wlID := *msg.Id
 	log.WithField("id", wlID).Debug("Workload endpoint removed")
-	wl := m.allWEPs[wlID]
-	for _, t := range wl.Tiers {
+	oldWEP := m.allWEPs[wlID]
+	for _, t := range oldWEP.Tiers {
 		for _, pol := range t.IngressPolicies {
 			polSet := m.policiesToWorkloads[proto.PolicyID{
 				Tier: t.Name,
@@ -312,9 +341,15 @@ func (m *bpfEndpointManager) onWorkloadEnpdointRemove(msg *proto.WorkloadEndpoin
 		}
 	}
 	delete(m.allWEPs, wlID)
-	delete(m.happyWEPs, wlID)
-	m.happyWEPsDirty = true
-	m.dirtyWorkloads.Add(wlID)
+	if m.happyWEPs[wlID] != nil {
+		delete(m.happyWEPs, wlID)
+		m.happyWEPsDirty = true
+	}
+
+	m.withIface(oldWEP.Name, func(iface *bpfInterface) bool {
+		iface.endpointID = nil
+		return false
+	})
 }
 
 // onPolicyUpdate stores the policy in the cache and marks any endpoints using it dirty.
@@ -360,7 +395,8 @@ func (m *bpfEndpointManager) markPolicyUsersDirty(id proto.PolicyID) {
 		return
 	}
 	wls.Iter(func(item interface{}) error {
-		m.dirtyWorkloads.Add(item)
+		wlID := item.(proto.WorkloadEndpointID)
+		m.markExistingWEPDirty(wlID)
 		return nil
 	})
 }
@@ -372,9 +408,20 @@ func (m *bpfEndpointManager) markProfileUsersDirty(id proto.ProfileID) {
 		return
 	}
 	wls.Iter(func(item interface{}) error {
-		m.dirtyWorkloads.Add(item)
+		wlID := item.(proto.WorkloadEndpointID)
+		m.markExistingWEPDirty(wlID)
 		return nil
 	})
+}
+
+func (m *bpfEndpointManager) markExistingWEPDirty(wlID proto.WorkloadEndpointID) {
+	wep := m.allWEPs[wlID]
+	if wep == nil {
+		log.WithField("wlID", wlID).Panic(
+			"BUG: policiesToWorkloads mapping points to unknown workload.")
+	} else {
+		m.dirtyIfaceNames.Add(wep.Name)
+	}
 }
 
 func (m *bpfEndpointManager) CompleteDeferredWork() error {
@@ -421,12 +468,12 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 	var mutex sync.Mutex
 	errs := map[string]error{}
 	var wg sync.WaitGroup
-	m.dirtyIfaces.Iter(func(item interface{}) error {
+	m.dirtyIfaceNames.Iter(func(item interface{}) error {
 		iface := item.(string)
-		if !m.dataIfaceRegex.MatchString(iface) {
+		if !m.isDataIface(iface) {
 			log.WithField("iface", iface).Debug(
 				"Ignoring interface that doesn't match the host data interface regex")
-			return set.RemoveItem
+			return nil
 		}
 		if m.getIfaceState(iface) != ifacemonitor.StateUp {
 			log.WithField("iface", iface).Debug("Ignoring interface that is down")
@@ -461,8 +508,13 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 		return nil
 	})
 	wg.Wait()
-	m.dirtyIfaces.Iter(func(item interface{}) error {
+	m.dirtyIfaceNames.Iter(func(item interface{}) error {
 		iface := item.(string)
+		if !m.isDataIface(iface) {
+			log.WithField("iface", iface).Debug(
+				"Ignoring interface that doesn't match the host data interface regex")
+			return nil
+		}
 		err := errs[iface]
 		if err == nil {
 			log.WithField("id", iface).Info("Applied program to host interface")
@@ -480,49 +532,57 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 
 func (m *bpfEndpointManager) updateWEPsInDataplane() {
 	var mutex sync.Mutex
-	errs := map[proto.WorkloadEndpointID]error{}
+	errs := map[string]error{}
 	var wg sync.WaitGroup
-	m.dirtyWorkloads.Iter(func(item interface{}) error {
+
+	m.dirtyIfaceNames.Iter(func(item interface{}) error {
+		ifaceName := item.(string)
+
+		if !m.isWorkloadIface(ifaceName) {
+			return nil
+		}
+
 		wg.Add(1)
-		go func() {
+		go func(ifaceName string) {
 			defer wg.Done()
-			wlID := item.(proto.WorkloadEndpointID)
-			err := m.applyPolicy(wlID)
+			err := m.applyPolicy(ifaceName)
 			mutex.Lock()
-			errs[wlID] = err
+			errs[ifaceName] = err
 			mutex.Unlock()
-		}()
+		}(ifaceName)
 		return nil
 	})
 	wg.Wait()
 
-	if m.dirtyWorkloads.Len() > 0 {
+	if m.dirtyIfaceNames.Len() > 0 {
 		// Clean up any left-over jump maps in the background...
 		m.mapCleanupRunner.Trigger()
 	}
 
-	m.dirtyWorkloads.Iter(func(item interface{}) error {
-		wlID := item.(proto.WorkloadEndpointID)
-		err := errs[wlID]
+	m.dirtyIfaceNames.Iter(func(item interface{}) error {
+		ifaceName := item.(string)
+
+		if !m.isWorkloadIface(ifaceName) {
+			return nil
+		}
+
+		err := errs[ifaceName]
+		wlID := m.nameToIface[ifaceName].endpointID
 		if err == nil {
-			log.WithField("id", wlID).Info("Applied policy to workload")
-			if m.allWEPs[wlID] != nil {
-				if m.happyWEPs[wlID] == nil {
+			log.WithField("iface", ifaceName).Info("Updated workload interface.")
+			if wlID != nil && m.allWEPs[*wlID] != nil {
+				if m.happyWEPs[*wlID] == nil {
 					log.WithField("id", wlID).Info("Adding workload interface to iptables allow list.")
 					m.happyWEPsDirty = true
 				}
-				m.happyWEPs[wlID] = m.allWEPs[wlID]
-			} else if m.happyWEPs[wlID] != nil {
-				// Workload was marked dirty because it's being deleted.  Clean up the happyWEPs entry.
-				delete(m.happyWEPs, wlID)
-				m.happyWEPsDirty = true
+				m.happyWEPs[*wlID] = m.allWEPs[*wlID]
 			}
 			return set.RemoveItem
 		} else {
-			if m.happyWEPs[wlID] != nil {
-				log.WithField("id", wlID).WithError(err).Error(
+			if wlID != nil && m.happyWEPs[*wlID] != nil {
+				log.WithField("id", *wlID).WithError(err).Error(
 					"Failed to add policy to workload, removing from iptables allow list")
-				delete(m.happyWEPs, wlID)
+				delete(m.happyWEPs, *wlID)
 				m.happyWEPsDirty = true
 			}
 		}
@@ -537,13 +597,35 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 }
 
 // applyPolicy actually applies the policy to the given workload.
-func (m *bpfEndpointManager) applyPolicy(wlID proto.WorkloadEndpointID) error {
+func (m *bpfEndpointManager) applyPolicy(ifaceName string) error {
 	startTime := time.Now()
-	wep := m.allWEPs[wlID]
-	if wep == nil {
-		// TODO clean up old workloads
-		return nil
+
+	// Other threads might be filling in jump map FDs in the map so take the lock.
+	m.ifacesLock.Lock()
+	var endpointID *proto.WorkloadEndpointID
+	m.withIface(ifaceName, func(iface *bpfInterface) (forceDirty bool) {
+		endpointID = iface.endpointID
+		if endpointID == nil {
+			for i := range iface.jumpMapFDs {
+				if iface.jumpMapFDs[i] > 0 {
+					err := iface.jumpMapFDs[i].Close()
+					if err != nil {
+						log.WithError(err).Error("Failed to close jump map.")
+					}
+					iface.jumpMapFDs[i] = 0
+				}
+			}
+		}
+		return false
+	})
+	m.ifacesLock.Unlock()
+
+	if endpointID == nil {
+		err := tc.RemoveQdisc(ifaceName)
+		return err
 	}
+
+	wep := m.allWEPs[*endpointID]
 
 	var ingressErr, egressErr error
 	var wg sync.WaitGroup
@@ -608,27 +690,34 @@ func (m *bpfEndpointManager) attachWorkloadProgram(endpoint *proto.WorkloadEndpo
 	return m.updatePolicyProgram(jumpMapFD, rules)
 }
 
-func (m *bpfEndpointManager) getJumpMapFD(ifaceName string, direction PolDirection) bpf.MapFD {
+func (m *bpfEndpointManager) getJumpMapFD(ifaceName string, direction PolDirection) (fd bpf.MapFD) {
 	m.ifacesLock.Lock()
 	defer m.ifacesLock.Unlock()
-	return m.ifaces[ifaceName].jumpMapFDs[direction]
+	m.withIface(ifaceName, func(iface *bpfInterface) bool {
+		fd = iface.jumpMapFDs[direction]
+		return false
+	})
+	return
 }
 
 func (m *bpfEndpointManager) setJumpMapFD(name string, direction PolDirection, fd bpf.MapFD) {
 	m.ifacesLock.Lock()
 	defer m.ifacesLock.Unlock()
-	iface := m.ifaces[name]
-	if iface.jumpMapFDs == nil {
-		iface.jumpMapFDs = map[PolDirection]bpf.MapFD{}
-	}
-	iface.jumpMapFDs[direction] = fd
-	m.ifaces[name] = iface
+
+	m.withIface(name, func(iface *bpfInterface) bool {
+		iface.jumpMapFDs[direction] = fd
+		return false
+	})
 }
 
-func (m *bpfEndpointManager) getIfaceState(iface string) ifacemonitor.State {
+func (m *bpfEndpointManager) getIfaceState(ifaceName string) (state ifacemonitor.State) {
 	m.ifacesLock.Lock()
 	defer m.ifacesLock.Unlock()
-	return m.ifaces[iface].State
+	m.withIface(ifaceName, func(iface *bpfInterface) bool {
+		state = iface.state
+		return false
+	})
+	return
 }
 
 func (m *bpfEndpointManager) updatePolicyProgram(jumpMapFD bpf.MapFD, rules [][][]*proto.Rule) error {
@@ -719,11 +808,11 @@ func (m *bpfEndpointManager) attachDataIfaceProgram(ifaceName string, polDirecti
 
 // PolDirection is the Calico datamodel direction of policy.  On a host endpoint, ingress is towards the host.
 // On a workload endpoint, ingress is towards the workload.
-type PolDirection string
+type PolDirection int
 
 const (
-	PolDirnIngress PolDirection = "ingress"
-	PolDirnEgress  PolDirection = "egress"
+	PolDirnIngress PolDirection = iota
+	PolDirnEgress
 )
 
 func (m *bpfEndpointManager) calculateTCAttachPoint(endpointType tc.EndpointType, policyDirection PolDirection, ifaceName string) tc.AttachPoint {
@@ -796,4 +885,12 @@ func (m *bpfEndpointManager) extractRules(tier *proto.TierInfo, profileNames []s
 	}
 	allRules = append(allRules, profs)
 	return allRules
+}
+
+func (m *bpfEndpointManager) isWorkloadIface(iface string) bool {
+	return m.workloadIfaceRegex.MatchString(iface)
+}
+
+func (m *bpfEndpointManager) isDataIface(iface string) bool {
+	return m.dataIfaceRegex.MatchString(iface)
 }

--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -507,19 +507,19 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 		if err == nil {
 			log.WithField("id", wlID).Info("Applied policy to workload")
 			if m.allWEPs[wlID] != nil {
-				if _, ok := m.happyWEPs[wlID]; !ok {
+				if m.happyWEPs[wlID] == nil {
 					log.WithField("id", wlID).Info("Adding workload interface to iptables allow list.")
 					m.happyWEPsDirty = true
 				}
 				m.happyWEPs[wlID] = m.allWEPs[wlID]
-			} else if _, ok := m.happyWEPs[wlID]; ok {
+			} else if m.happyWEPs[wlID] != nil {
 				// Workload was marked dirty because it's being deleted.  Clean up the happyWEPs entry.
 				delete(m.happyWEPs, wlID)
 				m.happyWEPsDirty = true
 			}
 			return set.RemoveItem
 		} else {
-			if _, ok := m.happyWEPs[wlID]; ok {
+			if m.happyWEPs[wlID] != nil {
 				log.WithField("id", wlID).WithError(err).Error(
 					"Failed to add policy to workload, removing from iptables allow list")
 				delete(m.happyWEPs, wlID)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Felix didn't properly clean up when a BPF-configured workload endpoint was deleted.  This led to failing to re-apply policy to the new interface with the same name.

* Add a back reference from the interface name to workload endpoint ID so that we can keep track of interfaces we need to clean up.
* When applying policy, check that the interface still has its BPF programs in place.

## Todos
- [x] Clean up data/workload interface split.
- [x] Check that BPF program is really installed, don't assume.
- [x] Tests
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, Felix now correctly handles the case where a workload endpoint interface is recreated with the same name.
```
