### PR TITLE
bpf: enforce RPF check for possible spoofed TCP

### DIFF
--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -377,6 +377,7 @@ enum calico_ct_result_type {
 
 #define ct_result_rc(rc)		((rc) & 0xff)
 #define ct_result_flags(rc)		((rc) & ~0xff)
+#define ct_result_set_rc(val, rc)	((val) = ct_result_flags(val) | (rc))
 #define ct_result_set_flag(val, flags)	((val) |= (flags))
 
 #define ct_result_is_related(rc)	((rc) & CALI_CT_RELATED)
@@ -803,6 +804,9 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct ct_ctx
 			} else {
 				CALI_CT_DEBUG("RPF expected %d to equal %d\n",
 						src_to_dst->ifindex, ctx->skb->ingress_ifindex);
+				if (ct_result_rc(result.rc) == CALI_CT_ESTABLISHED_BYPASS) {
+					ct_result_set_rc(result.rc, CALI_CT_ESTABLISHED);
+				}
 				ct_result_set_flag(result.rc, CALI_CT_RPF_FAILED);
 			}
 		} else {


### PR DESCRIPTION
TCP sets CALI_CT_ESTABLISHED_BYPASS which avoids parsing the packet by
the second program on established connections. However, if we detected
change in where the packets come from - possible spoof - disable the
bypass. As the packet is forced through the kernel's RPF check, avoiding
the bypass updates the ifindex if the packet passes through.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
