### PR TITLE
Fix wireguard resync processing: correctly flag already handled nodes

### DIFF
--- a/netlinkshim/mocknetlink/netlink.go
+++ b/netlinkshim/mocknetlink/netlink.go
@@ -224,6 +224,7 @@ type MockNetlinkDataplane struct {
 	NumRuleAddCalls        int
 	NumRuleDelCalls        int
 	WireguardConfigUpdated bool
+	LastWireguardUpdates   map[wgtypes.Key]wgtypes.PeerConfig
 
 	PersistentlyFailToConnect bool
 

--- a/netlinkshim/mocknetlink/wireguard.go
+++ b/netlinkshim/mocknetlink/wireguard.go
@@ -126,6 +126,14 @@ func (d *MockNetlinkDataplane) ConfigureDevice(name string, cfg wgtypes.Config) 
 	defer d.mutex.Unlock()
 	defer GinkgoRecover()
 
+	// Track the last set of wireguard device updates. Note that we should only get each peer appearing at most once in
+	// the update.
+	d.LastWireguardUpdates = make(map[wgtypes.Key]wgtypes.PeerConfig)
+	for _, p := range cfg.Peers {
+		d.LastWireguardUpdates[p.PublicKey] = p
+	}
+	Expect(cfg.Peers).To(HaveLen(len(d.LastWireguardUpdates)))
+
 	Expect(d.WireguardOpen).To(BeTrue())
 	if d.shouldFail(FailNextWireguardConfigureDevice) {
 		return SimulatedError


### PR DESCRIPTION
## Description
Fix wireguard re-sync processing.

There were a couple of issues:
-  Nodes that were not deleted were the being treated as new and undergoing a full update (actually they might actually have two updates).  The tracking of whether a node was handled via delta was incorrect.
-  The tracking did not handle CIDRs missing from the node allowed IPs.

This PR fixes both of these.

The existing tests should still cover this - it's just before we ended up doing a full node update so the data plane values were still correct. 

I have, however, beefed up the tests to check the actual contents of the updates to check:
-  We don't have multiple entries for the same peer in a single update
-  The correct update/replace flag is set

Hopeful this will fix https://github.com/projectcalico/calico/issues/4091

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix Wireguard resync processing to properly track deltas
```
