### PR TITLE
[v3.16] BPF: If packet is too short, try to pull more data

### DIFF
--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -83,6 +83,7 @@ MAKEFUNC(int, fib_lookup, void *ctx, struct bpf_fib_lookup *params, int plen, __
 MAKEFUNC(int, skb_change_head, void *ctx, __u32 len, __u64 flags)
 MAKEFUNC(int, skb_change_tail, void *ctx, __u32 len, __u64 flags)
 MAKEFUNC(int, skb_adjust_room, void *ctx, __s32 len, __u32 mode, __u64 flags)
+MAKEFUNC(int, skb_pull_data, void *ctx, __u32 len)
 MAKEFUNC(int, csum_diff, __be32 *from, __u32 from_size, __be32 *to, __u32 to_size, __wsum seed)
 MAKEFUNC(uint64_t, get_socket_cookie, void *ctx)
 

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -44,14 +44,22 @@
 
 static CALI_BPF_INLINE bool skb_too_short(struct __sk_buff *skb)
 {
+	int min_size;
 	if (CALI_F_IPIP_ENCAPPED) {
-		return skb_shorter(skb, ETH_IPV4_UDP_SIZE + sizeof(struct iphdr));
+		min_size = ETH_IPV4_UDP_SIZE + sizeof(struct iphdr);
 	} else if (CALI_F_L3) {
-		return skb_shorter(skb, IPV4_UDP_SIZE);
+		min_size = IPV4_UDP_SIZE;
 	} else {
-		return skb_shorter(skb, ETH_IPV4_UDP_SIZE);
+		min_size = ETH_IPV4_UDP_SIZE;
 	}
-	// TODO Deal with IP header with options.
+	if (skb_shorter(skb, min_size)) {
+		// Try to pull in more data.
+		if (bpf_skb_pull_data(skb, min_size)) {
+			return true;
+		}
+		return skb_shorter(skb, min_size);
+	}
+	return false;
 }
 
 static CALI_BPF_INLINE long skb_iphdr_offset(struct __sk_buff *skb)

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -56,10 +56,13 @@ static CALI_BPF_INLINE bool skb_too_short(struct __sk_buff *skb)
 	if (skb_shorter(skb, min_size)) {
 		// Try to pull in more data.  Ideally enough for TCP, or, failing that, enough for UDP.
 		if (bpf_skb_pull_data(skb, min_size + sizeof(struct tcphdr) - sizeof(struct udphdr))) {
+			CALI_DEBUG("Pull failed (TCP len)\n");
 			if (bpf_skb_pull_data(skb, min_size)) {
+				CALI_DEBUG("Pull failed (UDP len)\n");
 				return true;
 			}
 		}
+		CALI_DEBUG("Pulled data\n");
 		return skb_shorter(skb, min_size);
 	}
 	return false;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

We use direct packet access to read and write the packet; for that to be effective we need to make sure that the SKB has enough data in its head segment.

If we detect that the packet is too short, issue a bpf_skb_data_pull.

Backports #2461

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, fix that packets could be dropped if the UDP/TCP header didn't fit in the SKB's head buffer.
```
