### PR TITLE
bpf: skip FIB for WEP egress leaving the cluster

### DIFF
--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -61,6 +61,7 @@ enum cali_ct_type {
 #define CALI_CT_FLAG_NAT_OUT	(1 << 0)
 #define CALI_CT_FLAG_DSR_FWD	(1 << 1) /* marks entry into the tunnel on the fwd node when dsr */
 #define CALI_CT_FLAG_NP_FWD	(1 << 2) /* marks entry into the tunnel on the fwd node */
+#define CALI_CT_FLAG_SKIP_FIB	(1 << 3) /* marks traffic that should pass through host IP stack */
 
 #define ct_result_np_node(res)		((res).flags & CALI_CT_FLAG_NP_FWD)
 

--- a/bpf-gpl/jump.h
+++ b/bpf-gpl/jump.h
@@ -48,7 +48,8 @@ struct cali_tc_state {
 };
 
 enum cali_state_flags {
-	CALI_ST_NAT_OUTGOING = 1,
+	CALI_ST_NAT_OUTGOING	= (1 << 0),
+	CALI_ST_SKIP_FIB	= (1 << 1),
 };
 
 CALI_MAP_V1(cali_v4_state,

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -587,6 +587,9 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 
 	/* skip policy if we get conntrack hit */
 	if (ct_result_rc(state.ct_result.rc) != CALI_CT_NEW) {
+		if (state.ct_result.flags & CALI_CT_FLAG_SKIP_FIB) {
+			state.flags |= CALI_ST_SKIP_FIB;
+		}
 		goto skip_policy;
 	}
 
@@ -659,6 +662,13 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 				CALI_DEBUG("Source is in NAT-outgoing pool "
 					   "but dest is not, need to SNAT.\n");
 				state.flags |= CALI_ST_NAT_OUTGOING;
+			}
+		} if (!(r->flags & CALI_RT_IN_POOL)) {
+			CALI_DEBUG("Source %x not in IP pool\n", be32_to_host(state.ip_src));
+			r = cali_rt_lookup(state.post_nat_ip_dst);
+			if (!r || !(r->flags & (CALI_RT_WORKLOAD | CALI_RT_HOST))) {
+				CALI_DEBUG("Outside cluster dest %x\n", be32_to_host(state.post_nat_ip_dst));
+				state.flags |= CALI_ST_SKIP_FIB;
 			}
 		}
 	}
@@ -793,10 +803,12 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 		// to trigger that and leave the fib lookup disabled.
 		seen_mark = CALI_SKB_MARK_NAT_OUT;
 	} else {
-		// Non-SNAT case, allow FIB lookup only if RPF check passed.  Note: tried to pass in
-		// the calculated value from calico_tc but hit verifier issues so recalculate it
-		// here.
-		if (CALI_F_TO_HOST && !ct_result_rpf_failed(state->ct_result.rc)) {
+		if (state->flags & CALI_ST_SKIP_FIB) {
+			fib = false;
+		} else if (CALI_F_TO_HOST && !ct_result_rpf_failed(state->ct_result.rc)) {
+			// Non-SNAT case, allow FIB lookup only if RPF check passed.
+			// Note: tried to pass in the calculated value from calico_tc but
+			// hit verifier issues so recalculate it here.
 			fib = true;
 		}
 		seen_mark = CALI_SKB_MARK_SEEN;
@@ -936,6 +948,9 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 		ct_nat_ctx.tun_ip = state->tun_ip;
 		if (state->flags & CALI_ST_NAT_OUTGOING) {
 			ct_nat_ctx.flags |= CALI_CT_FLAG_NAT_OUT;
+		}
+		if (CALI_F_FROM_WEP && state->flags & CALI_ST_SKIP_FIB) {
+			ct_nat_ctx.flags |= CALI_CT_FLAG_SKIP_FIB;
 		}
 
 		if (state->ip_proto == IPPROTO_TCP) {

--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -54,6 +54,7 @@ type TopologyOptions struct {
 	TriggerDelayedFelixStart  bool
 	FelixStopGraceful         bool
 	ExternalIPs               bool
+	UseIPPools                bool
 }
 
 func DefaultTopologyOptions() TopologyOptions {
@@ -67,6 +68,7 @@ func DefaultTopologyOptions() TopologyOptions {
 		TyphaLogSeverity:  "info",
 		IPIPEnabled:       true,
 		IPIPRoutesEnabled: true,
+		UseIPPools:        true,
 	}
 }
 
@@ -160,19 +162,21 @@ func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (feli
 		Eventually(func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			ipPool := api.NewIPPool()
-			ipPool.Name = "test-pool"
-			ipPool.Spec.CIDR = "10.65.0.0/16"
-			ipPool.Spec.NATOutgoing = opts.NATOutgoingEnabled
-			if opts.IPIPEnabled {
-				ipPool.Spec.IPIPMode = api.IPIPModeAlways
-			} else {
-				ipPool.Spec.IPIPMode = api.IPIPModeNever
+			if opts.UseIPPools {
+				ipPool := api.NewIPPool()
+				ipPool.Name = "test-pool"
+				ipPool.Spec.CIDR = "10.65.0.0/16"
+				ipPool.Spec.NATOutgoing = opts.NATOutgoingEnabled
+				if opts.IPIPEnabled {
+					ipPool.Spec.IPIPMode = api.IPIPModeAlways
+				} else {
+					ipPool.Spec.IPIPMode = api.IPIPModeNever
+				}
+
+				ipPool.Spec.VXLANMode = opts.VXLANMode
+
+				_, err = client.IPPools().Create(ctx, ipPool, options.SetOptions{})
 			}
-
-			ipPool.Spec.VXLANMode = opts.VXLANMode
-
-			_, err = client.IPPools().Create(ctx, ipPool, options.SetOptions{})
 			return err
 		}).ShouldNot(HaveOccurred())
 	}


### PR DESCRIPTION
When traffic from a pod is leaving the cluster, we may want to decide
to skip FIB and thus force it to go through the host IP stack and IP
tables.

For instance, in EKS, the AWS CNI programs nat outgoing rules and we
want the traffic to hit them.

We skip the fib when the source IP of the workload is not in any IP
pool, which suggests that a non-calico CNI is in use.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that, in eBPF mode, when using a non-Calico CNI (such as the AWS VPC CNI), the non-Calico CNI's SNAT rules could be skipped.  This fixes access from pods to non-cluster resources in EKS, for example.
```
