### PR TITLE
Multiple node addresses result in multiple routes

### DIFF
--- a/calc/calc_graph_fv_test.go
+++ b/calc/calc_graph_fv_test.go
@@ -382,6 +382,12 @@ var baseTests = []StateList{
 		vxlanWithBlockDupNodeIP,
 		vxlanWithDupNodeIPRemoved,
 	},
+	{
+		nodesWithMoreIPs,
+		nodesWithMoreIPsAndDuplicates,
+		nodesWithDifferentAddressTypes,
+		nodesWithMoreIPsDeleted,
+	},
 }
 
 var logOnce sync.Once

--- a/dataplane/linux/bpf_route_mgr.go
+++ b/dataplane/linux/bpf_route_mgr.go
@@ -265,6 +265,12 @@ func (m *bpfRouteManager) calculateRoute(cidr ip.V4CIDR) *routes.Value {
 		nodeIP := net.ParseIP(cgRoute.DstNodeIp)
 		routeVal := routes.NewValueWithNextHop(flags, ip.FromNetIP(nodeIP).(ip.V4Addr))
 		route = &routeVal
+	case proto.RouteType_LOCAL_HOST:
+		// It may be a localhost IP that is not assigned to a device like an
+		// k8s ExternalIP. Route resolver knew that it was assigned to our
+		// hostname.
+		flags |= routes.FlagsLocalHost
+		fallthrough
 	default: // proto.RouteType_CIDR_INFO / LOCAL_HOST or no route at all
 		if flags != 0 {
 			// We have something to say about this route.

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -155,6 +155,9 @@ const expectedRouteDump = `10.65.0.0/16: remote in-pool nat-out
 10.65.0.4/32: local workload in-pool nat-out idx -
 10.65.1.0/26: remote workload in-pool nat-out nh FELIX_1
 10.65.2.0/26: remote workload in-pool nat-out nh FELIX_2
+111.222.0.1/32: local host
+111.222.1.1/32: remote host
+111.222.2.1/32: remote host
 FELIX_0/32: local host idx -
 FELIX_1/32: remote host
 FELIX_2/32: remote host`
@@ -166,6 +169,9 @@ const expectedRouteDumpWithTunnelAddr = `10.65.0.0/16: remote in-pool nat-out
 10.65.0.4/32: local workload in-pool nat-out idx -
 10.65.1.0/26: remote workload in-pool nat-out nh FELIX_1
 10.65.2.0/26: remote workload in-pool nat-out nh FELIX_2
+111.222.0.1/32: local host
+111.222.1.1/32: remote host
+111.222.2.1/32: remote host
 FELIX_0/32: local host idx -
 FELIX_1/32: remote host
 FELIX_2/32: remote host`
@@ -270,6 +276,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			if testOpts.dsr {
 				options.ExtraEnvVars["FELIX_BPFExternalServiceMode"] = "dsr"
 			}
+			options.ExternalIPs = true
 		})
 
 		JustAfterEach(func() {
@@ -1498,9 +1505,13 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						})
 						It("should have connectivity via the node port to workload 0", func() {
 							node1IP := felixes[1].IP
+							node1IPExt := felixes[1].ExternalIP
 							cc.ExpectSome(w[0][1], TargetIP(node1IP), npPort)
 							cc.ExpectSome(w[1][0], TargetIP(node1IP), npPort)
 							cc.ExpectSome(w[1][1], TargetIP(node1IP), npPort)
+							cc.ExpectSome(w[0][1], TargetIP(node1IPExt), npPort)
+							cc.ExpectSome(w[1][0], TargetIP(node1IPExt), npPort)
+							cc.ExpectSome(w[1][1], TargetIP(node1IPExt), npPort)
 							cc.CheckConnectivity()
 						})
 

--- a/fv/infrastructure/felix.go
+++ b/fv/infrastructure/felix.go
@@ -47,6 +47,10 @@ type Felix struct {
 	// IP of the Typha that this Felix is using (if any).
 	TyphaIP string
 
+	// If sets, acts like an external IP of a node. Filled in by AddNode().
+	// XXX setup routes
+	ExternalIP string
+
 	startupDelayed bool
 }
 

--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -529,6 +529,11 @@ func (kds *K8sDatastoreInfra) SetExpectedWireguardTunnelAddr(felix *Felix, idx i
 	felix.ExtraSourceIPs = append(felix.ExtraSourceIPs, felix.ExpectedWireguardTunnelAddr)
 }
 
+func (kds *K8sDatastoreInfra) SetExternalIP(felix *Felix, idx int) {
+	felix.ExternalIP = fmt.Sprintf("111.222.%d.1", idx)
+	felix.ExtraSourceIPs = append(felix.ExtraSourceIPs, felix.ExternalIP)
+}
+
 func (kds *K8sDatastoreInfra) AddNode(felix *Felix, idx int, needBGP bool) {
 	nodeIn := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -538,6 +543,19 @@ func (kds *K8sDatastoreInfra) AddNode(felix *Felix, idx int, needBGP bool) {
 			},
 		},
 		Spec: v1.NodeSpec{PodCIDR: fmt.Sprintf("10.65.%d.0/24", idx)},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{{
+				Address: felix.IP,
+				Type:    v1.NodeInternalIP,
+			}},
+		},
+	}
+	if felix.ExternalIP != "" {
+		nodeIn.Status.Addresses = append(nodeIn.Status.Addresses,
+			v1.NodeAddress{
+				Address: felix.ExternalIP,
+				Type:    v1.NodeInternalIP,
+			})
 	}
 	if felix.ExpectedIPIPTunnelAddr != "" {
 		nodeIn.Annotations["projectcalico.org/IPv4IPIPTunnelAddr"] = felix.ExpectedIPIPTunnelAddr

--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -53,6 +53,7 @@ type TopologyOptions struct {
 	AutoHEPsEnabled           bool
 	TriggerDelayedFelixStart  bool
 	FelixStopGraceful         bool
+	ExternalIPs               bool
 }
 
 func DefaultTopologyOptions() TopologyOptions {
@@ -205,6 +206,10 @@ func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (feli
 
 		expectedIPs := []string{felix.IP}
 
+		if kdd, ok := infra.(*K8sDatastoreInfra); ok && opts.ExternalIPs {
+			kdd.SetExternalIP(felix, i)
+			expectedIPs = append(expectedIPs, felix.ExternalIP)
+		}
 		if opts.IPIPEnabled {
 			infra.SetExpectedIPIPTunnelAddr(felix, i, bool(n > 1))
 			expectedIPs = append(expectedIPs, felix.ExpectedIPIPTunnelAddr)


### PR DESCRIPTION
If external IP on a k8s node is set, it generates a route to host and
that allows pods to access nodeport on that address.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
