### PR TITLE
aws: set src/dest readiness state unconditionally

### DIFF
--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -327,12 +327,12 @@ func StartDataplaneDriver(configParams *config.Config,
 
 			go func(check, healthName string, healthAgg *health.HealthAggregator) {
 				log.Infof("Setting AWS EC2 source-destination-check to %s", check)
-				err := aws.UpdateSrcDstCheck(check)
-				if err != nil {
+				ready := true
+				if err := aws.UpdateSrcDstCheck(check); err != nil {
 					log.WithField("src-dst-check", check).Errorf("Failed to set source-destination-check: %v", err)
-					// set not-ready.
-					healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: false})
+					ready = false
 				}
+				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: ready})
 			}(configParams.AWSSrcDstCheck, healthName, healthAggregator)
 		}
 


### PR DESCRIPTION
## Description

When directed to disable [AWS ENI source/destination checks](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#eni-basics), Felix reports the outcome of the reconciliation attempt as the "aws-source-destination-check" heath report. Previously, Felix only updated its registered health report upon failure, perhaps assuming that the initially registered health state already indicated that we are "ready." Leaving the most recent health report as the initial state actually indicates that we're "live" but not yet "ready."

After attempting to reconcile the hosting EC2 instance's primary ENI's source/destination check, report the outcome on our assessed readiness unconditionally, noting either that we're newly ready or that we remain unready.

Fixes projectcalico/calico#4154.


## Todos
- [ ] Unit tests (full coverage)  
  I don't see any existing unit tests for this component.
- [ ] Integration tests (delete as appropriate) In plan  
  I am unsure if we have integration tests for this feature. I haven't found any yet.
- [ ] Documentation
- [ ] Backport
- [x] Release note


## Release Note

```release-note
When managing AWS ENI source/destination checks, upon success Felix now reports its readiness accurately.
```
