### PR TITLE
Add specific deny rules for IPIP and VXLAN traffic originating from workloads.

### DIFF
--- a/dataplane/linux/endpoint_mgr.go
+++ b/dataplane/linux/endpoint_mgr.go
@@ -583,6 +583,7 @@ func (m *endpointManager) resolveWorkloadEndpoints() {
 						ingressPolicyNames,
 						egressPolicyNames,
 						workload.ProfileIds,
+						m.ipVersion,
 					)
 					m.filterTable.UpdateChains(chains)
 					m.activeWlIDToChains[id] = chains
@@ -906,6 +907,7 @@ func (m *endpointManager) resolveHostEndpoints() {
 				ingressForwardPolicyNames,
 				egressForwardPolicyNames,
 				hostEp.ProfileIds,
+				m.ipVersion,
 			)
 
 			if !reflect.DeepEqual(filtChains, m.activeHostIfaceToFiltChains[ifaceName]) {
@@ -928,6 +930,7 @@ func (m *endpointManager) resolveHostEndpoints() {
 			mangleChains := m.ruleRenderer.HostEndpointToMangleChains(
 				ifaceName,
 				ingressPolicyNames,
+				m.ipVersion,
 			)
 			if !reflect.DeepEqual(mangleChains, m.activeHostIfaceToMangleChains[ifaceName]) {
 				m.mangleTable.UpdateChains(mangleChains)
@@ -951,6 +954,7 @@ func (m *endpointManager) resolveHostEndpoints() {
 				ifaceName,
 				ingressPolicyNames,
 				egressPolicyNames,
+				m.ipVersion,
 			)
 			if !reflect.DeepEqual(rawChains, m.activeHostIfaceToRawChains[ifaceName]) {
 				m.rawTable.UpdateChains(rawChains)

--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -183,8 +183,8 @@ func chainsForIfaces(ipVersion uint8, ifaceMetadata []string,
 		dropEncapRules = []iptables.Rule{
 			{
 				Match: iptables.Match().ProtocolNum(ProtoUDP).
-					DestIPSet(ipSetVXLANSourceHosts).
-					DestPorts(uint16(VXLANPort)),
+					DestPorts(uint16(VXLANPort)).
+					DestIPSet(ipSetVXLANSourceHosts),
 				Action:  iptables.DropAction{},
 				Comment: []string{"Drop VXLAN encapped packets originating in pods destined to the cluster nodes"},
 			},

--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -654,7 +654,6 @@ func endpointManagerTests(ipVersion uint8) func() {
 				IptablesMarkNonCaliEndpoint: 0x0100,
 				KubeIPVSSupportEnabled:      true,
 				WorkloadIfacePrefixes:       []string{"cali", "tap"},
-				VXLANEnabled:                true,
 				VXLANPort:                   4789,
 				VXLANVNI:                    4096,
 			}

--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -172,13 +172,13 @@ func chainsForIfaces(ifaceMetadata []string,
 				DestIPSet(ipSetVXLANSourceHosts).
 				DestPorts(uint16(VXLANPort)),
 			Action:  iptables.DropAction{},
-			Comment: []string{"Drop VXLAN encapped packets originating in pods"},
+			Comment: []string{"Drop VXLAN encapped packets originating in pods destined to the cluster nodes"},
 		},
 		{
 			Match: iptables.Match().ProtocolNum(ProtoIPIP).
 				DestIPSet(ipSetAllHosts),
 			Action:  iptables.DropAction{},
-			Comment: []string{"Drop IPinIP encapped packets originating in pods"},
+			Comment: []string{"Drop IPinIP encapped packets originating in pods destined to the cluster nodes"},
 		},
 	}
 

--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -164,15 +164,19 @@ func chainsForIfaces(ifaceMetadata []string,
 	epMarkFromName := "cali-from-endpoint-mark"
 	epMarkSetOnePrefix := "cali-sm-"
 	epmarkFromPrefix := outPrefix[:6]
+	ipSetVXLANSourceHosts := "cali40all-vxlan-net"
+	ipSetAllHosts := "cali40all-hosts-net"
 	dropEncapRules := []iptables.Rule{
 		{
 			Match: iptables.Match().ProtocolNum(ProtoUDP).
+				DestIPSet(ipSetVXLANSourceHosts).
 				DestPorts(uint16(VXLANPort)),
 			Action:  iptables.DropAction{},
 			Comment: []string{"Drop VXLAN encapped packets originating in pods"},
 		},
 		{
-			Match:   iptables.Match().ProtocolNum(ProtoIPIP),
+			Match: iptables.Match().ProtocolNum(ProtoIPIP).
+				DestIPSet(ipSetAllHosts),
 			Action:  iptables.DropAction{},
 			Comment: []string{"Drop IPinIP encapped packets originating in pods"},
 		},

--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -635,6 +635,7 @@ func endpointManagerTests(ipVersion uint8) func() {
 				IptablesMarkNonCaliEndpoint: 0x0100,
 				KubeIPVSSupportEnabled:      true,
 				WorkloadIfacePrefixes:       []string{"cali", "tap"},
+				VXLANEnabled:                true,
 				VXLANPort:                   4789,
 				VXLANVNI:                    4096,
 			}

--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -654,6 +654,7 @@ func endpointManagerTests(ipVersion uint8) func() {
 				IptablesMarkNonCaliEndpoint: 0x0100,
 				KubeIPVSSupportEnabled:      true,
 				WorkloadIfacePrefixes:       []string{"cali", "tap"},
+				VXLANEnabled:                true,
 				VXLANPort:                   4789,
 				VXLANVNI:                    4096,
 			}

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -322,8 +322,8 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 		},
 	})
 
-	if dropEncap && r.Config.VXLANEnabled {
-		// If VXLANEnabled, block the endpoint from sending VXLAN traffic with destination IP
+	if dropEncap {
+		// Block the endpoint from sending VXLAN traffic with destination IP
 		// address matching any of the VXLAN hosts.
 		match := Match().ProtocolNum(ProtoUDP).DestPorts(uint16(r.Config.VXLANPort))
 		comment := "Drop VXLAN encapped packets originating in pods"
@@ -341,12 +341,10 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 			Action:  DropAction{},
 			Comment: []string{comment},
 		})
-	}
-	if dropEncap && r.Config.IPIPEnabled {
-		// If IPIP is enabled, block the endpoint from sending IPIP traffic with destination IP
+		// Block the endpoint from sending IPIP traffic with destination IP
 		// address matching any of our hosts.
-		match := Match().ProtocolNum(ProtoIPIP)
-		comment := "Drop IPinIP encapped packets originating in pods"
+		match = Match().ProtocolNum(ProtoIPIP)
+		comment = "Drop IPinIP encapped packets originating in pods"
 		if ipVersion == 4 {
 			// The IPIP blocking rules uses a IPv4 specific ipset, so in the
 			// case of IPv6, we leave the rule broad.

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -328,8 +328,11 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 		match := Match().ProtocolNum(ProtoUDP).DestPorts(uint16(r.Config.VXLANPort))
 		comment := "Drop VXLAN encapped packets originating in pods"
 		if ipVersion == 4 {
-			// The VXLAN blocking rules use a IPv4 specific ipset, so in the
+			// The VXLAN blocking rules uses a IPv4 specific ipset, so in the
 			// case of IPv6, we leave the rule broad.
+			// The IPSet variable name here is referred to as "sources" but it actually
+			// contains a maintained list of all VXLAN tunnel endpoints making it suitable
+			// to be used in a destination IPSet.
 			match = match.DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets))
 			comment = "Drop VXLAN encapped packets originating in pods destined to the cluster nodes"
 		}
@@ -345,7 +348,7 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 		match := Match().ProtocolNum(ProtoIPIP)
 		comment := "Drop IPinIP encapped packets originating in pods"
 		if ipVersion == 4 {
-			// The IPIP blocking rules use a IPv4 specific ipset, so in the
+			// The IPIP blocking rules uses a IPv4 specific ipset, so in the
 			// case of IPv6, we leave the rule broad.
 			match = match.DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllHostNets))
 			comment = "Drop IPinIP encapped packets originating in pods destined to the cluster nodes"

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -34,6 +34,7 @@ func (r *DefaultRuleRenderer) WorkloadEndpointToIptablesChains(
 	ingressPolicies []string,
 	egressPolicies []string,
 	profileIDs []string,
+	ipVersion uint8,
 ) []*Chain {
 	result := []*Chain{}
 	result = append(result,
@@ -50,6 +51,7 @@ func (r *DefaultRuleRenderer) WorkloadEndpointToIptablesChains(
 			adminUp,
 			r.filterAllowAction, // Workload endpoint chains are only used in the filter table
 			dontDropEncap,
+			ipVersion,
 		),
 		// Chain for traffic _from_ the endpoint.
 		r.endpointIptablesChain(
@@ -64,6 +66,7 @@ func (r *DefaultRuleRenderer) WorkloadEndpointToIptablesChains(
 			adminUp,
 			r.filterAllowAction, // Workload endpoint chains are only used in the filter table
 			dropEncap,
+			ipVersion,
 		),
 	)
 
@@ -89,6 +92,7 @@ func (r *DefaultRuleRenderer) HostEndpointToFilterChains(
 	ingressForwardPolicyNames []string,
 	egressForwardPolicyNames []string,
 	profileIDs []string,
+	ipVersion uint8,
 ) []*Chain {
 	log.WithField("ifaceName", ifaceName).Debug("Rendering filter host endpoint chain.")
 	result := []*Chain{}
@@ -106,6 +110,7 @@ func (r *DefaultRuleRenderer) HostEndpointToFilterChains(
 			true, // Host endpoints are always admin up.
 			r.filterAllowAction,
 			dontDropEncap,
+			ipVersion,
 		),
 		// Chain for input traffic _from_ the endpoint.
 		r.endpointIptablesChain(
@@ -120,6 +125,7 @@ func (r *DefaultRuleRenderer) HostEndpointToFilterChains(
 			true, // Host endpoints are always admin up.
 			r.filterAllowAction,
 			dontDropEncap,
+			ipVersion,
 		),
 		// Chain for forward traffic _to_ the endpoint.
 		r.endpointIptablesChain(
@@ -134,6 +140,7 @@ func (r *DefaultRuleRenderer) HostEndpointToFilterChains(
 			true, // Host endpoints are always admin up.
 			r.filterAllowAction,
 			dontDropEncap,
+			ipVersion,
 		),
 		// Chain for forward traffic _from_ the endpoint.
 		r.endpointIptablesChain(
@@ -148,6 +155,7 @@ func (r *DefaultRuleRenderer) HostEndpointToFilterChains(
 			true, // Host endpoints are always admin up.
 			r.filterAllowAction,
 			dontDropEncap,
+			ipVersion,
 		),
 	)
 
@@ -169,6 +177,7 @@ func (r *DefaultRuleRenderer) HostEndpointToRawChains(
 	ifaceName string,
 	ingressPolicyNames []string,
 	egressPolicyNames []string,
+	ipVersion uint8,
 ) []*Chain {
 	log.WithField("ifaceName", ifaceName).Debug("Rendering raw (untracked) host endpoint chain.")
 	return []*Chain{
@@ -185,6 +194,7 @@ func (r *DefaultRuleRenderer) HostEndpointToRawChains(
 			true, // Host endpoints are always admin up.
 			AcceptAction{},
 			dontDropEncap,
+			ipVersion,
 		),
 		// Chain for traffic _from_ the endpoint.
 		r.endpointIptablesChain(
@@ -199,6 +209,7 @@ func (r *DefaultRuleRenderer) HostEndpointToRawChains(
 			true, // Host endpoints are always admin up.
 			AcceptAction{},
 			dontDropEncap,
+			ipVersion,
 		),
 	}
 }
@@ -206,6 +217,7 @@ func (r *DefaultRuleRenderer) HostEndpointToRawChains(
 func (r *DefaultRuleRenderer) HostEndpointToMangleChains(
 	ifaceName string,
 	preDNATPolicyNames []string,
+	ipVersion uint8,
 ) []*Chain {
 	log.WithField("ifaceName", ifaceName).Debug("Rendering pre-DNAT host endpoint chain.")
 	return []*Chain{
@@ -223,6 +235,7 @@ func (r *DefaultRuleRenderer) HostEndpointToMangleChains(
 			true, // Host endpoints are always admin up.
 			r.mangleAllowAction,
 			dontDropEncap,
+			ipVersion,
 		),
 	}
 }
@@ -270,6 +283,7 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 	adminUp bool,
 	allowAction Action,
 	dropEncap bool,
+	ipVersion uint8,
 ) *Chain {
 	rules := []Rule{}
 	chainName := EndpointChainName(endpointPrefix, name)
@@ -311,10 +325,15 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 	if dropEncap && r.Config.VXLANEnabled {
 		// If VXLANEnabled, block the endpoint from sending VXLAN traffic with destination IP
 		// address matching any of the VXLAN hosts.
+		match := Match().ProtocolNum(ProtoUDP).
+			DestPorts(uint16(r.Config.VXLANPort))
+		if ipVersion == 4 {
+			// The VXLAN blocking rules use a IPv4 specific ipset, so in the
+			// case of IPv6, we leave the rule broad.
+			match = match.DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets))
+		}
 		rules = append(rules, Rule{
-			Match: Match().ProtocolNum(ProtoUDP).
-				DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets)).
-				DestPorts(uint16(r.Config.VXLANPort)),
+			Match:   match,
 			Action:  DropAction{},
 			Comment: []string{"Drop VXLAN encapped packets originating in pods"},
 		})
@@ -322,9 +341,14 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 	if dropEncap && r.Config.IPIPEnabled {
 		// If IPIP is enabled, block the endpoint from sending IPIP traffic with destination IP
 		// address matching any of our hosts.
+		match := Match().ProtocolNum(ProtoIPIP)
+		if ipVersion == 4 {
+			// The IPIP blocking rules use a IPv4 specific ipset, so in the
+			// case of IPv6, we leave the rule broad.
+			match = match.DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllHostNets))
+		}
 		rules = append(rules, Rule{
-			Match: Match().ProtocolNum(ProtoIPIP).
-				DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllHostNets)),
+			Match:   match,
 			Action:  DropAction{},
 			Comment: []string{"Drop IPinIP encapped packets originating in pods"},
 		})

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -322,8 +322,8 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 		},
 	})
 
