### PR TITLE
BPF fs root override

### DIFF
--- a/bpf/arp/map.go
+++ b/bpf/arp/map.go
@@ -25,7 +25,7 @@ import (
 )
 
 var MapParams = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_arp",
+	Filename:   "/tc/globals/cali_v4_arp",
 	Type:       "lru_hash",
 	KeySize:    KeySize,
 	ValueSize:  ValueSize,

--- a/bpf/bpf.go
+++ b/bpf/bpf.go
@@ -76,8 +76,6 @@ const (
 	sockMapName                = "calico_sock_map_" + sockMapVersion
 	sockmapEndpointsMapVersion = "v1"
 	sockmapEndpointsMapName    = "calico_sk_endpoints_" + sockmapEndpointsMapVersion
-
-	defaultBPFfsPath = "/sys/fs/bpf"
 )
 
 var (
@@ -195,20 +193,20 @@ func NewBPFLib(binDir string) (*BPFLib, error) {
 
 func MaybeMountBPFfs() (string, error) {
 	var err error
-	bpffsPath := defaultBPFfsPath
+	bpffsPath := FSRoot
 
-	mnt, err := isMount(defaultBPFfsPath)
+	mnt, err := isMount(FSRoot)
 	if err != nil {
 		return "", err
 	}
 
-	fsBPF, err := isBPF(defaultBPFfsPath)
+	fsBPF, err := isBPF(FSRoot)
 	if err != nil {
 		return "", err
 	}
 
 	if !mnt {
-		err = mountBPFfs(defaultBPFfsPath)
+		err = mountBPFfs(FSRoot)
 	} else if !fsBPF {
 		var runfsBPF bool
 

--- a/bpf/conntrack/map.go
+++ b/bpf/conntrack/map.go
@@ -360,7 +360,7 @@ func (e Value) IsForwardDSR() bool {
 }
 
 var MapParams = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_ct",
+	Filename:   "/tc/globals/cali_v4_ct",
 	Type:       "hash",
 	KeySize:    KeySize,
 	ValueSize:  ValueSize,

--- a/bpf/ipsets/map.go
+++ b/bpf/ipsets/map.go
@@ -42,7 +42,7 @@ type IPSetEntry [IPSetEntrySize]byte
 
 func Map(mc *bpf.MapContext) bpf.Map {
 	return mc.NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/tc/globals/cali_v4_ip_sets",
+		Filename:   "/tc/globals/cali_v4_ip_sets",
 		Type:       "lpm_trie",
 		KeySize:    IPSetEntrySize,
 		ValueSize:  4,

--- a/bpf/jump/map.go
+++ b/bpf/jump/map.go
@@ -20,7 +20,7 @@ import (
 
 func MapForTest(mc *bpf.MapContext) bpf.Map {
 	return mc.NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/tc/globals/cali_v4_jump",
+		Filename:   "/tc/globals/cali_v4_jump",
 		Type:       "prog_array",
 		KeySize:    4,
 		ValueSize:  4,

--- a/bpf/mock_bpf_lib.go
+++ b/bpf/mock_bpf_lib.go
@@ -115,7 +115,7 @@ func NewMockBPFLib(binDir string) *MockBPFLib {
 }
 
 func (b *MockBPFLib) GetBPFCalicoDir() string {
-	return "/sys/fs/bpf/calico"
+	return FSRoot + "/calico"
 }
 
 func (b *MockBPFLib) NewCIDRMap(ifName string, family IPFamily) (string, error) {
@@ -132,7 +132,7 @@ func (b *MockBPFLib) NewCIDRMap(ifName string, family IPFamily) (string, error) 
 
 	id += 1
 
-	return fmt.Sprintf("/sys/fs/bpf/calico/xdp/%s_ipv4_v1_blacklist", ifName), nil
+	return fmt.Sprintf(FSRoot+"/calico/xdp/%s_ipv4_v1_blacklist", ifName), nil
 }
 
 func (b *MockBPFLib) NewFailsafeMap() (string, error) {
@@ -140,7 +140,7 @@ func (b *MockBPFLib) NewFailsafeMap() (string, error) {
 
 	id += 1
 
-	return "/sys/fs/bpf/calico/xdp/calico_failsafe_ports_v1", nil
+	return FSRoot + "/calico/xdp/calico_failsafe_ports_v1", nil
 }
 
 func (b *MockBPFLib) DumpCIDRMap(ifName string, family IPFamily) (map[CIDRMapKey]uint32, error) {
@@ -668,7 +668,7 @@ func (b *MockBPFLib) NewSockmapEndpointsMap() (string, error) {
 
 	id += 1
 
-	return "/sys/fs/bpf/calico/sockmap/calico_sockmap_endpoints", nil
+	return FSRoot + "/calico/sockmap/calico_sockmap_endpoints", nil
 }
 
 func (b *MockBPFLib) NewSockmap() (string, error) {
@@ -677,7 +677,7 @@ func (b *MockBPFLib) NewSockmap() (string, error) {
 
 	id += 1
 
-	return "/sys/fs/bpf/calico/sockmap/calico_sock_map", nil
+	return FSRoot + "/calico/sockmap/calico_sock_map", nil
 }
 
 func (b *MockBPFLib) UpdateSockmapEndpoints(ip net.IP, mask int) error {

--- a/bpf/nat/connecttime.go
+++ b/bpf/nat/connecttime.go
@@ -74,7 +74,7 @@ func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 		}
 	}
 
-	bpf.CleanUpCalicoPins("/sys/fs/bpf/calico_connect4")
+	bpf.CleanUpCalicoPins("/calico_connect4")
 
 	return nil
 }

--- a/bpf/nat/maps.go
+++ b/bpf/nat/maps.go
@@ -230,7 +230,7 @@ func (k BackendValue) AsBytes() []byte {
 }
 
 var FrontendMapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_nat_fe",
+	Filename:   "/tc/globals/cali_v4_nat_fe",
 	Type:       "lpm_trie",
 	KeySize:    frontendKeySize,
 	ValueSize:  frontendValueSize,
@@ -245,7 +245,7 @@ func FrontendMap(mc *bpf.MapContext) bpf.Map {
 }
 
 var BackendMapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_nat_be",
+	Filename:   "/tc/globals/cali_v4_nat_be",
 	Type:       "hash",
 	KeySize:    backendKeySize,
 	ValueSize:  backendValueSize,
@@ -462,7 +462,7 @@ func (v AffinityValue) AsBytes() []byte {
 
 // AffinityMapParameters describe the AffinityMap
 var AffinityMapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_nat_aff",
+	Filename:   "/tc/globals/cali_v4_nat_aff",
 	Type:       "lru_hash",
 	KeySize:    affinityKeySize,
 	ValueSize:  affinityValueSize,
@@ -566,7 +566,7 @@ func (v SendRecvMsgValue) String() string {
 
 // SendRecvMsgMapParameters define SendRecvMsgMap
 var SendRecvMsgMapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_srmsg",
+	Filename:   "/tc/globals/cali_v4_srmsg",
 	Type:       "lru_hash",
 	KeySize:    sendRecvMsgKeySize,
 	ValueSize:  sendRecvMsgValueSize,

--- a/bpf/proxy/syncer_test.go
+++ b/bpf/proxy/syncer_test.go
@@ -913,7 +913,7 @@ func (m *mockNATMap) GetName() string {
 }
 
 func (m *mockNATMap) Path() string {
-	return "/sys/fs/bpf/tc/nat"
+	return "/tc/nat"
 }
 
 func (m *mockNATMap) Iter(iter bpf.IterCallback) error {
@@ -998,7 +998,7 @@ func (m *mockNATBackendMap) GetName() string {
 }
 
 func (m *mockNATBackendMap) Path() string {
-	return "/sys/fs/bpf/tc/natbe"
+	return "/tc/natbe"
 }
 
 func (m *mockNATBackendMap) Iter(iter bpf.IterCallback) error {
@@ -1079,7 +1079,7 @@ func (m *mockAffinityMap) GetName() string {
 }
 
 func (m *mockAffinityMap) Path() string {
-	return "/sys/fs/bpf/tc/aff"
+	return "/tc/aff"
 }
 
 func (m *mockAffinityMap) Iter(iter bpf.IterCallback) error {

--- a/bpf/routes/map.go
+++ b/bpf/routes/map.go
@@ -178,7 +178,7 @@ func NewValueWithIfIndex(flags Flags, ifIndex int) Value {
 }
 
 var MapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_routes",
+	Filename:   "/tc/globals/cali_v4_routes",
 	Type:       "lpm_trie",
 	KeySize:    KeySize,
 	ValueSize:  ValueSize,

--- a/bpf/state/map.go
+++ b/bpf/state/map.go
@@ -87,7 +87,7 @@ func StateFromBytes(bytes []byte) State {
 
 func Map(mc *bpf.MapContext) bpf.Map {
 	return mc.NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/tc/globals/cali_v4_state",
+		Filename:   "/tc/globals/cali_v4_state",
 		Type:       "percpu_array",
 		KeySize:    4,
 		ValueSize:  expectedSize,
@@ -98,7 +98,7 @@ func Map(mc *bpf.MapContext) bpf.Map {
 
 func MapForTest(mc *bpf.MapContext) bpf.Map {
 	return mc.NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/tc/globals/test_v4_state",
+		Filename:   "/tc/globals/test_v4_state",
 		Type:       "array",
 		KeySize:    4,
 		ValueSize:  expectedSize,

--- a/bpf/tc/attach.go
+++ b/bpf/tc/attach.go
@@ -244,7 +244,7 @@ func CleanUpJumpMaps() {
 
 	// Find the maps we care about by walking the BPF filesystem.
 	mapIDToPath := make(map[int]string)
-	err := filepath.Walk("/sys/fs/bpf/tc", func(p string, info os.FileInfo, err error) error {
+	err := filepath.Walk(bpf.FSRoot+"/tc", func(p string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -336,7 +336,7 @@ func CleanUpJumpMaps() {
 
 	// Look for empty dirs.
 	emptyAutoDirs := set.New()
-	err = filepath.Walk("/sys/fs/bpf/tc", func(p string, info os.FileInfo, err error) error {
+	err = filepath.Walk(bpf.FSRoot+"/tc", func(p string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/bpf/tc/cleanup.go
+++ b/bpf/tc/cleanup.go
@@ -120,7 +120,7 @@ func CleanUpProgramsAndPins() {
 		return nil
 	})
 
-	bpf.CleanUpCalicoPins("/sys/fs/bpf/tc")
+	bpf.CleanUpCalicoPins("/tc")
 }
 
 var tcFiltRegex = regexp.MustCompile(`filter .*? bpf .*? id (\d+)`)

--- a/bpf/ut/attach_test.go
+++ b/bpf/ut/attach_test.go
@@ -33,7 +33,7 @@ func TestJumpMapCleanup(t *testing.T) {
 
 	bpffs, err := bpf.MaybeMountBPFfs()
 	Expect(err).NotTo(HaveOccurred())
-	Expect(bpffs).To(Equal("/sys/fs/bpf"))
+	Expect(bpffs).To(Equal(bpf.FSRoot))
 
 	ap := tc.AttachPoint{
 		Type:     tc.EpTypeWorkload,
@@ -92,7 +92,7 @@ func TestJumpMapCleanup(t *testing.T) {
 
 func countJumpMaps() int {
 	var count int
-	err := filepath.Walk("/sys/fs/bpf/tc", func(p string, info os.FileInfo, err error) error {
+	err := filepath.Walk(bpf.FSRoot+"/tc", func(p string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -111,7 +111,7 @@ func countJumpMaps() int {
 
 func countTCDirs() int {
 	var count int
-	err := filepath.Walk("/sys/fs/bpf/tc", func(p string, info os.FileInfo, err error) error {
+	err := filepath.Walk(bpf.FSRoot+"/tc", func(p string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -154,7 +154,7 @@ func setupAndRun(logger testLogger, loglevel string, section string, rules polpr
 	defer os.RemoveAll(tempDir)
 
 	unique := path.Base(tempDir)
-	bpfFsDir := "/sys/fs/bpf/" + unique
+	bpfFsDir := "/" + unique
 
 	err = os.Mkdir(bpfFsDir, os.ModePerm)
 	Expect(err).NotTo(HaveOccurred())
@@ -415,7 +415,7 @@ func runBpfUnitTest(t *testing.T, source string, testFn func(bpfProgRunFn)) {
 	defer os.RemoveAll(tempDir)
 
 	unique := path.Base(tempDir)
-	bpfFsDir := "/sys/fs/bpf/" + unique
+	bpfFsDir := "/" + unique
 
 	err = os.Mkdir(bpfFsDir, os.ModePerm)
 	Expect(err).NotTo(HaveOccurred())
@@ -719,7 +719,7 @@ func TestMapIterWithDelete(t *testing.T) {
 	RegisterTestingT(t)
 
 	m := (&bpf.MapContext{}).NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/tc/globals/cali_tmap",
+		Filename:   "/tc/globals/cali_tmap",
 		Type:       "hash",
 		KeySize:    8,
 		ValueSize:  8,
@@ -767,7 +767,7 @@ func TestMapIterWithDeleteLastOfBatch(t *testing.T) {
 	RegisterTestingT(t)
 
 	m := (&bpf.MapContext{}).NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/tc/globals/cali_tmap",
+		Filename:   "/tc/globals/cali_tmap",
 		Type:       "hash",
 		KeySize:    8,
 		ValueSize:  8,

--- a/bpf/ut/precompilation_test.go
+++ b/bpf/ut/precompilation_test.go
@@ -35,7 +35,7 @@ func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 
 	bpffs, err := bpf.MaybeMountBPFfs()
 	Expect(err).NotTo(HaveOccurred())
-	Expect(bpffs).To(Equal("/sys/fs/bpf"))
+	Expect(bpffs).To(Equal(bpf.FSRoot))
 
 	for _, logLevel := range []string{"OFF", "INFO", "DEBUG"} {
 		logLevel := logLevel

--- a/cmd/calico-bpf/commands/root.go
+++ b/cmd/calico-bpf/commands/root.go
@@ -22,6 +22,8 @@ import (
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
+
+	"github.com/projectcalico/felix/bpf"
 )
 
 var cfgFile string
@@ -43,15 +45,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.calico-bpf.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.PersistentFlags().StringVar(&bpf.FSRoot, "bpffs", "/sys/fs/bpf", "Sets the BPF fs root")
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
## Description

    calico-bpf can use alternative bpffs root
    
    For instance, EKS Bottle rocket has the bpffs mounted at
    /.bottlerocket/rootfs/sys/fs/bpf

    bpf: bpf.FSRoot is a configurable bpffs root


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
