### PR TITLE
Enable UDP bypass, tighten RPF check accordingly

### DIFF
--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -648,7 +648,6 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 		fwd_fib_set(&fwd, false);
 	}
 
-
 	/* skip policy if we get conntrack hit */
 	if (ct_result_rc(state->ct_result.rc) != CALI_CT_NEW) {
 		if (state->ct_result.flags & CALI_CT_FLAG_SKIP_FIB) {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

* Enable the bypass mark pattern for UDP flows.
* Tighten up the RPF logic so that the initial response packet goes through RPF.  This is more important for UDP because UDP may be unidirectional so there's an arbitrarily large window where another interface could slip in a "response" packet.
* Add a TCP spoofing test.  This works by adding a secondary interface to the workload and moving routes between interfaces so that we can move an active TCP connection from one interface to the other.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, skip second conntrack lookup when flow is established.  Tighten up the RPF check to ensure this is safe.
```
