### PR TITLE
bpf/proxy: do not update unchanged services

### DIFF
--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -411,7 +411,11 @@ func (s *Syncer) applySvc(skey svcKey, sinfo k8sp.ServicePort, eps []k8sp.Endpoi
 	if exists {
 		if ServicePortEqual(old.svc, sinfo) {
 			id = old.id
-			count, local, err = s.updateExistingSvc(skey.sname, sinfo, id, old.count, eps)
+			if !ServiceEpsEqual(s.prevEpsMap[skey.sname], eps) {
+				count, local, err = s.updateExistingSvc(skey.sname, sinfo, id, old.count, eps)
+			} else {
+				count = old.count
+			}
 		} else {
 			if err := s.deleteSvc(old.svc, old.id, old.count); err != nil {
 				return err
@@ -1423,6 +1427,27 @@ func ServicePortEqual(a, b k8sp.ServicePort) bool {
 		stringsEqual(a.LoadBalancerIPStrings(), b.LoadBalancerIPStrings()) &&
 		stringsEqual(a.LoadBalancerSourceRanges(), b.LoadBalancerSourceRanges()) &&
 		stringsEqual(a.TopologyKeys(), b.TopologyKeys())
+}
+
+func ServiceEpsEqual(a, b []k8sp.Endpoint) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for _, aa := range a {
+		found := false
+		for _, bb := range b {
+			if aa.Equal(bb) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
 }
 
 func stringsEqual(a, b []string) bool {

--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -839,7 +839,6 @@ func getSvcNATKey(svc k8sp.ServicePort) (nat.FrontendKey, error) {
 }
 
 func getSvcNATKeyLBSrcRange(svc k8sp.ServicePort) ([]nat.FrontendKey, error) {
-	var keys []nat.FrontendKey
 	ipaddr := svc.ClusterIP()
 	port := svc.Port()
 	loadBalancerSourceRanges := svc.LoadBalancerSourceRanges()
@@ -848,8 +847,11 @@ func getSvcNATKeyLBSrcRange(svc k8sp.ServicePort) ([]nat.FrontendKey, error) {
 	}
 	proto, err := ProtoV1ToInt(svc.Protocol())
 	if err != nil {
-		return keys, err
+		return nil, err
 	}
+
+	keys := make([]nat.FrontendKey, 0, len(loadBalancerSourceRanges))
+
 	for _, src := range loadBalancerSourceRanges {
 		// Ignore IPv6 addresses
 		if strings.Contains(src, ":") {

--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -398,33 +398,35 @@ func (s *Syncer) cleanupDerived(id uint32) error {
 }
 
 func (s *Syncer) applySvc(skey svcKey, sinfo k8sp.ServicePort, eps []k8sp.Endpoint,
-	cleanupDerived func(uint32) error) error {
+	cleanupDerived func(uint32) error) (error, bool) {
 
 	var (
-		err   error
-		id    uint32
-		count int
-		local int
+		err        error
+		id         uint32
+		count      int
+		local      int
+		svcChanged = true
 	)
 
 	old, exists := s.prevSvcMap[skey]
 	if exists {
 		if ServicePortEqual(old.svc, sinfo) {
 			id = old.id
-			if !ServiceEpsEqual(s.prevEpsMap[skey.sname], eps) {
+			if !s.synced || !ServiceEpsEqual(s.prevEpsMap[skey.sname], eps) {
 				count, local, err = s.updateExistingSvc(skey.sname, sinfo, id, old.count, eps)
 			} else {
+				svcChanged = false
 				count = old.count
 			}
 		} else {
 			if err := s.deleteSvc(old.svc, old.id, old.count); err != nil {
-				return err
+				return err, false
 			}
 
 			delete(s.prevSvcMap, skey)
 			if cleanupDerived != nil {
 				if err := cleanupDerived(old.id); err != nil {
-					return errors.WithMessage(err, "cleanupDerived")
+					return errors.WithMessage(err, "cleanupDerived"), false
 				}
 			}
 
@@ -436,7 +438,7 @@ func (s *Syncer) applySvc(skey svcKey, sinfo k8sp.ServicePort, eps []k8sp.Endpoi
 		count, local, err = s.newSvc(skey.sname, sinfo, id, eps)
 	}
 	if err != nil {
-		return err
+		return err, false
 	}
 
 	s.newSvcMap[skey] = svcInfo{
@@ -449,10 +451,11 @@ func (s *Syncer) applySvc(skey svcKey, sinfo k8sp.ServicePort, eps []k8sp.Endpoi
 	s.newEpsMap[skey.sname] = eps
 
 	if log.GetLevel() >= log.DebugLevel {
-		log.Debugf("applied a service %s update: sinfo=%+v", skey, s.newSvcMap[skey])
+		log.Debugf("applied a service %s update: sinfo=%+v changed: %t",
+			skey, s.newSvcMap[skey], svcChanged)
 	}
 
-	return nil
+	return nil, svcChanged
 }
 
 func (s *Syncer) addActiveEps(id uint32, svc k8sp.ServicePort, eps []k8sp.Endpoint) {
@@ -482,7 +485,7 @@ func (s *Syncer) applyExpandedNP(sname k8sp.ServicePortName, sinfo k8sp.ServiceP
 	si.clusterIP = node.AsNetIP()
 	si.port = nport
 
-	if err := s.applySvc(skey, si, eps, nil); err != nil {
+	if err, _ := s.applySvc(skey, si, eps, nil); err != nil {
 		return errors.Errorf("apply NodePortRemote for %s node %s", sname, node)
 	}
 
@@ -537,7 +540,12 @@ func (s *Syncer) expandNodePorts(sname k8sp.ServicePortName, sinfo k8sp.ServiceP
 	return miss
 }
 
-func (s *Syncer) applyDerived(sname k8sp.ServicePortName, t svcType, sinfo k8sp.ServicePort) error {
+func (s *Syncer) applyDerived(
+	sname k8sp.ServicePortName,
+	t svcType,
+	sinfo k8sp.ServicePort,
+	svcChanged bool,
+) error {
 
 	svc, ok := s.newSvcMap[getSvcKey(sname, "")]
 	if !ok {
@@ -564,7 +572,7 @@ func (s *Syncer) applyDerived(sname k8sp.ServicePortName, t svcType, sinfo k8sp.
 		svc:        sinfo,
 	}
 
-	if oldInfo, ok := s.prevSvcMap[skey]; !ok || oldInfo != newInfo {
+	if _, ok := s.prevSvcMap[skey]; !ok || !s.synced || svcChanged {
 		if err := s.writeSvc(sinfo, svc.id, count, local); err != nil {
 			return err
 		}
@@ -600,14 +608,17 @@ func (s *Syncer) apply(state DPSyncerState) error {
 	for sname, sinfo := range state.SvcMap {
 		skey := getSvcKey(sname, "")
 		eps := state.EpsMap[sname]
-		if err := s.applySvc(skey, sinfo, eps, s.cleanupDerived); err != nil {
+
+		err, svcChanged := s.applySvc(skey, sinfo, eps, s.cleanupDerived)
+		if err != nil {
 			return err
 		}
+
 		for _, lbIP := range sinfo.LoadBalancerIPStrings() {
 			if lbIP != "" {
 				extInfo := serviceInfoFromK8sServicePort(sinfo)
 				extInfo.clusterIP = net.ParseIP(lbIP)
-				err := s.applyDerived(sname, svcTypeLoadBalancer, extInfo)
+				err := s.applyDerived(sname, svcTypeLoadBalancer, extInfo, svcChanged)
 				if err != nil {
 					log.Errorf("failed to apply LoadBalancer IP %s for service %s : %s", lbIP, sname, err)
 					continue
@@ -619,7 +630,7 @@ func (s *Syncer) apply(state DPSyncerState) error {
 		for _, extIP := range sinfo.ExternalIPStrings() {
 			extInfo := serviceInfoFromK8sServicePort(sinfo)
 			extInfo.clusterIP = net.ParseIP(extIP)
-			err := s.applyDerived(sname, svcTypeExternalIP, extInfo)
+			err := s.applyDerived(sname, svcTypeExternalIP, extInfo, svcChanged)
 			if err != nil {
 				log.Errorf("failed to apply ExternalIP %s for service %s : %s", extIP, sname, err)
 				continue
@@ -636,7 +647,7 @@ func (s *Syncer) apply(state DPSyncerState) error {
 					// separately
 					continue
 				}
-				err := s.applyDerived(sname, svcTypeNodePort, npInfo)
+				err := s.applyDerived(sname, svcTypeNodePort, npInfo, svcChanged)
 				if err != nil {
 					log.Errorf("failed to apply NodePort %s for service %s : %s", npip, sname, err)
 					continue
@@ -692,7 +703,6 @@ func (s *Syncer) Apply(state DPSyncerState) error {
 		if err := s.startupSync(state); err != nil {
 			return errors.WithMessage(err, "startup sync")
 		}
-		s.synced = true
 		// deallocate, no further use
 		s.origSvcs = nil
 		s.origEps = nil
@@ -723,6 +733,11 @@ func (s *Syncer) Apply(state DPSyncerState) error {
 		// dont bother to cleanup affinity since we do not know in what state we
 		// are anyway. Will get resolved once we get in a good state
 		return err
+	}
+
+	// we are fully synced now
+	if !s.synced {
+		s.synced = true
 	}
 
 	// We wrote all updates, noone will create new records in affinity table

--- a/bpf/proxy/syncer_bench_test.go
+++ b/bpf/proxy/syncer_bench_test.go
@@ -205,9 +205,17 @@ func BenchmarkServiceUpdate(b *testing.B) {
 	logrus.SetLevel(logrus.WarnLevel)
 	defer logrus.SetLevel(loglevel)
 
+	dynaNodePort := func() K8sServicePortOption {
+		np := 0
+		return func(s interface{}) {
+			np = (np + 1) % 30000
+			K8sSvcWithNodePort(30000 + np)(s)
+		}
+	}
+
 	for _, svcs := range []int{1, 10, 100, 1000, 10000} {
 		for _, eps := range []int{1, 10} {
-			for _, opts := range [][]K8sServicePortOption{nil, {K8sSvcWithNodePort(30333)}} {
+			for _, opts := range [][]K8sServicePortOption{nil, {dynaNodePort()}} {
 				for _, mock := range []bool{true, false} {
 					runBenchmarkServiceUpdate(b, svcs, eps, mock, opts...)
 				}

--- a/bpf/proxy/syncer_bench_test.go
+++ b/bpf/proxy/syncer_bench_test.go
@@ -170,14 +170,8 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 		Expect(err).ShouldNot(HaveOccurred())
 	}
 
-	benchS := benchSyncer{
-		DPSyncer: syncer,
-		syncC:    make(chan struct{}, 1),
-	}
-
-	err = benchS.Apply(state)
+	err = syncer.Apply(state)
 	Expect(err).ShouldNot(HaveOccurred())
-	<-benchS.syncC
 
 	title := fmt.Sprintf("Services %d Endpoints %d mockMaps %t", svcCnt, epCnt, mockMaps)
 	if len(opts) > 0 {
@@ -197,9 +191,8 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 
 			b.StartTimer()
 
-			err := benchS.Apply(state)
+			err := syncer.Apply(state)
 			Expect(err).ShouldNot(HaveOccurred())
-			<-benchS.syncC
 
 			b.StopTimer()
 		}
@@ -221,15 +214,4 @@ func BenchmarkServiceUpdate(b *testing.B) {
 			}
 		}
 	}
-}
-
-type benchSyncer struct {
-	DPSyncer
-	syncC chan struct{}
-}
-
-func (s *benchSyncer) Apply(state DPSyncerState) error {
-	err := s.DPSyncer.Apply(state)
-	s.syncC <- struct{}{}
-	return err
 }


### PR DESCRIPTION
## Description

before:

```
BenchmarkServiceUpdate/Services_1_Endpoints_1_mockMaps_true-12         	  162416	      7359 ns/op	    2854 B/op	      29 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_1_mockMaps_false-12        	   81061	     15542 ns/op	    3465 B/op	      58 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_1_mockMaps_true_+_derived-12         	  138472	      9048 ns/op	    3258 B/op	      42 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_1_mockMaps_false_+_derived-12        	   65394	     21141 ns/op	    4201 B/op	      86 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_10_mockMaps_true-12                  	   97296	     11597 ns/op	    3646 B/op	      88 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_10_mockMaps_false-12                 	   23743	     59862 ns/op	    7812 B/op	     286 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_10_mockMaps_true_+_derived-12        	   94364	     13713 ns/op	    4058 B/op	     101 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_10_mockMaps_false_+_derived-12       	   22196	     67150 ns/op	    8744 B/op	     322 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_1_mockMaps_true-12                  	   54650	     24844 ns/op	    6592 B/op	     137 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_1_mockMaps_false-12                 	   17290	    106666 ns/op	   14427 B/op	     439 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_1_mockMaps_true_+_derived-12        	   33363	     44043 ns/op	   16546 B/op	     246 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_1_mockMaps_false_+_derived-12       	   10000	    104883 ns/op	   18782 B/op	     454 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_10_mockMaps_true-12                 	   20980	     80944 ns/op	   17695 B/op	     840 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_10_mockMaps_false-12                	    4599	    315012 ns/op	   34078 B/op	    1540 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_10_mockMaps_true_+_derived-12       	   15526	    119980 ns/op	   31465 B/op	    1053 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_10_mockMaps_false_+_derived-12      	    3004	    372549 ns/op	   43812 B/op	    1721 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_1_mockMaps_true-12                 	    6814	    334825 ns/op	   81528 B/op	    1796 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_1_mockMaps_false-12                	    2146	    660768 ns/op	   81352 B/op	    2632 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_1_mockMaps_true_+_derived-12       	    3351	    360457 ns/op	  112309 B/op	    1729 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_1_mockMaps_false_+_derived-12      	    1080	    969643 ns/op	  166891 B/op	    4142 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_10_mockMaps_true-12                	    2587	    542724 ns/op	  110076 B/op	    5532 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_10_mockMaps_false-12               	     430	   3359818 ns/op	  312542 B/op	   14371 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_10_mockMaps_true_+_derived-12      	    1594	    749268 ns/op	  177226 B/op	    6237 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_10_mockMaps_false_+_derived-12     	     324	   3614548 ns/op	  397823 B/op	   15874 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_1_mockMaps_true-12                	     604	   2086942 ns/op	  579936 B/op	   10020 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_1_mockMaps_false-12               	     157	   6931701 ns/op	  939961 B/op	   26020 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_1_mockMaps_true_+_derived-12      	     326	   3641477 ns/op	 1402845 B/op	   17057 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_1_mockMaps_false_+_derived-12     	     116	   9721405 ns/op	 1946979 B/op	   41056 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_10_mockMaps_true-12               	     214	   5358566 ns/op	 1227952 B/op	   55023 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_10_mockMaps_false-12              	      39	  33622087 ns/op	 3244300 B/op	  143037 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_10_mockMaps_true_+_derived-12     	     176	   6786472 ns/op	 2051127 B/op	   62058 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_10_mockMaps_false_+_derived-12    	      30	  35768808 ns/op	 4253767 B/op	  158129 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_1_mockMaps_true-12               	      58	  22102178 ns/op	 4824745 B/op	  100022 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_1_mockMaps_false-12              	      16	  73805093 ns/op	 8424858 B/op	  260019 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_1_mockMaps_true_+_derived-12     	      31	  38136083 ns/op	11935406 B/op	  170311 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_1_mockMaps_false_+_derived-12    	       9	 111704593 ns/op	17386875 B/op	  410344 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_10_mockMaps_true-12              	      20	  60660517 ns/op	11306271 B/op	  550023 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_10_mockMaps_false-12             	       3	 355060990 ns/op	31465437 B/op	 1430075 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_10_mockMaps_true_+_derived-12    	      15	  79439345 ns/op	18422458 B/op	  620336 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_10_mockMaps_false_+_derived-12   	       3	 367723247 ns/op	40420541 B/op	 1580352 allocs/op
```

after:

```
BenchmarkServiceUpdate/Services_1_Endpoints_1_mockMaps_true-12         	  176314	      7559 ns/op	    2848 B/op	      29 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_1_mockMaps_false-12        	   78752	     15063 ns/op	    3408 B/op	      54 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_1_mockMaps_true_+_derived-12         	  138424	      8882 ns/op	    3247 B/op	      41 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_1_mockMaps_false_+_derived-12        	   64789	     19201 ns/op	    4094 B/op	      80 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_10_mockMaps_true-12                  	   98176	     11411 ns/op	    3568 B/op	      83 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_10_mockMaps_false-12                 	   25051	     46003 ns/op	    6640 B/op	     225 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_10_mockMaps_true_+_derived-12        	   96440	     13263 ns/op	    3973 B/op	      95 allocs/op
BenchmarkServiceUpdate/Services_1_Endpoints_10_mockMaps_false_+_derived-12       	   23035	     52635 ns/op	    7392 B/op	     252 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_1_mockMaps_true-12                  	   69788	     17477 ns/op	    5226 B/op	      29 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_1_mockMaps_false-12                 	   48255	     25608 ns/op	    6032 B/op	      55 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_1_mockMaps_true_+_derived-12        	   43879	     35228 ns/op	   13950 B/op	      76 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_1_mockMaps_false_+_derived-12       	   28060	     50083 ns/op	   16154 B/op	     119 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_10_mockMaps_true-12                 	   47505	     28737 ns/op	    6206 B/op	      83 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_10_mockMaps_false-12                	   18351	     73060 ns/op	   10560 B/op	     226 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_10_mockMaps_true_+_derived-12       	   27679	     49572 ns/op	   16093 B/op	     134 allocs/op
BenchmarkServiceUpdate/Services_10_Endpoints_10_mockMaps_false_+_derived-12      	   12722	    101302 ns/op	   23997 B/op	     303 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_1_mockMaps_true-12                 	   10000	    105758 ns/op	   34130 B/op	      33 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_1_mockMaps_false-12                	   10000	    120311 ns/op	   34691 B/op	      59 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_1_mockMaps_true_+_derived-12       	    5769	    353167 ns/op	  157594 B/op	     542 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_1_mockMaps_false_+_derived-12      	    5979	    227843 ns/op	   98097 B/op	     383 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_10_mockMaps_true-12                	    7845	    161347 ns/op	   34840 B/op	      86 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_10_mockMaps_false-12               	    6801	    205133 ns/op	   37863 B/op	     227 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_10_mockMaps_true_+_derived-12      	    4336	    276856 ns/op	   97997 B/op	     398 allocs/op
BenchmarkServiceUpdate/Services_100_Endpoints_10_mockMaps_false_+_derived-12     	    3667	    335963 ns/op	  101334 B/op	     554 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_1_mockMaps_true-12                	    1110	   1163689 ns/op	  468045 B/op	      29 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_1_mockMaps_false-12               	    1137	   1037475 ns/op	  468555 B/op	      53 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_1_mockMaps_true_+_derived-12      	     552	   2584943 ns/op	 1250671 B/op	    3073 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_1_mockMaps_false_+_derived-12     	     519	   2252204 ns/op	 1251467 B/op	    3112 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_10_mockMaps_true-12               	     658	   1725658 ns/op	  468642 B/op	      74 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_10_mockMaps_false-12              	     650	   1613262 ns/op	  471240 B/op	     195 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_10_mockMaps_true_+_derived-12     	     370	   2781708 ns/op	 1251768 B/op	    3127 allocs/op
BenchmarkServiceUpdate/Services_1000_Endpoints_10_mockMaps_false_+_derived-12    	     441	   2790953 ns/op	 1254930 B/op	    3283 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_1_mockMaps_true-12               	      84	  12613745 ns/op	 3705096 B/op	      32 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_1_mockMaps_false-12              	      98	  12628490 ns/op	 3705673 B/op	      58 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_1_mockMaps_true_+_derived-12     	      46	  27247028 ns/op	10417729 B/op	   30336 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_1_mockMaps_false_+_derived-12    	      49	  29184740 ns/op	10417524 B/op	   30374 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_10_mockMaps_true-12              	      62	  21360122 ns/op	 3705309 B/op	      85 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_10_mockMaps_false-12             	      62	  22940588 ns/op	 3708641 B/op	     226 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_10_mockMaps_true_+_derived-12    	      36	  35517080 ns/op	10422811 B/op	   30395 allocs/op
BenchmarkServiceUpdate/Services_10000_Endpoints_10_mockMaps_false_+_derived-12   	      37	  37341294 ns/op	10421588 B/op	   30546 allocs/op
```
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
