### PR TITLE
[v3.16] Fix that broadcast routes weren't filtered out.

### DIFF
--- a/ifacemonitor/iface_monitor.go
+++ b/ifacemonitor/iface_monitor.go
@@ -319,7 +319,8 @@ func (m *InterfaceMonitor) storeAndNotifyLinkInner(ifaceExists bool, ifaceName s
 				log.WithError(err).Warn("Netlink route list operation failed.")
 			}
 			for _, route := range routes {
-				if route.Type != unix.RTN_LOCAL {
+				if !routeIsLocalUnicast(route) {
+					log.WithField("route", route).Debug("Ignoring non-local route.")
 					continue
 				}
 				newAddrs.Add(route.Dst.IP.String())

--- a/ifacemonitor/update_filter.go
+++ b/ifacemonitor/update_filter.go
@@ -101,7 +101,7 @@ mainLoop:
 				})
 		case routeUpd := <-routeInC:
 			logrus.WithField("route", routeUpd).Debug("Route update")
-			if routeUpd.Route.Type&unix.RTN_LOCAL == 0 {
+			if !routeIsLocalUnicast(routeUpd.Route) {
 				logrus.WithField("route", routeUpd).Debug("Ignoring non-local route.")
 				continue
 			}
@@ -226,4 +226,8 @@ func ipNetsEqual(a *net.IPNet, b *net.IPNet) bool {
 	aSize, aBits := a.Mask.Size()
 	bSize, bBits := b.Mask.Size()
 	return a.IP.Equal(b.IP) && aSize == bSize && aBits == bBits
+}
+
+func routeIsLocalUnicast(route netlink.Route) bool {
+	return route.Type == unix.RTN_LOCAL
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Backports #2495 

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that broadcast routes weren't filtered out of felix's list of local IPs.  In BPF mode, this caused dataplane route flaps.
```
