### PR TITLE
Handling LoadBalancerIPStrings as a derived service

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,14 +61,6 @@ blocks:
     jobs:
     - name: FV Test matrix
       commands:
-      # Check that Wireguard is NOT available on the normal Semaphore VM.  If it becomes
-      # available in future, then:
-      #
-      # 1. We should remove the `make fv GINKGO_FOCUS=WireGuard-Supported` that we're
-      # running on the newer kernel VMs (below), so as not to run those tests twice.
-      #
-      # 2. We should delete the WireGuard-Unsupported tests, or find another way to run
-      # them in CI, as they only do anything when WireGuard is NOT available.
       - " make check-wireguard"
       - make fv FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}" FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT}
       parallelism: 3

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -69,7 +69,7 @@ blocks:
       #
       # 2. We should delete the WireGuard-Unsupported tests, or find another way to run
       # them in CI, as they only do anything when WireGuard is NOT available.
-      - "! make check-wireguard"
+      - " make check-wireguard"
       - make fv FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}" FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT}
       parallelism: 3
     epilogue:
@@ -96,7 +96,6 @@ blocks:
       commands:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} ut-bpf
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} check-wireguard
-      - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv GINKGO_FOCUS=WireGuard-Supported
     - name: FV on newer kernel
       commands:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-bpf GINKGO_FOCUS=BPF-SAFE FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT} FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}"

