### PR TITLE
Changes to fix wireguard ci failure

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,15 +61,7 @@ blocks:
     jobs:
     - name: FV Test matrix
       commands:
-      # Check that Wireguard is NOT available on the normal Semaphore VM.  If it becomes
-      # available in future, then:
-      #
-      # 1. We should remove the `make fv GINKGO_FOCUS=WireGuard-Supported` that we're
-      # running on the newer kernel VMs (below), so as not to run those tests twice.
-      #
-      # 2. We should delete the WireGuard-Unsupported tests, or find another way to run
-      # them in CI, as they only do anything when WireGuard is NOT available.
-      - "! make check-wireguard"
+      - " make check-wireguard"
       - make fv FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}" FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT}
       parallelism: 3
     epilogue:
@@ -96,7 +88,6 @@ blocks:
       commands:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} ut-bpf
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} check-wireguard
-      - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv GINKGO_FOCUS=WireGuard-Supported
     - name: FV on newer kernel
       commands:
       - ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv-bpf GINKGO_FOCUS=BPF-SAFE FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT} FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,7 +61,7 @@ blocks:
     jobs:
     - name: FV Test matrix
       commands:
-      - " make check-wireguard"
+      - make check-wireguard
       - make fv FV_BATCHES_TO_RUN="${SEMAPHORE_JOB_INDEX}" FV_NUM_BATCHES=${SEMAPHORE_JOB_COUNT}
       parallelism: 3
     epilogue:


### PR DESCRIPTION
Changes to fix wireguard felix fv failures as the semaphore VMs have the wireguard module.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note


```release-note
None required
```
