### PR TITLE
Expand MTU interface regex

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -117,7 +117,7 @@ type Config struct {
 	BPFEnabled                         bool           `config:"bool;false"`
 	BPFDisableUnprivileged             bool           `config:"bool;true"`
 	BPFLogLevel                        string         `config:"oneof(off,info,debug);off;non-zero"`
-	BPFDataIfacePattern                *regexp.Regexp `config:"regexp;^(en[opsx].*|eth.*|tunl0$|wireguard.cali$)"`
+	BPFDataIfacePattern                *regexp.Regexp `config:"regexp;^((en|wl|ww|sl|ib)[opsx].*|(eth|wlan|wwan).*|tunl0$|wireguard.cali$)"`
 	BPFConnectTimeLoadBalancingEnabled bool           `config:"bool;true"`
 	BPFExternalServiceMode             string         `config:"oneof(tunnel,dsr);tunnel;non-zero"`
 	BPFKubeProxyIptablesCleanupEnabled bool           `config:"bool;true"`
@@ -281,7 +281,7 @@ type Config struct {
 	Variant string `config:"string;Calico"`
 
 	// Configures MTU auto-detection.
-	MTUIfacePattern *regexp.Regexp `config:"regexp;^(en[opsx].*|eth.*)"`
+	MTUIfacePattern *regexp.Regexp `config:"regexp;^((en|wl|ww|sl|ib)[opsx].*|(eth|wlan|wwan).*)"`
 
 	// State tracking.
 

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -295,6 +295,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		// We default the values even if the encap is not enabled, in order to match behavior
 		// from earlier versions of Calico. However, they MTU will only be considered for allocation
 		// to pod interfaces if the encap is enabled.
+		log.WithField("mtu", mtu).Info("Detected host MTU.")
 		config.hostMTU = mtu
 		if config.IPIPMTU == 0 {
 			log.Debug("Defaulting IPIP MTU based on host")
@@ -789,8 +790,10 @@ func findHostMTU(matchRegex *regexp.Regexp) (int, error) {
 
 	// Iterate through them, keeping track of the lowest MTU.
 	smallest := 0
+	var names []string
 	for _, l := range links {
 		// Skip links that we know are not external interfaces.
+		names = append(names, l.Attrs().Name)
 		fields := log.Fields{"mtu": l.Attrs().MTU, "name": l.Attrs().Name}
 		if matchRegex == nil || !matchRegex.MatchString(l.Attrs().Name) {
 			log.WithFields(fields).Debug("Skipping interface for MTU detection")
@@ -801,6 +804,17 @@ func findHostMTU(matchRegex *regexp.Regexp) (int, error) {
 			smallest = l.Attrs().MTU
 		}
 	}
+
+	if smallest == 0 {
+		pattern := "<nil>"
+		if matchRegex != nil {
+			pattern = matchRegex.String()
+		}
+		log.WithFields(log.Fields{"interfaceNames": names, "regex": pattern}).Warn(
+			"No host interfaces matched the MTUIfacePattern regular expression; either set MTUIfacePattern " +
+				"to match your host interfaces or force explicit MTU settings.")
+	}
+
 	return smallest, nil
 }
 

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -810,9 +810,9 @@ func findHostMTU(matchRegex *regexp.Regexp) (int, error) {
 		if matchRegex != nil {
 			pattern = matchRegex.String()
 		}
-		log.WithFields(log.Fields{"interfaceNames": names, "regex": pattern}).Warn(
-			"No host interfaces matched the MTUIfacePattern regular expression; either set MTUIfacePattern " +
-				"to match your host interfaces or force explicit MTU settings.")
+		return 0, fmt.Errorf("no host interfaces matched the MTU detection interface pattern; " +
+			"set MTUIfacePattern to match (only) your host's data interfaces (interface names: %v; pattern: %v)",
+			names, pattern)
 	}
 
 	return smallest, nil

--- a/rules/static.go
+++ b/rules/static.go
@@ -645,13 +645,6 @@ func (r *DefaultRuleRenderer) filterOutputChain(ipVersion uint8) *Chain {
 		},
 	)
 
-	// Jump to chain for blocking service CIDR loops.
-	rules = append(rules,
-		Rule{
-			Action: JumpAction{Target: ChainCIDRBlock},
-		},
-	)
-
 	return &Chain{
 		Name:  ChainFilterOutput,
 		Rules: rules,

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -313,7 +313,6 @@ var _ = Describe("Static", func() {
 										Action:  AcceptAction{},
 										Comment: []string{"Host endpoint policy accepted packet."},
 									},
-									{Action: JumpAction{Target: ChainCIDRBlock}},
 								},
 							}))
 						} else {
@@ -336,7 +335,6 @@ var _ = Describe("Static", func() {
 										Action:  AcceptAction{},
 										Comment: []string{"Host endpoint policy accepted packet."},
 									},
-									{Action: JumpAction{Target: ChainCIDRBlock}},
 								},
 							}))
 						}
@@ -701,7 +699,6 @@ var _ = Describe("Static", func() {
 						Action:  AcceptAction{},
 						Comment: []string{"Host endpoint policy accepted packet."},
 					},
-					{Action: JumpAction{Target: ChainCIDRBlock}},
 				},
 			}
 
@@ -732,7 +729,6 @@ var _ = Describe("Static", func() {
 						Action:  AcceptAction{},
 						Comment: []string{"Host endpoint policy accepted packet."},
 					},
-					{Action: JumpAction{Target: ChainCIDRBlock}},
 				},
 			}
 
@@ -760,7 +756,6 @@ var _ = Describe("Static", func() {
 						Action:  AcceptAction{},
 						Comment: []string{"Host endpoint policy accepted packet."},
 					},
-					{Action: JumpAction{Target: ChainCIDRBlock}},
 				},
 			}
 
@@ -782,7 +777,6 @@ var _ = Describe("Static", func() {
 						Action:  AcceptAction{},
 						Comment: []string{"Host endpoint policy accepted packet."},
 					},
-					{Action: JumpAction{Target: ChainCIDRBlock}},
 				},
 			}
 
@@ -1255,7 +1249,6 @@ var _ = Describe("Static", func() {
 							Action:  ReturnAction{},
 							Comment: []string{"Host endpoint policy accepted packet."},
 						},
-						{Action: JumpAction{Target: ChainCIDRBlock}},
 					},
 				}))
 			})


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Tests were failing on some systems because Felix couldn't detect MTU.  Turns out there are more possible prefixes for data interfaces.  This PR expands the regex to cover other cases.  The prefixes were found by reviewing hte systemd source code where they are generated: https://github.com/systemd/systemd/blob/master/src/udev/udev-builtin-net_id.c#L801

Beefed up the BPF regex equivalently.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Broaden the data interface detection regex to cover wifi and other devices.
```