-	if dropEncap {
-		// Block the endpoint from sending VXLAN traffic with destination IP
+	if dropEncap && r.Config.VXLANEnabled {
+		// If VXLANEnabled, block the endpoint from sending VXLAN traffic with destination IP
 		// address matching any of the VXLAN hosts.
 		match := Match().ProtocolNum(ProtoUDP).DestPorts(uint16(r.Config.VXLANPort))
 		comment := "Drop VXLAN encapped packets originating in pods"
@@ -341,10 +341,12 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 			Action:  DropAction{},
 			Comment: []string{comment},
 		})
-		// Block the endpoint from sending IPIP traffic with destination IP
+	}
+	if dropEncap && r.Config.IPIPEnabled {
+		// If IPIP is enabled, block the endpoint from sending IPIP traffic with destination IP
 		// address matching any of our hosts.
-		match = Match().ProtocolNum(ProtoIPIP)
-		comment = "Drop IPinIP encapped packets originating in pods"
+		match := Match().ProtocolNum(ProtoIPIP)
+		comment := "Drop IPinIP encapped packets originating in pods"
 		if ipVersion == 4 {
 			// The IPIP blocking rules uses a IPv4 specific ipset, so in the
 			// case of IPv6, we leave the rule broad.

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -308,13 +308,15 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 		},
 	})
 
