### PR TITLE
bpf/proxy: add info logging when Syncer iteration start/ends

### DIFF
--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -601,7 +601,7 @@ func (s *Syncer) applyDerived(
 }
 
 func (s *Syncer) apply(state DPSyncerState) error {
-	log.Debug("applying new state")
+	log.Infof("applying new state, %d service", len(state.SvcMap))
 
 	// we need to copy the maps from the new state to compute the diff in the
 	// next call. We cannot keep the provided maps as the generic k8s proxy code
@@ -697,7 +697,7 @@ func (s *Syncer) apply(state DPSyncerState) error {
 		log.Infof("removed stale service %q", skey)
 	}
 
-	log.Debug("new state written")
+	log.Info("new state written")
 
 	s.runExpandNPFixup(expNPMisses)
 


### PR DESCRIPTION
felix-0-20143-5-felixfv[stdout] 2020-09-11 18:30:48.868 [INFO][7] felix/syncer.go 710: Syncing k8s state and bpf maps after start
felix-0-20143-5-felixfv[stdout] 2020-09-11 18:30:48.869 [INFO][7] felix/syncer.go 717: Startup sync complete
felix-0-20143-5-felixfv[stdout] 2020-09-11 18:30:48.869 [INFO][7] felix/syncer.go 604: applying new state, 1 service
felix-0-20143-5-felixfv[stdout] 2020-09-11 18:30:48.873 [INFO][7] felix/syncer.go 700: new state written

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
