### PR TITLE
Address/Investigate a WG fv flake

### DIFF
--- a/fv/wireguard_test.go
+++ b/fv/wireguard_test.go
@@ -452,6 +452,24 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 			return fmt.Errorf("policy not applied")
 		}
 
+		AfterEach(func() {
+			fmt.Printf("Check if the workload connectivity is indeed bad")
+
+			fmt.Printf("Test wls0 to wls1 connectivity")
+			err, errstr := wls[0].SendPacketsTo(wls[1].IP, 5, 100)
+			if err != nil {
+				fmt.Printf("Connection from wls0 to wls1 failed: %s\n", errstr)
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			fmt.Printf("Test wls1 to wls0 connectivity")
+			err, errstr = wls[1].SendPacketsTo(wls[0].IP, 5, 100)
+			if err != nil {
+				fmt.Printf("Connection from wls1 to wls0 failed: %s\n", errstr)
+			}
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("between pod to pod should be encrypted using wg tunnel with egress policies applied", func() {
 			policy := api.NewGlobalNetworkPolicy()
 
@@ -484,6 +502,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 
 			cc.ResetExpectations()
 
+			policy = api.NewGlobalNetworkPolicy()
 			policy.Name = "f01-egress-allow"
 			order = float64(10)
 			policy.Spec.Order = &order // prioritized over deny policy above.
@@ -495,6 +514,19 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 			Eventually(func() error {
 				return readPolicy(policy.Name, api.Allow)
 			}, "5s", "100ms").ShouldNot(HaveOccurred())
+
+			/*
+				err, errstr := wls[0].SendPacketsTo(wls[1].IP, 5, 100)
+				if err != nil {
+					fmt.Printf("Connection from wls0 to wls1 failed: %s\n", errstr)
+				}
+				Expect(err).NotTo(HaveOccurred())
+				err, errstr = wls[1].SendPacketsTo(wls[0].IP, 5, 100)
+				if err != nil {
+					fmt.Printf("Connection from wls1 to wls0 failed: %s\n", errstr)
+				}
+				Expect(err).NotTo(HaveOccurred())
+			*/
 
 			cc.ExpectSome(wls[0], wls[1])
 			cc.ExpectSome(wls[1], wls[0])


### PR DESCRIPTION
## Description

Address/investigate a WG fv flake, by:
* increasing connectivity-test timeout.
* adding a callback to check the connection if the connectivity-test fails. This will help isolate if there are any issue in connectivity-test or just pod connectivity in general.

This is a speculative fix and in case of issue will provide debugging information using failed callback tests.

This being a flake, ran it several times through CI to see if the error can be reproduced. I wasn't able to repro the flake in 10 CI runs.

## Release Note
```release-note
None required
```