-	if dropEncap {
+	if dropEncap && r.Config.VXLANEnabled {
 		rules = append(rules, Rule{
 			Match: Match().ProtocolNum(ProtoUDP).
 				DestPorts(uint16(r.Config.VXLANPort)),
 			Action:  DropAction{},
 			Comment: []string{"Drop VXLAN encapped packets originating in pods"},
 		})
+	}
+	if dropEncap && r.Config.IPIPEnabled {
 		rules = append(rules, Rule{
 			Match:   Match().ProtocolNum(ProtoIPIP),
 			Action:  DropAction{},

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -309,16 +309,22 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 	})
 
 	if dropEncap && r.Config.VXLANEnabled {
+		// If VXLANEnabled, block the endpoint from sending VXLAN traffic with destination IP
+		// address matching any of the VXLAN hosts.
 		rules = append(rules, Rule{
 			Match: Match().ProtocolNum(ProtoUDP).
+				DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets)).
 				DestPorts(uint16(r.Config.VXLANPort)),
 			Action:  DropAction{},
 			Comment: []string{"Drop VXLAN encapped packets originating in pods"},
 		})
 	}
 	if dropEncap && r.Config.IPIPEnabled {
+		// If IPIP is enabled, block the endpoint from sending IPIP traffic with destination IP
+		// address matching any of our hosts.
 		rules = append(rules, Rule{
-			Match:   Match().ProtocolNum(ProtoIPIP),
+			Match: Match().ProtocolNum(ProtoIPIP).
+				DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllHostNets)),
 			Action:  DropAction{},
 			Comment: []string{"Drop IPinIP encapped packets originating in pods"},
 		})

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -325,32 +325,35 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 	if dropEncap && r.Config.VXLANEnabled {
 		// If VXLANEnabled, block the endpoint from sending VXLAN traffic with destination IP
 		// address matching any of the VXLAN hosts.
-		match := Match().ProtocolNum(ProtoUDP).
-			DestPorts(uint16(r.Config.VXLANPort))
+		match := Match().ProtocolNum(ProtoUDP).DestPorts(uint16(r.Config.VXLANPort))
+		comment := "Drop VXLAN encapped packets originating in pods"
 		if ipVersion == 4 {
 			// The VXLAN blocking rules use a IPv4 specific ipset, so in the
 			// case of IPv6, we leave the rule broad.
 			match = match.DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets))
