### PR TITLE
BPF: allow host traffic when conntrack is full

### DIFF
--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -956,6 +956,13 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 		if (nat_dest == NULL) {
 			if (conntrack_create(&ct_nat_ctx, CT_CREATE_NORMAL)) {
 				CALI_DEBUG("Creating normal conntrack failed\n");
+
+				if ((CALI_F_FROM_HEP && rt_addr_is_local_host(ct_nat_ctx.dst)) ||
+						(CALI_F_TO_HEP && rt_addr_is_local_host(ct_nat_ctx.src))) {
+					CALI_DEBUG("Allowing local host traffic without CT\n");
+					goto allow;
+				}
+
 				goto deny;
 			}
 			goto allow;

--- a/bpf/ut/to_host_allowed_test.go
+++ b/bpf/ut/to_host_allowed_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"golang.org/x/sys/unix"
+	"net"
+	"testing"
+
+	"github.com/projectcalico/felix/bpf/conntrack"
+	"github.com/projectcalico/felix/bpf/nat"
+	"github.com/projectcalico/felix/bpf/routes"
+	"github.com/projectcalico/felix/ip"
+
+	"github.com/google/gopacket/layers"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+func TestToHostAllowedCTFull(t *testing.T) {
+	RegisterTestingT(t)
+
+	hostIP := net.IPv4(1, 1, 1, 1)
+	hostPort := uint16(666)
+
+	srcPort := uint16(12345)
+
+	defer func() {
+		// Disable debug while cleaning up the map
+		logrus.SetLevel(logrus.WarnLevel)
+		resetCTMap(ctMap)
+	}()
+
+	// Disable debug while filling up the map
+	loglevel := logrus.GetLevel()
+	logrus.SetLevel(logrus.WarnLevel)
+	defer logrus.SetLevel(loglevel)
+
+	val := conntrack.NewValueNormal(0, 0, 0, conntrack.Leg{}, conntrack.Leg{})
+
+	var err error
+	var firstCTKey conntrack.Key
+	var firstCTVal conntrack.Value
+
+	for i := 1; err == nil; i++ {
+		srcIP := net.IPv4(10, byte((i&0xff0000)>>16), byte((i&0xff00)>>8), byte(i&0xff))
+
+		key := conntrack.NewKey(1, srcIP, srcPort, hostIP, hostPort)
+		err = ctMap.Update(key[:], val[:])
+
+		if i == 1 {
+			copy(firstCTKey[:], key[:])
+			copy(firstCTVal[:], val[:])
+		}
+	}
+
+	// Make sure we failed because the CT table is full
+	Expect(err).To(Equal(unix.E2BIG))
+
+	// re-enable debug
+	logrus.SetLevel(loglevel)
+
+	tcpSyn := &layers.TCP{
+		SrcPort:    54321,
+		DstPort:    7890,
+		SYN:        true,
+		DataOffset: 5,
+	}
+
+	_, ipv4, _, _, synPkt, err := testPacket(nil, nil, tcpSyn, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	destCIDR := net.IPNet{
+		IP:   ipv4.DstIP,
+		Mask: net.IPv4Mask(255, 255, 255, 255),
+	}
+
+	defer resetRTMap(rtMap)
+	defer func() { bpfIfaceName = "" }()
+
+	// Not NAT programmed
+
+	// No route - should not pass
+	bpfIfaceName = "ctNO"
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
+	// Destination is a local workload - should not pass
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&destCIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsLocalWorkload).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	bpfIfaceName = "ctLW"
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
+	// Destination is a remote workload - should not pass
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&destCIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsRemoteWorkload).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	bpfIfaceName = "ctRW"
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
+	// Destination is a remote host - should not pass
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&destCIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsRemoteHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	bpfIfaceName = "ctRH"
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
+	// Destination is the local host - should pass
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&destCIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsLocalHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	bpfIfaceName = "ctLH"
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+
+	// Source is the local host - should pass
+	tcpSynAck := &layers.TCP{
+		SrcPort:    7890,
+		DstPort:    54321,
+		SYN:        true,
+		ACK:        true,
+		DataOffset: 5,
+	}
+
+	ipv4Ret := *ipv4
+	ipv4Ret.SrcIP, ipv4Ret.DstIP = ipv4Ret.DstIP, ipv4Ret.SrcIP
+
+	_, _, _, _, synAckPkt, err := testPacket(nil, &ipv4Ret, tcpSynAck, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synAckPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+
+	// Non-SYN packet
+	tcpAck := &layers.TCP{
+		SrcPort:    54321,
+		DstPort:    7890,
+		ACK:        true,
+		DataOffset: 5,
+	}
+
+	_, _, _, _, ackPkt, err := testPacket(nil, nil, tcpAck, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(ackPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+
+	// Make space in the CT table
+	err = ctMap.Delete(firstCTKey[:])
+	Expect(err).NotTo(HaveOccurred())
+
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(ackPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+
+	// Conntrack created - the table is full again
+	err = ctMap.Update(firstCTKey[:], firstCTVal[:])
+	Expect(err).To(Equal(unix.E2BIG))
+
+	// Delete the newly created key to allow the rest of the tests pass - they
+	// expect full table and no match
+	key := conntrack.NewKey(6, ipv4.SrcIP, uint16(tcpAck.SrcPort), ipv4.DstIP, uint16(tcpAck.DstPort))
+	err = ctMap.Delete(key[:])
+	Expect(err).NotTo(HaveOccurred())
+
+	// Refill the table
+	err = ctMap.Update(firstCTKey[:], firstCTVal[:])
+	Expect(err).NotTo(HaveOccurred())
+
+	// Towards WEP, the feature is disabled - should not pass
+	//
+	// Such a packet would not make it here anyway due to routing.
+	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
+	// It we hit NAT, the feature is disabled - should not pass
+	//
+	// Create NAT entry
+	err = natMap.Update(
+		nat.NewNATKey(ipv4.DstIP, uint16(tcpSyn.DstPort), uint8(ipv4.Protocol)).AsBytes(),
+		nat.NewNATValue(0, 1, 0, 0).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	natIP := net.IPv4(8, 8, 8, 8)
+	natPort := uint16(666)
+
+	err = natBEMap.Update(
+		nat.NewNATBackendKey(0, 0).AsBytes(),
+		nat.NewNATBackendValue(natIP, natPort).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Setup routing to allow NAT on HEP (encap)
+	node2wCIDR := net.IPNet{
+		IP:   natIP,
+		Mask: net.IPv4Mask(255, 255, 255, 0),
+	}
+
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node2wCIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValueWithNextHop(routes.FlagsRemoteWorkload, ip.FromNetIP(node2ip).(ip.V4Addr)).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node1CIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsLocalHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node2CIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsRemoteHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+}

--- a/bpf/ut/to_host_allowed_test.go
+++ b/bpf/ut/to_host_allowed_test.go
@@ -38,9 +38,9 @@ func TestToHostAllowedCTFull(t *testing.T) {
 	srcPort := uint16(12345)
 
 	defer func() {
-		// Disable debug while cleaning up the map
+		// Disable debug while cleaning up the maps
 		logrus.SetLevel(logrus.WarnLevel)
-		resetCTMap(ctMap)
+		cleanUpMaps()
 	}()
 
 	// Disable debug while filling up the map


### PR DESCRIPTION
## Description

    When the conntrack table becomes full and felix cannot clean it up for
    any reason (e.g., crashed, cannot reach k8s api server ...), a node
    becomes unreachable as well as the outter world from the node.
    
    We allow traffic that is towards the host or originates on the host to
    pass without creating conntrack entries. Each packet is policed
    individually. Once space is available in the table a conntrack entry
    will get created.
    
    TCP entries will not have SYN seen set.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, ensure that the host is always reachable, even if the conntrack table gets full.
```
