### PR TITLE
Always apply BPF programs to workload interfaces

### DIFF
--- a/calc/async_calc_graph.go
+++ b/calc/async_calc_graph.go
@@ -231,7 +231,7 @@ func (acg *AsyncCalcGraph) onEvent(event interface{}) {
 	log.Debug("Sending output event on channel(s)")
 	healthTickCount := 0
 	startTime := time.Now()
-	channelLoop:
+channelLoop:
 	for _, c := range acg.outputChannels {
 		for {
 			select {


### PR DESCRIPTION
Rather than applying programs only when there's an associated
endpoint, apply programs to all workload interfaces.  This closes
a race between removing the program and removig it from the iptables
allow list that polices unknown endpoints.

As a side benefit, it means we get a program ready on a newly-created
interface, ready to revcieve policy when the endpoint is created.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
