### PR TITLE
Fix application of normal HEP policy to traffic from host to a DNAT'd IP

### DIFF
--- a/dataplane/linux/endpoint_mgr.go
+++ b/dataplane/linux/endpoint_mgr.go
@@ -175,9 +175,10 @@ type endpointManager struct {
 	// hostEndpointsDirty is set to true when host endpoints are updated.
 	hostEndpointsDirty bool
 	// activeHostIfaceToChains maps host interface name to the chains that we've programmed.
-	activeHostIfaceToRawChains    map[string][]*iptables.Chain
-	activeHostIfaceToFiltChains   map[string][]*iptables.Chain
-	activeHostIfaceToMangleChains map[string][]*iptables.Chain
+	activeHostIfaceToRawChains           map[string][]*iptables.Chain
+	activeHostIfaceToFiltChains          map[string][]*iptables.Chain
+	activeHostIfaceToMangleIngressChains map[string][]*iptables.Chain
+	activeHostIfaceToMangleEgressChains  map[string][]*iptables.Chain
 	// Dispatch chains that we've programmed for host endpoints.
 	activeHostRawDispatchChains    map[string]*iptables.Chain
 	activeHostFilterDispatchChains map[string]*iptables.Chain
@@ -287,9 +288,10 @@ func newEndpointManagerWithShims(
 		rawHostEndpoints:   map[proto.HostEndpointID]*proto.HostEndpoint{},
 		hostEndpointsDirty: true,
 
-		activeHostIfaceToRawChains:    map[string][]*iptables.Chain{},
-		activeHostIfaceToFiltChains:   map[string][]*iptables.Chain{},
-		activeHostIfaceToMangleChains: map[string][]*iptables.Chain{},
+		activeHostIfaceToRawChains:           map[string][]*iptables.Chain{},
+		activeHostIfaceToFiltChains:          map[string][]*iptables.Chain{},
+		activeHostIfaceToMangleIngressChains: map[string][]*iptables.Chain{},
+		activeHostIfaceToMangleEgressChains:  map[string][]*iptables.Chain{},
 
 		// Caches of the current dispatch chains indexed by chain name.  We use these to
 		// calculate deltas when we need to update the chains.
@@ -882,11 +884,12 @@ func (m *endpointManager) resolveHostEndpoints() {
 	if !m.bpfEnabled {
 		// Set up programming for the host endpoints that are now to be used.
 		newHostIfaceFiltChains := map[string][]*iptables.Chain{}
+		newHostIfaceMangleEgressChains := map[string][]*iptables.Chain{}
 		for ifaceName, id := range newIfaceNameToHostEpID {
-			log.WithField("id", id).Info("Updating host endpoint chains.")
+			log.WithField("id", id).Info("Updating host endpoint normal policy chains.")
 			hostEp := m.rawHostEndpoints[id]
 
-			// Update the filter chain, for normal traffic.
+			// Update chains in the filter and mangle tables, for normal traffic.
 			var ingressPolicyNames, egressPolicyNames []string
 			var ingressForwardPolicyNames, egressForwardPolicyNames []string
 			if len(hostEp.Tiers) > 0 {
@@ -913,27 +916,38 @@ func (m *endpointManager) resolveHostEndpoints() {
 			}
 			newHostIfaceFiltChains[ifaceName] = filtChains
 			delete(m.activeHostIfaceToFiltChains, ifaceName)
+
+			mangleChains := m.ruleRenderer.HostEndpointToMangleEgressChains(
+				ifaceName,
+				egressPolicyNames,
+				hostEp.ProfileIds,
+			)
+			if !reflect.DeepEqual(mangleChains, m.activeHostIfaceToMangleEgressChains[ifaceName]) {
+				m.mangleTable.UpdateChains(mangleChains)
+			}
+			newHostIfaceMangleEgressChains[ifaceName] = mangleChains
+			delete(m.activeHostIfaceToMangleEgressChains, ifaceName)
 		}
 
-		newHostIfaceMangleChains := map[string][]*iptables.Chain{}
+		newHostIfaceMangleIngressChains := map[string][]*iptables.Chain{}
 		for ifaceName, id := range newPreDNATIfaceNameToHostEpID {
-			log.WithField("id", id).Info("Updating host endpoint mangle chains.")
+			log.WithField("id", id).Info("Updating host endpoint mangle ingress chains.")
 			hostEp := m.rawHostEndpoints[id]
 
-			// Update the mangle table, for preDNAT policy.
+			// Update the mangle table for preDNAT policy.
 			var ingressPolicyNames []string
 			if len(hostEp.PreDnatTiers) > 0 {
 				ingressPolicyNames = hostEp.PreDnatTiers[0].IngressPolicies
 			}
-			mangleChains := m.ruleRenderer.HostEndpointToMangleChains(
+			mangleChains := m.ruleRenderer.HostEndpointToMangleIngressChains(
 				ifaceName,
 				ingressPolicyNames,
 			)
-			if !reflect.DeepEqual(mangleChains, m.activeHostIfaceToMangleChains[ifaceName]) {
+			if !reflect.DeepEqual(mangleChains, m.activeHostIfaceToMangleIngressChains[ifaceName]) {
 				m.mangleTable.UpdateChains(mangleChains)
 			}
-			newHostIfaceMangleChains[ifaceName] = mangleChains
-			delete(m.activeHostIfaceToMangleChains, ifaceName)
+			newHostIfaceMangleIngressChains[ifaceName] = mangleChains
+			delete(m.activeHostIfaceToMangleIngressChains, ifaceName)
 		}
 
 		newHostIfaceRawChains := map[string][]*iptables.Chain{}
@@ -965,7 +979,12 @@ func (m *endpointManager) resolveHostEndpoints() {
 				"Host interface no longer protected, deleting its normal chains.")
 			m.filterTable.RemoveChains(chains)
 		}
-		for ifaceName, chains := range m.activeHostIfaceToMangleChains {
+		for ifaceName, chains := range m.activeHostIfaceToMangleEgressChains {
+			log.WithField("ifaceName", ifaceName).Info(
+				"Host interface no longer protected, deleting its mangle egress chains.")
+			m.mangleTable.RemoveChains(chains)
+		}
+		for ifaceName, chains := range m.activeHostIfaceToMangleIngressChains {
 			log.WithField("ifaceName", ifaceName).Info(
 				"Host interface no longer protected, deleting its preDNAT chains.")
 			m.mangleTable.RemoveChains(chains)
@@ -977,7 +996,8 @@ func (m *endpointManager) resolveHostEndpoints() {
 		}
 		m.callbacks.InvokeInterfaceCallbacks(m.activeIfaceNameToHostEpID, newIfaceNameToHostEpID)
 		m.activeHostIfaceToFiltChains = newHostIfaceFiltChains
-		m.activeHostIfaceToMangleChains = newHostIfaceMangleChains
+		m.activeHostIfaceToMangleEgressChains = newHostIfaceMangleEgressChains
+		m.activeHostIfaceToMangleIngressChains = newHostIfaceMangleIngressChains
 		m.activeHostIfaceToRawChains = newHostIfaceRawChains
 	}
 
@@ -1000,6 +1020,7 @@ func (m *endpointManager) resolveHostEndpoints() {
 		delete(newIfaceNameToHostEpID, allInterfaces)
 	}
 	newFilterDispatchChains := m.ruleRenderer.HostDispatchChains(newIfaceNameToHostEpID, defaultIfaceName, true)
+	newMangleEgressDispatchChains := m.ruleRenderer.ToHostDispatchChains(newIfaceNameToHostEpID, defaultIfaceName)
 	m.updateDispatchChains(m.activeHostFilterDispatchChains, newFilterDispatchChains, m.filterTable)
 	// Set flag to update endpoint mark chains.
 	m.needToCheckEndpointMarkChains = true
@@ -1013,7 +1034,8 @@ func (m *endpointManager) resolveHostEndpoints() {
 		defaultIfaceName = allInterfaces
 		delete(newPreDNATIfaceNameToHostEpID, allInterfaces)
 	}
-	newMangleDispatchChains := m.ruleRenderer.FromHostDispatchChains(newPreDNATIfaceNameToHostEpID, defaultIfaceName)
+	newMangleIngressDispatchChains := m.ruleRenderer.FromHostDispatchChains(newPreDNATIfaceNameToHostEpID, defaultIfaceName)
+	newMangleDispatchChains := append(newMangleIngressDispatchChains, newMangleEgressDispatchChains...)
 	m.updateDispatchChains(m.activeHostMangleDispatchChains, newMangleDispatchChains, m.mangleTable)
 
 	// Rewrite the raw dispatch chains if they've changed.

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -1206,6 +1206,9 @@ func (d *InternalDataplane) setUpIptablesNormal() {
 		t.InsertOrAppendRules("PREROUTING", []iptables.Rule{{
 			Action: iptables.JumpAction{Target: rules.ChainManglePrerouting},
 		}})
+		t.InsertOrAppendRules("POSTROUTING", []iptables.Rule{{
+			Action: iptables.JumpAction{Target: rules.ChainManglePostrouting},
+		}})
 	}
 	if d.xdpState != nil {
 		if err := d.setXDPFailsafePorts(); err != nil {

--- a/dataplane/linux/policy_mgr_test.go
+++ b/dataplane/linux/policy_mgr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2019-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -225,8 +225,10 @@ var _ = Describe("Policy manager", func() {
 			}})
 		})
 
-		It("should not install to the mangle table", func() {
-			mangleTable.checkChains([][]*iptables.Chain{})
+		It("should install the out chain to the mangle table", func() {
+			mangleTable.checkChains([][]*iptables.Chain{{
+				{Name: "cali-pro-prof1"},
+			}})
 		})
 
 		Describe("after a policy remove", func() {
@@ -255,13 +257,14 @@ func (r *mockPolRenderer) PolicyToIptablesChains(policyID *proto.PolicyID, polic
 		{Name: outName},
 	}
 }
-func (r *mockPolRenderer) ProfileToIptablesChains(profID *proto.ProfileID, policy *proto.Profile, ipVersion uint8) []*iptables.Chain {
-	inName := rules.ProfileChainName(rules.ProfileInboundPfx, profID)
-	outName := rules.ProfileChainName(rules.ProfileOutboundPfx, profID)
-	return []*iptables.Chain{
-		{Name: inName},
-		{Name: outName},
+func (r *mockPolRenderer) ProfileToIptablesChains(profID *proto.ProfileID, policy *proto.Profile, ipVersion uint8) (inbound, outbound *iptables.Chain) {
+	inbound = &iptables.Chain{
+		Name: rules.ProfileChainName(rules.ProfileInboundPfx, profID),
 	}
+	outbound = &iptables.Chain{
+		Name: rules.ProfileChainName(rules.ProfileOutboundPfx, profID),
+	}
+	return
 }
 
 func newMockPolRenderer() *mockPolRenderer {

--- a/fv/hostendpoints_test.go
+++ b/fv/hostendpoints_test.go
@@ -122,14 +122,7 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 			serviceIP := fmt.Sprintf("10.96.0.%v", i+1)
 
 			// Add a NAT rule for the service IP.
-			felixes[i].Exec(
-				"iptables",
-				"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
-				"-W", "100000", // How often to probe the lock in microsecs.
-				"-t", "nat", "-A", "OUTPUT",
-				"--destination", serviceIP,
-				"-j", "DNAT", "--to-destination", w[i].IP,
-			)
+			felixes[i].ProgramIptablesDNAT(serviceIP, w[i].IP, "OUTPUT")
 
 			// Expect connectivity to the service IP.
 			cc.ExpectSome(felixes[i], connectivity.TargetIP(serviceIP), 8055)
@@ -142,14 +135,7 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 			serviceIP := fmt.Sprintf("10.96.10.%v", i+1)
 
 			// Add a NAT rule for the service IP.
-			felixes[i].Exec(
-				"iptables",
-				"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
-				"-W", "100000", // How often to probe the lock in microsecs.
-				"-t", "nat", "-A", "OUTPUT",
-				"--destination", serviceIP,
-				"-j", "DNAT", "--to-destination", w[1-i].IP,
-			)
+			felixes[i].ProgramIptablesDNAT(serviceIP, w[1-i].IP, "OUTPUT")
 
 			// Expect not to be able to connect to the service IP.
 			cc.ExpectNone(felixes[i], connectivity.TargetIP(serviceIP), 8055)
@@ -165,14 +151,7 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 			serviceIP := fmt.Sprintf("10.96.10.%v", i+1)
 
 			// Add a NAT rule for the service IP.
-			felixes[i].Exec(
-				"iptables",
-				"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
-				"-W", "100000", // How often to probe the lock in microsecs.
-				"-t", "nat", "-A", "PREROUTING",
-				"--destination", serviceIP,
-				"-j", "DNAT", "--to-destination", w[1-i].IP,
-			)
+			felixes[i].ProgramIptablesDNAT(serviceIP, w[1-i].IP, "PREROUTING")
 
 			// Expect to connect from local pod to the service IP.
 			cc.ExpectSome(w[i], connectivity.TargetIP(serviceIP), 8055)

--- a/fv/infrastructure/felix.go
+++ b/fv/infrastructure/felix.go
@@ -200,3 +200,14 @@ func (f *Felix) Restart() {
 func (f *Felix) AttachTCPDump(iface string) *tcpdump.TCPDump {
 	return tcpdump.Attach(f.Container.Name, "", iface)
 }
+
+func (f *Felix) ProgramIptablesDNAT(serviceIP, targetIP, chain string) {
+	f.Exec(
+		"iptables",
+		"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
+		"-W", "100000", // How often to probe the lock in microsecs.
+		"-t", "nat", "-A", chain,
+		"--destination", serviceIP,
+		"-j", "DNAT", "--to-destination", targetIP,
+	)
+}

--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	"github.com/projectcalico/libcalico-go/lib/options"
 )
 
@@ -170,6 +171,106 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 			cc.ExpectSome(w[0], w[1])
 			cc.ExpectSome(w[1], w[0])
 			cc.CheckConnectivity()
+		})
+
+		Context("with policy allowing port 8055", func() {
+			BeforeEach(func() {
+				tcp := numorstring.ProtocolFromString("tcp")
+				udp := numorstring.ProtocolFromString("udp")
+				p8055 := numorstring.SinglePort(8055)
+				policy := api.NewGlobalNetworkPolicy()
+				policy.Name = "allow-8055"
+				policy.Spec.Ingress = []api.Rule{
+					{
+						Protocol: &udp,
+						Destination: api.EntityRule{
+							Ports: []numorstring.Port{p8055},
+						},
+						Action: api.Allow,
+					},
+					{
+						Protocol: &tcp,
+						Destination: api.EntityRule{
+							Ports: []numorstring.Port{p8055},
+						},
+						Action: api.Allow,
+					},
+				}
+				policy.Spec.Egress = []api.Rule{
+					{
+						Protocol: &udp,
+						Destination: api.EntityRule{
+							Ports: []numorstring.Port{p8055},
+						},
+						Action: api.Allow,
+					},
+					{
+						Protocol: &tcp,
+						Destination: api.EntityRule{
+							Ports: []numorstring.Port{p8055},
+						},
+						Action: api.Allow,
+					},
+				}
+				policy.Spec.Selector = fmt.Sprintf("has(host-endpoint)")
+				_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			// Test each of these cases separately, to avoid the possibility of one case
+			// setting up conntrack state that allows a different case to pass.
+			It("allows host0 to remote host-networked workload", func() {
+				cc.ExpectSome(felixes[0], hostW[1])
+				cc.CheckConnectivity()
+			})
+			It("allows host1 to remote host-networked workload", func() {
+				cc.ExpectSome(felixes[1], hostW[0])
+				cc.CheckConnectivity()
+			})
+			It("allows host0 to remote Calico-networked workload", func() {
+				cc.ExpectSome(felixes[0], w[1])
+				cc.CheckConnectivity()
+			})
+			It("allows host1 to remote Calico-networked workload", func() {
+				cc.ExpectSome(felixes[1], w[0])
+				cc.CheckConnectivity()
+			})
+			It("allows host0 to remote Calico-networked workload via service IP", func() {
+				// Allocate a service IP.
+				serviceIP := "10.96.10.1"
+
+				// Add a NAT rule for the service IP.
+				felixes[0].Exec(
+					"iptables",
+					"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
+					"-W", "100000", // How often to probe the lock in microsecs.
+					"-t", "nat", "-A", "OUTPUT",
+					"--destination", serviceIP,
+					"-j", "DNAT", "--to-destination", w[1].IP,
+				)
+
+				// Expect to connect to the service IP.
+				cc.ExpectSome(felixes[0], connectivity.TargetIP(serviceIP), 8055)
+				cc.CheckConnectivity()
+			})
+			It("allows host1 to remote Calico-networked workload via service IP", func() {
+				// Allocate a service IP.
+				serviceIP := "10.96.10.2"
+
+				// Add a NAT rule for the service IP.
+				felixes[1].Exec(
+					"iptables",
+					"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
+					"-W", "100000", // How often to probe the lock in microsecs.
+					"-t", "nat", "-A", "OUTPUT",
+					"--destination", serviceIP,
+					"-j", "DNAT", "--to-destination", w[0].IP,
+				)
+
+				// Expect to connect to the service IP.
+				cc.ExpectSome(felixes[1], connectivity.TargetIP(serviceIP), 8055)
+				cc.CheckConnectivity()
+			})
 		})
 	})
 

--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -304,14 +304,7 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 				serviceIP := "10.96.10.1"
 
 				// Add a NAT rule for the service IP.
-				felixes[0].Exec(
-					"iptables",
-					"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
-					"-W", "100000", // How often to probe the lock in microsecs.
-					"-t", "nat", "-A", "OUTPUT",
-					"--destination", serviceIP,
-					"-j", "DNAT", "--to-destination", w[1].IP,
-				)
+				felixes[0].ProgramIptablesDNAT(serviceIP, w[1].IP, "OUTPUT")
 
 				// Expect to connect to the service IP.
 				cc.ExpectSome(felixes[0], connectivity.TargetIP(serviceIP), 8055)

--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -296,24 +296,9 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			// Test each of these cases separately, to avoid the possibility of one case
-			// setting up conntrack state that allows a different case to pass.
-			It("allows host0 to remote host-networked workload", func() {
-				cc.ExpectSome(felixes[0], hostW[1])
-				cc.CheckConnectivity()
-			})
-			It("allows host1 to remote host-networked workload", func() {
-				cc.ExpectSome(felixes[1], hostW[0])
-				cc.CheckConnectivity()
-			})
-			It("allows host0 to remote Calico-networked workload", func() {
-				cc.ExpectSome(felixes[0], w[1])
-				cc.CheckConnectivity()
-			})
-			It("allows host1 to remote Calico-networked workload", func() {
-				cc.ExpectSome(felixes[1], w[0])
-				cc.CheckConnectivity()
-			})
+			// Please take care if adding other connectivity checks into this case, to
+			// avoid those other checks setting up conntrack state that allows the
+			// existing case to pass for a different reason.
 			It("allows host0 to remote Calico-networked workload via service IP", func() {
 				// Allocate a service IP.
 				serviceIP := "10.96.10.1"
@@ -330,24 +315,6 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 
 				// Expect to connect to the service IP.
 				cc.ExpectSome(felixes[0], connectivity.TargetIP(serviceIP), 8055)
-				cc.CheckConnectivity()
-			})
-			It("allows host1 to remote Calico-networked workload via service IP", func() {
-				// Allocate a service IP.
-				serviceIP := "10.96.10.2"
-
-				// Add a NAT rule for the service IP.
-				felixes[1].Exec(
-					"iptables",
-					"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
-					"-W", "100000", // How often to probe the lock in microsecs.
-					"-t", "nat", "-A", "OUTPUT",
-					"--destination", serviceIP,
-					"-j", "DNAT", "--to-destination", w[0].IP,
-				)
-
-				// Expect to connect to the service IP.
-				cc.ExpectSome(felixes[1], connectivity.TargetIP(serviceIP), 8055)
 				cc.CheckConnectivity()
 			})
 		})

--- a/fv/vxlan_test.go
+++ b/fv/vxlan_test.go
@@ -324,14 +324,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 							serviceIP := "10.96.10.1"
 
 							// Add a NAT rule for the service IP.
-							felixes[0].Exec(
-								"iptables",
-								"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
-								"-W", "100000", // How often to probe the lock in microsecs.
-								"-t", "nat", "-A", "OUTPUT",
-								"--destination", serviceIP,
-								"-j", "DNAT", "--to-destination", w[1].IP,
-							)
+							felixes[0].ProgramIptablesDNAT(serviceIP, w[1].IP, "OUTPUT")
 
 							// Expect to connect to the service IP.
 							cc.ExpectSome(felixes[0], connectivity.TargetIP(serviceIP), 8055)

--- a/fv/vxlan_test.go
+++ b/fv/vxlan_test.go
@@ -316,24 +316,9 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 							Expect(err).NotTo(HaveOccurred())
 						})
 
-						// Test each of these cases separately, to avoid the possibility of one case
-						// setting up conntrack state that allows a different case to pass.
-						It("allows host0 to remote host-networked workload", func() {
-							cc.ExpectSome(felixes[0], hostW[1])
-							cc.CheckConnectivity()
-						})
-						It("allows host1 to remote host-networked workload", func() {
-							cc.ExpectSome(felixes[1], hostW[0])
-							cc.CheckConnectivity()
-						})
-						It("allows host0 to remote Calico-networked workload", func() {
-							cc.ExpectSome(felixes[0], w[1])
-							cc.CheckConnectivity()
-						})
-						It("allows host1 to remote Calico-networked workload", func() {
-							cc.ExpectSome(felixes[1], w[0])
-							cc.CheckConnectivity()
-						})
+						// Please take care if adding other connectivity checks into this case, to
+						// avoid those other checks setting up conntrack state that allows the
+						// existing case to pass for a different reason.
 						It("allows host0 to remote Calico-networked workload via service IP", func() {
 							// Allocate a service IP.
 							serviceIP := "10.96.10.1"
@@ -350,24 +335,6 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 
 							// Expect to connect to the service IP.
 							cc.ExpectSome(felixes[0], connectivity.TargetIP(serviceIP), 8055)
-							cc.CheckConnectivity()
-						})
-						It("allows host1 to remote Calico-networked workload via service IP", func() {
-							// Allocate a service IP.
-							serviceIP := "10.96.10.2"
-
-							// Add a NAT rule for the service IP.
-							felixes[1].Exec(
-								"iptables",
-								"-w", "10", // Retry this for 10 seconds, e.g. if something else is holding the lock
-								"-W", "100000", // How often to probe the lock in microsecs.
-								"-t", "nat", "-A", "OUTPUT",
-								"--destination", serviceIP,
-								"-j", "DNAT", "--to-destination", w[0].IP,
-							)
-
-							// Expect to connect to the service IP.
-							cc.ExpectSome(felixes[1], connectivity.TargetIP(serviceIP), 8055)
 							cc.CheckConnectivity()
 						})
 					})

--- a/fv/vxlan_test.go
+++ b/fv/vxlan_test.go
@@ -185,6 +185,92 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						cc.ExpectSome(w[1], w[0])
 						cc.CheckConnectivity()
 					})
+				})
+
+				Context("with all-interfaces host protection policy in place", func() {
+					BeforeEach(func() {
+						// Make sure our new host endpoints don't cut felix off from the datastore.
+						err := infra.AddAllowToDatastore("host-endpoint=='true'")
+						Expect(err).NotTo(HaveOccurred())
+
+						ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+						defer cancel()
+
+						for _, f := range felixes {
+							hep := api.NewHostEndpoint()
+							hep.Name = "all-interfaces-" + f.Name
+							hep.Labels = map[string]string{
+								"host-endpoint": "true",
+								"hostname":      f.Hostname,
+							}
+							hep.Spec.Node = f.Hostname
+							hep.Spec.ExpectedIPs = []string{f.IP}
+							hep.Spec.InterfaceName = "*"
+							_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
+							Expect(err).NotTo(HaveOccurred())
+						}
+					})
+
+					It("should have workload connectivity but not host connectivity", func() {
+						// Host endpoints (with no policies) block host-host traffic due to default drop.
+						cc.ExpectNone(felixes[0], hostW[1])
+						cc.ExpectNone(felixes[1], hostW[0])
+
+						// Host => workload is not allowed
+						cc.ExpectNone(felixes[0], w[1])
+						cc.ExpectNone(felixes[1], w[0])
+
+						// But host => own-workload is allowed
+						cc.ExpectSome(felixes[0], w[0])
+						cc.ExpectSome(felixes[1], w[1])
+
+						// But the rules to allow VXLAN between our hosts let the workload traffic through.
+						cc.ExpectSome(w[0], w[1])
+						cc.ExpectSome(w[1], w[0])
+						cc.CheckConnectivity()
+					})
+
+					It("should allow felixes[0] to reach felixes[1] if ingress and egress policies are in place", func() {
+						// Create a policy selecting felix[0] that allows egress.
+						policy := api.NewGlobalNetworkPolicy()
+						policy.Name = "f0-egress"
+						policy.Spec.Egress = []api.Rule{{Action: api.Allow}}
+						policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[0].Hostname)
+						_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+						Expect(err).NotTo(HaveOccurred())
+
+						// But there is no policy allowing ingress into felix[1].
+						cc.ExpectNone(felixes[0], hostW[1])
+
+						// felixes[1] can't reach felixes[0].
+						cc.ExpectNone(felixes[1], hostW[0])
+
+						// Workload connectivity is unchanged.
+						cc.ExpectSome(w[0], w[1])
+						cc.ExpectSome(w[1], w[0])
+						cc.CheckConnectivity()
+
+						cc.ResetExpectations()
+
+						// Now add a policy selecting felix[1] that allows ingress.
+						policy = api.NewGlobalNetworkPolicy()
+						policy.Name = "f1-ingress"
+						policy.Spec.Ingress = []api.Rule{{Action: api.Allow}}
+						policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[1].Hostname)
+						_, err = client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+						Expect(err).NotTo(HaveOccurred())
+
+						// Now felixes[0] can reach felixes[1].
+						cc.ExpectSome(felixes[0], hostW[1])
+
+						// felixes[1] still can't reach felixes[0].
+						cc.ExpectNone(felixes[1], hostW[0])
+
+						// Workload connectivity is unchanged.
+						cc.ExpectSome(w[0], w[1])
+						cc.ExpectSome(w[1], w[0])
+						cc.CheckConnectivity()
+					})
 
 					Context("with policy allowing port 8055", func() {
 						BeforeEach(func() {
@@ -284,92 +370,6 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 							cc.ExpectSome(felixes[1], connectivity.TargetIP(serviceIP), 8055)
 							cc.CheckConnectivity()
 						})
-					})
-				})
-
-				Context("with all-interfaces host protection policy in place", func() {
-					BeforeEach(func() {
-						// Make sure our new host endpoints don't cut felix off from the datastore.
-						err := infra.AddAllowToDatastore("host-endpoint=='true'")
-						Expect(err).NotTo(HaveOccurred())
-
-						ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-						defer cancel()
-
-						for _, f := range felixes {
-							hep := api.NewHostEndpoint()
-							hep.Name = "all-interfaces-" + f.Name
-							hep.Labels = map[string]string{
-								"host-endpoint": "true",
-								"hostname":      f.Hostname,
-							}
-							hep.Spec.Node = f.Hostname
-							hep.Spec.ExpectedIPs = []string{f.IP}
-							hep.Spec.InterfaceName = "*"
-							_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
-							Expect(err).NotTo(HaveOccurred())
-						}
-					})
-
-					It("should have workload connectivity but not host connectivity", func() {
-						// Host endpoints (with no policies) block host-host traffic due to default drop.
-						cc.ExpectNone(felixes[0], hostW[1])
-						cc.ExpectNone(felixes[1], hostW[0])
-
-						// Host => workload is not allowed
-						cc.ExpectNone(felixes[0], w[1])
-						cc.ExpectNone(felixes[1], w[0])
-
-						// But host => own-workload is allowed
-						cc.ExpectSome(felixes[0], w[0])
-						cc.ExpectSome(felixes[1], w[1])
-
-						// But the rules to allow VXLAN between our hosts let the workload traffic through.
-						cc.ExpectSome(w[0], w[1])
-						cc.ExpectSome(w[1], w[0])
-						cc.CheckConnectivity()
-					})
-
-					It("should allow felixes[0] to reach felixes[1] if ingress and egress policies are in place", func() {
-						// Create a policy selecting felix[0] that allows egress.
-						policy := api.NewGlobalNetworkPolicy()
-						policy.Name = "f0-egress"
-						policy.Spec.Egress = []api.Rule{{Action: api.Allow}}
-						policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[0].Hostname)
-						_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
-						Expect(err).NotTo(HaveOccurred())
-
-						// But there is no policy allowing ingress into felix[1].
-						cc.ExpectNone(felixes[0], hostW[1])
-
-						// felixes[1] can't reach felixes[0].
-						cc.ExpectNone(felixes[1], hostW[0])
-
-						// Workload connectivity is unchanged.
-						cc.ExpectSome(w[0], w[1])
-						cc.ExpectSome(w[1], w[0])
-						cc.CheckConnectivity()
-
-						cc.ResetExpectations()
-
-						// Now add a policy selecting felix[1] that allows ingress.
-						policy = api.NewGlobalNetworkPolicy()
-						policy.Name = "f1-ingress"
-						policy.Spec.Ingress = []api.Rule{{Action: api.Allow}}
-						policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[1].Hostname)
-						_, err = client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
-						Expect(err).NotTo(HaveOccurred())
-
-						// Now felixes[0] can reach felixes[1].
-						cc.ExpectSome(felixes[0], hostW[1])
-
-						// felixes[1] still can't reach felixes[0].
-						cc.ExpectNone(felixes[1], hostW[0])
-
-						// Workload connectivity is unchanged.
-						cc.ExpectSome(w[0], w[1])
-						cc.ExpectSome(w[1], w[0])
-						cc.CheckConnectivity()
 					})
 				})
 

