### PR TITLE
Export multipath route to kernel

### DIFF
--- a/etc/bird/calico-bird.conf.template
+++ b/etc/bird/calico-bird.conf.template
@@ -29,6 +29,7 @@ protocol kernel {
   import all;
   graceful restart;
   export all;     # Default is export none
+  merge paths on; # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.


### PR DESCRIPTION
Allow ECMP egress gw propagation to kernel.
Actual behavior that bird sees the received multipath routes (e.g. default routes 0.0.0.0/0) 
but exports only one path to the kernel not all paths.

## Description
See issue that I opened here: https://github.com/projectcalico/calico/issues/4114
(Please move this issue to this repository)
