### PR TITLE
Avoid missing bpf.h problem, often seen with 'make ut'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,11 +210,12 @@ ALL_BPF_PROGS=$(BPF_GPL_O_FILES) $(BPF_APACHE_O_FILES)
 # unnecessary rebuilds of anything that depends on the BPF prgrams.)
 .PHONY: build-bpf clean-bpf
 build-bpf:
-	rm -f bpf-gpl/*.d
+	rm -f bpf-gpl/*.d bpf-apache/*.d
 	$(DOCKER_GO_BUILD) sh -c "make -j -C bpf-apache all && \
 	                          make -j -C bpf-gpl all ut-objs"
 
 clean-bpf:
+	rm -f bpf-gpl/*.d bpf-apache/*.d
 	$(DOCKER_GO_BUILD) sh -c "make -j -C bpf-apache clean && \
 	                          make -j -C bpf-gpl clean"
 

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ ALL_BPF_PROGS=$(BPF_GPL_O_FILES) $(BPF_APACHE_O_FILES)
 # unnecessary rebuilds of anything that depends on the BPF prgrams.)
 .PHONY: build-bpf clean-bpf
 build-bpf:
+	rm -f bpf-gpl/*.d
 	$(DOCKER_GO_BUILD) sh -c "make -j -C bpf-apache all && \
 	                          make -j -C bpf-gpl all ut-objs"
 


### PR DESCRIPTION
    make: *** No rule to make target '/usr/src/linux-headers-5.4.0-0.bpo.3-common/include/uapi/linux/bpf.h', needed by 'connect_balancer.d'.  Stop.
    Makefile:261: recipe for target 'build-bpf' failed

According to Slack discussion the solution is to delete the .d files,
so let's always do that as part of the 'build-bpf' target.