+			comment = "Drop VXLAN encapped packets originating in pods destined to the cluster nodes"
 		}
 		rules = append(rules, Rule{
 			Match:   match,
 			Action:  DropAction{},
-			Comment: []string{"Drop VXLAN encapped packets originating in pods"},
+			Comment: []string{comment},
 		})
 	}
 	if dropEncap && r.Config.IPIPEnabled {
 		// If IPIP is enabled, block the endpoint from sending IPIP traffic with destination IP
 		// address matching any of our hosts.
 		match := Match().ProtocolNum(ProtoIPIP)
+		comment := "Drop IPinIP encapped packets originating in pods"
 		if ipVersion == 4 {
 			// The IPIP blocking rules use a IPv4 specific ipset, so in the
 			// case of IPv6, we leave the rule broad.
 			match = match.DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllHostNets))
+			comment = "Drop IPinIP encapped packets originating in pods destined to the cluster nodes"
 		}
 		rules = append(rules, Rule{
 			Match:   match,
 			Action:  DropAction{},
-			Comment: []string{"Drop IPinIP encapped packets originating in pods"},
+			Comment: []string{comment},
 		})
 	}
 

--- a/rules/endpoints_test.go
+++ b/rules/endpoints_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Endpoints", func() {
 			IptablesMarkNonCaliEndpoint: 0x0100,
 			KubeIPVSSupportEnabled:      kubeIPVSEnabled,
 			IptablesMangleAllowAction:   "RETURN",
+			VXLANEnabled:                true,
 			VXLANPort:                   4789,
 			VXLANVNI:                    4096,
 		}
@@ -67,6 +68,7 @@ var _ = Describe("Endpoints", func() {
 			KubeIPVSSupportEnabled:      kubeIPVSEnabled,
 			DisableConntrackInvalid:     true,
 			IptablesFilterAllowAction:   "RETURN",
+			VXLANEnabled:                true,
 			VXLANPort:                   4789,
 			VXLANVNI:                    4096,
 		}
@@ -608,6 +610,169 @@ var _ = Describe("Endpoints", func() {
 						},
 					},
 				}))