--- a/bpf/proxy/lb_src_range_test.go
+++ b/bpf/proxy/lb_src_range_test.go
@@ -36,193 +36,212 @@ func init() {
 }
 
 var _ = Describe("BPF Load Balancer source range", func() {
-	svcs := newMockNATMap()
-	eps := newMockNATBackendMap()
-	aff := newMockAffinityMap()
 
-	nodeIPs := []net.IP{net.IPv4(192, 168, 0, 1), net.IPv4(10, 123, 0, 1)}
-	rt := proxy.NewRTCache()
+	testfn := func(extIPs, lbIPs []string) {
+		svcs := newMockNATMap()
+		eps := newMockNATBackendMap()
+		aff := newMockAffinityMap()
 
-	s, _ := proxy.NewSyncer(nodeIPs, svcs, eps, aff, rt)
+		nodeIPs := []net.IP{net.IPv4(192, 168, 0, 1), net.IPv4(10, 123, 0, 1)}
+		rt := proxy.NewRTCache()
 
-	svcKey := k8sp.ServicePortName{
-		NamespacedName: types.NamespacedName{
-			Namespace: "default",
-			Name:      "test-service",
-		},
-	}
-	state := proxy.DPSyncerState{
-		SvcMap: k8sp.ServiceMap{
-			svcKey: proxy.NewK8sServicePort(
-				net.IPv4(10, 0, 0, 2),
-				2222,
-				v1.ProtocolTCP,
-				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
-				proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24", "33.0.1.2/16"}),
-			),
-		},
-		EpsMap: k8sp.EndpointsMap{
-			svcKey: []k8sp.Endpoint{&k8sp.BaseEndpointInfo{Endpoint: "10.1.0.1:5555"}},
-		},
-	}
-	makestep := func(step func()) func() {
-		return func() {
-			defer func() {
-				log("svcs = %+v\n", svcs)
-				log("eps = %+v\n", eps)
-			}()
+		s, _ := proxy.NewSyncer(nodeIPs, svcs, eps, aff, rt)
 
-			step()
+		svcKey := k8sp.ServicePortName{
+			NamespacedName: types.NamespacedName{
+				Namespace: "default",
+				Name:      "test-service",
+			},
 		}
+
+		state := proxy.DPSyncerState{
+			SvcMap: k8sp.ServiceMap{
+				svcKey: proxy.NewK8sServicePort(
+					net.IPv4(10, 0, 0, 2),
+					2222,
+					v1.ProtocolTCP,
+					proxy.K8sSvcWithExternalIPs(extIPs),
+					proxy.K8sSvcWithLoadBalancerIPs(lbIPs),
+					proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24", "33.0.1.2/16"}),
+				),
+			},
+			EpsMap: k8sp.EndpointsMap{
+				svcKey: []k8sp.Endpoint{&k8sp.BaseEndpointInfo{Endpoint: "10.1.0.1:5555"}},
+			},
+		}
+		makestep := func(step func()) func() {
+			return func() {
+				defer func() {
+					log("svcs = %+v\n", svcs)
+					log("eps = %+v\n", eps)
+				}()
+
+				step()
+			}
+		}
+
+		saddr1 := ip.MustParseCIDROrIP("35.0.1.2/24").(ip.V4CIDR)
+		saddr2 := ip.MustParseCIDROrIP("33.0.1.2/16").(ip.V4CIDR)
+		saddr3 := ip.MustParseCIDROrIP("23.0.1.2/16").(ip.V4CIDR)
+
+		extIP := net.IPv4(35, 0, 0, 2)
+		proto := proxy.ProtoV1ToIntPanic(v1.ProtocolTCP)
+		keyWithSaddr1 := nat.NewNATKeySrc(extIP, 2222, proto, saddr1)
+		keyWithSaddr2 := nat.NewNATKeySrc(extIP, 2222, proto, saddr2)
+		keyWithSaddr3 := nat.NewNATKeySrc(extIP, 2222, proto, saddr3)
+		keyWithExtIP := nat.NewNATKey(extIP, 2222, proto)
+		BlackholeNATVal := nat.NewNATValue(0, nat.BlackHoleCount, 0, 0)
+
+		It("should make the right test transitions", func() {
+
+			By("adding LBSourceRangeIP for existing service", makestep(func() {
+
+				err := s.Apply(state)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(svcs.m).To(HaveLen(4))
+
+				key := nat.NewNATKeySrc(net.IPv4(10, 0, 0, 2), 2222, proto, saddr1)
+				Expect(svcs.m).NotTo(HaveKey(key))
+
+				key = nat.NewNATKeySrc(net.IPv4(10, 0, 0, 2), 2222, proto, saddr2)
+				Expect(svcs.m).NotTo(HaveKey(key))
+
+				key = nat.NewNATKey(net.IPv4(10, 0, 0, 2), 2222, proto)
+				Expect(svcs.m).To(HaveKey(key))
+
+				Expect(svcs.m).To(HaveKey(keyWithSaddr1))
+				Expect(svcs.m).To(HaveKey(keyWithSaddr2))
+				Expect(svcs.m).To(HaveKey(keyWithExtIP))
+
+				val, ok := svcs.m[keyWithExtIP]
+				Expect(ok).To(BeTrue())
+				Expect(val).To(Equal(BlackholeNATVal))
+
+			}))
+
+			By("updating LBSourceRangeIP for existing service", makestep(func() {
+				Expect(svcs.m).To(HaveLen(4))
+				state.SvcMap[svcKey] = proxy.NewK8sServicePort(
+					net.IPv4(10, 0, 0, 2),
+					2222,
+					v1.ProtocolTCP,
+					proxy.K8sSvcWithExternalIPs(extIPs),
+					proxy.K8sSvcWithLoadBalancerIPs(lbIPs),
+					proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24", "23.0.1.2/16"}),
+				)
+
+				err := s.Apply(state)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(svcs.m).To(HaveLen(4))
+
+				Expect(svcs.m).To(HaveKey(keyWithSaddr1))
+				Expect(svcs.m).To(HaveKey(keyWithSaddr3))
+				Expect(svcs.m).NotTo(HaveKey(keyWithSaddr2))
+
+			}))
+
+			By("Deleting one LBSourceRangeIP for existing service", makestep(func() {
+				state.SvcMap[svcKey] = proxy.NewK8sServicePort(
+					net.IPv4(10, 0, 0, 2),
+					2222,
+					v1.ProtocolTCP,
+					proxy.K8sSvcWithExternalIPs(extIPs),
+					proxy.K8sSvcWithLoadBalancerIPs(lbIPs),
+					proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24"}),
+				)
+
+				err := s.Apply(state)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(svcs.m).To(HaveLen(3))
+
+				Expect(svcs.m).To(HaveKey(keyWithSaddr1))
+				Expect(svcs.m).NotTo(HaveKey(keyWithSaddr3))
+
+			}))
+
+			By("Deleting LBSourceRangeIP for existing service", makestep(func() {
+				state.SvcMap[svcKey] = proxy.NewK8sServicePort(
+					net.IPv4(10, 0, 0, 2),
+					2222,
+					v1.ProtocolTCP,
+					proxy.K8sSvcWithExternalIPs(extIPs),
+					proxy.K8sSvcWithLoadBalancerIPs(lbIPs),
+					proxy.K8sSvcWithLBSourceRangeIPs([]string{}),
+				)
+
+				err := s.Apply(state)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(svcs.m).To(HaveLen(2))
+
+				Expect(svcs.m).NotTo(HaveKey(keyWithSaddr1))
+				Expect(svcs.m).NotTo(HaveKey(keyWithSaddr3))
+
+			}))
+
+			By("Adding new entries to the map with different source IPs", makestep(func() {
+				var tempLbIPs, tempExtIPs []string
+				if len(extIPs) == 0 {
+					tempLbIPs = append(lbIPs, "45.0.1.2")
+				} else {
+					tempExtIPs = append(extIPs, "45.0.1.2")
+				}
+				state.SvcMap[svcKey] = proxy.NewK8sServicePort(
+					net.IPv4(10, 0, 0, 2),
+					2222,
+					v1.ProtocolTCP,
+					proxy.K8sSvcWithExternalIPs(tempExtIPs),
+					proxy.K8sSvcWithLoadBalancerIPs(tempLbIPs),
+					proxy.K8sSvcWithLBSourceRangeIPs([]string{"33.0.1.2/24", "38.0.1.2/16", "40.0.1.2/32"}),
+				)
+
+				err := s.Apply(state)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(svcs.m).To(HaveLen(9))
+				s.Stop()
+			}))
+
+			By("Remove stale src range entries after syncer restarts", makestep(func() {
+				state.SvcMap[svcKey] = proxy.NewK8sServicePort(
+					net.IPv4(10, 0, 0, 2),
+					2222,
+					v1.ProtocolTCP,
+					proxy.K8sSvcWithExternalIPs(extIPs),
+					proxy.K8sSvcWithLoadBalancerIPs(lbIPs),
+					proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24"}),
+				)
+				s, _ = proxy.NewSyncer(nodeIPs, svcs, eps, aff, rt)
+				err := s.Apply(state)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(svcs.m).To(HaveLen(3))
+			}))
+
+			By("Remove all stale src ranges after syncer restarts", makestep(func() {
+				state.SvcMap[svcKey] = proxy.NewK8sServicePort(
+					net.IPv4(10, 0, 0, 2),
+					2222,
+					v1.ProtocolTCP,
+					proxy.K8sSvcWithExternalIPs(extIPs),
+					proxy.K8sSvcWithLoadBalancerIPs(lbIPs),
+				)
+				s, _ = proxy.NewSyncer(nodeIPs, svcs, eps, aff, rt)
+				err := s.Apply(state)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(svcs.m).To(HaveLen(2))
+			}))
+
+			By("deleting the services", makestep(func() {
+				delete(state.SvcMap, svcKey)
+
+				err := s.Apply(state)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(svcs.m).To(HaveLen(0))
+				Expect(eps.m).To(HaveLen(0))
+			}))
+
+		})
 	}
-
-	saddr1 := ip.MustParseCIDROrIP("35.0.1.2/24").(ip.V4CIDR)
-	saddr2 := ip.MustParseCIDROrIP("33.0.1.2/16").(ip.V4CIDR)
-	saddr3 := ip.MustParseCIDROrIP("23.0.1.2/16").(ip.V4CIDR)
-
-	extIP := net.IPv4(35, 0, 0, 2)
-	proto := proxy.ProtoV1ToIntPanic(v1.ProtocolTCP)
-	keyWithSaddr1 := nat.NewNATKeySrc(extIP, 2222, proto, saddr1)
-	keyWithSaddr2 := nat.NewNATKeySrc(extIP, 2222, proto, saddr2)
-	keyWithSaddr3 := nat.NewNATKeySrc(extIP, 2222, proto, saddr3)
-	keyWithExtIP := nat.NewNATKey(extIP, 2222, proto)
-	BlackholeNATVal := nat.NewNATValue(0, nat.BlackHoleCount, 0, 0)
-
-	It("should make the right test transitions", func() {
-
-		By("adding LBSourceRangeIP for existing service", makestep(func() {
-
-			err := s.Apply(state)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(svcs.m).To(HaveLen(4))
-
-			key := nat.NewNATKeySrc(net.IPv4(10, 0, 0, 2), 2222, proto, saddr1)
-			Expect(svcs.m).NotTo(HaveKey(key))
-
-			key = nat.NewNATKeySrc(net.IPv4(10, 0, 0, 2), 2222, proto, saddr2)
-			Expect(svcs.m).NotTo(HaveKey(key))
-
-			key = nat.NewNATKey(net.IPv4(10, 0, 0, 2), 2222, proto)
-			Expect(svcs.m).To(HaveKey(key))
-
-			Expect(svcs.m).To(HaveKey(keyWithSaddr1))
-			Expect(svcs.m).To(HaveKey(keyWithSaddr2))
-			Expect(svcs.m).To(HaveKey(keyWithExtIP))
-
-			val, ok := svcs.m[keyWithExtIP]
-			Expect(ok).To(BeTrue())
-			Expect(val).To(Equal(BlackholeNATVal))
-
-		}))
-
-		By("updating LBSourceRangeIP for existing service", makestep(func() {
-			Expect(svcs.m).To(HaveLen(4))
-			state.SvcMap[svcKey] = proxy.NewK8sServicePort(
-				net.IPv4(10, 0, 0, 2),
-				2222,
-				v1.ProtocolTCP,
-				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
-				proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24", "23.0.1.2/16"}),
-			)
-
-			err := s.Apply(state)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(svcs.m).To(HaveLen(4))
-
-			Expect(svcs.m).To(HaveKey(keyWithSaddr1))
-			Expect(svcs.m).To(HaveKey(keyWithSaddr3))
-			Expect(svcs.m).NotTo(HaveKey(keyWithSaddr2))
-
-		}))
-
-		By("Deleting one LBSourceRangeIP for existing service", makestep(func() {
-			state.SvcMap[svcKey] = proxy.NewK8sServicePort(
-				net.IPv4(10, 0, 0, 2),
-				2222,
-				v1.ProtocolTCP,
-				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
-				proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24"}),
-			)
-
-			err := s.Apply(state)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(svcs.m).To(HaveLen(3))
-
-			Expect(svcs.m).To(HaveKey(keyWithSaddr1))
-			Expect(svcs.m).NotTo(HaveKey(keyWithSaddr3))
-
-		}))
-
-		By("Deleting LBSourceRangeIP for existing service", makestep(func() {
-			state.SvcMap[svcKey] = proxy.NewK8sServicePort(
-				net.IPv4(10, 0, 0, 2),
-				2222,
-				v1.ProtocolTCP,
-				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
-				proxy.K8sSvcWithLBSourceRangeIPs([]string{}),
-			)
-
-			err := s.Apply(state)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(svcs.m).To(HaveLen(2))
-
-			Expect(svcs.m).NotTo(HaveKey(keyWithSaddr1))
-			Expect(svcs.m).NotTo(HaveKey(keyWithSaddr3))
-
-		}))
-
-		By("Adding new entries to the map with different source IPs", makestep(func() {
-			state.SvcMap[svcKey] = proxy.NewK8sServicePort(
-				net.IPv4(10, 0, 0, 2),
-				2222,
-				v1.ProtocolTCP,
-				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2", "45.0.1.2"}),
-				proxy.K8sSvcWithLBSourceRangeIPs([]string{"33.0.1.2/24", "38.0.1.2/16", "40.0.1.2/32"}),
-			)
-
-			err := s.Apply(state)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(svcs.m).To(HaveLen(9))
-			s.Stop()
-		}))
-
-		By("Remove stale src range entries after syncer restarts", makestep(func() {
-			state.SvcMap[svcKey] = proxy.NewK8sServicePort(
-				net.IPv4(10, 0, 0, 2),
-				2222,
-				v1.ProtocolTCP,
-				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
-				proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24"}),
-			)
-			s, _ = proxy.NewSyncer(nodeIPs, svcs, eps, aff, rt)
-			err := s.Apply(state)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(svcs.m).To(HaveLen(3))
-		}))
-
-		By("Remove all stale src ranges after syncer restarts", makestep(func() {
-			state.SvcMap[svcKey] = proxy.NewK8sServicePort(
-				net.IPv4(10, 0, 0, 2),
-				2222,
-				v1.ProtocolTCP,
-				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
-			)
-			s, _ = proxy.NewSyncer(nodeIPs, svcs, eps, aff, rt)
-			err := s.Apply(state)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(svcs.m).To(HaveLen(2))
-		}))
-
-		By("deleting the services", makestep(func() {
-			delete(state.SvcMap, svcKey)
-
-			err := s.Apply(state)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(svcs.m).To(HaveLen(0))
-			Expect(eps.m).To(HaveLen(0))
-		}))
-
-	})
+	testfn([]string{}, []string{"35.0.0.2"})
+	testfn([]string{"35.0.0.2"}, []string{})
 })

--- a/bpf/proxy/lb_src_range_test.go
+++ b/bpf/proxy/lb_src_range_test.go
@@ -57,7 +57,7 @@ var _ = Describe("BPF Load Balancer source range", func() {
 				net.IPv4(10, 0, 0, 2),
 				2222,
 				v1.ProtocolTCP,
-				proxy.K8sSvcWithExternalIPs([]string{"35.0.0.2"}),
+				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
 				proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24", "33.0.1.2/16"}),
 			),
 		},
@@ -122,7 +122,7 @@ var _ = Describe("BPF Load Balancer source range", func() {
 				net.IPv4(10, 0, 0, 2),
 				2222,
 				v1.ProtocolTCP,
-				proxy.K8sSvcWithExternalIPs([]string{"35.0.0.2"}),
+				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
 				proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24", "23.0.1.2/16"}),
 			)
 
@@ -141,7 +141,7 @@ var _ = Describe("BPF Load Balancer source range", func() {
 				net.IPv4(10, 0, 0, 2),
 				2222,
 				v1.ProtocolTCP,
-				proxy.K8sSvcWithExternalIPs([]string{"35.0.0.2"}),
+				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
 				proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24"}),
 			)
 
@@ -159,7 +159,7 @@ var _ = Describe("BPF Load Balancer source range", func() {
 				net.IPv4(10, 0, 0, 2),
 				2222,
 				v1.ProtocolTCP,
-				proxy.K8sSvcWithExternalIPs([]string{"35.0.0.2"}),
+				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
 				proxy.K8sSvcWithLBSourceRangeIPs([]string{}),
 			)
 
@@ -177,7 +177,7 @@ var _ = Describe("BPF Load Balancer source range", func() {
 				net.IPv4(10, 0, 0, 2),
 				2222,
 				v1.ProtocolTCP,
-				proxy.K8sSvcWithExternalIPs([]string{"35.0.0.2", "45.0.1.2"}),
+				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2", "45.0.1.2"}),
 				proxy.K8sSvcWithLBSourceRangeIPs([]string{"33.0.1.2/24", "38.0.1.2/16", "40.0.1.2/32"}),
 			)
 
@@ -192,7 +192,7 @@ var _ = Describe("BPF Load Balancer source range", func() {
 				net.IPv4(10, 0, 0, 2),
 				2222,
 				v1.ProtocolTCP,
-				proxy.K8sSvcWithExternalIPs([]string{"35.0.0.2"}),
+				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
 				proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24"}),
 			)
 			s, _ = proxy.NewSyncer(nodeIPs, svcs, eps, aff, rt)
@@ -206,7 +206,7 @@ var _ = Describe("BPF Load Balancer source range", func() {
 				net.IPv4(10, 0, 0, 2),
 				2222,
 				v1.ProtocolTCP,
-				proxy.K8sSvcWithExternalIPs([]string{"35.0.0.2"}),
+				proxy.K8sSvcWithLoadBalancerIPs([]string{"35.0.0.2"}),
 			)
 			s, _ = proxy.NewSyncer(nodeIPs, svcs, eps, aff, rt)
 			err := s.Apply(state)

--- a/bpf/proxy/service_type_change_test.go
+++ b/bpf/proxy/service_type_change_test.go
@@ -344,7 +344,6 @@ func setSvcTypeToExternalIP(testSvc *v1.Service, extIP []string, k8s *fake.Clien
 }
 
 func setSvcTypeToLoadBalancer(testSvc *v1.Service, extIP, srcRange []string, k8s *fake.Clientset) {
-	//testSvc.Spec.ExternalIPs = extIP
 	testSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: extIP[0]}}
 	testSvc.Spec.LoadBalancerSourceRanges = srcRange
 	testSvc.Spec.Ports[0].NodePort = 0
@@ -358,6 +357,7 @@ func setSvcTypeToNodePort(testSvc *v1.Service, npPort int32, k8s *fake.Clientset
 	testSvc.Spec.LoadBalancerSourceRanges = []string{}
 	testSvc.Spec.Ports[0].NodePort = npPort
 	testSvc.Spec.Type = v1.ServiceTypeNodePort
+	testSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{}
 	_, err := k8s.CoreV1().Services(v1.NamespaceDefault).Update(testSvc)
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/bpf/proxy/service_type_change_test.go
+++ b/bpf/proxy/service_type_change_test.go
@@ -326,6 +326,7 @@ var _ = Describe("BPF service type change", func() {
 
 func setSvcTypeToClusterIP(testSvc *v1.Service, k8s *fake.Clientset) {
 	testSvc.Spec.ExternalIPs = []string{}
+	testSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{}
 	testSvc.Spec.LoadBalancerSourceRanges = []string{}
 	testSvc.Spec.Type = v1.ServiceTypeClusterIP
 	testSvc.Spec.Ports[0].NodePort = 0
@@ -343,7 +344,8 @@ func setSvcTypeToExternalIP(testSvc *v1.Service, extIP []string, k8s *fake.Clien
 }
 
 func setSvcTypeToLoadBalancer(testSvc *v1.Service, extIP, srcRange []string, k8s *fake.Clientset) {
-	testSvc.Spec.ExternalIPs = extIP
+	//testSvc.Spec.ExternalIPs = extIP
+	testSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: extIP[0]}}
 	testSvc.Spec.LoadBalancerSourceRanges = srcRange
 	testSvc.Spec.Ports[0].NodePort = 0
 	testSvc.Spec.Type = v1.ServiceTypeLoadBalancer


### PR DESCRIPTION
In case of LoadBalancers, the public IP is present in the LoadBalancerIPStrings in the service info. This is handled as a derived service and proper NAT entries are programmed for the LB public IP
1) This fixes the GCP loadbalancer issue
2) In case of aws, we get Loadbalancer domain names and not public IP. Hence we dont see a NAT entry for the resolved domain name in FE BPF map. The loadbalancer in turn does a DNAT of the <public ip:80> to <node_ip:nodeport>. Hence we will only nodeport NAT entries for aws. 

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
