### PR TITLE
[WIP] Add ability to use wireguard directly between host IPs

### DIFF
--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -228,7 +228,9 @@ func StartDataplaneDriver(configParams *config.Config,
 				AllowIPIPPacketsFromWorkloads:  configParams.AllowIPIPPacketsFromWorkloads,
 
 				WireguardEnabled:       configParams.WireguardEnabled,
+				WireguardListeningPort: configParams.WireguardListeningPort,
 				WireguardInterfaceName: configParams.WireguardInterfaceName,
+				WireguardFirewallMark:  markWireguard,
 
 				IptablesLogPrefix:         configParams.LogPrefix,
 				EndpointToHostAction:      configParams.DefaultEndpointToHostAction,

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/go-ini/ini v1.44.0
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/golang/protobuf v1.4.2

--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -741,20 +741,22 @@ func (r *RouteTable) createL3Route(linkAttrs *netlink.LinkAttrs, target Target) 
 	}
 	cidr := target.CIDR
 	ipNet := cidr.ToIPNet()
+	scope := target.RouteScope()
 	route := netlink.Route{
 		LinkIndex: linkIndex,
 		Dst:       &ipNet,
 		Type:      target.RouteType(),
 		Protocol:  r.deviceRouteProtocol,
-		Scope:     target.RouteScope(),
+		Scope:     scope,
 		Table:     r.tableIndex,
 	}
 
-	if r.deviceRouteSourceAddress != nil {
+	if r.deviceRouteSourceAddress != nil && scope == netlink.SCOPE_LINK {
+		// For link scope routes include a source address if configured.
 		route.Src = r.deviceRouteSourceAddress
 	}
 
-	if target.GW != nil {
+	if target.GW != nil{
 		route.Gw = target.GW.AsNetIP()
 	}
 

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -280,7 +280,9 @@ type Config struct {
 	AllowIPIPPacketsFromWorkloads  bool
 
 	WireguardEnabled       bool
+	WireguardListeningPort int
 	WireguardInterfaceName string
+	WireguardFirewallMark  uint32
 
 	IptablesLogPrefix         string
 	EndpointToHostAction      string

--- a/wireguard/wireguard.go
+++ b/wireguard/wireguard.go
@@ -282,7 +282,26 @@ func (w *Wireguard) EndpointUpdate(name string, ipv4Addr ip.Addr) {
 	}
 
 	update := w.getOrInitNodeUpdateData(name)
-	if existing, ok := w.nodes[name]; ok && existing.ipv4EndpointAddr == ipv4Addr {
+	existing, ok := w.nodes[name]
+
+	// We include the endpoint IP address in the list of routes to the same endpoint (i.e. we route traffic
+	// for the host via the wireguard endpoint on the same host). Delete existing route and any pending update, and
+	// add the new route in.
+	if update.ipv4EndpointAddr != nil && *update.ipv4EndpointAddr != nil && *update.ipv4EndpointAddr != ipv4Addr {
+		// Remove route associated with previous update.
+		w.RouteRemove((*update.ipv4EndpointAddr).AsCIDR())
+	}
+	if ok && existing.ipv4EndpointAddr != nil && existing.ipv4EndpointAddr != ipv4Addr {
+		// Remove route associated with current programming.
+		w.RouteRemove(existing.ipv4EndpointAddr.AsCIDR())
+	}
+	if ipv4Addr != nil {
+		// Make sure the endpoint is included as a route.
+		w.RouteUpdate(name, ipv4Addr.AsCIDR())
+	}
+
+	// Modify the endpoint address update, removing the update if another update undoes the change.
+	if ok && existing.ipv4EndpointAddr == ipv4Addr {
 		logCxt.Debug("Update contains unchanged IPv4 address")
 		update.ipv4EndpointAddr = nil
 	} else {
@@ -1008,7 +1027,7 @@ func (w *Wireguard) updateCacheFromNodeUpdates(conflictingKeys set.Set) {
 
 // updateRouteTable updates the route table from the node updates.
 func (w *Wireguard) updateRouteTableFromNodeUpdates() {
-	// Do all deletes first. Then adds or updates separarately. This ensures a CIDR that has been deleted from one node
+	// Do all deletes first. Then adds or updates separately. This ensures a CIDR that has been deleted from one node
 	// and added to another will not add first then delete (which will remove the route, since the route table does not
 	// care about destination node).
 	for name, update := range w.nodeUpdates {


### PR DESCRIPTION
## Description
Prototyping some additional changes to the wg routing:
- Add the wireguard endpoint IPs as routes   (so we can encapsulated using wireguard for host to host connections).  This effectively adds routes to the wireguard endpoints to route via wg, and adds the endpoint IP to it's own set of  allowed IPs.
- Add some pre routing IP tables rules to set the remark bit for packets destined to the wireguard port on the local host IPs.

I think the only thing we might want in addition to this is:
-  Set the source IP in the routing rule to  be the wireguard endpoint IP.  This will provide a "hint" to the kernel to use the wireguard endpoint IP if not explicitly set.  We probably don't need this when the wireguard device has an IP, but I think these changes might allow wg to work correctly without the wg device needing an IP (which simplifies EKS deployments since you won't need an IP pool).


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
