### PR TITLE
bpf: fixup dst MAC for host networked nodeport backends

### DIFF
--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -481,8 +481,8 @@ func TestNATNodePort(t *testing.T) {
 	arpKey := arp.NewKey(node1ip, 1 /* ifindex is always 1 in UT */)
 	Expect(arpMapN2).To(HaveKey(arpKey))
 	macDst := encapedPkt[0:6]
-	macScr := encapedPkt[6:12]
-	Expect(arpMapN2[arpKey]).To(Equal(arp.NewValue(macDst, macScr)))
+	macSrc := encapedPkt[6:12]
+	Expect(arpMapN2[arpKey]).To(Equal(arp.NewValue(macDst, macSrc)))
 
 	// try a spoofed tunnel packet, should be dropped and have no effect
 	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
@@ -535,7 +535,7 @@ func TestNATNodePort(t *testing.T) {
 	// Response leaving workload at node 2
 	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		respPkt := udpResposeRaw(recvPkt)
-		// Change the MAC addressesso that we can observe that the right
+		// Change the MAC addresses so that we can observe that the right
 		// addresses were patched in.
 		copy(respPkt[:6], []byte{1, 2, 3, 4, 5, 6})
 		copy(respPkt[6:12], []byte{6, 5, 4, 3, 2, 1})
@@ -551,7 +551,7 @@ func TestNATNodePort(t *testing.T) {
 		ethR := ethL.(*layers.Ethernet)
 		Expect(ethR).To(layersMatchFields(&layers.Ethernet{
 			SrcMAC:       macDst,
-			DstMAC:       macScr,
+			DstMAC:       macSrc,
 			EthernetType: layers.EthernetTypeIPv4,
 		}))
 
@@ -792,7 +792,11 @@ func TestNATNodePort(t *testing.T) {
 		runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 			respPkt := udpResposeRaw(recvPkt)
 
-			// No need to check MACs, no FIB, no forwarding, nopatching
+			// Change the MAC addresses so that we can observe that the right
+			// addresses were patched in.
+			macUntouched := []byte{6, 5, 4, 3, 2, 1}
+			copy(respPkt[:6], []byte{1, 2, 3, 4, 5, 6})
+			copy(respPkt[6:12], macUntouched)
 
 			res, err := bpfrun(respPkt)
 			Expect(err).NotTo(HaveOccurred())
@@ -800,6 +804,15 @@ func TestNATNodePort(t *testing.T) {
 
 			pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 			fmt.Printf("pktR = %+v\n", pktR)
+
+			ethL := pktR.Layer(layers.LayerTypeEthernet)
+			Expect(ethL).NotTo(BeNil())
+			ethR := ethL.(*layers.Ethernet)
+			Expect(ethR).To(layersMatchFields(&layers.Ethernet{
+				SrcMAC:       macUntouched, // Source is set by net stack and should not be touched.
+				DstMAC:       macSrc,
+				EthernetType: layers.EthernetTypeIPv4,
+			}))
 
 			ipv4L := pktR.Layer(layers.LayerTypeIPv4)
 			Expect(ipv4L).NotTo(BeNil())


### PR DESCRIPTION
Because routing happens based on the dest IP (which is at that time the
client's) before we get hands on the packet on HEP, the MAC is likely
different (in the same subnet) than the MAC of the node that forwarded
the nodeport to us. Therefore once we place the packet in VXLAN and thus
change the dest IP, we must fix up the dest MAC based on what we
recorded when we received the inbound packets.

This is a similar case to the MAC fixing for regular pods. The only
difference is that the src MAC is already set correctly if we are on the
right device.

We cannot handle the case (yet) when the routes to the original client
and to the node on the other side of the vxland tunnel use different
NICs. We would need to redirect the packet to the other NIC first.

Fixes https://github.com/projectcalico/calico/issues/4242

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
