### PR TITLE
[v3.17] Backport source/dest readiness fix

### DIFF
--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -332,7 +332,10 @@ func StartDataplaneDriver(configParams *config.Config,
 					log.WithField("src-dst-check", check).Errorf("Failed to set source-destination-check: %v", err)
 					// set not-ready.
 					healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: false})
+					return
 				}
+				// set ready.
+				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
 			}(configParams.AWSSrcDstCheck, healthName, healthAggregator)
 		}
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Backport of #2592 

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Mark aws-src-dst-check report ready when successful. This fix addresses the issue with calico-node not being ready in EKS setup using Calico CNI.
```
