### PR TITLE
bpf: harden accept_local using iptables rpfilter

### DIFF
--- a/bpf/tc/tc_defs.go
+++ b/bpf/tc/tc_defs.go
@@ -27,4 +27,6 @@ const (
 	MarkSeenBypassSkipRPFMask        = MarkSeenBypassMask | 0x00f00000
 	MarkSeenNATOutgoing              = MarkSeenBypass | 0x00800000
 	MarkSeenNATOutgoingMask          = MarkSeenBypassMask | MarkSeenNATOutgoing
+
+	MarksMask = 0xfff00000
 )

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -981,13 +981,22 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 	}
 
 	for _, t := range d.iptablesRawTables {
+		// Do not RPF check what is marked as to be skipped by RPF check.
 		rpfRules := []iptables.Rule{{
 			Match:  iptables.Match().MarkMatchesWithMask(tc.MarkSeenBypassSkipRPF, tc.MarkSeenBypassSkipRPFMask),
 			Action: iptables.ReturnAction{},
 		}}
 
+		// For anything we approved for forward, permit accept_local as it is
+		// traffic encapped for NodePort, ICMP replies etc. - stuff we trust.
+		rpfRules = append(rpfRules, iptables.Rule{
+			Match:  iptables.Match().MarkMatchesWithMask(tc.MarkSeenBypassForward, tc.MarksMask).RPFCheckPassed(true),
+			Action: iptables.ReturnAction{},
+		})
+
+		// Do the full RPF check and dis-allow accept_local for anything else.
 		rpfRules = append(rpfRules, rules.RPFilter(t.IPVersion, tc.MarkSeen, tc.MarkSeenMask,
-			d.config.RulesConfig.OpenStackSpecialCasesEnabled, true)...)
+			d.config.RulesConfig.OpenStackSpecialCasesEnabled, false)...)
 
 		rpfChain := []*iptables.Chain{{
 			Name:  rules.ChainNamePrefix + "RPF",


### PR DESCRIPTION
We need accept_local for traffic that local IP when we turn the packet
around from ingress to egress side. The primary reason is ICMP reponses,
however, it is also used the vxlan NodePort tunnel.

The NodePort tunnel could avoid that, however, that would require
relaxing the RPF check when an overlay is used for pod-pod networking as
we decap the packets on external phys interfaces, but the best route is
through the tunnel interface.

It is easier to harden accept_local then to relax rpf for selected
packet in iptables.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