+			})
+		})
+		Describe("Drop encap rules", func() {
+
+			Context("VXLAN disabled, IPIP enabled", func() {
+				It("should render a minimal workload endpoint without VXLAN drop encap rule and with IPIP drop encap rule", func() {
+					rrConfigNormalMangleReturn.VXLANEnabled = false
+					renderer = NewRenderer(rrConfigNormalMangleReturn)
+					epMarkMapper = NewEndpointMarkMapper(rrConfigNormalMangleReturn.IptablesMarkEndpoint,
+						rrConfigNormalMangleReturn.IptablesMarkNonCaliEndpoint)
+					Expect(renderer.WorkloadEndpointToIptablesChains(
+						"cali1234", epMarkMapper,
+						true,
+						nil,
+						nil,
+						nil,
+						4,
+					)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
+						{
+							Name: "cali-tw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-fw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								dropIPIPRule,
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-sm-cali1234",
+							Rules: []Rule{
+								{Action: SetMaskedMarkAction{Mark: 0xd400, Mask: 0xff00}},
+							},
+						},
+					})))
+				})
+			})
+			Context("VXLAN disabled, IPIP enabled", func() {
+				It("should render a minimal workload endpoint with VXLAN drop encap rule and without IPIP drop encap rule", func() {
+					rrConfigNormalMangleReturn.IPIPEnabled = false
+					renderer = NewRenderer(rrConfigNormalMangleReturn)
+					epMarkMapper = NewEndpointMarkMapper(rrConfigNormalMangleReturn.IptablesMarkEndpoint,
+						rrConfigNormalMangleReturn.IptablesMarkNonCaliEndpoint)
+					Expect(renderer.WorkloadEndpointToIptablesChains(
+						"cali1234", epMarkMapper,
+						true,
+						nil,
+						nil,
+						nil,
+						4,
+					)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
+						{
+							Name: "cali-tw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-fw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								dropVXLANRule,
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-sm-cali1234",
+							Rules: []Rule{
+								{Action: SetMaskedMarkAction{Mark: 0xd400, Mask: 0xff00}},
+							},
+						},
+					})))
+				})
+			})
+			Context("VXLAN and IPIP disabled", func() {
+				It("should render a minimal workload endpoint without both VXLAN and IPIP drop encap rule", func() {
+					rrConfigNormalMangleReturn.IPIPEnabled = false
+					rrConfigNormalMangleReturn.VXLANEnabled = false
+					renderer = NewRenderer(rrConfigNormalMangleReturn)
+					epMarkMapper = NewEndpointMarkMapper(rrConfigNormalMangleReturn.IptablesMarkEndpoint,
+						rrConfigNormalMangleReturn.IptablesMarkNonCaliEndpoint)
+					Expect(renderer.WorkloadEndpointToIptablesChains(
+						"cali1234", epMarkMapper,
+						true,
+						nil,
+						nil,
+						nil,
+						4,
+					)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
+						{
+							Name: "cali-tw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-fw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-sm-cali1234",
+							Rules: []Rule{
+								{Action: SetMaskedMarkAction{Mark: 0xd400, Mask: 0xff00}},
+							},
+						},
+					})))
+				})
+			})
+			AfterEach(func() {
+				rrConfigNormalMangleReturn.VXLANEnabled = true
+				rrConfigNormalMangleReturn.IPIPEnabled = true
 			})
 		})
 	}

--- a/rules/endpoints_test.go
+++ b/rules/endpoints_test.go
@@ -49,7 +49,6 @@ var _ = Describe("Endpoints", func() {
 			IptablesMarkNonCaliEndpoint: 0x0100,
 			KubeIPVSSupportEnabled:      kubeIPVSEnabled,
 			IptablesMangleAllowAction:   "RETURN",
-			VXLANEnabled:                true,
 			VXLANPort:                   4789,
 			VXLANVNI:                    4096,
 		}
@@ -68,7 +67,6 @@ var _ = Describe("Endpoints", func() {
 			KubeIPVSSupportEnabled:      kubeIPVSEnabled,
 			DisableConntrackInvalid:     true,
 			IptablesFilterAllowAction:   "RETURN",
-			VXLANEnabled:                true,
 			VXLANPort:                   4789,
 			VXLANVNI:                    4096,
 		}
@@ -610,169 +608,6 @@ var _ = Describe("Endpoints", func() {
 						},
 					},
 				}))
