### PR TITLE
BPF: no need for accept_local

### DIFF
--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -139,7 +139,7 @@ struct bpf_map_def_extended {
 #define CALI_F_WG_INGRESS    (CALI_F_INGRESS && CALI_F_WIREGUARD)
 
 #define CALI_F_CGROUP	(((CALI_COMPILE_FLAGS) & CALI_CGROUP) != 0)
-#define CALI_F_DSR	(CALI_COMPILE_FLAGS & CALI_TC_DSR)
+#define CALI_F_DSR	((CALI_COMPILE_FLAGS & CALI_TC_DSR) != 0)
 
 #define CALI_RES_REDIR_IFINDEX	(TC_ACT_VALUE_MAX + 100) /* packet should be sent back the same iface */
 

--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -403,23 +403,6 @@ func (m *bpfEndpointManager) CompleteDeferredWork() error {
 	return nil
 }
 
-func (m *bpfEndpointManager) setAcceptLocal(iface string, val bool) error {
-	numval := "0"
-	if val {
-		numval = "1"
-	}
-
-	path := fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/accept_local", iface)
-	err := writeProcSys(path, numval)
-	if err != nil {
-		log.WithField("err", err).Errorf("Failed to  set %s to %s", path, numval)
-		return err
-	}
-
-	log.Infof("%s set to %s", path, numval)
-	return nil
-}
-
 func (m *bpfEndpointManager) ensureStarted() {
 	m.startupOnce.Do(func() {
 		log.Info("Starting map cleanup runner.")
@@ -467,11 +450,6 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 			ingressWG.Wait()
 			if err == nil {
 				err = ingressErr
-			}
-			if err == nil {
-				// This is required to allow NodePort forwarding with
-				// encapsulation with the host's IP as the source address
-				err = m.setAcceptLocal(iface, true)
 			}
 			mutex.Lock()
 			errs[iface] = err


### PR DESCRIPTION
## Description

    All NATing is done on the first node (the one that forwards) instead of
    doing the return SNAT when the packet is leaving the backing pod and is
    being encaped.
    
    The source IP of the encaped packet remains the client's IP and is fixed
    up when leaving the forwarding node.
    
    As a result, we never pass a packet with the local source IP through the
    local IP stack when forwarding from ingress to egress, thus no need for
    setting the accept_local=1.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
