### PR TITLE
WG fv test fixes and bpf code simplifications

### DIFF
--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -133,7 +133,7 @@ struct bpf_map_def_extended {
 
 #define CALI_F_TO_HOST       (CALI_F_FROM_HEP || CALI_F_FROM_WEP)
 #define CALI_F_FROM_HOST     (!CALI_F_TO_HOST)
-#define CALI_F_L3            (CALI_F_TO_HEP && CALI_F_TUNNEL)
+#define CALI_F_L3            ((CALI_F_TO_HEP && CALI_F_TUNNEL) || CALI_F_WIREGUARD)
 #define CALI_F_IPIP_ENCAPPED (CALI_F_INGRESS && CALI_F_TUNNEL)
 #define CALI_F_WG_INGRESS    (CALI_F_INGRESS && CALI_F_WIREGUARD)
 

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -46,7 +46,7 @@ static CALI_BPF_INLINE bool skb_too_short(struct __sk_buff *skb)
 {
 	if (CALI_F_IPIP_ENCAPPED) {
 		return skb_shorter(skb, ETH_IPV4_UDP_SIZE + sizeof(struct iphdr));
-	} else if (CALI_F_L3 | CALI_F_WIREGUARD) {
+	} else if (CALI_F_L3) {
 		return skb_shorter(skb, IPV4_UDP_SIZE);
 	} else {
 		return skb_shorter(skb, ETH_IPV4_UDP_SIZE);
@@ -59,7 +59,7 @@ static CALI_BPF_INLINE long skb_iphdr_offset(struct __sk_buff *skb)
 	if (CALI_F_IPIP_ENCAPPED) {
 		// Ingress on an IPIP tunnel: skb is [ether|outer IP|inner IP|payload]
 		return sizeof(struct ethhdr) + sizeof(struct iphdr);
-	} else if (CALI_F_L3 | CALI_F_WIREGUARD) {
+	} else if (CALI_F_L3) {
 		// Egress on an IPIP tunnel, or Wireguard both directions:
 		// skb is [inner IP|payload]
 		return 0;

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -73,7 +73,8 @@ static CALI_BPF_INLINE struct iphdr *skb_iphdr(struct __sk_buff *skb)
 {
 	long offset = skb_iphdr_offset(skb);
 	struct iphdr *ip = skb_ptr(skb, offset);
-	CALI_DEBUG("IP@%d; s=%x d=%x\n", offset, be32_to_host(ip->saddr), be32_to_host(ip->daddr));
+	CALI_DEBUG("IP id=%d s=%x d=%x\n",
+			be16_to_host(ip->id), be32_to_host(ip->saddr), be32_to_host(ip->daddr));
 	return ip;
 }
 

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -211,14 +211,6 @@ static CALI_BPF_INLINE int forward_or_drop(struct __sk_buff *skb,
 #if FIB_ENABLED
 	// Try a short-circuit FIB lookup.
 	if (fwd_fib(fwd)) {
-		if (CALI_F_WG_INGRESS) {
-			// Don't try redirect from Wireguard ingress, because it doesn't work.
-			// Wireguard SKBs are L3 and we think we need to add on an Ethernet header
-			// before redirecting to a local cali* veth, so that the veth doesn't drop
-			// the packet.
-			goto cancel_fib;
-		}
-
 		/* XXX we might include the tot_len in the fwd, set it once when
 		 * we get the ip_header the first time and only adjust the value
 		 * when we modify the packet - to avoid geting the header here

--- a/bpf/ut/precompilation_test.go
+++ b/bpf/ut/precompilation_test.go
@@ -47,7 +47,13 @@ func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 			for _, fibEnabled := range []bool{false, true} {
 				fibEnabled := fibEnabled
 				logCxt = logCxt.WithField("fibEnabled", fibEnabled)
-				for _, epType := range []tc.EndpointType{tc.EpTypeWorkload, tc.EpTypeHost, tc.EpTypeTunnel} {
+				epTypes := []tc.EndpointType{
+					tc.EpTypeWorkload,
+					tc.EpTypeHost,
+					tc.EpTypeTunnel,
+					tc.EpTypeWireguard,
+				}
+				for _, epType := range epTypes {
 					epType := epType
 					logCxt = logCxt.WithField("epType", epType)
 					if epToHostDrop && epType != tc.EpTypeWorkload {

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -78,6 +78,7 @@ var _ = describeBPFTests(withProto("udp"), withDSR())
 var _ = describeBPFTests(withTunnel("ipip"), withProto("tcp"), withDSR())
 var _ = describeBPFTests(withTunnel("ipip"), withProto("udp"), withDSR())
 var _ = describeBPFTests(withTunnel("wireguard"), withProto("tcp"))
+var _ = describeBPFTests(withTunnel("wireguard"), withProto("tcp"), withConnTimeLoadBalancingEnabled())
 
 // Run a stripe of tests with BPF logging disabled since the compiler tends to optimise the code differently
 // with debug disabled and that can lead to verifier issues.

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -1938,9 +1938,13 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 									hostW0SrcIP := ExpectWithSrcIPs(node0IP)
 									hostW1SrcIP := ExpectWithSrcIPs(node1IP)
 
-									if testOpts.tunnel == "ipip" {
+									switch testOpts.tunnel {
+									case "ipip":
 										hostW0SrcIP = ExpectWithSrcIPs(felixes[0].ExpectedIPIPTunnelAddr)
 										hostW1SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedIPIPTunnelAddr)
+									case "wireguard":
+										hostW1SrcIP = ExpectWithSrcIPs(felixes[0].ExpectedWireguardTunnelAddr)
+										hostW1SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedWireguardTunnelAddr)
 									}
 
 									ports := ExpectWithPorts(npPort)

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -239,10 +239,12 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			options.FelixLogSeverity = "debug"
 			options.NATOutgoingEnabled = true
 			options.AutoHEPsEnabled = true
+			// override IPIP being enabled by default
+			options.IPIPEnabled = false
+			options.IPIPRoutesEnabled = false
 			switch testOpts.tunnel {
 			case "none":
-				options.IPIPEnabled = false
-				options.IPIPRoutesEnabled = false
+				// nothing
 			case "ipip":
 				options.IPIPEnabled = true
 				options.IPIPRoutesEnabled = true

--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -500,11 +500,13 @@ func (kds *K8sDatastoreInfra) SetExpectedIPIPTunnelAddr(felix *Felix, idx int, n
 
 func (kds *K8sDatastoreInfra) SetExpectedVXLANTunnelAddr(felix *Felix, idx int, needBGP bool) {
 	felix.ExpectedVXLANTunnelAddr = fmt.Sprintf("10.65.%d.0", idx)
+	felix.ExtraSourceIPs = append(felix.ExtraSourceIPs, felix.ExpectedVXLANTunnelAddr)
 }
 
 func (kds *K8sDatastoreInfra) SetExpectedWireguardTunnelAddr(felix *Felix, idx int, needWg bool) {
 	// Set to be the same as IPIP tunnel address.
 	felix.ExpectedWireguardTunnelAddr = fmt.Sprintf("10.65.%d.1", idx)
+	felix.ExtraSourceIPs = append(felix.ExtraSourceIPs, felix.ExpectedWireguardTunnelAddr)
 }
 
 func (kds *K8sDatastoreInfra) AddNode(felix *Felix, idx int, needBGP bool) {

--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -210,9 +210,11 @@ func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (feli
 		}
 		if opts.VXLANMode != api.VXLANModeNever {
 			infra.SetExpectedVXLANTunnelAddr(felix, i, bool(n > 1))
+			expectedIPs = append(expectedIPs, felix.ExpectedVXLANTunnelAddr)
 		}
 		if opts.WireguardEnabled {
 			infra.SetExpectedWireguardTunnelAddr(felix, i, bool(n > 1))
+			expectedIPs = append(expectedIPs, felix.ExpectedWireguardTunnelAddr)
 		}
 
 		var w chan struct{}


### PR DESCRIPTION
## Description

    bpf/fv: fix AutoHEPs for wireguard tests

    bpf: skb_iphdr() also prints IP id
    
    Having the id helps tracking packet in the logs

    bpf/fv: do not test 2 tunnels at the same time

    bpf/ut: test compile/load  wireguard prog versions

    bpf: CALI_F_L3 unifies WG nad IPIP egress
    
    Whenever we get L3 packet, use the CALI_F_L3


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
