### PR TITLE
bpf/proxy: stopExpandNPFixup only if runExpandNPFixup

### DIFF
--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -1117,10 +1117,10 @@ func (s *Syncer) matchBpfSvc(bpfSvc nat.FrontendKey, k8sSvc k8sp.ServicePortName
 }
 
 func (s *Syncer) runExpandNPFixup(misses []*expandMiss) {
-	s.expFixupStop = make(chan struct{})
 	if len(misses) == 0 {
 		return
 	}
+	s.expFixupStop = make(chan struct{})
 	s.expFixupWg.Add(1)
 
 	// start the fixer routine and exit
@@ -1172,8 +1172,12 @@ func (s *Syncer) runExpandNPFixup(misses []*expandMiss) {
 }
 
 func (s *Syncer) stopExpandNPFixup() {
-	close(s.expFixupStop)
-	s.expFixupWg.Wait()
+	// If there was an error before we started ExpandNPFixup, there is nothing to stop
+	if s.expFixupStop != nil {
+		close(s.expFixupStop)
+		s.expFixupWg.Wait()
+		s.expFixupStop = nil
+	}
 }
 
 // Stop stops the syncer


### PR DESCRIPTION
If there was an error in Apply() before the fixer got started, there is
nothing to stop. Clean the stop channel after stop to avoid closing a
closed channel.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
