### PR TITLE
Set aws-src-dst-check report ready

### DIFF
--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -332,7 +332,10 @@ func StartDataplaneDriver(configParams *config.Config,
 					log.WithField("src-dst-check", check).Errorf("Failed to set source-destination-check: %v", err)
 					// set not-ready.
 					healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: false})
+					return
 				}
+				// set ready.
+				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
 			}(configParams.AWSSrcDstCheck, healthName, healthAggregator)
 		}
 


### PR DESCRIPTION
## Description

Set aws-src-dst-check report ready.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Mark aws-src-dst-check report ready when successful. This fix addresses the issue with calico-node not being ready in EKS setup using Calico CNI.
```
