### PR TITLE
bpf/proxy: fix stale NAT entries cleanup

### DIFF
--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -1272,7 +1272,13 @@ func (s *Syncer) ConntrackFrontendHasBackend(ip net.IP, port uint16,
 
 	id, ok := s.activeSvcsMap[ipPortProto{ipPort{ip.String(), int(port)}, proto}]
 	if !ok {
-		return false
+		// Double check if it is a nodeport as if we are on the node that has
+		// the backing pod for a nodeport and the nodeport was forwarded here,
+		// the frontend is different.
+		id, ok = s.activeSvcsMap[ipPortProto{ipPort{"255.255.255.255", int(port)}, proto}]
+		if !ok {
+			return false
+		}
 	}
 
 	backends := s.activeEpsMap[id]


### PR DESCRIPTION
When nodeport is forwarded to another node, it does not have the first
node's IP in its tables, therefore it thinks that the conntrack entries
are for a service that is gone. We also need to match against the
wildcard to check if the front end might be a nodeport.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In eBPF mode, fix that node port conntrack entries could be improperly cleaned up if there was no traffic for some time.  In particular, long-lived connections from AWS load balancers were affected.
```
