### PR TITLE
bpf: nodeport return with multiple ifaces

### DIFF
--- a/bpf-gpl/arp.h
+++ b/bpf-gpl/arp.h
@@ -1,0 +1,33 @@
+// Project Calico BPF dataplane programs.
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#ifndef __CALI_ARP_H__
+#define __CALI_ARP_H__
+
+struct arp_key {
+	uint32_t ip;
+	uint32_t ifindex;
+};
+
+struct arp_value {
+	char mac_src[6];
+	char mac_dst[6];
+};
+
+CALI_MAP(cali_v4_arp, 2, BPF_MAP_TYPE_LRU_HASH, struct arp_key, struct arp_value, 10000, 0, MAP_PIN_GLOBAL)
+
+#endif /* __CALI_ARP_H__ */

--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -141,7 +141,10 @@ struct bpf_map_def_extended {
 #define CALI_F_CGROUP	(((CALI_COMPILE_FLAGS) & CALI_CGROUP) != 0)
 #define CALI_F_DSR	(CALI_COMPILE_FLAGS & CALI_TC_DSR)
 
-#define CALI_RES_REDIR_IFINDEX	(TC_ACT_VALUE_MAX + 100) /* packet should be sent back the same iface */
+#define CALI_RES_REDIR_BACK	(TC_ACT_VALUE_MAX + 100) /* packet should be sent back the same iface */
+#define CALI_RES_REDIR_IFINDEX	(TC_ACT_VALUE_MAX + 101) /* packet should be sent straight to
+							  * state->ct_result->ifindex_fwd
+							  */
 
 #define FIB_ENABLED (!CALI_F_L3 && CALI_FIB_LOOKUP_ENABLED && CALI_F_TO_HOST)
 

--- a/bpf-gpl/calculate-flags
+++ b/bpf-gpl/calculate-flags
@@ -45,6 +45,7 @@ fi
 
 if [[ "${filename}" =~ .*skb([0-9a-fA-Fx]+).* ]]; then
   args+=("-DCALI_SET_SKB_MARK=${BASH_REMATCH[1]}")
+  args+=("-DUNITTEST")
 fi
 
 if [[ "${filename}" =~ test_.* ]]; then

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -97,6 +97,16 @@ static CALI_BPF_INLINE long skb_l4hdr_offset(struct __sk_buff *skb, __u8 ihl)
 	return skb_iphdr_offset(skb) + ihl;
 }
 
+static CALI_BPF_INLINE __u32 skb_ingress_ifindex(struct __sk_buff *skb)
+{
+#ifdef UNITTEST
+	/* ingress_ifindex is not set in PROG_RUN */
+	return skb->ingress_ifindex ? : skb->ifindex;
+#else
+	return skb->ingress_ifindex;
+#endif
+}
+
 #define skb_is_gso(skb) ((skb)->gso_segs > 1)
 
 #endif /* __SKB_H__ */

--- a/bpf/arp/map.go
+++ b/bpf/arp/map.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arp
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/bpf"
+)
+
+var MapParams = bpf.MapParameters{
+	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_arp",
+	Type:       "lru_hash",
+	KeySize:    KeySize,
+	ValueSize:  ValueSize,
+	MaxEntries: 10000, // max number of nodes that can forward nodeports to a single node
+	Name:       "cali_v4_arp",
+	Version:    2,
+}
+
+func Map(mc *bpf.MapContext) bpf.Map {
+	return mc.NewPinnedMap(MapParams)
+}
+
+const KeySize = 8
+
+type Key [KeySize]byte
+
+func NewKey(ip net.IP, ifIndex uint32) Key {
+	var k Key
+
+	ip = ip.To4()
+	if len(ip) != 4 {
+		log.WithField("ip", ip).Panic("Bad IP")
+	}
+
+	copy(k[:4], ip)
+	binary.LittleEndian.PutUint32(k[4:8], ifIndex)
+
+	return k
+}
+
+func (k Key) IP() net.IP {
+	return net.IP(k[:4])
+}
+
+func (k Key) IfIndex() uint32 {
+	return binary.LittleEndian.Uint32(k[4:8])
+}
+
+func (k Key) String() string {
+	return fmt.Sprintf("ip %s ifindex %d", k.IP(), k.IfIndex())
+}
+
+const ValueSize = 12
+
+type Value [ValueSize]byte
+
+func NewValue(macSrc, macDst []byte) Value {
+	var v Value
+
+	copy(v[0:6], macSrc)
+	copy(v[6:12], macDst)
+
+	return v
+}
+
+func (v Value) SrcMAC() net.HardwareAddr {
+	return net.HardwareAddr(v[0:6])
+}
+
+func (v Value) DstMAC() net.HardwareAddr {
+	return net.HardwareAddr(v[6:12])
+}
+
+func (v Value) String() string {
+	return fmt.Sprintf("src: %s dst %s", v.SrcMAC(), v.DstMAC())
+}
+
+type MapMem map[Key]Value
+
+// LoadMapMem loads ConntrackMap into memory
+func LoadMapMem(m bpf.Map) (MapMem, error) {
+	ret := make(MapMem)
+
+	err := m.Iter(func(k, v []byte) bpf.IteratorAction {
+		ks := len(Key{})
+		vs := len(Value{})
+
+		var key Key
+		copy(key[:ks], k[:ks])
+
+		var val Value
+		copy(val[:vs], v[:vs])
+
+		ret[key] = val
+		return bpf.IterNone
+	})
+
+	return ret, err
+}
+
+// MapMemIter returns bpf.MapIter that loads the provided MapMem
+func MapMemIter(m MapMem) bpf.IterCallback {
+	ks := len(Key{})
+	vs := len(Value{})
+
+	return func(k, v []byte) bpf.IteratorAction {
+		var key Key
+		copy(key[:ks], k[:ks])
+
+		var val Value
+		copy(val[:vs], v[:vs])
+
+		m[key] = val
+		return bpf.IterNone
+	}
+}

