### PR TITLE
[v3.17] bpf: encap nodeport return from host networked pods

### DIFF
--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -1184,7 +1184,14 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct __sk_buff *skb,
 			goto deny;
 		}
 
-		if (dnat_return_should_encap() && state->ct_result.tun_ip) {
+		/* In addition to dnat_return_should_encap() we also need to encap on the
+		 * host endpoint for egress traffic, when we hit an SNAT rule. This is the
+		 * case when the target was host namespace. If the target was a pod, the
+		 * already encaped traffic would not reach this point and would not be
+		 * able to match as SNAT.
+		 */
+		if ((dnat_return_should_encap() || (CALI_F_TO_HEP && !CALI_F_DSR)) &&
+									state->ct_result.tun_ip) {
 			state->ip_dst = state->ct_result.tun_ip;
 			seen_mark = CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP;
 			goto nat_encap;

--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -385,6 +385,10 @@ func TestNATNodePort(t *testing.T) {
 
 	dumpCTMap(ctMap)
 	fromHostCT := saveCTMap(ctMap)
+
+	encapedPktArrivesAtNode2 := make([]byte, len(encapedPkt))
+	copy(encapedPktArrivesAtNode2, encapedPkt)
+
 	resetCTMap(ctMap)
 
 	var recvPkt []byte
@@ -671,6 +675,115 @@ func TestNATNodePort(t *testing.T) {
 	 * TEST that unknown VNI is passed through
 	 */
 	testUnrelatedVXLAN(t, node2ip, vni)
+
+	// TEST host-networked backend
+	{
+		resetCTMap(ctMap)
+
+		var recvPkt []byte
+
+		hostIP = node2ip
+		skbMark = 0
+
+		// we must know that the encaped packet src ip is from a known host
+		err = rtMap.Update(
+			routes.NewKey(ip.CIDRFromIPNet(&node1CIDR).(ip.V4CIDR)).AsBytes(),
+			routes.NewValue(routes.FlagsRemoteHost).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		err = rtMap.Update(
+			routes.NewKey(ip.CIDRFromIPNet(&node2CIDR).(ip.V4CIDR)).AsBytes(),
+			routes.NewValue(routes.FlagsLocalHost).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		dumpRTMap(rtMap)
+
+		// now we are at the node with local workload
+		err = natMap.Update(
+			nat.NewNATKey(net.IPv4(255, 255, 255, 255), uint16(udp.DstPort), uint8(ipv4.Protocol)).AsBytes(),
+			nat.NewNATValue(0 /* count */, 1 /* local */, 1, 0).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// make it point to the local host - host networked backend
+		err = natBEMap.Update(
+			nat.NewNATBackendKey(0, 0).AsBytes(),
+			nat.NewNATBackendValue(node2ip, natPort).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Arriving at node 2
+		bpfIfaceName = "NP-2"
+
+		runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(encapedPktArrivesAtNode2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+			pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+			fmt.Printf("pktR = %+v\n", pktR)
+
+			ipv4L := pktR.Layer(layers.LayerTypeIPv4)
+			ipv4R := ipv4L.(*layers.IPv4)
+			Expect(ipv4R.SrcIP.String()).To(Equal(ipv4.SrcIP.String()))
+			Expect(ipv4R.DstIP.String()).To(Equal(node2ip.String()))
+
+			udpL := pktR.Layer(layers.LayerTypeUDP)
+			Expect(udpL).NotTo(BeNil())
+			udpR := udpL.(*layers.UDP)
+			Expect(udpR.SrcPort).To(Equal(layers.UDPPort(udp.SrcPort)))
+			Expect(udpR.DstPort).To(Equal(layers.UDPPort(natPort)))
+
+			ct, err := conntrack.LoadMapMem(ctMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctKey := conntrack.NewKey(uint8(ipv4.Protocol),
+				ipv4.DstIP, uint16(udp.DstPort), ipv4.SrcIP, uint16(udp.SrcPort))
+
+			Expect(ct).Should(HaveKey(ctKey))
+			ctr := ct[ctKey]
+			Expect(ctr.Type()).To(Equal(conntrack.TypeNATForward))
+
+			ctKey = ctr.ReverseNATKey()
+			Expect(ct).Should(HaveKey(ctKey))
+			ctr = ct[ctKey]
+			Expect(ctr.Type()).To(Equal(conntrack.TypeNATReverse))
+
+			// Whitlisted source side
+			Expect(ctr.Data().A2B.Whitelisted).To(BeTrue())
+			// Dest not whitelisted yet
+			Expect(ctr.Data().B2A.Whitelisted).NotTo(BeTrue())
+
+			recvPkt = res.dataOut
+		})
+
+		dumpCTMap(ctMap)
+
+		skbMark = 0
+
+		// Response leaving workload at node 2
+		runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			respPkt := udpResposeRaw(recvPkt)
+
+			// No need to check MACs, no FIB, no forwarding, nopatching
+
+			res, err := bpfrun(respPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+			pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+			fmt.Printf("pktR = %+v\n", pktR)
+
+			ipv4L := pktR.Layer(layers.LayerTypeIPv4)
+			Expect(ipv4L).NotTo(BeNil())
+			ipv4R := ipv4L.(*layers.IPv4)
+			Expect(ipv4R.SrcIP.String()).To(Equal(node2ip.String()))
+			Expect(ipv4R.DstIP.String()).To(Equal(node1ip.String()))
+
+			checkVxlan(pktR)
+		})
+	}
 }
 
 func TestNATNodePortNoFWD(t *testing.T) {


### PR DESCRIPTION
## Description

When a nodeport is backed by a host-networked pod, we also need to encap
the return traffic and send it back through the vxlan tunnel. Otherwise
we always act like in DSR mode.

Closing projectcalico/calico#4242

Backport https://github.com/projectcalico/felix/pull/2620

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
