### PR TITLE
bpf: pick a random backend after affinity timeo expires

### DIFF
--- a/bpf/maps.go
+++ b/bpf/maps.go
@@ -151,6 +151,31 @@ func DumpMapCmd(m Map) ([]string, error) {
 	return nil, errors.Errorf("unrecognized map type %T", m)
 }
 
+func MapDeleteKeyCmd(m Map, key []byte) ([]string, error) {
+	if pm, ok := m.(*PinnedMap); ok {
+		keyData := make([]string, len(key))
+		for i, b := range key {
+			keyData[i] = fmt.Sprintf("%d", b)
+		}
+		cmd := []string{
+			"bpftool",
+			"--json",
+			"--pretty",
+			"map",
+			"delete",
+			"pinned",
+			pm.versionedFilename(),
+			"key",
+		}
+
+		cmd = append(cmd, keyData...)
+
+		return cmd, nil
+	}
+
+	return nil, errors.Errorf("unrecognized map type %T", m)
+}
+
 // IterMapCmdOutput iterates over the outout of a command obtained by DumpMapCmd
 func IterMapCmdOutput(output []byte, f IterCallback) error {
 	var mp []mapEntry

--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -723,7 +723,7 @@ func (s *Syncer) Apply(state DPSyncerState) error {
 		s.prevEpsMap = s.newEpsMap
 	}
 
-	// preallocate maps the track sticky service for cleanup
+	// preallocate maps to track sticky services for cleanup
 	s.stickySvcs = make(map[nat.FrontEndAffinityKey]stickyFrontend)
 	s.stickyEps = make(map[uint32]map[nat.BackendValue]struct{})
 	s.stickySvcDeleted = false


### PR DESCRIPTION
When session affinity time out expires, we should make a new pick of the
backend.

Currently, we were using a stable hash of the client's IP which would
result in the same pick if the set of backends did not change.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode, choose the backend randomly for service VIPs with service affinity enabled.  This ensures a more random distribution and good rebalancing (as expected by the k8s conformance tests).
```
