### PR TITLE
bpf: use state from map, free up stack

### DIFF
--- a/bpf-gpl/list-ut-objs
+++ b/bpf-gpl/list-ut-objs
@@ -60,3 +60,5 @@ for ep_type in $ep_types; do
     done
   done
 done
+
+echo "bin/test_from_hep_fib_no_log_skb0x0.o"

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -92,13 +92,18 @@ allow:
 
 #endif /* CALI_DEBUG_ALLOW_ALL */
 
+static CALI_BPF_INLINE struct cali_tc_state * state_get(void)
+{
+	__u32 key = 0;
+	return cali_v4_state_lookup_elem(&key);
+}
+
 __attribute__((section("1/0")))
 int calico_tc_norm_pol_tail(struct __sk_buff *skb)
 {
 	CALI_DEBUG("Entering normal policy tail call\n");
 
-	__u32 key = 0;
-	struct cali_tc_state *state = cali_v4_state_lookup_elem(&key);
+	struct cali_tc_state *state = state_get();
 	if (!state) {
 	        CALI_DEBUG("State map lookup failed: DROP\n");
 	        goto deny;
@@ -161,12 +166,6 @@ static CALI_BPF_INLINE int skb_nat_l4_csum_ipv4(struct __sk_buff *skb, size_t of
 	}
 
 	return ret;
-}
-
-static CALI_BPF_INLINE int update_state_map(struct cali_tc_state *state)
-{
-	int key = 0;
-	return cali_v4_state_update_elem(&key, state, BPF_EXIST);
 }
 
 static CALI_BPF_INLINE int forward_or_drop(struct __sk_buff *skb,
@@ -372,7 +371,7 @@ deny:
 
 static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 {
-	struct cali_tc_state state = {};
+	struct cali_tc_state *state;
 	struct fwd fwd = {
 		.res = TC_ACT_UNSPEC,
 		.reason = CALI_REASON_UNKNOWN,
@@ -380,15 +379,22 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	struct calico_nat_dest *nat_dest = NULL;
 	nat_lookup_result nat_res = NAT_LOOKUP_ALLOW;
 
+	state = state_get();
+	if (!state) {
+	        CALI_DEBUG("State map lookup failed: DROP\n");
+		return TC_ACT_SHOT;
+	}
+	__builtin_memset(state, 0, sizeof(*state));
+
 	/* We only try a FIB lookup and redirect for packets that are towards the host.
 	 * For packets that are leaving the host namespace, routing has already been done.
 	 */
 	fwd_fib_set(&fwd, CALI_F_TO_HOST);
 
 	if (CALI_LOG_LEVEL >= CALI_LOG_LEVEL_INFO) {
-		state.prog_start_time = bpf_ktime_get_ns();
+		state->prog_start_time = bpf_ktime_get_ns();
 	}
-	state.tun_ip = 0;
+	state->tun_ip = 0;
 
 #ifdef CALI_SET_SKB_MARK
 	/* workaround for test since bpftool run cannot set it in context, wont
@@ -512,7 +518,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 			cali_v4_arp_update_elem(&arpk, eth, 0);
 			CALI_DEBUG("ARP update for ifindex %d ip %x\n", arpk.ifindex, be32_to_host(arpk.ip));
 
-			state.tun_ip = ip_header->saddr;
+			state->tun_ip = ip_header->saddr;
 			CALI_DEBUG("vxlan decap\n");
 			if (vxlan_v4_decap(skb)) {
 				fwd.reason = CALI_REASON_DECAP_FAIL;
@@ -526,7 +532,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 			}
 			ip_header = skb_iphdr(skb);
 
-			CALI_DEBUG("vxlan decap origin %x\n", be32_to_host(state.tun_ip));
+			CALI_DEBUG("vxlan decap origin %x\n", be32_to_host(state->tun_ip));
 		}
 	}
 
@@ -552,23 +558,23 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	struct udphdr *udp_header = (void*)(ip_header+1);
 	struct icmphdr *icmp_header = (void*)(ip_header+1);
 
-	tc_state_fill_from_iphdr(&state, ip_header);
+	tc_state_fill_from_iphdr(state, ip_header);
 
-	switch (state.ip_proto) {
+	switch (state->ip_proto) {
 	case IPPROTO_TCP:
 		// Re-check buffer space for TCP (has larger headers than UDP).
 		if (!skb_has_data_after(skb, ip_header, sizeof(struct tcphdr))) {
 			CALI_DEBUG("Too short for TCP: DROP\n");
 			goto deny;
 		}
-		state.sport = be16_to_host(tcp_header->source);
-		state.dport = be16_to_host(tcp_header->dest);
-		CALI_DEBUG("TCP; ports: s=%d d=%d\n", state.sport, state.dport);
+		state->sport = be16_to_host(tcp_header->source);
+		state->dport = be16_to_host(tcp_header->dest);
+		CALI_DEBUG("TCP; ports: s=%d d=%d\n", state->sport, state->dport);
 		break;
 	case IPPROTO_UDP:
-		state.sport = be16_to_host(udp_header->source);
-		state.dport = be16_to_host(udp_header->dest);
-		CALI_DEBUG("UDP; ports: s=%d d=%d\n", state.sport, state.dport);
+		state->sport = be16_to_host(udp_header->source);
+		state->dport = be16_to_host(udp_header->dest);
+		CALI_DEBUG("UDP; ports: s=%d d=%d\n", state->sport, state->dport);
 		break;
 	case IPPROTO_ICMP:
 		icmp_header = (void*)(ip_header+1);
@@ -584,12 +590,12 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 			goto allow;
 		}
 	default:
-		CALI_DEBUG("Unknown protocol (%d), unable to extract ports\n", (int)state.ip_proto);
+		CALI_DEBUG("Unknown protocol (%d), unable to extract ports\n", (int)state->ip_proto);
 	}
 
-	state.pol_rc = CALI_POL_NO_MATCH;
+	state->pol_rc = CALI_POL_NO_MATCH;
 
-	switch (state.ip_proto) {
+	switch (state->ip_proto) {
 	case IPPROTO_TCP:
 	case IPPROTO_UDP:
 	case IPPROTO_ICMP:
@@ -605,15 +611,15 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 
 	struct ct_ctx ct_lookup_ctx = {
 		.skb = skb,
-		.proto	= state.ip_proto,
-		.src	= state.ip_src,
-		.sport	= state.sport,
-		.dst	= state.ip_dst,
-		.dport	= state.dport,
-		.tun_ip = state.tun_ip,
+		.proto	= state->ip_proto,
+		.src	= state->ip_src,
+		.sport	= state->sport,
+		.dst	= state->ip_dst,
+		.dport	= state->dport,
+		.tun_ip = state->tun_ip,
 	};
 
-	if (state.ip_proto == IPPROTO_TCP) {
+	if (state->ip_proto == IPPROTO_TCP) {
 		if (!skb_has_data_after(skb, ip_header, sizeof(struct tcphdr))) {
 			CALI_DEBUG("Too short for TCP: DROP\n");
 			goto deny;
@@ -623,30 +629,30 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	}
 
 	/* Do conntrack lookup before anything else */
-	state.ct_result = calico_ct_v4_lookup(&ct_lookup_ctx);
+	state->ct_result = calico_ct_v4_lookup(&ct_lookup_ctx);
 
 	/* check if someone is trying to spoof a tunnel packet */
-	if (CALI_F_FROM_HEP && ct_result_tun_src_changed(state.ct_result.rc)) {
+	if (CALI_F_FROM_HEP && ct_result_tun_src_changed(state->ct_result.rc)) {
 		CALI_DEBUG("dropping tunnel pkt with changed source node\n");
 		goto deny;
 	}
 
-	if (state.ct_result.flags & CALI_CT_FLAG_NAT_OUT) {
-		state.flags |= CALI_ST_NAT_OUTGOING;
+	if (state->ct_result.flags & CALI_CT_FLAG_NAT_OUT) {
+		state->flags |= CALI_ST_NAT_OUTGOING;
 	}
 
 	/* We are possibly past (D)NAT, but that is ok, we need to let the IP
 	 * stack do the RPF check on the source, dest is not important.
 	 */
-	if (ct_result_rpf_failed(state.ct_result.rc)) {
+	if (ct_result_rpf_failed(state->ct_result.rc)) {
 		fwd_fib_set(&fwd, false);
 	}
 
 
 	/* skip policy if we get conntrack hit */
-	if (ct_result_rc(state.ct_result.rc) != CALI_CT_NEW) {
-		if (state.ct_result.flags & CALI_CT_FLAG_SKIP_FIB) {
-			state.flags |= CALI_ST_SKIP_FIB;
+	if (ct_result_rc(state->ct_result.rc) != CALI_CT_NEW) {
+		if (state->ct_result.flags & CALI_CT_FLAG_SKIP_FIB) {
+			state->flags |= CALI_ST_SKIP_FIB;
 		}
 		goto skip_policy;
 	}
@@ -657,13 +663,13 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	 * This will make it to skip fib in calico_tc_skb_accepted()
 	 */
 	if (CALI_F_FROM_HEP) {
-		ct_result_set_flag(state.ct_result.rc, CALI_CT_RPF_FAILED);
+		ct_result_set_flag(state->ct_result.rc, CALI_CT_RPF_FAILED);
 	}
 
 	/* No conntrack entry, check if we should do NAT */
-	nat_dest = calico_v4_nat_lookup2(state.ip_src, state.ip_dst,
-					 state.ip_proto, state.dport,
-					 state.tun_ip != 0, &nat_res);
+	nat_dest = calico_v4_nat_lookup2(state->ip_src, state->ip_dst,
+					 state->ip_proto, state->dport,
+					 state->tun_ip != 0, &nat_res);
 
 	if (nat_res == NAT_FE_LOOKUP_DROP) {
 		CALI_DEBUG("Packet is from an unauthorised source: DROP\n");
@@ -671,35 +677,35 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 		goto deny;
 	}
 	if (nat_dest != NULL) {
-		state.post_nat_ip_dst = nat_dest->addr;
-		state.post_nat_dport = nat_dest->port;
+		state->post_nat_ip_dst = nat_dest->addr;
+		state->post_nat_dport = nat_dest->port;
 	} else if (nat_res == NAT_NO_BACKEND) {
 		/* send icmp port unreachable if there is no backend for a service */
-		state.icmp_type = ICMP_DEST_UNREACH;
-		state.icmp_code = ICMP_PORT_UNREACH;
-		state.tun_ip = 0;
+		state->icmp_type = ICMP_DEST_UNREACH;
+		state->icmp_code = ICMP_PORT_UNREACH;
+		state->tun_ip = 0;
 		goto icmp_send_reply;
 	} else {
-		state.post_nat_ip_dst = state.ip_dst;
-		state.post_nat_dport = state.dport;
+		state->post_nat_ip_dst = state->ip_dst;
+		state->post_nat_dport = state->dport;
 	}
 
 	if (CALI_F_TO_WEP &&
 			skb->mark != CALI_SKB_MARK_SEEN &&
-			cali_rt_flags_local_host(cali_rt_lookup_flags(state.ip_src))) {
+			cali_rt_flags_local_host(cali_rt_lookup_flags(state->ip_src))) {
 		/* Host to workload traffic always allowed.  We discount traffic that was
 		 * seen by another program since it must have come in via another interface.
 		 */
 		CALI_DEBUG("Packet is from the host: ACCEPT\n");
-		state.pol_rc = CALI_POL_ALLOW;
+		state->pol_rc = CALI_POL_ALLOW;
 		goto skip_policy;
 	}
 
 	if (CALI_F_FROM_WEP) {
 		/* Do RPF check since it's our responsibility to police that. */
 		CALI_DEBUG("Workload RPF check src=%x skb iface=%d.\n",
-				be32_to_host(state.ip_src), skb->ifindex);
-		struct cali_rt *r = cali_rt_lookup(state.ip_src);
+				be32_to_host(state->ip_src), skb->ifindex);
+		struct cali_rt *r = cali_rt_lookup(state->ip_src);
 		if (!r) {
 			CALI_INFO("Workload RPF fail: missing route.\n");
 			goto deny;
@@ -716,17 +722,17 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 
 		// Check whether the workload needs outgoing NAT to this address.
 		if (r->flags & CALI_RT_NAT_OUT) {
-			if (!(cali_rt_lookup_flags(state.post_nat_ip_dst) & CALI_RT_IN_POOL)) {
+			if (!(cali_rt_lookup_flags(state->post_nat_ip_dst) & CALI_RT_IN_POOL)) {
 				CALI_DEBUG("Source is in NAT-outgoing pool "
 					   "but dest is not, need to SNAT.\n");
-				state.flags |= CALI_ST_NAT_OUTGOING;
+				state->flags |= CALI_ST_NAT_OUTGOING;
 			}
 		} if (!(r->flags & CALI_RT_IN_POOL)) {
-			CALI_DEBUG("Source %x not in IP pool\n", be32_to_host(state.ip_src));
-			r = cali_rt_lookup(state.post_nat_ip_dst);
+			CALI_DEBUG("Source %x not in IP pool\n", be32_to_host(state->ip_src));
+			r = cali_rt_lookup(state->post_nat_ip_dst);
 			if (!r || !(r->flags & (CALI_RT_WORKLOAD | CALI_RT_HOST))) {
-				CALI_DEBUG("Outside cluster dest %x\n", be32_to_host(state.post_nat_ip_dst));
-				state.flags |= CALI_ST_SKIP_FIB;
+				CALI_DEBUG("Outside cluster dest %x\n", be32_to_host(state->post_nat_ip_dst));
+				state->flags |= CALI_ST_SKIP_FIB;
 			}
 		}
 	}
@@ -734,37 +740,26 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	 * the ports set to 0 to do the conntrack lookup, we can set the ICMP fields
 	 * for policy.
 	 */
-	if (state.ip_proto == IPPROTO_ICMP) {
-		state.icmp_type = icmp_header->type;
-		state.icmp_code = icmp_header->code;
+	if (state->ip_proto == IPPROTO_ICMP) {
+		state->icmp_type = icmp_header->type;
+		state->icmp_code = icmp_header->code;
 	}
 
 
-	// Set up an entry in the state map and then jump to the normal policy program.
-	int key = 0;
-	struct cali_tc_state *map_state = cali_v4_state_lookup_elem(&key);
-	if (!map_state) {
-		// Shouldn't be possible; the map is pre-allocated.
-		CALI_INFO("State map lookup failed: DROP\n");
-		goto deny;
-	}
-
-	state.pol_rc = CALI_POL_NO_MATCH;
+	state->pol_rc = CALI_POL_NO_MATCH;
 	if (nat_dest) {
-		state.nat_dest.addr = nat_dest->addr;
-		state.nat_dest.port = nat_dest->port;
+		state->nat_dest.addr = nat_dest->addr;
+		state->nat_dest.port = nat_dest->port;
 	} else {
-		state.nat_dest.addr = 0;
-		state.nat_dest.port = 0;
+		state->nat_dest.addr = 0;
+		state->nat_dest.port = 0;
 	}
-
-	*map_state = state;
 
 	if (CALI_F_HEP) {
 		/* We don't support host-endpoint policy yet, skip straight to
 		 * the epilogue program.
 		 */
-		state.pol_rc = CALI_POL_ALLOW;
+		state->pol_rc = CALI_POL_ALLOW;
 		goto skip_policy;
 	}
 
@@ -775,18 +770,16 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	return TC_ACT_SHOT;
 
 icmp_send_reply:
-	if (update_state_map(&state) == 0) {
-		bpf_tail_call(skb, &cali_jump, ICMP_PROG_INDEX);
-	}
+	bpf_tail_call(skb, &cali_jump, ICMP_PROG_INDEX);
 	/* should not reach here */
 	goto deny;
 
 skip_policy:
-	fwd = calico_tc_skb_accepted(skb, ip_header, &state, nat_dest);
+	fwd = calico_tc_skb_accepted(skb, ip_header, state, nat_dest);
 
 allow:
 finalize:
-	return forward_or_drop(skb, &state, &fwd);
+	return forward_or_drop(skb, state, &fwd);
 deny:
 	fwd.res = TC_ACT_SHOT;
 	goto finalize;
@@ -802,8 +795,7 @@ int calico_tc_skb_accepted_entrypoint(struct __sk_buff *skb)
 		goto deny;
 	}
 	ip_header = skb_iphdr(skb);
-	__u32 key = 0;
-	struct cali_tc_state *state = bpf_map_lookup_elem(&cali_v4_state, &key);
+	struct cali_tc_state *state = state_get();
 	if (!state) {
 		CALI_DEBUG("State map lookup failed: DROP\n");
 		goto deny;
@@ -1302,9 +1294,7 @@ icmp_too_big:
 	goto icmp_send_reply;
 
 icmp_send_reply:
-	if (update_state_map(state) == 0) {
-		bpf_tail_call(skb, &cali_jump, ICMP_PROG_INDEX);
-	}
+	bpf_tail_call(skb, &cali_jump, ICMP_PROG_INDEX);
 	goto deny;
 
 nat_encap:
@@ -1357,8 +1347,7 @@ int calico_tc_skb_send_icmp_replies(struct __sk_buff *skb)
 		goto deny;
 	}
 	struct iphdr *ip_header = skb_iphdr(skb);
-	__u32 key = 0;
-	struct cali_tc_state *state = bpf_map_lookup_elem(&cali_v4_state, &key);
+	struct cali_tc_state *state = state_get();
 	if (!state) {
 		CALI_DEBUG("State map lookup failed: DROP\n");
 		goto deny;

--- a/bpf/ut/benchmarks_test.go
+++ b/bpf/ut/benchmarks_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func BenchmarkHEP(b *testing.B) {
+	RegisterTestingT(b)
+
+	_, _, _, _, pktBytes, err := testPacketUDPDefaultNP(node1ip)
+	Expect(err).NotTo(HaveOccurred())
+
+	cleanUpMaps()
+	defer cleanUpMaps()
+
+	// Run once to create conntrack entry
+	setupAndRun(b, "no_log", "calico_from_host_ep", rulesDefaultAllow, func(progName string) {
+		res, err := bpftoolProgRun(progName, pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+
+	setupAndRun(b, "no_log", "calico_from_host_ep", rulesDefaultAllow, func(progName string) {
+		b.ResetTimer()
+		res, err := bpftoolProgRunN(progName, pktBytes, b.N)
+		b.StopTimer()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		fmt.Printf("%7d iterations avg %d\n", b.N, res.Duration)
+	})
+}

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -135,10 +135,12 @@ func TestLoadZeroProgram(t *testing.T) {
 	Expect(err).To(Equal(unix.E2BIG))
 }
 
-// runBpfTest runs a specific section of the entire bpf program in isolation
-func runBpfTest(t *testing.T, section string, rules [][][]*proto.Rule, testFn func(bpfProgRunFn)) {
-	RegisterTestingT(t)
+type testLogger interface {
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+}
 
+func setupAndRun(logger testLogger, loglevel string, section string, rules [][][]*proto.Rule, runFn func(progName string)) {
 	tempDir, err := ioutil.TempDir("", "calico-bpf-")
 	Expect(err).NotTo(HaveOccurred())
 	defer os.RemoveAll(tempDir)
@@ -168,7 +170,7 @@ func runBpfTest(t *testing.T, section string, rules [][][]*proto.Rule, testFn fu
 	}
 
 	log.WithField("hostIP", hostIP).Info("Host IP")
-	obj += fmt.Sprintf("fib_debug_skb0x%x", skbMark)
+	obj += fmt.Sprintf("fib_%s_skb0x%x", loglevel, skbMark)
 
 	if strings.Contains(section, "_dsr") {
 		obj += "_dsr"
@@ -192,7 +194,7 @@ func runBpfTest(t *testing.T, section string, rules [][][]*proto.Rule, testFn fu
 	Expect(err).NotTo(HaveOccurred())
 
 	if err != nil {
-		t.Log("Error:", string(err.(*exec.ExitError).Stderr))
+		logger.Log("Error:", string(err.(*exec.ExitError).Stderr))
 	}
 	Expect(err).NotTo(HaveOccurred())
 
@@ -208,14 +210,22 @@ func runBpfTest(t *testing.T, section string, rules [][][]*proto.Rule, testFn fu
 	err = jumpMap.Update([]byte{0, 0, 0, 0}, progFDBytes)
 	Expect(err).NotTo(HaveOccurred())
 
-	t.Run(section, func(_ *testing.T) {
-		testFn(func(dataIn []byte) (bpfRunResult, error) {
-			res, err := bpftoolProgRun(bpfFsDir+"/"+section, dataIn)
-			log.Debugf("dataIn  = %+v", dataIn)
-			if err == nil {
-				log.Debugf("dataOut = %+v", res.dataOut)
-			}
-			return res, err
+	runFn(bpfFsDir + "/" + section)
+}
+
+// runBpfTest runs a specific section of the entire bpf program in isolation
+func runBpfTest(t *testing.T, section string, rules [][][]*proto.Rule, testFn func(bpfProgRunFn)) {
+	RegisterTestingT(t)
+	setupAndRun(t, "debug", section, rules, func(progName string) {
+		t.Run(section, func(_ *testing.T) {
+			testFn(func(dataIn []byte) (bpfRunResult, error) {
+				res, err := bpftoolProgRun(progName, dataIn)
+				log.Debugf("dataIn  = %+v", dataIn)
+				if err == nil {
+					log.Debugf("dataOut = %+v", res.dataOut)
+				}
+				return res, err
+			})
 		})
 	})
 }
@@ -345,6 +355,10 @@ func (r bpfRunResult) RetvalStr() string {
 }
 
 func bpftoolProgRun(progName string, dataIn []byte) (bpfRunResult, error) {
+	return bpftoolProgRunN(progName, dataIn, 1)
+}
+
+func bpftoolProgRunN(progName string, dataIn []byte, N int) (bpfRunResult, error) {
 	var res bpfRunResult
 
 	tempDir, err := ioutil.TempDir("", "bpftool-data-")
@@ -359,7 +373,12 @@ func bpftoolProgRun(progName string, dataIn []byte) (bpfRunResult, error) {
 		return res, errors.Errorf("failed to write input data in file: %s", err)
 	}
 
-	out, err := bpftool("prog", "run", "pinned", progName, "data_in", dataInFname, "data_out", dataOutFname)
+	args := []string{"prog", "run", "pinned", progName, "data_in", dataInFname, "data_out", dataOutFname}
+	if N > 1 {
+		args = append(args, "repeat", fmt.Sprintf("%d", N))
+	}
+
+	out, err := bpftool(args...)
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
We are running out of space on stack, especially when DEBUG is enabled.
Therefore this change frees up 60 bytes of stack space (limit is 512)
move the jump state away from the stack and getting it from the map
where we are going to update it anyway if we needed to go through
policy.

This adds a lookup in CPU local array (fast) for each packet, removes
updates for packets that go through policy.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
