### PR TITLE
bpf/ut: fix TestMapIterWithDelete*

### DIFF
--- a/bpf/bpf_syscall.go
+++ b/bpf/bpf_syscall.go
@@ -456,7 +456,7 @@ func DeleteMapEntry(mapFD MapFD, k []byte, valueSize int) error {
 }
 
 // Batch size established by trial and error; 8-32 seemed to be the sweet spot for the conntrack map.
-const mapIteratorNumKeys = 16
+const MapIteratorNumKeys = 16
 
 // MapIterator handles one pass of iteration over the map.
 type MapIterator struct {
@@ -477,9 +477,9 @@ type MapIterator struct {
 	// bpf_map_load_multi.
 	keyBeforeNextBatch unsafe.Pointer
 
-	// keys points to a buffer containing up to mapIteratorNumKeys keys
+	// keys points to a buffer containing up to MapIteratorNumKeys keys
 	keys unsafe.Pointer
-	// values points to a buffer containing up to mapIteratorNumKeys values
+	// values points to a buffer containing up to MapIteratorNumKeys values
 	values unsafe.Pointer
 
 	// valueStride is the step through the values buffer.  I.e. the size of the value rounded up for alignment.
@@ -512,8 +512,8 @@ func NewMapIterator(mapFD MapFD, keySize, valueSize, maxEntries int) (*MapIterat
 	keyStride := align64(keySize)
 	valueStride := align64(valueSize)
 
-	keysBufSize := (C.size_t)(keyStride * mapIteratorNumKeys)
-	valueBufSize := (C.size_t)(valueStride * mapIteratorNumKeys)
+	keysBufSize := (C.size_t)(keyStride * MapIteratorNumKeys)
+	valueBufSize := (C.size_t)(valueStride * MapIteratorNumKeys)
 
 	m := &MapIterator{
 		mapFD:       mapFD,
@@ -548,7 +548,7 @@ func (m *MapIterator) Next() (k, v []byte, err error) {
 	if m.numEntriesLoaded == m.entryIdx {
 		// Need to load a new batch of KVs from the kernel.
 		var count C.int
-		rc := C.bpf_map_load_multi(C.uint(m.mapFD), m.keyBeforeNextBatch, mapIteratorNumKeys, C.int(m.keyStride), m.keys, C.int(m.valueStride), m.values)
+		rc := C.bpf_map_load_multi(C.uint(m.mapFD), m.keyBeforeNextBatch, MapIteratorNumKeys, C.int(m.keyStride), m.keys, C.int(m.valueStride), m.values)
 		if rc < 0 {
 			err = unix.Errno(-rc)
 			return

--- a/bpf/bpf_syscall_stub.go
+++ b/bpf/bpf_syscall_stub.go
@@ -20,6 +20,8 @@ import (
 	"github.com/projectcalico/felix/bpf/asm"
 )
 
+const MapIteratorNumKeys = 16
+
 func SyscallSupport() bool {
 	return false
 }

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -687,17 +687,68 @@ func TestMapIterWithDelete(t *testing.T) {
 		v := binary.LittleEndian.Uint64(V)
 
 		out[k] = v
-
-		err := m.Delete(K)
-		Expect(err).NotTo(HaveOccurred())
 		cnt++
-		return bpf.IterNone
+
+		return bpf.IterDelete
 	})
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(cnt).To(Equal(10))
 
 	for i := 0; i < 10; i++ {
+		Expect(out).To(HaveKey(uint64(i)))
+		Expect(out[uint64(i)]).To(Equal(uint64(i * 7)))
+	}
+}
+
+func TestMapIterWithDeleteLastOfBatch(t *testing.T) {
+	RegisterTestingT(t)
+
+	m := (&bpf.MapContext{}).NewPinnedMap(bpf.MapParameters{
+		Filename:   "/sys/fs/bpf/tc/globals/cali_tmap",
+		Type:       "hash",
+		KeySize:    8,
+		ValueSize:  8,
+		MaxEntries: 1000,
+		Name:       "cali_tmap",
+		Flags:      unix.BPF_F_NO_PREALLOC,
+	})
+
+	err := m.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+
+	for i := 0; i < 40; i++ {
+		var k, v [8]byte
+
+		binary.LittleEndian.PutUint64(k[:], uint64(i))
+		binary.LittleEndian.PutUint64(v[:], uint64(i*7))
+
+		err := m.Update(k[:], v[:])
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	out := make(map[uint64]uint64)
+
+	cnt := 0
+	err = m.Iter(func(K, V []byte) bpf.IteratorAction {
+		k := binary.LittleEndian.Uint64(K)
+		v := binary.LittleEndian.Uint64(V)
+
+		out[k] = v
+
+		cnt++
+		// Delete the last of the first batch. Must not make the iteration to
+		// restart from the begining.
+		if cnt == bpf.MapIteratorNumKeys {
+			return bpf.IterDelete
+		}
+		return bpf.IterNone
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(cnt).To(Equal(40))
+
+	for i := 0; i < 40; i++ {
 		Expect(out).To(HaveKey(uint64(i)))
 		Expect(out[uint64(i)]).To(Equal(uint64(i * 7)))
 	}


### PR DESCRIPTION
TestMapIterWithDelete must not delete directly, must return IterDelete.

TestMapIterWithDeleteLastOfBatch checks that we do not delete the last
key before we get the next batch.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
