### PR TITLE
BPF conntrack scanner moved outside of kube-proxy

### DIFF
--- a/bpf/conntrack/cleanup.go
+++ b/bpf/conntrack/cleanup.go
@@ -49,88 +49,6 @@ func DefaultTimeouts() Timeouts {
 	}
 }
 
-// ScanVerdict represents the set of values returned by EntryScan
-type ScanVerdict int
-
-const (
-	// ScanVerdictOK means entry is fine and should remain
-	ScanVerdictOK ScanVerdict = iota
-	// ScanVerdictDelete means entry should be deleted
-	ScanVerdictDelete
-)
-
-// EntryGet is a function prototype provided to EntryScanner in case it needs to
-// evaluate other entries to make a verdict
-type EntryGet func(Key) (Value, error)
-
-// EntryScanner is a function prototype to be called on every entry by the scanner
-type EntryScanner func(Key, Value, EntryGet) ScanVerdict
-
-// Scanner iterates over a provided conntrack map and call a set of EntryScanner
-// functions on each entry in the order as they were passed to NewScanner. If
-// any of the EntryScanner returns ScanVerdictDelete, it deletes the entry, does
-// not call any other EntryScanner and continues the iteration.
-//
-// It provides a delete-save iteration over the conntrack table for multiple
-// evaluation functions, to keep their implementation simpler.
-type Scanner struct {
-	ctMap    bpf.Map
-	scanners []EntryScanner
-}
-
-// NewScanner returns a scanner for the given conntrack map and the set of
-// EntryScanner. They are executed in the provided order on each entry.
-func NewScanner(ctMap bpf.Map, scanners ...EntryScanner) *Scanner {
-	return &Scanner{
-		ctMap:    ctMap,
-		scanners: scanners,
-	}
-}
-
-// Scan executes a scanning iteration
-func (s *Scanner) Scan() {
-	debug := log.GetLevel() >= log.DebugLevel
-
-	var ctKey Key
-	var ctVal Value
-
-	err := s.ctMap.Iter(func(k, v []byte) bpf.IteratorAction {
-		copy(ctKey[:], k[:])
-		copy(ctVal[:], v[:])
-
-		if debug {
-			log.WithFields(log.Fields{
-				"key":   ctKey,
-				"entry": ctVal,
-			}).Debug("Examining conntrack entry")
-		}
-
-		for _, scanner := range s.scanners {
-			if verdict := scanner(ctKey, ctVal, s.get); verdict == ScanVerdictDelete {
-				if debug {
-					log.Debug("Deleting conntrack entry.")
-				}
-				return bpf.IterDelete
-			}
-		}
-		return bpf.IterNone
-	})
-
-	if err != nil {
-		log.WithError(err).Warn("Failed to iterate over conntrack map")
-	}
-}
-
-func (s *Scanner) get(k Key) (Value, error) {
-	v, err := s.ctMap.Get(k.AsBytes())
-
-	if err != nil {
-		return Value{}, err
-	}
-
-	return ValueFromBytes(v), nil
-}
-
 type LivenessScanner struct {
 	timeouts Timeouts
 	dsr      bool
@@ -163,7 +81,7 @@ func WithTimeShim(shim timeshim.Interface) LivenessScannerOpt {
 	}
 }
 
