### PR TITLE
Fix watchdog timeouts in various cases

### DIFF
--- a/bpf/tc/attach.go
+++ b/bpf/tc/attach.go
@@ -143,7 +143,8 @@ func isCannotFindDevice(err error) bool {
 	}
 	if err, ok := err.(*exec.ExitError); ok {
 		stderr := string(err.Stderr)
-		if strings.Contains(stderr, "Cannot find device") {
+		if strings.Contains(stderr, "Cannot find device") ||
+			strings.Contains(stderr, "No such device") {
 			return true
 		}
 	}

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -125,6 +125,15 @@ func TestCompileTemplateRun(t *testing.T) {
 	})
 }
 
+func TestLoadZeroProgram(t *testing.T) {
+	RegisterTestingT(t)
+	fd, err := bpf.LoadBPFProgramFromInsns(nil, "Apache-2.0")
+	if err == nil {
+		_ = fd.Close()
+	}
+	Expect(err).To(Equal(unix.E2BIG))
+}
+
 // runBpfTest runs a specific section of the entire bpf program in isolation
 func runBpfTest(t *testing.T, section string, rules [][][]*proto.Rule, testFn func(bpfProgRunFn)) {
 	RegisterTestingT(t)

--- a/calc/async_calc_graph.go
+++ b/calc/async_calc_graph.go
@@ -74,13 +74,14 @@ type AsyncCalcGraph struct {
 	*CalcGraph
 	inputEvents      chan interface{}
 	outputChannels   []chan<- interface{}
-	eventBuffer      *EventSequencer
+	eventSequencer   *EventSequencer
 	beenInSync       bool
 	needToSendInSync bool
 	syncStatusNow    api.SyncStatus
 	healthAggregator *health.HealthAggregator
 
 	flushTicks       <-chan time.Time
+	healthTicks      <-chan time.Time
 	flushLeakyBucket int
 	dirty            bool
 
@@ -97,13 +98,13 @@ func NewAsyncCalcGraph(
 	outputChannels []chan<- interface{},
 	healthAggregator *health.HealthAggregator,
 ) *AsyncCalcGraph {
-	eventBuffer := NewEventSequencer(conf)
-	calcGraph := NewCalculationGraph(eventBuffer, conf)
+	eventSequencer := NewEventSequencer(conf)
+	calcGraph := NewCalculationGraph(eventSequencer, conf)
 	g := &AsyncCalcGraph{
 		CalcGraph:        calcGraph,
 		inputEvents:      make(chan interface{}, 10),
 		outputChannels:   outputChannels,
-		eventBuffer:      eventBuffer,
+		eventSequencer:   eventSequencer,
 		healthAggregator: healthAggregator,
 	}
 	if conf.DebugSimulateCalcGraphHangAfter != 0 {
@@ -111,7 +112,7 @@ func NewAsyncCalcGraph(
 			"Simulating a calculation graph hang.")
 		g.debugHangC = time.After(conf.DebugSimulateCalcGraphHangAfter)
 	}
-	eventBuffer.Callback = g.onEvent
+	eventSequencer.Callback = g.onEvent
 	if healthAggregator != nil {
 		healthAggregator.RegisterReporter(healthName, &health.HealthReport{Live: true, Ready: true}, healthInterval*2)
 	}
@@ -134,7 +135,6 @@ func (acg *AsyncCalcGraph) OnStatusUpdated(status api.SyncStatus) {
 
 func (acg *AsyncCalcGraph) loop() {
 	log.Info("AsyncCalcGraph running")
-	healthTicks := time.NewTicker(healthInterval).C
 	acg.reportHealth()
 	for {
 		select {
@@ -182,7 +182,7 @@ func (acg *AsyncCalcGraph) loop() {
 			if acg.flushLeakyBucket < leakyBucketSize {
 				acg.flushLeakyBucket++
 			}
-		case <-healthTicks:
+		case <-acg.healthTicks:
 			acg.reportHealth()
 		case <-acg.debugHangC:
 			log.Warning("Debug hang simulation timer popped, hanging the calculation graph!!")
@@ -210,7 +210,12 @@ func (acg *AsyncCalcGraph) maybeFlush() {
 	if acg.flushLeakyBucket > 0 {
 		log.Debug("Not throttled: flushing event buffer")
 		acg.flushLeakyBucket--
-		acg.eventBuffer.Flush()
+		flushStart := time.Now()
+		acg.eventSequencer.Flush()
+		flushDuration := time.Since(flushStart)
+		if flushDuration > time.Second {
+			log.WithField("time", flushDuration).Info("Flush took over 1s.")
+		}
 		if acg.needToSendInSync {
 			log.Info("First flush after becoming in sync, sending InSync message.")
 			acg.onEvent(&proto.InSync{})
@@ -223,17 +228,32 @@ func (acg *AsyncCalcGraph) maybeFlush() {
 }
 
 func (acg *AsyncCalcGraph) onEvent(event interface{}) {
-	log.Debug("Sending output event on channel")
+	log.Debug("Sending output event on channel(s)")
+	healthTickCount := 0
+	startTime := time.Now()
+	channelLoop:
 	for _, c := range acg.outputChannels {
-		c <- event
+		for {
+			select {
+			case c <- event:
+				continue channelLoop
+			case <-acg.healthTicks:
+				acg.reportHealth()
+				healthTickCount++
+				if healthTickCount > 1 {
+					log.WithField("time", startTime).Info(
+						"Flushing updates to the dataplane is taking a long time")
+				}
+			}
+		}
 	}
 	countOutputEvents.Inc()
-	log.Debug("Sent output event on channel")
+	log.Debug("Sent output event on channel(s)")
 }
 
 func (acg *AsyncCalcGraph) Start() {
 	log.Info("Starting AsyncCalcGraph")
-	flushTicker := time.NewTicker(tickInterval)
-	acg.flushTicks = flushTicker.C
+	acg.flushTicks = time.NewTicker(tickInterval).C
+	acg.healthTicks = time.NewTicker(healthInterval).C
 	go acg.loop()
 }

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -525,6 +525,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			stateMap,
 			ruleRenderer,
 			filterTableV4,
+			dp.reportHealth,
 		))
 
 		// Pre-create the NAT maps so that later operations can assume access.

--- a/dataplane/linux/status_combiner.go
+++ b/dataplane/linux/status_combiner.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017,2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ func (e *endpointStatusCombiner) Apply() {
 			status := statuses[id]
 			logCxt := logCxt.WithField("ipVersion", ipVer).WithField("status", status)
 			if status == "error" {
-				logCxt.Warn("Endpoint is in error, will report error")
+				logCxt.Info("Endpoint is in error, will report error")
 				statusToReport = "error"
 			} else if status == "down" && statusToReport != "error" {
 				logCxt.Info("Endpoint down for at least one IP version")

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/spf13/viper v1.6.1
 	github.com/vishvananda/netlink v1.0.0
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	golang.org/x/tools v0.0.0-20200502202811-ed308ab3e770 // indirect
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200324154536-ceff61240acf

--- a/go.sum
+++ b/go.sum
@@ -756,7 +756,10 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20171026204733-164713f0dfce/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Various fixes from the robustness testing:
* Make sure the dataplane checks in with the watchdog while it's applying programs by limiting parallelism and checking in from the loop starting the updates.
* Handle another tc error output that also means that the device is missing; ensures we go through the special case path for that error and avoid spammy logs and retries.
* Fix that the async calc graph did not check in with the health monitor while it was blocked sending updates downstream.  We were seeing this in BPF mode at start of day but I think it's an error we've had reported from the field too.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that the async_calc_graph health watchdog could time out while the calc graph was blocked sending its output downstream.
```