--- a/cmd/calico-bpf/commands/arp.go
+++ b/cmd/calico-bpf/commands/arp.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/projectcalico/felix/bpf"
+	"github.com/projectcalico/felix/bpf/arp"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	arpCmd.AddCommand(arpDumpCmd)
+	arpCmd.AddCommand(arpCleanCmd)
+	rootCmd.AddCommand(arpCmd)
+}
+
+var arpDumpCmd = &cobra.Command{
+	Use:   "dump",
+	Short: "dumps arp",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := dumpARP(); err != nil {
+			log.WithError(err).Error("Failed to dump the arp table.")
+		}
+	},
+}
+
+var arpCleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "removes all arp entries",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := cleanARP(); err != nil {
+			log.WithError(err).Error("Failed to clean the arp table.")
+		}
+	},
+}
+
+// arpCmd represents the arp command
+var arpCmd = &cobra.Command{
+	Use:   "arp",
+	Short: "Manipulates arp",
+}
+
+func dumpARP() error {
+	arpMap := arp.Map(&bpf.MapContext{})
+
+	if err := arpMap.Open(); err != nil {
+		return errors.WithMessage(err, "failed to open map")
+	}
+
+	err := arpMap.Iter(func(k, v []byte) bpf.IteratorAction {
+		var (
+			key arp.Key
+			val arp.Value
+		)
+
+		copy(key[:], k[:arp.KeySize])
+		copy(val[:], v[:arp.ValueSize])
+
+		fmt.Printf("dev %4d: %15s : %s -> %s\n", key.IfIndex(), key.IP(), val.SrcMAC(), val.DstMAC())
+
+		return bpf.IterNone
+	})
+
+	return err
+}
+
+func cleanARP() error {
+	arpMap := arp.Map(&bpf.MapContext{})
+
+	if err := arpMap.Open(); err != nil {
+		return errors.WithMessage(err, "failed to open map")
+	}
+
+	err := arpMap.Iter(func(k, v []byte) bpf.IteratorAction {
+		return bpf.IterDelete
+	})
+
+	return err
+}

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -44,6 +44,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/set"
 
 	"github.com/projectcalico/felix/bpf"
+	"github.com/projectcalico/felix/bpf/arp"
 	"github.com/projectcalico/felix/bpf/conntrack"
 	bpfipsets "github.com/projectcalico/felix/bpf/ipsets"
 	"github.com/projectcalico/felix/bpf/nat"
@@ -544,6 +545,13 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		if err != nil {
 			log.WithError(err).Panic("Failed to create state BPF map.")
 		}
+
+		arpMap := arp.Map(bpfMapContext)
+		err = arpMap.EnsureExists()
+		if err != nil {
+			log.WithError(err).Panic("Failed to create ARP BPF map.")
+		}
+
 		workloadIfaceRegex := regexp.MustCompile(strings.Join(interfaceRegexes, "|"))
 		dp.RegisterManager(newBPFEndpointManager(
 			config.BPFLogLevel,


### PR DESCRIPTION
In environments like EKS, where the egress route is determined by the
source IP as well, the return VXLAN packet for the nodeport tunnel may
end up at a wrong interface (and route) because the packet has the
source IP of the backing pod - to avoid being dropped by RPF check etc.

This fix uses the knowledge of the iface where the nodeport ingress
packets came from (recorded for the purpose of RPF check) and send the
packet out straight to the same interface.

Until we get bpf_redirect_neigh() in our supported kernels (5.10+) we
need to maintain an ARP lookup cache that allows us to patch in the
right MAC addresses so that the packet, once forwarded by the host
interface, can reach the next hop.

We use the tunnel IP where we are sending the egress packet to and the
ifindex of the device where it came from look up the MAC addresses we should
patch in.

The lookup map is an LRU hash with 10k entries. That allows 10k other
nodes to forward their nodeports to a node.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In eBPF mode, return nodeport traffic from the backing pod to the same interface that it arrived at.  This prevents incorrect routing in environments like EKS, which use source-based routing.
```