-func (l *LivenessScanner) ScanEntry(ctKey Key, ctVal Value, get EntryGet) ScanVerdict {
+func (l *LivenessScanner) Check(ctKey Key, ctVal Value, get EntryGet) ScanVerdict {
 	if l.cachedKTime == 0 || l.time.Since(l.goTimeOfLastKTimeLookup) > time.Second {
 		l.cachedKTime = l.time.KTimeNanos()
 		l.goTimeOfLastKTimeLookup = l.time.Now()
@@ -264,103 +182,127 @@ func (l *LivenessScanner) EntryExpired(nowNanos int64, proto uint8, entry Value)
 }
 
 // NATChecker returns true a given combination of frontend-backend exists
-type NATChecker func(frontIP net.IP, frontPort uint16, backIP net.IP, backPort uint16, proto uint8) bool
+type NATChecker interface {
+	ConntrackScanStart()
+	ConntrackScanEnd()
+	ConntrackFrontendHasBackend(ip net.IP, port uint16, backendIP net.IP, backendPort uint16, proto uint8) bool
+}
+
+// StaleNATScanner removes any entries to frontend that do not have the backend anymore.
+type StaleNATScanner struct {
+	natChecker NATChecker
+}
 
 // NewStaleNATScanner returns an EntryScanner that checks if entries have
 // exisitng NAT entries using the provided NATChecker and if not, it deletes
 // them.
-func NewStaleNATScanner(frontendHasBackend NATChecker) EntryScanner {
+func NewStaleNATScanner(frontendHasBackend NATChecker) *StaleNATScanner {
+	return &StaleNATScanner{
+		natChecker: frontendHasBackend,
+	}
+}
+
+// Check checks the conntrack entry
+func (sns *StaleNATScanner) Check(k Key, v Value, _ EntryGet) ScanVerdict {
 	debug := log.GetLevel() >= log.DebugLevel
 
-	return func(k Key, v Value, _ EntryGet) ScanVerdict {
-		switch v.Type() {
-		case TypeNormal:
-			// skip non-NAT entry
+	switch v.Type() {
+	case TypeNormal:
+		// skip non-NAT entry
 
-		case TypeNATReverse:
-			proto := k.Proto()
-			ipA := k.AddrA()
-			ipB := k.AddrB()
+	case TypeNATReverse:
+		proto := k.Proto()
+		ipA := k.AddrA()
+		ipB := k.AddrB()
 
-			portA := k.PortA()
-			portB := k.PortB()
+		portA := k.PortA()
+		portB := k.PortB()
 
-			svcIP := v.OrigIP()
-			svcPort := v.OrigPort()
+		svcIP := v.OrigIP()
+		svcPort := v.OrigPort()
 
-			// We cannot tell which leg is EP and which is the client, we must
-			// try both. If there is a record for one of them, it is still most
-			// likely an active entry.
-			if !frontendHasBackend(svcIP, svcPort, ipA, portA, proto) &&
-				!frontendHasBackend(svcIP, svcPort, ipB, portB, proto) {
-				if debug {
-					log.WithField("key", k).Debugf("TypeNATReverse is stale")
-				}
-				return ScanVerdictDelete
-			}
+		// We cannot tell which leg is EP and which is the client, we must
+		// try both. If there is a record for one of them, it is still most
+		// likely an active entry.
+		if !sns.natChecker.ConntrackFrontendHasBackend(svcIP, svcPort, ipA, portA, proto) &&
+			!sns.natChecker.ConntrackFrontendHasBackend(svcIP, svcPort, ipB, portB, proto) {
 			if debug {
-				log.WithField("key", k).Debugf("TypeNATReverse still active")
+				log.WithField("key", k).Debugf("TypeNATReverse is stale")
 			}
-
-		case TypeNATForward:
-			proto := k.Proto()
-			kA := k.AddrA()
-			kAport := k.PortA()
-			kB := k.AddrB()
-			kBport := k.PortB()
-			revKey := v.ReverseNATKey()
-			revA := revKey.AddrA()
-			revAport := revKey.PortA()
-			revB := revKey.AddrB()
-			revBport := revKey.PortB()
-
-			var (
-				svcIP, epIP     net.IP
-				svcPort, epPort uint16
-			)
-
-			// Because client IP/Port are both in fwd key and rev key, we can
-			// can tell which one it is and thus determine exactly meaning of
-			// the other values.
-			if kA.Equal(revA) && kAport == revAport {
-				epIP = revB
-				epPort = revBport
-				svcIP = kB
-				svcPort = kBport
-			} else if kB.Equal(revA) && kBport == revAport {
-				epIP = revB
-				epPort = revBport
-				svcIP = kA
-				svcPort = kAport
-			} else if kA.Equal(revB) && kAport == revBport {
-				epIP = revA
-				epPort = revAport
-				svcIP = kB
-				svcPort = kBport
-			} else if kB.Equal(revB) && kBport == revBport {
-				epIP = revA
-				epPort = revAport
-				svcIP = kA
-				svcPort = kAport
-			} else {
-				log.WithFields(log.Fields{"key": k, "value": v}).Error("Mismatch between key and rev key")
-				return ScanVerdictOK // don't touch, will get deleted when expired
-			}
-
-			if !frontendHasBackend(svcIP, svcPort, epIP, epPort, proto) {
-				if debug {
-					log.WithField("key", k).Debugf("TypeNATForward is stale")
-				}
-				return ScanVerdictDelete
-			}
-			if debug {
-				log.WithField("key", k).Debugf("TypeNATForward still active")
-			}
-
-		default:
-			log.WithField("conntrack.Value.Type()", v.Type()).Warn("Unknown type")
+			return ScanVerdictDelete
+		}
+		if debug {
+			log.WithField("key", k).Debugf("TypeNATReverse still active")
 		}
 
-		return ScanVerdictOK
+	case TypeNATForward:
+		proto := k.Proto()
+		kA := k.AddrA()
+		kAport := k.PortA()
+		kB := k.AddrB()
+		kBport := k.PortB()
+		revKey := v.ReverseNATKey()
+		revA := revKey.AddrA()
+		revAport := revKey.PortA()
+		revB := revKey.AddrB()
+		revBport := revKey.PortB()
+
+		var (
+			svcIP, epIP     net.IP
+			svcPort, epPort uint16
+		)
+
+		// Because client IP/Port are both in fwd key and rev key, we can
+		// can tell which one it is and thus determine exactly meaning of
+		// the other values.
+		if kA.Equal(revA) && kAport == revAport {
+			epIP = revB
+			epPort = revBport
+			svcIP = kB
+			svcPort = kBport
+		} else if kB.Equal(revA) && kBport == revAport {
+			epIP = revB
+			epPort = revBport
+			svcIP = kA
+			svcPort = kAport
+		} else if kA.Equal(revB) && kAport == revBport {
+			epIP = revA
+			epPort = revAport
+			svcIP = kB
+			svcPort = kBport
+		} else if kB.Equal(revB) && kBport == revBport {
+			epIP = revA
+			epPort = revAport
+			svcIP = kA
+			svcPort = kAport
+		} else {
+			log.WithFields(log.Fields{"key": k, "value": v}).Error("Mismatch between key and rev key")
+			return ScanVerdictOK // don't touch, will get deleted when expired
+		}
+
+		if !sns.natChecker.ConntrackFrontendHasBackend(svcIP, svcPort, epIP, epPort, proto) {
+			if debug {
+				log.WithField("key", k).Debugf("TypeNATForward is stale")
+			}
+			return ScanVerdictDelete
+		}
+		if debug {
+			log.WithField("key", k).Debugf("TypeNATForward still active")
+		}
+
+	default:
+		log.WithField("conntrack.Value.Type()", v.Type()).Warn("Unknown type")
 	}
+
+	return ScanVerdictOK
+}
+
+// IterationStart satisfies EntryScannerSynced
+func (sns *StaleNATScanner) IterationStart() {
+	sns.natChecker.ConntrackScanStart()
+}
+
+// IterationEnd satisfies EntryScannerSynced
+func (sns *StaleNATScanner) IterationEnd() {
+	sns.natChecker.ConntrackScanEnd()
 }

--- a/bpf/conntrack/conntrack_test.go
+++ b/bpf/conntrack/conntrack_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BPF Conntrack LivenessCalculator", func() {
 		"expiry tests",
 		func(key conntrack.Key, entry conntrack.Value, expExpired bool) {
 			By("calculating expiry of normal entry")
-			reason, expired := lc.EntryExpired(int64(now), key.Proto(), entry)
+			reason, expired := timeouts.EntryExpired(int64(now), key.Proto(), entry)
 			Expect(expired).To(Equal(expExpired), fmt.Sprintf("EntryExpired returned unexpected value with reason: %s", reason))
 			if expired {
 				Expect(reason).ToNot(BeEmpty())
@@ -99,7 +99,7 @@ var _ = Describe("BPF Conntrack LivenessCalculator", func() {
 			copy(eReversed[:], entry[:])
 			copy(eReversed[24:32], entry[32:40])
 			copy(eReversed[32:40], entry[24:32])
-			reason, expired = lc.EntryExpired(int64(now), key.Proto(), entry)
+			reason, expired = timeouts.EntryExpired(int64(now), key.Proto(), entry)
 			Expect(expired).To(Equal(expExpired), fmt.Sprintf("EntryExpired returned unexpected value (for reversed legs) with reason: %s", reason))
 			if expired {
 				Expect(reason).ToNot(BeEmpty())

--- a/bpf/conntrack/scanner.go
+++ b/bpf/conntrack/scanner.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conntrack
+
+import (
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/bpf"
+	"github.com/projectcalico/felix/jitter"
+)
+
+// ScanVerdict represents the set of values returned by EntryScan
+type ScanVerdict int
+
+const (
+	// ScanVerdictOK means entry is fine and should remain
+	ScanVerdictOK ScanVerdict = iota
+	// ScanVerdictDelete means entry should be deleted
+	ScanVerdictDelete
+
+	// ScanPeriod determines how often we iterate over the conntrack table.
+	ScanPeriod = 10 * time.Second
+)
+
+// EntryGet is a function prototype provided to EntryScanner in case it needs to
+// evaluate other entries to make a verdict
+type EntryGet func(Key) (Value, error)
+
+// EntryScanner is a function prototype to be called on every entry by the scanner
+type EntryScanner interface {
+	Check(Key, Value, EntryGet) ScanVerdict
+}
+
+// EntryScannerSynced is a scaner synchronized with the iteration start/end.
+type EntryScannerSynced interface {
+	EntryScanner
+	IterationStart()
+	IterationEnd()
+}
+
+// Scanner iterates over a provided conntrack map and call a set of EntryScanner
+// functions on each entry in the order as they were passed to NewScanner. If
+// any of the EntryScanner returns ScanVerdictDelete, it deletes the entry, does
+// not call any other EntryScanner and continues the iteration.
+//
+// It provides a delete-save iteration over the conntrack table for multiple
+// evaluation functions, to keep their implementation simpler.
+type Scanner struct {
+	ctMap    bpf.Map
+	scanners []EntryScanner
+
+	wg       sync.WaitGroup
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+// NewScanner returns a scanner for the given conntrack map and the set of
+// EntryScanner. They are executed in the provided order on each entry.
+func NewScanner(ctMap bpf.Map, scanners ...EntryScanner) *Scanner {
+	return &Scanner{
+		ctMap:    ctMap,
+		scanners: scanners,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Scan executes a scanning iteration
+func (s *Scanner) Scan() {
+	s.iterStart()
+	defer s.iterEnd()
+
+	debug := log.GetLevel() >= log.DebugLevel
+
+	var ctKey Key
+	var ctVal Value
+
+	err := s.ctMap.Iter(func(k, v []byte) bpf.IteratorAction {
+		copy(ctKey[:], k[:])
+		copy(ctVal[:], v[:])
+
+		if debug {
+			log.WithFields(log.Fields{
+				"key":   ctKey,
+				"entry": ctVal,
+			}).Debug("Examining conntrack entry")
+		}
+
+		for _, scanner := range s.scanners {
+			if verdict := scanner.Check(ctKey, ctVal, s.get); verdict == ScanVerdictDelete {
+				if debug {
+					log.Debug("Deleting conntrack entry.")
+				}
+				return bpf.IterDelete
+			}
+		}
+		return bpf.IterNone
+	})
+
+	if err != nil {
+		log.WithError(err).Warn("Failed to iterate over conntrack map")
+	}
+}
+
+func (s *Scanner) get(k Key) (Value, error) {
+	v, err := s.ctMap.Get(k.AsBytes())
+
+	if err != nil {
+		return Value{}, err
+	}
+
+	return ValueFromBytes(v), nil
+}
+
+// Start the periodic scanner
+func (s *Scanner) Start() {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		log.Debug("Conntrack scanner thread started")
+		defer log.Debug("Conntrack scanner thread stopped")
+
+		ticker := jitter.NewTicker(ScanPeriod, 100*time.Millisecond)
+
+		for {
+			s.Scan()
+
+			select {
+			case <-ticker.C:
+				log.Debug("Conntrack cleanup timer popped")
+			case <-s.stopCh:
+				log.Debug("Conntrack cleanup got stop signal")
+				return
+			}
+		}
+	}()
+}
+
+func (s *Scanner) iterStart() {
+	for _, scanner := range s.scanners {
+		if synced, ok := scanner.(EntryScannerSynced); ok {
+			synced.IterationStart()
+		}
+	}
+}
+
+func (s *Scanner) iterEnd() {
+	for _, scanner := range s.scanners {
+		if synced, ok := scanner.(EntryScannerSynced); ok {
+			synced.IterationEnd()
+		}
+	}
+}
+
+// Stop stops the Scanner and waits for it finishing.
+func (s *Scanner) Stop() {
+	s.stopOnce.Do(func() {
+		close(s.stopCh)
+		s.wg.Wait()
+	})
+}
+
+// AddUnlocked adds an additional EntryScanner to a non-running Scanner
+func (s *Scanner) AddUnlocked(scanner EntryScanner) {
+	s.scanners = append(s.scanners, scanner)
+}

--- a/bpf/proxy/health_check_nodeport_test.go
+++ b/bpf/proxy/health_check_nodeport_test.go
@@ -41,7 +41,7 @@ var _ = Describe("BPF Proxy healthCheckNodeport", func() {
 		By("creating proxy with fake client and mock syncer", func() {
 			var err error
 
-			p, err = proxy.New(k8s, &mockDummySyncer{}, nil,
+			p, err = proxy.New(k8s, &mockDummySyncer{},
 				testNodeName, proxy.WithMinSyncPeriod(200*time.Millisecond))
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/bpf/proxy/options.go
+++ b/bpf/proxy/options.go
@@ -18,8 +18,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-
-	"github.com/projectcalico/felix/bpf/conntrack"
 )
 
 // Option defines Proxy options
@@ -67,14 +65,6 @@ func WithEndpointsSlices() Option {
 	return makeOption(func(p *proxy) error {
 		p.endpointSlicesEnabled = true
 		log.Infof("proxy.WithEndpointsSlices()")
-		return nil
-	})
-}
-
-// WithConntrackTimeouts overrides the default timeouts for connection entries
-func WithConntrackTimeouts(timeouts conntrack.Timeouts) Option {
-	return makeKubeProxyOption(func(kp *KubeProxy) error {
-		kp.conntrackTimeouts = timeouts
 		return nil
 	})
 }

--- a/bpf/proxy/proxy_bench_test.go
+++ b/bpf/proxy/proxy_bench_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/projectcalico/felix/bpf/conntrack"
 	"github.com/projectcalico/felix/bpf/mock"
 	"github.com/projectcalico/felix/bpf/proxy"
 )
@@ -56,11 +55,9 @@ func benchmarkProxyUpdates(b *testing.B, svcN, epsN int) {
 			syncC:    make(chan struct{}, 1),
 		}
 
-		connScan := conntrack.NewScanner(&mock.DummyMap{})
-
 		b.StartTimer()
 
-		proxy, err := proxy.New(k8s, &benchS, connScan, "somename", proxy.WithImmediateSync())
+		proxy, err := proxy.New(k8s, &benchS, "somename", proxy.WithImmediateSync())
 		Expect(err).ShouldNot(HaveOccurred())
 		// Wait for the initial sync to complete
 		<-benchS.syncC

--- a/bpf/proxy/proxy_test.go
+++ b/bpf/proxy/proxy_test.go
@@ -41,10 +41,10 @@ var _ = Describe("BPF Proxy", func() {
 	var syncStop chan struct{}
 
 	It("should fail without k8s client", func() {
-		_, err := proxy.New(nil, nil, nil, "testnode")
+		_, err := proxy.New(nil, nil, "testnode")
 		Expect(err).To(HaveOccurred())
 
-		_, err = proxy.New(fake.NewSimpleClientset(), nil, nil, "testnode")
+		_, err = proxy.New(fake.NewSimpleClientset(), nil, "testnode")
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -54,7 +54,7 @@ var _ = Describe("BPF Proxy", func() {
 		syncStop = make(chan struct{})
 		dp := newMockSyncer(syncStop)
 
-		p, err := proxy.New(k8s, dp, nil, "testnode", proxy.WithImmediateSync())
+		p, err := proxy.New(k8s, dp, "testnode", proxy.WithImmediateSync())
 		Expect(err).NotTo(HaveOccurred())
 
 		defer func() {
@@ -175,7 +175,7 @@ var _ = Describe("BPF Proxy", func() {
 					opts = append(opts, proxy.WithEndpointsSlices())
 				}
 
-				p, err = proxy.New(k8s, dp, nil, "testnode", opts...)
+				p, err = proxy.New(k8s, dp, "testnode", opts...)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -549,7 +549,7 @@ var _ = Describe("BPF Proxy", func() {
 					opts = append(opts, proxy.WithEndpointsSlices())
 				}
 
-				p, err = proxy.New(k8s, dp, nil, testNodeName, opts...)
+				p, err = proxy.New(k8s, dp, testNodeName, opts...)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})

--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -1268,7 +1268,13 @@ func (s *Syncer) cleanupSticky() error {
 
 // ConntrackFrontendHasBackend returns true if the given front-backend pair exists
 func (s *Syncer) ConntrackFrontendHasBackend(ip net.IP, port uint16,
-	backendIP net.IP, backendPort uint16, proto uint8) bool {
+	backendIP net.IP, backendPort uint16, proto uint8) (ret bool) {
+
+	if log.GetLevel() >= log.DebugLevel {
+		defer func() {
+			log.WithField("ret", ret).Debug("ConntrackFrontendHasBackend")
+		}()
+	}
 
 	id, ok := s.activeSvcsMap[ipPortProto{ipPort{ip.String(), int(port)}, proto}]
 	if !ok {
@@ -1294,6 +1300,7 @@ func (s *Syncer) ConntrackFrontendHasBackend(ip net.IP, port uint16,
 // ConntrackScanStart excludes Apply from running and builds the active maps from
 // ConntrackFrontendHasBackend
 func (s *Syncer) ConntrackScanStart() {
+	log.Debug("ConntrackScanStart")
 	s.mapsLck.Lock()
 
 	s.activeSvcsMap = make(map[ipPortProto]uint32)
@@ -1319,6 +1326,7 @@ func (s *Syncer) ConntrackScanEnd() {
 	s.activeSvcsMap = nil
 	s.activeEpsMap = nil
 	s.mapsLck.Unlock()
+	log.Debug("ConntrackScanEnd")
 }
 
 func serviceInfoFromK8sServicePort(sport k8sp.ServicePort) *serviceInfo {

--- a/bpf/proxy/syncer_test.go
+++ b/bpf/proxy/syncer_test.go
@@ -140,7 +140,7 @@ var _ = Describe("BPF Syncer", func() {
 		}))
 
 		By("creating a CT scanner", func() {
-			connScan = conntrack.NewScanner(ct, conntrack.NewStaleNATScanner(s.ConntrackFrontendHasBackend))
+			connScan = conntrack.NewScanner(ct, conntrack.NewStaleNATScanner(s))
 		})
 
 		By("creating conntrack entries for test-service", makestep(func() {
@@ -178,9 +178,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("checking that a CT entry pair is cleaned up by connScan", makestep(func() {
 
-			s.ConntrackScanStart()
 			connScan.Scan()
-			s.ConntrackScanEnd()
 
 			cnt := 0
 
@@ -217,9 +215,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("checking that another CT entry pair is cleaned up by connScan", makestep(func() {
 
-			s.ConntrackScanStart()
 			connScan.Scan()
-			s.ConntrackScanEnd()
 
 			cnt := 0
 
@@ -871,14 +867,12 @@ var _ = Describe("BPF Syncer", func() {
 		}))
 
 		By("recreating a CT scanner for the actual syncer", func() {
-			connScan = conntrack.NewScanner(ct, conntrack.NewStaleNATScanner(s.ConntrackFrontendHasBackend))
+			connScan = conntrack.NewScanner(ct, conntrack.NewStaleNATScanner(s))
 		})
 
 		By("checking that CT table emptied by connScan", makestep(func() {
 
-			s.ConntrackScanStart()
 			connScan.Scan()
-			s.ConntrackScanEnd()
 
 			cnt := 0
 

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -51,7 +51,6 @@ import (
 	"github.com/projectcalico/felix/bpf"
 	"github.com/projectcalico/felix/bpf/conntrack"
 	"github.com/projectcalico/felix/bpf/nat"
-	"github.com/projectcalico/felix/bpf/proxy"
 	. "github.com/projectcalico/felix/fv/connectivity"
 	"github.com/projectcalico/felix/fv/containers"
 	"github.com/projectcalico/felix/fv/infrastructure"
@@ -2304,7 +2303,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 									// increasing.
 									start := time.Now()
 									prevCount := pc.PongCount()
-									for time.Since(start) < 2*proxy.ConntrackCleanerPeriod {
+									for time.Since(start) < 2*conntrack.ScanPeriod {
 										time.Sleep(time.Second)
 										newCount := pc.PongCount()
 										Expect(prevCount).Should(


### PR DESCRIPTION
## Description

It did not make a good sense to have it inside except that it was easier that way. Cleaning up expired connections had nothing to do with kube-proxy and cleaning connections to service that do not exist anymore only need to consult kube-proxy.

Taking it outside allows us to have a single iterator over the conntrack map and to add new entry scanners as the requirements and usecases emerge.

The one downside is that it is harder to sync with kube-proxy now. Therefore we kick off the first sweep asap before we add kube-proxy to clean up the map asap (as we did) but the next scan is not right after the next successful sync up of proxy, but is deffered to the next timer tick. That should not be a major difference given the timer period of 10s.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