-			})
-		})
-		Describe("Drop encap rules", func() {
-
-			Context("VXLAN disabled, IPIP enabled", func() {
-				It("should render a minimal workload endpoint without VXLAN drop encap rule and with IPIP drop encap rule", func() {
-					rrConfigNormalMangleReturn.VXLANEnabled = false
-					renderer = NewRenderer(rrConfigNormalMangleReturn)
-					epMarkMapper = NewEndpointMarkMapper(rrConfigNormalMangleReturn.IptablesMarkEndpoint,
-						rrConfigNormalMangleReturn.IptablesMarkNonCaliEndpoint)
-					Expect(renderer.WorkloadEndpointToIptablesChains(
-						"cali1234", epMarkMapper,
-						true,
-						nil,
-						nil,
-						nil,
-						4,
-					)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
-						{
-							Name: "cali-tw-cali1234",
-							Rules: []Rule{
-								// conntrack rules.
-								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
-									Action: AcceptAction{}},
-								{Match: Match().ConntrackState("INVALID"),
-									Action: DropAction{}},
-
-								{Action: ClearMarkAction{Mark: 0x8}},
-								{Action: DropAction{},
-									Comment: []string{"Drop if no profiles matched"}},
-							},
-						},
-						{
-							Name: "cali-fw-cali1234",
-							Rules: []Rule{
-								// conntrack rules.
-								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
-									Action: AcceptAction{}},
-								{Match: Match().ConntrackState("INVALID"),
-									Action: DropAction{}},
-
-								{Action: ClearMarkAction{Mark: 0x8}},
-								dropIPIPRule,
-								{Action: DropAction{},
-									Comment: []string{"Drop if no profiles matched"}},
-							},
-						},
-						{
-							Name: "cali-sm-cali1234",
-							Rules: []Rule{
-								{Action: SetMaskedMarkAction{Mark: 0xd400, Mask: 0xff00}},
-							},
-						},
-					})))
-				})
-			})
-			Context("VXLAN disabled, IPIP enabled", func() {
-				It("should render a minimal workload endpoint with VXLAN drop encap rule and without IPIP drop encap rule", func() {
-					rrConfigNormalMangleReturn.IPIPEnabled = false
-					renderer = NewRenderer(rrConfigNormalMangleReturn)
-					epMarkMapper = NewEndpointMarkMapper(rrConfigNormalMangleReturn.IptablesMarkEndpoint,
-						rrConfigNormalMangleReturn.IptablesMarkNonCaliEndpoint)
-					Expect(renderer.WorkloadEndpointToIptablesChains(
-						"cali1234", epMarkMapper,
-						true,
-						nil,
-						nil,
-						nil,
-						4,
-					)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
-						{
-							Name: "cali-tw-cali1234",
-							Rules: []Rule{
-								// conntrack rules.
-								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
-									Action: AcceptAction{}},
-								{Match: Match().ConntrackState("INVALID"),
-									Action: DropAction{}},
-
-								{Action: ClearMarkAction{Mark: 0x8}},
-								{Action: DropAction{},
-									Comment: []string{"Drop if no profiles matched"}},
-							},
-						},
-						{
-							Name: "cali-fw-cali1234",
-							Rules: []Rule{
-								// conntrack rules.
-								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
-									Action: AcceptAction{}},
-								{Match: Match().ConntrackState("INVALID"),
-									Action: DropAction{}},
-
-								{Action: ClearMarkAction{Mark: 0x8}},
-								dropVXLANRule,
-								{Action: DropAction{},
-									Comment: []string{"Drop if no profiles matched"}},
-							},
-						},
-						{
-							Name: "cali-sm-cali1234",
-							Rules: []Rule{
-								{Action: SetMaskedMarkAction{Mark: 0xd400, Mask: 0xff00}},
-							},
-						},
-					})))
-				})
-			})
-			Context("VXLAN and IPIP disabled", func() {
-				It("should render a minimal workload endpoint without both VXLAN and IPIP drop encap rule", func() {
-					rrConfigNormalMangleReturn.IPIPEnabled = false
-					rrConfigNormalMangleReturn.VXLANEnabled = false
-					renderer = NewRenderer(rrConfigNormalMangleReturn)
-					epMarkMapper = NewEndpointMarkMapper(rrConfigNormalMangleReturn.IptablesMarkEndpoint,
-						rrConfigNormalMangleReturn.IptablesMarkNonCaliEndpoint)
-					Expect(renderer.WorkloadEndpointToIptablesChains(
-						"cali1234", epMarkMapper,
-						true,
-						nil,
-						nil,
-						nil,
-						4,
-					)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
-						{
-							Name: "cali-tw-cali1234",
-							Rules: []Rule{
-								// conntrack rules.
-								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
-									Action: AcceptAction{}},
-								{Match: Match().ConntrackState("INVALID"),
-									Action: DropAction{}},
-
-								{Action: ClearMarkAction{Mark: 0x8}},
-								{Action: DropAction{},
-									Comment: []string{"Drop if no profiles matched"}},
-							},
-						},
-						{
-							Name: "cali-fw-cali1234",
-							Rules: []Rule{
-								// conntrack rules.
-								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
-									Action: AcceptAction{}},
-								{Match: Match().ConntrackState("INVALID"),
-									Action: DropAction{}},
-
-								{Action: ClearMarkAction{Mark: 0x8}},
-								{Action: DropAction{},
-									Comment: []string{"Drop if no profiles matched"}},
-							},
-						},
-						{
-							Name: "cali-sm-cali1234",
-							Rules: []Rule{
-								{Action: SetMaskedMarkAction{Mark: 0xd400, Mask: 0xff00}},
-							},
-						},
-					})))
-				})
-			})
-			AfterEach(func() {
-				rrConfigNormalMangleReturn.VXLANEnabled = true
-				rrConfigNormalMangleReturn.IPIPEnabled = true
 			})
 		})
 	}

--- a/rules/endpoints_test.go
+++ b/rules/endpoints_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Endpoints", func() {
 			IptablesMarkNonCaliEndpoint: 0x0100,
 			KubeIPVSSupportEnabled:      kubeIPVSEnabled,
 			IptablesMangleAllowAction:   "RETURN",
+			VXLANEnabled:                true,
 			VXLANPort:                   4789,
 			VXLANVNI:                    4096,
 		}
@@ -67,6 +68,7 @@ var _ = Describe("Endpoints", func() {
 			KubeIPVSSupportEnabled:      kubeIPVSEnabled,
 			DisableConntrackInvalid:     true,
 			IptablesFilterAllowAction:   "RETURN",
+			VXLANEnabled:                true,
 			VXLANPort:                   4789,
 			VXLANVNI:                    4096,
 		}
@@ -598,6 +600,163 @@ var _ = Describe("Endpoints", func() {
 						},
 					},
 				}))