--- a/iptables/match_builder.go
+++ b/iptables/match_builder.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -150,6 +150,10 @@ func (m MatchCriteria) DestAddrType(addrType AddrType) MatchCriteria {
 
 func (m MatchCriteria) ConntrackState(stateNames string) MatchCriteria {
 	return append(m, fmt.Sprintf("-m conntrack --ctstate %s", stateNames))
+}
+
+func (m MatchCriteria) NotConntrackState(stateNames string) MatchCriteria {
+	return append(m, fmt.Sprintf("-m conntrack ! --ctstate %s", stateNames))
 }
 
 func (m MatchCriteria) Protocol(name string) MatchCriteria {

--- a/iptables/table.go
+++ b/iptables/table.go
@@ -516,7 +516,7 @@ func (t *Table) UpdateChain(chain *Chain) {
 
 	// Defensive: make sure we re-read the dataplane state before we make updates.  While the
 	// code was originally designed not to need this, we found that other users of
-	// iptables-restore can still clobber out updates so it's safest to re-read the state before
+	// iptables-restore can still clobber our updates so it's safest to re-read the state before
 	// each write.
 	t.InvalidateDataplaneCache("chain update")
 }

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -182,7 +182,9 @@ func (r *DefaultRuleRenderer) HostEndpointToMangleEgressChains(
 ) []*Chain {
 	log.WithField("ifaceName", ifaceName).Debug("Render host endpoint mangle egress chain.")
 	return []*Chain{
-		// Chain for output traffic _to_ the endpoint.
+		// Chain for output traffic _to_ the endpoint.  Note, we use RETURN here rather than
+		// ACCEPT because the mangle table is typically used, if at all, for packet
+		// manipulations that might need to apply to our allowed traffic.
 		r.endpointIptablesChain(
 			egressPolicyNames,
 			profileIDs,
@@ -193,7 +195,7 @@ func (r *DefaultRuleRenderer) HostEndpointToMangleEgressChains(
 			ChainFailsafeOut,
 			chainTypeNormal,
 			true, // Host endpoints are always admin up.
-			r.filterAllowAction,
+			ReturnAction{},
 			alwaysAllowVXLANEncap,
 			alwaysAllowIPIPEncap,
 		),

--- a/rules/endpoints.go
+++ b/rules/endpoints.go
@@ -175,6 +175,31 @@ func (r *DefaultRuleRenderer) HostEndpointToFilterChains(
 	return result
 }
 
+func (r *DefaultRuleRenderer) HostEndpointToMangleEgressChains(
+	ifaceName string,
+	egressPolicyNames []string,
+	profileIDs []string,
+) []*Chain {
+	log.WithField("ifaceName", ifaceName).Debug("Render host endpoint mangle egress chain.")
+	return []*Chain{
+		// Chain for output traffic _to_ the endpoint.
+		r.endpointIptablesChain(
+			egressPolicyNames,
+			profileIDs,
+			ifaceName,
+			PolicyOutboundPfx,
+			ProfileOutboundPfx,
+			HostToEndpointPfx,
+			ChainFailsafeOut,
+			chainTypeNormal,
+			true, // Host endpoints are always admin up.
+			r.filterAllowAction,
+			alwaysAllowVXLANEncap,
+			alwaysAllowIPIPEncap,
+		),
+	}
+}
+
 func (r *DefaultRuleRenderer) HostEndpointToRawChains(
 	ifaceName string,
 	ingressPolicyNames []string,
@@ -215,7 +240,7 @@ func (r *DefaultRuleRenderer) HostEndpointToRawChains(
 	}
 }
 
-func (r *DefaultRuleRenderer) HostEndpointToMangleChains(
+func (r *DefaultRuleRenderer) HostEndpointToMangleIngressChains(
 	ifaceName string,
 	preDNATPolicyNames []string,
 ) []*Chain {

--- a/rules/endpoints_test.go
+++ b/rules/endpoints_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018,2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -477,7 +477,7 @@ var _ = Describe("Endpoints", func() {
 			})
 
 			It("should render host endpoint mangle chains with pre-DNAT policies", func() {
-				Expect(renderer.HostEndpointToMangleChains(
+				Expect(renderer.HostEndpointToMangleIngressChains(
 					"eth0",
 					[]string{"c"},
 				)).To(Equal([]*Chain{
@@ -570,7 +570,7 @@ var _ = Describe("Endpoints", func() {
 			})
 
 			It("should render host endpoint mangle chains with pre-DNAT policies", func() {
-				Expect(renderer.HostEndpointToMangleChains(
+				Expect(renderer.HostEndpointToMangleIngressChains(
 					"eth0",
 					[]string{"c"},
 				)).To(Equal([]*Chain{

--- a/rules/policy.go
+++ b/rules/policy.go
@@ -40,16 +40,16 @@ func (r *DefaultRuleRenderer) PolicyToIptablesChains(policyID *proto.PolicyID, p
 	return []*iptables.Chain{&inbound, &outbound}
 }
 
-func (r *DefaultRuleRenderer) ProfileToIptablesChains(profileID *proto.ProfileID, profile *proto.Profile, ipVersion uint8) []*iptables.Chain {
-	inbound := iptables.Chain{
+func (r *DefaultRuleRenderer) ProfileToIptablesChains(profileID *proto.ProfileID, profile *proto.Profile, ipVersion uint8) (inbound, outbound *iptables.Chain) {
+	inbound = &iptables.Chain{
 		Name:  ProfileChainName(ProfileInboundPfx, profileID),
 		Rules: r.ProtoRulesToIptablesRules(profile.InboundRules, ipVersion),
 	}
-	outbound := iptables.Chain{
+	outbound = &iptables.Chain{
 		Name:  ProfileChainName(ProfileOutboundPfx, profileID),
 		Rules: r.ProtoRulesToIptablesRules(profile.OutboundRules, ipVersion),
 	}
-	return []*iptables.Chain{&inbound, &outbound}
+	return
 }
 
 func (r *DefaultRuleRenderer) ProtoRulesToIptablesRules(protoRules []*proto.Rule, ipVersion uint8) []iptables.Rule {

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -187,6 +187,7 @@ type RuleRenderer interface {
 
 	HostDispatchChains(map[string]proto.HostEndpointID, string, bool) []*iptables.Chain
 	FromHostDispatchChains(map[string]proto.HostEndpointID, string) []*iptables.Chain
+	ToHostDispatchChains(map[string]proto.HostEndpointID, string) []*iptables.Chain
 	HostEndpointToFilterChains(
 		ifaceName string,
 		epMarkMapper EndpointMarkMapper,
@@ -196,12 +197,17 @@ type RuleRenderer interface {
 		egressForwardPolicyNames []string,
 		profileIDs []string,
 	) []*iptables.Chain
+	HostEndpointToMangleEgressChains(
+		ifaceName string,
+		egressPolicyNames []string,
+		profileIDs []string,
+	) []*iptables.Chain
 	HostEndpointToRawChains(
 		ifaceName string,
 		ingressPolicyNames []string,
 		egressPolicyNames []string,
 	) []*iptables.Chain
-	HostEndpointToMangleChains(
+	HostEndpointToMangleIngressChains(
 		ifaceName string,
 		preDNATPolicyNames []string,
 	) []*iptables.Chain

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -52,7 +52,8 @@ const (
 	ChainNATOutput      = ChainNamePrefix + "OUTPUT"
 	ChainNATOutgoing    = ChainNamePrefix + "nat-outgoing"
 
-	ChainManglePrerouting = ChainNamePrefix + "PREROUTING"
+	ChainManglePrerouting  = ChainNamePrefix + "PREROUTING"
+	ChainManglePostrouting = ChainNamePrefix + "POSTROUTING"
 
 	IPSetIDNATOutgoingAllPools  = "all-ipam-pools"
 	IPSetIDNATOutgoingMasqPools = "masq-ipam-pools"

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -213,7 +213,7 @@ type RuleRenderer interface {
 	) []*iptables.Chain
 
 	PolicyToIptablesChains(policyID *proto.PolicyID, policy *proto.Policy, ipVersion uint8) []*iptables.Chain
-	ProfileToIptablesChains(profileID *proto.ProfileID, policy *proto.Profile, ipVersion uint8) []*iptables.Chain
+	ProfileToIptablesChains(profileID *proto.ProfileID, policy *proto.Profile, ipVersion uint8) (inbound, outbound *iptables.Chain)
 	ProtoRuleToIptablesRules(pRule *proto.Rule, ipVersion uint8) []iptables.Rule
 
 	MakeNatOutgoingRule(protocol string, action iptables.Action, ipVersion uint8) iptables.Rule

--- a/rules/static.go
+++ b/rules/static.go
@@ -875,6 +875,12 @@ func (r *DefaultRuleRenderer) StaticManglePostroutingChain(ipVersion uint8) *Cha
 		r.addIPIPVXLANEgressAllowRules(&rules)
 	}
 
+	// Note: the similar sequence in filterOutputChain has rules here to detect traffic to local
+	// workloads, and to return early in that case.  We don't need those rules here because
+	// ChainDispatchToHostEndpoint also checks for traffic to a local workload, and avoids
+	// applying any host endpoint policy in that case.  Search for "Skip egress WHEP" in
+	// dispatch.go, to see that.
+
 	// Apply host endpoint policy to non-forwarded traffic that has been DNAT'd.  We do this
 	// here, rather than in filter-OUTPUT, because Linux is weird: when a host-originated packet
 	// is DNAT'd (typically in nat-OUTPUT), its destination IP is changed immediately, but Linux

--- a/rules/static.go
+++ b/rules/static.go
@@ -563,8 +563,8 @@ func (r *DefaultRuleRenderer) filterOutputChain(ipVersion uint8) *Chain {
 		// Divert those packets to a chain that handles them as we would if they had hit the FORWARD
 		// chain.
 		//
-		// We use a goto so that a RETURN from that chain will continue execution in the OUTPUT
-		// chain.
+		// We use a goto so that a RETURN from that chain will skip the rest of this chain
+		// and continue execution in the parent chain (OUTPUT).
 		rules = append(rules,
 			Rule{
 				Match:  Match().MarkNotClear(r.IptablesMarkEndpoint),
@@ -768,6 +768,7 @@ func (r *DefaultRuleRenderer) StaticMangleTableChains(ipVersion uint8) []*Chain 
 	chains = append(chains,
 		r.failsafeInChain("mangle"),
 		r.StaticManglePreroutingChain(ipVersion),
+		r.StaticManglePostroutingChain(ipVersion),
 	)
 
 	return chains
@@ -822,6 +823,15 @@ func (r *DefaultRuleRenderer) StaticManglePreroutingChain(ipVersion uint8) *Chai
 
 	return &Chain{
 		Name:  ChainManglePrerouting,
+		Rules: rules,
+	}
+}
+
+func (r *DefaultRuleRenderer) StaticManglePostroutingChain(ipVersion uint8) *Chain {
+	rules := []Rule{}
+
+	return &Chain{
+		Name:  ChainManglePostrouting,
 		Rules: rules,
 	}
 }

--- a/rules/static.go
+++ b/rules/static.go
@@ -638,7 +638,12 @@ func (r *DefaultRuleRenderer) filterOutputChain(ipVersion uint8) *Chain {
 	// only include nodes that support wireguard. This will tie in with whether or not we want to include external
 	// wireguard destinations.
 
-	// Apply host endpoint policy.
+	// Apply host endpoint policy to traffic that has not been DNAT'd.  In the DNAT case we
+	// can't correctly apply policy here because the packet's OIF is still the OIF from a
+	// routing lookup based on the pre-DNAT destination IP; Linux will shortly update it based
+	// on the new destination IP, but that hasn't happened yet.  Instead, in the DNAT case, we
+	// apply host endpoint in the mangle POSTROUTING chain; see StaticManglePostroutingChain for
+	// that.
 	rules = append(rules,
 		Rule{
 			Action: ClearMarkAction{Mark: r.allCalicoMarkBits()},

--- a/rules/static.go
+++ b/rules/static.go
@@ -873,11 +873,11 @@ func (r *DefaultRuleRenderer) StaticManglePostroutingChain(ipVersion uint8) *Cha
 	// At this point we know that the packet is not forwarded, so it must be originated by a
 	// host-based process or host-networked pod.
 
-	if ipVersion == 4 {
-		rules = r.appendIPIPVXLANEgressAllowRules(rules)
-	}
+	// The similar sequence in filterOutputChain has rules here to allow IPIP and VXLAN traffic.
+	// We don't need those rules here because the encapsulated traffic won't match `--ctstate
+	// DNAT` and so we won't try applying HEP policy to it anyway.
 
-	// Note: the similar sequence in filterOutputChain has rules here to detect traffic to local
+	// The similar sequence in filterOutputChain has rules here to detect traffic to local
 	// workloads, and to return early in that case.  We don't need those rules here because
 	// ChainDispatchToHostEndpoint also checks for traffic to a local workload, and avoids
 	// applying any host endpoint policy in that case.  Search for "Skip egress WHEP" in

--- a/rules/static.go
+++ b/rules/static.go
@@ -521,6 +521,14 @@ func (r *DefaultRuleRenderer) StaticFilterForwardChains() []*Chain {
 		},
 	)
 
+	// Set IptablesMarkAccept bit here, to indicate to our mangle-POSTROUTING chain that this is
+	// forwarded traffic and should not be subject to normal host endpoint policy.
+	rules = append(rules,
+		Rule{
+			Action: SetMarkAction{Mark: r.IptablesMarkAccept},
+		},
+	)
+
 	return []*Chain{{
 		Name:  ChainFilterForward,
 		Rules: rules,
@@ -595,40 +603,9 @@ func (r *DefaultRuleRenderer) filterOutputChain(ipVersion uint8) *Chain {
 	// If we reach here, the packet is not going to a workload so it must be going to a
 	// host endpoint. It also has no endpoint mark so it must be going from a process.
 
-	if ipVersion == 4 && r.IPIPEnabled {
-		// When IPIP is enabled, auto-allow IPIP traffic to other Calico nodes.  Without this,
-		// it's too easy to make a host policy that blocks IPIP traffic, resulting in very confusing
-		// connectivity problems.
-		rules = append(rules,
-			Rule{
-				Match: Match().ProtocolNum(ProtoIPIP).
-					DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllHostNets)).
-					SrcAddrType(AddrTypeLocal, false),
-				Action:  r.filterAllowAction,
-				Comment: []string{"Allow IPIP packets to other Calico hosts"},
-			},
-		)
+	if ipVersion == 4 {
+		r.addIPIPVXLANEgressAllowRules(&rules)
 	}
-
-	if ipVersion == 4 && r.VXLANEnabled {
-		// When VXLAN is enabled, auto-allow VXLAN traffic to other Calico nodes.  Without this,
-		// it's too easy to make a host policy that blocks VXLAN traffic, resulting in very confusing
-		// connectivity problems.
-		rules = append(rules,
-			Rule{
-				Match: Match().ProtocolNum(ProtoUDP).
-					DestPorts(uint16(r.Config.VXLANPort)).
-					SrcAddrType(AddrTypeLocal, false).
-					DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets)),
-				Action:  r.filterAllowAction,
-				Comment: []string{"Allow VXLAN packets to other whitelisted hosts"},
-			},
-		)
-	}
-
-	// TODO(rlb): For wireguard, we add the destination port to the failsafes. We may want to revisit this so that we
-	// only include nodes that support wireguard. This will tie in with whether or not we want to include external
-	// wireguard destinations.
 
 	// Apply host endpoint policy.
 	rules = append(rules,
@@ -650,6 +627,44 @@ func (r *DefaultRuleRenderer) filterOutputChain(ipVersion uint8) *Chain {
 		Name:  ChainFilterOutput,
 		Rules: rules,
 	}
+}
+
+func (r *DefaultRuleRenderer) addIPIPVXLANEgressAllowRules(rules *[]Rule) {
+
+	if r.IPIPEnabled {
+		// When IPIP is enabled, auto-allow IPIP traffic to other Calico nodes.  Without this,
+		// it's too easy to make a host policy that blocks IPIP traffic, resulting in very confusing
+		// connectivity problems.
+		*rules = append(*rules,
+			Rule{
+				Match: Match().ProtocolNum(ProtoIPIP).
+					DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllHostNets)).
+					SrcAddrType(AddrTypeLocal, false),
+				Action:  r.filterAllowAction,
+				Comment: []string{"Allow IPIP packets to other Calico hosts"},
+			},
+		)
+	}
+
+	if r.VXLANEnabled {
+		// When VXLAN is enabled, auto-allow VXLAN traffic to other Calico nodes.  Without this,
+		// it's too easy to make a host policy that blocks VXLAN traffic, resulting in very confusing
+		// connectivity problems.
+		*rules = append(*rules,
+			Rule{
+				Match: Match().ProtocolNum(ProtoUDP).
+					DestPorts(uint16(r.Config.VXLANPort)).
+					SrcAddrType(AddrTypeLocal, false).
+					DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets)),
+				Action:  r.filterAllowAction,
+				Comment: []string{"Allow VXLAN packets to other whitelisted hosts"},
+			},
+		)
+	}
+
+	// TODO(rlb): For wireguard, we add the destination port to the failsafes. We may want to revisit this so that we
+	// only include nodes that support wireguard. This will tie in with whether or not we want to include external
+	// wireguard destinations.
 }
 
 func (r *DefaultRuleRenderer) StaticNATTableChains(ipVersion uint8) (chains []*Chain) {
@@ -832,7 +847,40 @@ func (r *DefaultRuleRenderer) StaticManglePreroutingChain(ipVersion uint8) *Chai
 func (r *DefaultRuleRenderer) StaticManglePostroutingChain(ipVersion uint8) *Chain {
 	rules := []Rule{}
 
-	// Apply host endpoint policy.
+	// Accept immediately if IptablesMarkAccept is set.  Our filter-FORWARD chain sets this for
+	// any packets that reach the end of that chain.  The principle is that we don't want to
+	// apply normal host endpoint policy to forwarded traffic.
+	rules = append(rules, r.acceptAlreadyAccepted()...)
+
+	// Similarly, avoid applying normal host endpoint policy to IPVS-forwarded traffic.
+	// IPVS-forwarded traffic is identified by having a non-zero endpoint ID in the
+	// IptablesMarkEndpoint bits.  Note: we only need this check for when net.ipv4.vs.conntrack
+	// is enabled.  When net.ipv4.vs.conntrack is disabled (which is the default),
+	// IPVS-forwarded traffic will fail the ConntrackState("DNAT") match below, and so would
+	// avoid normal host endpoint policy anyway.  But it doesn't hurt to have this additional
+	// check even when not strictly needed.
+	if r.KubeIPVSSupportEnabled {
+		rules = append(rules,
+			Rule{
+				Match:  Match().MarkNotClear(r.IptablesMarkEndpoint),
+				Action: r.filterAllowAction,
+			},
+		)
+	}
+
+	// At this point we know that the packet is not forwarded, so it must be originated by a
+	// host-based process or host-networked pod.
+
+	if ipVersion == 4 {
+		r.addIPIPVXLANEgressAllowRules(&rules)
+	}
+
+	// Apply host endpoint policy to non-forwarded traffic that has been DNAT'd.  We do this
+	// here, rather than in filter-OUTPUT, because Linux is weird: when a host-originated packet
+	// is DNAT'd (typically in nat-OUTPUT), its destination IP is changed immediately, but Linux
+	// does not recalculate the outgoing interface (OIF) until AFTER the filter-OUTPUT chain.
+	// The OIF has been recalculated by the time we hit THIS chain (mangle-POSTROUTING), so we
+	// can reliably apply host endpoint policy here.
 	rules = append(rules,
 		Rule{
 			Action: ClearMarkAction{Mark: r.allCalicoMarkBits()},

--- a/rules/static.go
+++ b/rules/static.go
@@ -636,6 +636,7 @@ func (r *DefaultRuleRenderer) filterOutputChain(ipVersion uint8) *Chain {
 			Action: ClearMarkAction{Mark: r.allCalicoMarkBits()},
 		},
 		Rule{
+			Match:  Match().NotConntrackState("DNAT"),
 			Action: JumpAction{Target: ChainDispatchToHostEndpoint},
 		},
 		Rule{

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -307,7 +307,10 @@ var _ = Describe("Static", func() {
 
 									// Non-workload traffic, send to host chains.
 									{Action: ClearMarkAction{Mark: 0xf0}},
-									{Action: JumpAction{Target: ChainDispatchToHostEndpoint}},
+									{
+										Match:  Match().NotConntrackState("DNAT"),
+										Action: JumpAction{Target: ChainDispatchToHostEndpoint},
+									},
 									{
 										Match:   Match().MarkSingleBitSet(0x10),
 										Action:  AcceptAction{},
@@ -329,7 +332,10 @@ var _ = Describe("Static", func() {
 
 									// Non-workload traffic, send to host chains.
 									{Action: ClearMarkAction{Mark: 0xf0}},
-									{Action: JumpAction{Target: ChainDispatchToHostEndpoint}},
+									{
+										Match:  Match().NotConntrackState("DNAT"),
+										Action: JumpAction{Target: ChainDispatchToHostEndpoint},
+									},
 									{
 										Match:   Match().MarkSingleBitSet(0x10),
 										Action:  AcceptAction{},
@@ -693,7 +699,10 @@ var _ = Describe("Static", func() {
 
 					// Non-workload traffic, send to host chains.
 					{Action: ClearMarkAction{Mark: 0xf0}},
-					{Action: JumpAction{Target: ChainDispatchToHostEndpoint}},
+					{
+						Match:  Match().NotConntrackState("DNAT"),
+						Action: JumpAction{Target: ChainDispatchToHostEndpoint},
+					},
 					{
 						Match:   Match().MarkSingleBitSet(0x10),
 						Action:  AcceptAction{},
@@ -723,7 +732,10 @@ var _ = Describe("Static", func() {
 
 					// Non-workload traffic, send to host chains.
 					{Action: ClearMarkAction{Mark: 0xf0}},
-					{Action: JumpAction{Target: ChainDispatchToHostEndpoint}},
+					{
+						Match:  Match().NotConntrackState("DNAT"),
+						Action: JumpAction{Target: ChainDispatchToHostEndpoint},
+					},
 					{
 						Match:   Match().MarkSingleBitSet(0x10),
 						Action:  AcceptAction{},
@@ -750,7 +762,10 @@ var _ = Describe("Static", func() {
 
 					// Non-workload traffic, send to host chains.
 					{Action: ClearMarkAction{Mark: 0xf0}},
-					{Action: JumpAction{Target: ChainDispatchToHostEndpoint}},
+					{
+						Match:  Match().NotConntrackState("DNAT"),
+						Action: JumpAction{Target: ChainDispatchToHostEndpoint},
+					},
 					{
 						Match:   Match().MarkSingleBitSet(0x10),
 						Action:  AcceptAction{},
@@ -771,7 +786,10 @@ var _ = Describe("Static", func() {
 
 					// Non-workload traffic, send to host chains.
 					{Action: ClearMarkAction{Mark: 0xf0}},
-					{Action: JumpAction{Target: ChainDispatchToHostEndpoint}},
+					{
+						Match:  Match().NotConntrackState("DNAT"),
+						Action: JumpAction{Target: ChainDispatchToHostEndpoint},
+					},
 					{
 						Match:   Match().MarkSingleBitSet(0x10),
 						Action:  AcceptAction{},
@@ -1243,7 +1261,10 @@ var _ = Describe("Static", func() {
 
 						// Non-workload traffic, send to host chains.
 						{Action: ClearMarkAction{Mark: 0xf0}},
-						{Action: JumpAction{Target: ChainDispatchToHostEndpoint}},
+						{
+							Match:  Match().NotConntrackState("DNAT"),
+							Action: JumpAction{Target: ChainDispatchToHostEndpoint},
+						},
 						{
 							Match:   Match().MarkSingleBitSet(0x10),
 							Action:  ReturnAction{},

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -53,20 +53,6 @@ var _ = Describe("Static", func() {
 					Action: AcceptAction{},
 				})
 			}
-			if conf.IPIPEnabled {
-				expRules = append(expRules, Rule{
-					Match:   Match().ProtocolNum(4).DestIPSet("cali40all-hosts-net").SrcAddrType(AddrTypeLocal, false),
-					Action:  AcceptAction{},
-					Comment: []string{"Allow IPIP packets to other Calico hosts"},
-				})
-			}
-			if conf.VXLANEnabled {
-				expRules = append(expRules, Rule{
-					Match:   Match().ProtocolNum(17).DestPorts(0).SrcAddrType(AddrTypeLocal, false).DestIPSet("cali40all-vxlan-net"),
-					Action:  AcceptAction{},
-					Comment: []string{"Allow VXLAN packets to other whitelisted hosts"},
-				})
-			}
 			expRules = append(expRules, []Rule{
 				// Clear all Calico mark bits.
 				{Action: ClearMarkAction{Mark: 0xf0}},

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -43,14 +43,14 @@ var _ = Describe("Static", func() {
 			expRules := []Rule{
 				// Accept already accepted.
 				{Match: Match().MarkSingleBitSet(0x10),
-					Action: AcceptAction{},
+					Action: ReturnAction{},
 				},
 			}
 			if ipvs {
 				// Accept IPVS-forwarded traffic.
 				expRules = append(expRules, Rule{
 					Match:  Match().MarkNotClear(0xff00),
-					Action: AcceptAction{},
+					Action: ReturnAction{},
 				})
 			}
 			expRules = append(expRules, []Rule{
@@ -64,7 +64,7 @@ var _ = Describe("Static", func() {
 				// Accept if policy allowed packet.
 				{
 					Match:   Match().MarkSingleBitSet(0x10),
-					Action:  AcceptAction{},
+					Action:  ReturnAction{},
 					Comment: []string{"Host endpoint policy accepted packet."},
 				},
 			}...)

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -226,6 +226,7 @@ var _ = Describe("Static", func() {
 								// Outgoing host endpoint chains.
 								{Action: JumpAction{Target: ChainDispatchToHostEndpointForward}},
 								{Action: JumpAction{Target: ChainCIDRBlock}},
+								{Action: SetMarkAction{Mark: 0x10}},
 							},
 						}))
 					})
@@ -1221,6 +1222,7 @@ var _ = Describe("Static", func() {
 						// Outgoing host endpoint chains.
 						{Action: JumpAction{Target: ChainDispatchToHostEndpointForward}},
 						{Action: JumpAction{Target: ChainCIDRBlock}},
+						{Action: SetMarkAction{Mark: 0x10}},
 					},
 				}))
 			})


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Bugfix: HostEndpoint policy was incorrectly enforced on connections from a pod to a service IP, even when that service IP was resolved to another workload on the same host.
```
