### PR TITLE
Update ext dataplane with recent proto messages

### DIFF
--- a/dataplane/external/ext_dataplane.go
+++ b/dataplane/external/ext_dataplane.go
@@ -183,6 +183,21 @@ func (fc *extDataplaneConn) SendMessage(msg interface{}) error {
 		envelope.Payload = &proto.ToDataplane_NamespaceUpdate{NamespaceUpdate: msg}
 	case *proto.NamespaceRemove:
 		envelope.Payload = &proto.ToDataplane_NamespaceRemove{NamespaceRemove: msg}
+	case *proto.RouteUpdate:
+		envelope.Payload = &proto.ToDataplane_RouteUpdate{RouteUpdate: msg}
+	case *proto.RouteRemove:
+		envelope.Payload = &proto.ToDataplane_RouteRemove{RouteRemove: msg}
+	case *proto.VXLANTunnelEndpointUpdate:
+		envelope.Payload = &proto.ToDataplane_VtepUpdate{VtepUpdate: msg}
+	case *proto.VXLANTunnelEndpointRemove:
+		envelope.Payload = &proto.ToDataplane_VtepRemove{VtepRemove: msg}
+	case *proto.WireguardEndpointUpdate:
+		envelope.Payload = &proto.ToDataplane_WireguardEndpointUpdate{WireguardEndpointUpdate: msg}
+	case *proto.WireguardEndpointRemove:
+		envelope.Payload = &proto.ToDataplane_WireguardEndpointRemove{WireguardEndpointRemove: msg}
+	case *proto.GlobalBGPConfigUpdate:
+		envelope.Payload = &proto.ToDataplane_GlobalBgpConfigUpdate{GlobalBgpConfigUpdate: msg}
+
 	default:
 		log.WithField("msg", msg).Panic("Unknown message type")
 	}


### PR DESCRIPTION
## Description
This fixes a crash in felix when running with an external dataplane
configured.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
```release-note
None required
```