+			})
+		})
+		Describe("Drop encap rules", func() {
+
+			Context("VXLAN disabled, IPIP enabled", func() {
+				It("should render a minimal workload endpoint without VXLAN drop encap rule and with IPIP drop encap rule", func() {
+					rrConfigNormalMangleReturn.VXLANEnabled = false
+					renderer = NewRenderer(rrConfigNormalMangleReturn)
+					epMarkMapper = NewEndpointMarkMapper(rrConfigNormalMangleReturn.IptablesMarkEndpoint,
+						rrConfigNormalMangleReturn.IptablesMarkNonCaliEndpoint)
+					Expect(renderer.WorkloadEndpointToIptablesChains(
+						"cali1234", epMarkMapper,
+						true,
+						nil,
+						nil,
+						nil)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
+						{
+							Name: "cali-tw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-fw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								dropIPIPRule,
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-sm-cali1234",
+							Rules: []Rule{
+								{Action: SetMaskedMarkAction{Mark: 0xd400, Mask: 0xff00}},
+							},
+						},
+					})))
+				})
+			})
+			Context("VXLAN disabled, IPIP enabled", func() {
+				It("should render a minimal workload endpoint with VXLAN drop encap rule and without IPIP drop encap rule", func() {
+					rrConfigNormalMangleReturn.IPIPEnabled = false
+					renderer = NewRenderer(rrConfigNormalMangleReturn)
+					epMarkMapper = NewEndpointMarkMapper(rrConfigNormalMangleReturn.IptablesMarkEndpoint,
+						rrConfigNormalMangleReturn.IptablesMarkNonCaliEndpoint)
+					Expect(renderer.WorkloadEndpointToIptablesChains(
+						"cali1234", epMarkMapper,
+						true,
+						nil,
+						nil,
+						nil)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
+						{
+							Name: "cali-tw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-fw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								dropVXLANRule,
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-sm-cali1234",
+							Rules: []Rule{
+								{Action: SetMaskedMarkAction{Mark: 0xd400, Mask: 0xff00}},
+							},
+						},
+					})))
+				})
+			})
+			Context("VXLAN and IPIP disabled", func() {
+				It("should render a minimal workload endpoint without both VXLAN and IPIP drop encap rule", func() {
+					rrConfigNormalMangleReturn.IPIPEnabled = false
+					rrConfigNormalMangleReturn.VXLANEnabled = false
+					renderer = NewRenderer(rrConfigNormalMangleReturn)
+					epMarkMapper = NewEndpointMarkMapper(rrConfigNormalMangleReturn.IptablesMarkEndpoint,
+						rrConfigNormalMangleReturn.IptablesMarkNonCaliEndpoint)
+					Expect(renderer.WorkloadEndpointToIptablesChains(
+						"cali1234", epMarkMapper,
+						true,
+						nil,
+						nil,
+						nil)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
+						{
+							Name: "cali-tw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-fw-cali1234",
+							Rules: []Rule{
+								// conntrack rules.
+								{Match: Match().ConntrackState("RELATED,ESTABLISHED"),
+									Action: AcceptAction{}},
+								{Match: Match().ConntrackState("INVALID"),
+									Action: DropAction{}},
+
+								{Action: ClearMarkAction{Mark: 0x8}},
+								{Action: DropAction{},
+									Comment: []string{"Drop if no profiles matched"}},
+							},
+						},
+						{
+							Name: "cali-sm-cali1234",
+							Rules: []Rule{
+								{Action: SetMaskedMarkAction{Mark: 0xd400, Mask: 0xff00}},
+							},
+						},
+					})))
+				})
+			})
+			AfterEach(func() {
+				rrConfigNormalMangleReturn.VXLANEnabled = true
+				rrConfigNormalMangleReturn.IPIPEnabled = true
 			})
 		})
 	}

