### PR TITLE
bpf/proxy: ignore bpf deletes ENOENT errors

### DIFF
--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -377,7 +377,11 @@ func (s *Syncer) cleanupDerived(id uint32) error {
 				log.Debugf("bpf map deleting derived %s:%s", key, nat.NewNATValue(id, 0, 0, 0))
 			}
 			if err := s.bpfSvcs.Delete(key[:]); err != nil {
-				return errors.Errorf("bpfSvcs.Delete: %s", err)
+				if bpf.IsNotExists(err) {
+					log.Debugf("frontend key %s does not exist", key)
+				} else {
+					return errors.Errorf("bpfSvcs.Delete: %s", err)
+				}
 			}
 			keys, err := getSvcNATKeyLBSrcRange(si.svc)
 			if err != nil {
@@ -388,7 +392,11 @@ func (s *Syncer) cleanupDerived(id uint32) error {
 					log.Debugf("bpf map deleting derived %s:%s", key, nat.NewNATValue(id, 0, 0, 0))
 				}
 				if err := s.bpfSvcs.Delete(key[:]); err != nil {
-					return errors.Errorf("bpfSvcs.Delete: %s", err)
+					if bpf.IsNotExists(err) {
+						log.Debugf("frontend key %s does not exist", key)
+					} else {
+						return errors.Errorf("bpfSvcs.Delete: %s", err)
+					}
 				}
 			}
 		}
@@ -840,7 +848,11 @@ func (s *Syncer) deleteSvcBackend(svcID uint32, idx uint32) error {
 		log.Debugf("bpf map deleting %s", key)
 	}
 	if err := s.bpfEps.Delete(key[:]); err != nil {
-		return errors.Errorf("bpfEps.Delete: %s", err)
+		if bpf.IsNotExists(err) {
+			log.Debugf("backend key %s does not exist", key)
+		} else {
+			return errors.Errorf("bpfEps.Delete: %s", err)
+		}
 	}
 	return nil
 }
@@ -965,7 +977,11 @@ func (s *Syncer) deleteSvc(svc k8sp.ServicePort, svcID uint32, count int) error 
 		log.Debugf("bpf map deleting %s:%s", key, nat.NewNATValue(svcID, uint32(count), 0, 0))
 	}
 	if err := s.bpfSvcs.Delete(key[:]); err != nil {
-		return errors.WithMessage(err, "Delete svc")
+		if bpf.IsNotExists(err) {
+			log.Debugf("frontend key %s does not exist", key)
+		} else {
+			return errors.WithMessage(err, "Delete svc")
+		}
 	}
 
 	keys, err := getSvcNATKeyLBSrcRange(svc)
@@ -976,9 +992,12 @@ func (s *Syncer) deleteSvc(svc k8sp.ServicePort, svcID uint32, count int) error 
 		if log.GetLevel() >= log.DebugLevel {
 			log.Debugf("bpf map deleting %s:%s", key, nat.NewNATValue(svcID, uint32(count), 0, 0))
 		}
-		err := s.bpfSvcs.Delete(key[:])
-		if err != nil && !bpf.IsNotExists(err) {
-			return errors.WithMessage(err, "Delete svc")
+		if err := s.bpfSvcs.Delete(key[:]); err != nil {
+			if bpf.IsNotExists(err) {
+				log.Debugf("frontend key %s does not exist", key)
+			} else {
+				return errors.WithMessage(err, "Delete svc")
+			}
 		}
 	}
 


### PR DESCRIPTION
When trying to delete something that does not exist may be an issue, but
should not stop the syncer from continuing as the result is that the key
does not exist anyway.

There is at least one genuine reason why this happens - when LB source
ranges changed. For simplicity of the code, the service is completely
cleaned up before applying changes, while it is nbeing deleted once
again when cleaning up stale derived services.

This may also happend when either bug or external delete modified the
tables. Therefore we do log it when debug is on.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