--- a/rules/endpoints_test.go
+++ b/rules/endpoints_test.go
@@ -80,8 +80,8 @@ var _ = Describe("Endpoints", func() {
 		ipSetAllHosts := "cali40all-hosts-net"
 		dropVXLANRule := Rule{
 			Match: Match().ProtocolNum(ProtoUDP).
-				DestIPSet(ipSetVXLANSourceHosts).
-				DestPorts(uint16(VXLANPort)),
+				DestPorts(uint16(VXLANPort)).
+				DestIPSet(ipSetVXLANSourceHosts),
 			Action:  DropAction{},
 			Comment: []string{"Drop VXLAN encapped packets originating in pods"},
 		}
@@ -105,7 +105,8 @@ var _ = Describe("Endpoints", func() {
 					true,
 					nil,
 					nil,
-					nil)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
+					nil,
+					4)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
 					{
 						Name: "cali-tw-cali1234",
 						Rules: []Rule{
@@ -152,6 +153,7 @@ var _ = Describe("Endpoints", func() {
 					nil,
 					nil,
 					nil,
+					4,
 				)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
 					{
 						Name: "cali-tw-cali1234",
@@ -184,6 +186,7 @@ var _ = Describe("Endpoints", func() {
 					[]string{"ai", "bi"},
 					[]string{"ae", "be"},
 					[]string{"prof1", "prof2"},
+					4,
 				)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
 					{
 						Name: "cali-tw-cali1234",
@@ -281,7 +284,7 @@ var _ = Describe("Endpoints", func() {
 					epMarkMapper,
 					[]string{"ai", "bi"}, []string{"ae", "be"},
 					[]string{"afi", "bfi"}, []string{"afe", "bfe"},
-					[]string{"prof1", "prof2"})).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
+					[]string{"prof1", "prof2"}, 4)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
 					{
 						Name: "cali-th-eth0",
 						Rules: []Rule{
@@ -434,7 +437,7 @@ var _ = Describe("Endpoints", func() {
 			})
 
 			It("should render host endpoint raw chains with untracked policies", func() {
-				Expect(renderer.HostEndpointToRawChains("eth0", []string{"c"}, []string{"c"})).To(Equal([]*Chain{
+				Expect(renderer.HostEndpointToRawChains("eth0", []string{"c"}, []string{"c"}, 4)).To(Equal([]*Chain{
 					{
 						Name: "cali-th-eth0",
 						Rules: []Rule{
@@ -486,6 +489,7 @@ var _ = Describe("Endpoints", func() {
 				Expect(renderer.HostEndpointToMangleChains(
 					"eth0",
 					[]string{"c"},
+					4,
 				)).To(Equal([]*Chain{
 					{
 						Name: "cali-fh-eth0",
@@ -533,6 +537,7 @@ var _ = Describe("Endpoints", func() {
 					nil,
 					nil,
 					nil,
+					4,
 				)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
 					{
 						Name: "cali-tw-cali1234",
@@ -579,6 +584,7 @@ var _ = Describe("Endpoints", func() {
 				Expect(renderer.HostEndpointToMangleChains(
 					"eth0",
 					[]string{"c"},
+					4,
 				)).To(Equal([]*Chain{
 					{
 						Name: "cali-fh-eth0",
@@ -619,7 +625,9 @@ var _ = Describe("Endpoints", func() {
 						true,
 						nil,
 						nil,
-						nil)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
+						nil,
+						4,
+					)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
 						{
 							Name: "cali-tw-cali1234",
 							Rules: []Rule{
@@ -669,7 +677,9 @@ var _ = Describe("Endpoints", func() {
 						true,
 						nil,
 						nil,
-						nil)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
+						nil,
+						4,
+					)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
 						{
 							Name: "cali-tw-cali1234",
 							Rules: []Rule{
@@ -720,7 +730,9 @@ var _ = Describe("Endpoints", func() {
 						true,
 						nil,
 						nil,
-						nil)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
+						nil,
+						4,
+					)).To(Equal(trimSMChain(kubeIPVSEnabled, []*Chain{
 						{
 							Name: "cali-tw-cali1234",
 							Rules: []Rule{

--- a/rules/endpoints_test.go
+++ b/rules/endpoints_test.go
@@ -76,14 +76,18 @@ var _ = Describe("Endpoints", func() {
 		var renderer RuleRenderer
 		var epMarkMapper EndpointMarkMapper
 
+		ipSetVXLANSourceHosts := "cali40all-vxlan-net"
+		ipSetAllHosts := "cali40all-hosts-net"
 		dropVXLANRule := Rule{
 			Match: Match().ProtocolNum(ProtoUDP).
+				DestIPSet(ipSetVXLANSourceHosts).
 				DestPorts(uint16(VXLANPort)),
 			Action:  DropAction{},
 			Comment: []string{"Drop VXLAN encapped packets originating in pods"},
 		}
 		dropIPIPRule := Rule{
-			Match:   Match().ProtocolNum(ProtoIPIP),
+			Match: Match().ProtocolNum(ProtoIPIP).
+				DestIPSet(ipSetAllHosts),
 			Action:  DropAction{},
 			Comment: []string{"Drop IPinIP encapped packets originating in pods"},
 		}

--- a/rules/endpoints_test.go
+++ b/rules/endpoints_test.go
@@ -83,13 +83,13 @@ var _ = Describe("Endpoints", func() {
 				DestPorts(uint16(VXLANPort)).
 				DestIPSet(ipSetVXLANSourceHosts),
 			Action:  DropAction{},
-			Comment: []string{"Drop VXLAN encapped packets originating in pods"},
+			Comment: []string{"Drop VXLAN encapped packets originating in pods destined to the cluster nodes"},
 		}
 		dropIPIPRule := Rule{
 			Match: Match().ProtocolNum(ProtoIPIP).
 				DestIPSet(ipSetAllHosts),
 			Action:  DropAction{},
-			Comment: []string{"Drop IPinIP encapped packets originating in pods"},
+			Comment: []string{"Drop IPinIP encapped packets originating in pods destined to the cluster nodes"},
 		}
 
 		Context("with normal config", func() {

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -172,6 +172,7 @@ type RuleRenderer interface {
 		ingressPolicies []string,
 		egressPolicies []string,
 		profileIDs []string,
+		ipVersion uint8,
 	) []*iptables.Chain
 
 	WorkloadInterfaceAllowChains(endpoints map[proto.WorkloadEndpointID]*proto.WorkloadEndpoint) []*iptables.Chain
@@ -192,15 +193,18 @@ type RuleRenderer interface {
 		ingressForwardPolicyNames []string,
 		egressForwardPolicyNames []string,
 		profileIDs []string,
+		ipVersion uint8,
 	) []*iptables.Chain
 	HostEndpointToRawChains(
 		ifaceName string,
 		ingressPolicyNames []string,
 		egressPolicyNames []string,
+		ipVersion uint8,
 	) []*iptables.Chain
 	HostEndpointToMangleChains(
 		ifaceName string,
 		preDNATPolicyNames []string,
+		ipVersion uint8,
 	) []*iptables.Chain
 
 	PolicyToIptablesChains(policyID *proto.PolicyID, policy *proto.Policy, ipVersion uint8) []*iptables.Chain


### PR DESCRIPTION
## Description

Rather than blanket deny all VXLAN and IPIP traffic from workloads, tweak the existing rule so that we only drop if the packet's destination IP address is a node with a tunnel endpoint. This will provide some additional flexibility where if a workload does want to run VXLAN/IPIP traffic, we still let the workload do this, but prevent spoofed packets to our nodes.

Related PR with an alternate fix: #2480 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) Not needed
- [ ] Backport
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Only drop specific encapsulation traffic originating from workloads if corresponding encapsulation is enabled and if packet is destined to a host.
```
