### PR TITLE
BPF: Host endpoint support

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -63,6 +63,12 @@ blocks:
   task:
     prologue:
       commands:
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during the build.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
       # Free up space on the build machine.
       - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,6 @@ ALL_BPF_PROGS=$(BPF_GPL_O_FILES) $(BPF_APACHE_O_FILES)
 # unnecessary rebuilds of anything that depends on the BPF prgrams.)
 .PHONY: build-bpf clean-bpf
 build-bpf:
-	rm -f bpf-gpl/*.d bpf-apache/*.d
 	$(DOCKER_GO_BUILD) sh -c "make -j -C bpf-apache all && \
 	                          make -j -C bpf-gpl all ut-objs"
 

--- a/bpf-gpl/Makefile
+++ b/bpf-gpl/Makefile
@@ -76,8 +76,6 @@ connect_time_%v6.ll: connect_balancer_v6.c connect_balancer_v6.d calculate-flags
 UT_CFLAGS=\
 	-D__BPFTOOL_LOADER__ \
 	-DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG \
-	-DCALI_VXLAN_PORT=5665 \
-	-DCALI_NAT_TUNNEL_MTU=700 \
 	-DUNITTEST \
 	-DCALI_LOG_PFX=UNITTEST \
 	-I .

--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -111,16 +111,47 @@ static CALI_BPF_INLINE void __compile_asserts(void) {
 }
 
 enum calico_skb_mark {
-	// TODO allocate marks from the mark pool.
+	/* Bits that we set in all _our_ mark patterns. */
 	CALI_MARK_CALICO                     = 0xc0000000,
 	CALI_MARK_CALICO_MASK                = 0xf0000000,
+	/* The "SEEN" bit is set by any BPF program that allows a packet through.  It allows
+	 * a second BPF program that handles the same packet to determine that another program
+	 * handled it first. */
 	CALI_SKB_MARK_SEEN                   = CALI_MARK_CALICO      | 0x01000000,
 	CALI_SKB_MARK_SEEN_MASK              = CALI_MARK_CALICO_MASK | CALI_SKB_MARK_SEEN,
+	/* The "BYPASS" bit is an even stronger indication than "SEEN". It is set by BPF programs
+	 * that have determined that the packet is approved and any downstream programs do not need
+	 * to further validate the packet. */
 	CALI_SKB_MARK_BYPASS                 = CALI_SKB_MARK_SEEN    | 0x02000000,
+	/* "BYPASS_FWD" is a special case of "BYPASS" used when a packet returns from one of our
+	 * VXLAN tunnels.  It tells the downstream program to forward the packet. */
 	CALI_SKB_MARK_BYPASS_FWD             = CALI_SKB_MARK_BYPASS  | 0x00300000,
+	/* "BYPASS_FWD_SRC_FIXUP" is a special case of "BYPASS" used when a from-workload program
+	 * is returning a packet to our VXLAN tunnel.  The from-workload program does the encapsulation
+	 * but, due to RPF, it cannot set the source IP of the outer IP header.  The mark bit
+	 * tells the downstream HEP program to fix up the source IP to be the host IP as it leaves the
+	 * host namespace. */
 	CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP   = CALI_SKB_MARK_BYPASS  | 0x00500000,
+	CALI_SKB_MARK_BYPASS_MASK            = CALI_SKB_MARK_SEEN_MASK | 0x02700000,
+	/* The FALLTHROUGH bit is used by programs that are towards the host namespace to indicate
+	 * that the packet is not known in BPF conntrack. We have iptables rules to drop or allow
+	 * such packets based on their Linux conntrack state. This allows for us to handle flows that
+	 * were live before BPF was enabled. */
+	CALI_SKB_MARK_FALLTHROUGH            = CALI_SKB_MARK_SEEN    | 0x04000000,
+	/* The SKIP_RPF bit is used by programs that are towards the host namespace to disable our
+	 * RPF check for htat packet.  Typically used for a packet that we originate (such as an ICMP
+	 * response). */
 	CALI_SKB_MARK_SKIP_RPF               = CALI_SKB_MARK_BYPASS  | 0x00400000,
+	/* The NAT_OUT bit is used by programs that are towards the host namespace to tell iptables to
+	 * do SNAT for this flow.  Subsequent packets will also be allowed to fall through to the host
+	 * netns. */
 	CALI_SKB_MARK_NAT_OUT                = CALI_SKB_MARK_BYPASS  | 0x00800000,
+
+	/* CT_ESTABLISHED is used by iptables to tell the BPF programs that the packet is part of an
+	 * established Linux conntrack flow. This allows the BPF program to let through pre-existing
+	 * flows at start of day. */
+	CALI_SKB_MARK_CT_ESTABLISHED         = CALI_MARK_CALICO      | 0x08000000,
+	CALI_SKB_MARK_CT_ESTABLISHED_MASK    = CALI_MARK_CALICO      | 0x08000000,
 };
 
 /* bpf_exit inserts a BPF exit instruction with the given return value. In a fully-inlined

--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -46,11 +46,27 @@ struct bpf_map_def_extended {
 };
 
 /* These constants must be kept in sync with the calculate-flags script. */
+
+// CALI_TC_HOST_EP is set for all host interfaces including tunnels.
 #define CALI_TC_HOST_EP		(1<<0)
+// CALI_TC_INGRESS is set when compiling a program in the "ingress" direction as defined by
+// policy.  For host endpoints, ingress has its natural meaning (towards the host namespace)
+// and it agrees with TC's definition of ingress. For workload endpoint programs, ingress is
+// relative to the workload so the ingress program is applied at egress from the host namespace
+// and vice-versa.
 #define CALI_TC_INGRESS		(1<<1)
+// CALI_TC_TUNNEL is set when compiling the program for the IPIP tunnel. It is *not* set
+// when compiling the wireguard or tunnel program (or VXLAN).  IPIP is a special case because
+// it is a layer 3 device, so we don't see an ethernet header on packets arriving from the IPIP
+// device.
 #define CALI_TC_TUNNEL		(1<<2)
+// CALI_CGROUP is set when compiling the cgroup connect-time load balancer programs.
 #define CALI_CGROUP		(1<<3)
+// CALI_TC_DSR is set when compiling programs for DSR mode.  In DSR mode, traffic to node
+// ports is encapped on the "request" leg but the response is returned directly from the
+// node with the backing workload.
 #define CALI_TC_DSR		(1<<4)
+// CALI_TC_WIREGUARD is set for the programs attached to the wireguard interface.
 #define CALI_TC_WIREGUARD	(1<<5)
 
 #ifndef CALI_DROP_WORKLOAD_TO_HOST

--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -216,9 +216,11 @@ static CALI_BPF_INLINE __be32 cali_configurable_##name()					\
 
 CALI_CONFIGURABLE_DEFINE(host_ip, 0x54534f48) /* be 0x54534f48 = ASCII(HOST) */
 CALI_CONFIGURABLE_DEFINE(tunnel_mtu, 0x55544d54) /* be 0x55544d54 = ASCII(TMTU) */
+CALI_CONFIGURABLE_DEFINE(vxlan_port, 0x52505856) /* be 0x52505856 = ASCII(VXPR) */
 
 #define HOST_IP		CALI_CONFIGURABLE(host_ip)
 #define TUNNEL_MTU 	CALI_CONFIGURABLE(tunnel_mtu)
+#define VXLAN_PORT 	CALI_CONFIGURABLE(vxlan_port)
 
 #define MAP_PIN_GLOBAL	2
 

--- a/bpf-gpl/calculate-flags
+++ b/bpf-gpl/calculate-flags
@@ -50,8 +50,6 @@ fi
 
 if [[ "${filename}" =~ test_.* ]]; then
   args+=("-D__BPFTOOL_LOADER__")
-  args+=("-DCALI_VXLAN_PORT=5665")
-  args+=("-DCALI_NAT_TUNNEL_MTU=700")
 fi
 
 flags=0

--- a/bpf-gpl/calculate-flags
+++ b/bpf-gpl/calculate-flags
@@ -67,7 +67,7 @@ flags=0
 if [[ "${filename}" =~ .*hep.* ]]; then
   # Host endpoint.
   ((flags |= CALI_TC_HOST_EP))
-  args+=("-DCALI_DEBUG_ALLOW_ALL" "-DCALI_LOG_PFX=CALICOLO")
+  args+=("-DCALI_NO_DEFAULT_POLICY_PROG" "-DCALI_LOG_PFX=CALICOLO")
   ep_type="host"
 elif [[ "${filename}" =~ .*tnl.* ]]; then
   # Tunnel.

--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -451,20 +451,49 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 
 	struct calico_ct_value *v = cali_v4_ct_lookup_elem(&k);
 	if (!v) {
+		if (CALI_F_FROM_HOST && proto_orig == IPPROTO_TCP) {
+			// Mid-flow TCP packet with no conntrack entry leaving the host namespace.
+			CALI_DEBUG("BPF CT Miss for mid-flow TCP\n");
+			if ((tc_ctx->skb->mark & CALI_SKB_MARK_CT_ESTABLISHED_MASK) == CALI_SKB_MARK_CT_ESTABLISHED) {
+				// Linux Conntrack has marked the packet as part of an established flow.
+				// TODO-HEP Create a tracking entry for uplifted flow so that we handle the reverse traffic more efficiently.
+				 CALI_DEBUG("BPF CT Miss but have Linux CT entry: established\n");
+				 result.rc = CALI_CT_ESTABLISHED;
+				 return result;
+			}
+			CALI_DEBUG("BPF CT Miss but Linux CT entry not signalled\n");
+			result.rc = CALI_CT_MID_FLOW_MISS;
+			return result;
+		}
+		if (CALI_F_TO_HOST && proto_orig == IPPROTO_TCP) {
+			// Miss for a mid-flow TCP packet towards the host.  This may be part of a
+			// connection that predates the BPF program so we need to let it fall through
+			// to iptables.
+			CALI_DEBUG("BPF CT Miss for mid-flow TCP\n");
+			result.rc = CALI_CT_MID_FLOW_MISS;
+			return result;
+		}
 		if (ct_ctx->proto != IPPROTO_ICMP) {
+			// Not ICMP so can't be a "related" packet.
 			CALI_CT_DEBUG("Miss.\n");
 			goto out_lookup_fail;
 		}
+
 		if (!icmp_type_is_err(tc_ctx->icmp_header->type)) {
+			// ICMP but not an error response packet.
 			CALI_DEBUG("CT-ICMP: type %d not an error\n", tc_ctx->icmp_header->type);
 			goto out_lookup_fail;
 		}
 
+		// ICMP error packets are a response to a failed UDP/TCP/etc packet.  Try to extract the
+		// details of the inner packet.
 		if (!skb_icmp_err_unpack(tc_ctx, ct_ctx)) {
-			CALI_CT_DEBUG("Failed to parse ICMP error.\n");
+			CALI_CT_DEBUG("Failed to parse ICMP error packet.\n");
 			goto out_invalid;
 		}
 
+		// skb_icmp_err_unpack updates the ct_ctx with the details of the inner packet;
+		// look for a conntrack entry for the inner packet...
 		CALI_CT_DEBUG("related lookup from %x:%d\n", bpf_ntohl(ct_ctx->src), ct_ctx->sport);
 		CALI_CT_DEBUG("related lookup to   %x:%d\n", bpf_ntohl(ct_ctx->dst), ct_ctx->dport);
 
@@ -472,6 +501,25 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 		k = ct_make_key(srcLTDest, ct_ctx->proto, ct_ctx->src, ct_ctx->dst, ct_ctx->sport, ct_ctx->dport);
 		v = cali_v4_ct_lookup_elem(&k);
 		if (!v) {
+			if (CALI_F_FROM_HOST &&
+				proto_orig == IPPROTO_TCP &&
+				(tc_ctx->skb->mark & CALI_SKB_MARK_CT_ESTABLISHED_MASK) == CALI_SKB_MARK_CT_ESTABLISHED) {
+				// Linux Conntrack has marked the packet as part of a known flow.
+				// TODO-HEP Create a tracking entry for uplifted flow so that we handle the reverse traffic more efficiently.
+				CALI_DEBUG("BPF CT related miss but have Linux CT entry: established\n");
+				result.rc = CALI_CT_ESTABLISHED;
+				return result;
+			}
+
+			if (CALI_F_TO_HOST && ct_ctx->proto) {
+				// Miss for a related packet towards the host.  This may be part of a
+				// connection that predates the BPF program so we need to let it fall through
+				// to iptables.
+				CALI_DEBUG("BPF CT related miss for mid-flow TCP\n");
+				result.rc = CALI_CT_MID_FLOW_MISS;
+				return result;
+			}
+
 			CALI_CT_DEBUG("Miss on ICMP related\n");
 			goto out_lookup_fail;
 		}

--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -768,7 +768,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 				// Disable bypass so the kernel can do its RPF check.
 				// The next BPF program to see the packet will update the interface
 				// after the RPF has passed.
-				CALI_CT_DEBUG("Disabling bypass to allow kernel RPF.");
+				CALI_CT_DEBUG("Disabling bypass to allow kernel RPF.\n");
 				ct_result_set_rc(result.rc, CALI_CT_ESTABLISHED);
 			}
 			ct_result_set_flag(result.rc, CALI_CT_RPF_FAILED);

--- a/bpf-gpl/failsafe.h
+++ b/bpf-gpl/failsafe.h
@@ -1,0 +1,67 @@
+// Project Calico BPF dataplane programs.
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#ifndef __CALI_BPF_FAILSAFE_H__
+#define __CALI_BPF_FAILSAFE_H__
+
+#include "bpf.h"
+#include "types.h"
+
+struct failsafe_key {
+	__u16 port;
+	__u8 ip_proto;
+	__u8 flags;
+};
+
+struct failsafe_val {
+	__u32 unused;
+};
+
+CALI_MAP_V1(cali_v4_fsafes,
+		BPF_MAP_TYPE_HASH,
+		struct failsafe_key, struct failsafe_val,
+		65536,
+		BPF_F_NO_PREALLOC,
+		MAP_PIN_GLOBAL)
+
+#define CALI_FSAFE_OUT 1
+
+static CALI_BPF_INLINE bool is_failsafe_in(__u8 ip_proto, __u16 dport) {
+	struct failsafe_key key = {
+		.ip_proto = ip_proto,
+		.port = dport,
+		.flags = 0,
+	};
+	if (cali_v4_fsafes_lookup_elem(&key)) {
+		return true;
+	}
+	return false;
+}
+
+static CALI_BPF_INLINE bool is_failsafe_out(__u8 ip_proto, __u16 dport) {
+	struct failsafe_key key = {
+		.ip_proto = ip_proto,
+		.port = dport,
+		.flags = CALI_FSAFE_OUT,
+	};
+	if (cali_v4_fsafes_lookup_elem(&key)) {
+		return true;
+	}
+	return false;
+}
+
+#endif /* __CALI_BPF_FAILSAFE_H__ */

--- a/bpf-gpl/jump.h
+++ b/bpf-gpl/jump.h
@@ -21,12 +21,7 @@
 #include "conntrack.h"
 #include "policy.h"
 
-enum cali_state_flags {
-	CALI_ST_NAT_OUTGOING	= (1 << 0),
-	CALI_ST_SKIP_FIB	= (1 << 1),
-};
-
-CALI_MAP_V1(cali_v4_state,
+CALI_MAP(cali_v4_state, 2,
 		BPF_MAP_TYPE_PERCPU_ARRAY,
 		__u32, struct cali_tc_state,
 		1, 0, MAP_PIN_GLOBAL)

--- a/bpf-gpl/jump.h
+++ b/bpf-gpl/jump.h
@@ -52,8 +52,8 @@ static CALI_BPF_INLINE void tc_state_fill_from_iphdr(struct cali_tc_state *state
 
 /* Add new values to the end as these are program indices */
 enum cali_jump_index {
-	POL_PROG_INDEX,
-	EPILOGUE_PROG_INDEX,
-	ICMP_PROG_INDEX,
+	PROG_INDEX_POLICY,
+	PROG_INDEX_EPILOGUE,
+	PROG_INDEX_ICMP,
 };
 #endif /* __CALI_BPF_JUMP_H__ */

--- a/bpf-gpl/policy_program.h
+++ b/bpf-gpl/policy_program.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@
 #ifndef __CALI_POL_PROG_H__
 #define __CALI_POL_PROG_H__
 
+#ifndef CALI_NO_DEFAULT_POLICY_PROG
 #ifdef CALI_DEBUG_ALLOW_ALL
 
 /* If we want to just compile the code without defining any policies and to
@@ -89,5 +90,7 @@ int calico_tc_norm_pol_tail(struct __sk_buff *skb)
 deny:
 	return TC_ACT_SHOT;
 }
+
+#endif /* CALI_DEBUG_NO_PROG */
 
 #endif /*  __CALI_POL_PROG_H__ */

--- a/bpf-gpl/policy_program.h
+++ b/bpf-gpl/policy_program.h
@@ -84,7 +84,7 @@ int calico_tc_norm_pol_tail(struct __sk_buff *skb)
 	state->pol_rc = execute_policy_norm(skb, state->ip_proto, state->ip_src,
 					    state->ip_dst, state->sport, state->dport);
 
-	bpf_tail_call(skb, &cali_jump, EPILOGUE_PROG_INDEX);
+	bpf_tail_call(skb, &cali_jump, PROG_INDEX_EPILOGUE);
 	CALI_DEBUG("Tail call to post-policy program failed: DROP\n");
 
 deny:

--- a/bpf-gpl/routes.h
+++ b/bpf-gpl/routes.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -87,6 +87,11 @@ static CALI_BPF_INLINE enum cali_rt_flags cali_rt_lookup_flags(__be32 addr)
 static CALI_BPF_INLINE bool rt_addr_is_local_host(__be32 addr)
 {
 	return  cali_rt_flags_local_host(cali_rt_lookup_flags(addr));
+}
+
+static CALI_BPF_INLINE bool rt_addr_is_remote_host(__be32 addr)
+{
+	return  cali_rt_flags_remote_host(cali_rt_lookup_flags(addr));
 }
 
 #endif /* __CALI_ROUTES_H__ */

--- a/bpf-gpl/routes.h
+++ b/bpf-gpl/routes.h
@@ -82,6 +82,7 @@ static CALI_BPF_INLINE enum cali_rt_flags cali_rt_lookup_flags(__be32 addr)
 #define cali_rt_flags_local_host(t) (((t) & (CALI_RT_LOCAL | CALI_RT_HOST)) == (CALI_RT_LOCAL | CALI_RT_HOST))
 #define cali_rt_flags_local_workload(t) (((t) & CALI_RT_LOCAL) && ((t) & CALI_RT_WORKLOAD))
 #define cali_rt_flags_remote_workload(t) (!((t) & CALI_RT_LOCAL) && ((t) & CALI_RT_WORKLOAD))
+#define cali_rt_flags_remote_host(t) (((t) & (CALI_RT_LOCAL | CALI_RT_HOST)) == CALI_RT_HOST)
 
 static CALI_BPF_INLINE bool rt_addr_is_local_host(__be32 addr)
 {

--- a/bpf-gpl/sendrecv.h
+++ b/bpf-gpl/sendrecv.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -33,6 +33,19 @@ CALI_MAP_V1(cali_v4_srmsg,
 		BPF_MAP_TYPE_LRU_HASH,
 		struct sendrecv4_key, struct sendrecv4_val,
 		510000, 0, MAP_PIN_GLOBAL)
+
+struct ct_nats_key {
+	__u64 cookie;
+	__u32 ip;
+	__u32 port; /* because bpf_sock_addr uses 32bit */
+	__u8 proto;
+	__u8 pad[7];
+};
+
+CALI_MAP_V1(cali_v4_ct_nats,
+		BPF_MAP_TYPE_LRU_HASH,
+		struct ct_nats_key, struct sendrecv4_val,
+		10000, 0, MAP_PIN_GLOBAL)
 
 static CALI_BPF_INLINE __u16 ctx_port_to_host(__u32 port)
 {

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -423,7 +423,7 @@ skip_pre_dnat_default:
 	}
 
 icmp_send_reply:
-	bpf_tail_call(skb, &cali_jump, ICMP_PROG_INDEX);
+	bpf_tail_call(skb, &cali_jump, PROG_INDEX_ICMP);
 	/* should not reach here */
 	goto deny;
 
@@ -976,7 +976,7 @@ icmp_too_big:
 	goto icmp_send_reply;
 
 icmp_send_reply:
-	bpf_tail_call(skb, &cali_jump, ICMP_PROG_INDEX);
+	bpf_tail_call(skb, &cali_jump, PROG_INDEX_ICMP);
 	goto deny;
 
 nat_encap:

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -184,12 +184,12 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 			if (CALI_F_TO_HEP) {
 				if (rt_addr_is_remote_host(ctx.state->ip_dst) &&
 						rt_addr_is_local_host(ctx.state->ip_src)) {
-					CALI_DEBUG("VXLAN packet to known Calico host, allow.");
+					CALI_DEBUG("VXLAN packet to known Calico host, allow.\n");
 					goto allow;
 				} else {
 					/* Unlike IPIP, the user can be using VXLAN on a different VNI so we don't
 					 * simply drop it. */
-					CALI_DEBUG("VXLAN packet to unknown dest, fall through to policy.");
+					CALI_DEBUG("VXLAN packet to unknown dest, fall through to policy.\n");
 				}
 			}
 		}
@@ -202,31 +202,31 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 		// IPIP
 		if (CALI_F_TUNNEL | CALI_F_WIREGUARD) {
 			// IPIP should never be sent down the tunnel.
-			CALI_DEBUG("IPIP traffic to/from tunnel: drop");
+			CALI_DEBUG("IPIP traffic to/from tunnel: drop\n");
 			ctx.fwd.reason = CALI_REASON_UNAUTH_SOURCE;
 			goto deny;
 		}
 		if (CALI_F_FROM_HEP) {
 			if (rt_addr_is_remote_host(ctx.state->ip_src)) {
-				CALI_DEBUG("IPIP packet from known Calico host, allow.");
+				CALI_DEBUG("IPIP packet from known Calico host, allow.\n");
 				goto allow;
 			} else {
-				CALI_DEBUG("IPIP packet from unknown source, drop.");
+				CALI_DEBUG("IPIP packet from unknown source, drop.\n");
 				ctx.fwd.reason = CALI_REASON_UNAUTH_SOURCE;
 				goto deny;
 			}
 		} else if (CALI_F_TO_HEP && !CALI_F_TUNNEL && !CALI_F_WIREGUARD) {
 			if (rt_addr_is_remote_host(ctx.state->ip_dst)) {
-				CALI_DEBUG("IPIP packet to known Calico host, allow.");
+				CALI_DEBUG("IPIP packet to known Calico host, allow.\n");
 				goto allow;
 			} else {
-				CALI_DEBUG("IPIP packet to unknown dest, drop.");
+				CALI_DEBUG("IPIP packet to unknown dest, drop.\n");
 				ctx.fwd.reason = CALI_REASON_UNAUTH_SOURCE;
 				goto deny;
 			}
 		}
 		if (CALI_F_FROM_WEP) {
-			CALI_DEBUG("IPIP traffic from workload: drop");
+			CALI_DEBUG("IPIP traffic from workload: drop\n");
 			ctx.fwd.reason = CALI_REASON_UNAUTH_SOURCE;
 			goto deny;
 		}
@@ -247,7 +247,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 			goto allow;
 		}
 		// FIXME non-port based conntrack.
-		CALI_DEBUG("Unknown protocol from workload.");
+		CALI_DEBUG("Unknown protocol from workload.\n");
 		goto deny;
 	}
 

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -58,6 +58,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	 */
 	skb->mark = CALI_SET_SKB_MARK;
 #endif
+	CALI_DEBUG("New packet; mark=%x\n", skb->mark);
 
 	/* Optimisation: if another BPF program has already pre-approved the packet,
 	 * skip all processing. */
@@ -94,7 +95,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 		/* We're leaving the host namespace, check for other bypass mark bits.
 		 * These are a bit more complex to handle so we do it after creating the
 		 * context/state. */
-		switch (skb->mark) {
+		switch (skb->mark & CALI_SKB_MARK_BYPASS_MASK) {
 		case CALI_SKB_MARK_BYPASS_FWD:
 			CALI_DEBUG("Packet approved for forward.\n");
 			ctx.fwd.reason = CALI_REASON_BYPASS;
@@ -178,7 +179,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	case 4:
 		// IPIP
 		if (CALI_F_HEP) {
-			// TODO IPIP whitelist.
+			// TODO-HEPs IPIP whitelist.
 			CALI_DEBUG("IPIP: allow\n");
 			fwd_fib_set(&ctx.fwd, false);
 			goto allow;
@@ -196,7 +197,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 		break;
 	default:
 		if (CALI_F_HEP) {
-			// FIXME: allow unknown protocols through on host endpoints.
+			// TODO-HEPs allow unknown protocols through on host endpoints.
 			goto allow;
 		}
 		// FIXME non-port based conntrack.
@@ -222,6 +223,29 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	 */
 	if (ct_result_rpf_failed(ctx.state->ct_result.rc)) {
 		fwd_fib_set(&ctx.fwd, false);
+	}
+
+	if (ct_result_rc(ctx.state->ct_result.rc) == CALI_CT_MID_FLOW_MISS) {
+		if (CALI_F_TO_HOST) {
+			/* Mid-flow miss: let iptables handle it in case it's an existing flow
+			 * in the Linux conntrack table. We can't apply policy or DNAT because
+			 * it's too late in the flow.  iptables will drop if the flow is not
+			 * known.
+			 */
+			CALI_DEBUG("CT mid-flow miss; fall through to iptables.\n");
+			ctx.fwd.mark = CALI_SKB_MARK_FALLTHROUGH;
+			fwd_fib_set(&ctx.fwd, false);
+			goto finalize;
+		} else {
+			if (CALI_F_HEP) {
+				// TODO-HEP for data interfaces, this should allow, for active HEPs it should drop or apply policy.
+				CALI_DEBUG("CT mid-flow miss away from host with no Linux conntrack entry, allow.\n");
+				goto allow;
+			} else {
+				CALI_DEBUG("CT mid-flow miss away from host with no Linux conntrack entry, drop.\n");
+				goto deny;
+			}
+		}
 	}
 
 	/* Skip policy if we get conntrack hit */
@@ -398,7 +422,7 @@ int calico_tc_skb_accepted_entrypoint(struct __sk_buff *skb)
 		CALI_DEBUG("State map lookup failed: DROP\n");
 		return TC_ACT_SHOT;
 	}
-	
+
 	if (skb_refresh_validate_ptrs(&ctx, UDP_SIZE)) {
 		ctx.fwd.reason = CALI_REASON_SHORT;
 		CALI_DEBUG("Too short\n");
@@ -427,7 +451,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 	CALI_DEBUG("Entering calico_tc_skb_accepted\n");
 	struct __sk_buff *skb = ctx->skb;
 	struct cali_tc_state *state = ctx->state;
-	
+
 	enum calico_reason reason = CALI_REASON_UNKNOWN;
 	int rc = TC_ACT_UNSPEC;
 	bool fib = false;
@@ -1000,7 +1024,7 @@ int calico_tc_skb_send_icmp_replies(struct __sk_buff *skb)
 		CALI_DEBUG("State map lookup failed: DROP\n");
 		return TC_ACT_SHOT;
 	}
-	
+
 	CALI_DEBUG("ICMP type %d and code %d\n",ctx.state->icmp_type, ctx.state->icmp_code);
 
 	if (ctx.state->icmp_code == ICMP_FRAG_NEEDED) {

--- a/bpf-gpl/tc.h
+++ b/bpf-gpl/tc.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/bpf-gpl/types.h
+++ b/bpf-gpl/types.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -33,16 +33,35 @@
 #include "reasons.h"
 
 // struct cali_tc_state holds state that is passed between the BPF programs.
-// WARNING: must be kept in sync with the definitions in bpf/polprog/pol_prog_builder.go.
+// WARNING: must be kept in sync with
+// - the definitions in bpf/polprog/pol_prog_builder.go.
+// - the Go version of the struct in bpf/state/map.go
 struct cali_tc_state {
+	/* Initial IP read from the packet, updated to host's IP when doing NAT encap/ICMP error.
+	 * updated when doing CALI_CT_ESTABLISHED_SNAT handling. Used for FIB lookup. */
 	__be32 ip_src;
+	/* Initial IP read from packet. Updated when doing encap and ICMP errors or CALI_CT_ESTABLISHED_DNAT.
+	 * If connect-time load balancing is enabled, this will be the post-NAT IP because the connect-time
+	 * load balancer gets in before TC. */
 	__be32 ip_dst;
+	/* Set when invoking the policy program; if no NAT, ip_dst; otherwise, the pre-DNAT IP.  If the connect
+	 * time load balancer is enabled, this may be different from ip_dst. */
+	__be32 pre_nat_ip_dst;
+	/* If no NAT, ip_dst.  Otherwise the NAT dest that we look up from the NAT maps or the conntrack entry
+	 * for CALI_CT_ESTABLISHED_DNAT. */
 	__be32 post_nat_ip_dst;
+	/* For packets that arrived over our VXLAN tunnel, the source IP of the tunnel packet.
+	 * Zeroed out when we decide to respond with an ICMP error.
+	 * Also used to stash the ICMP MTU when calling the ICMP response program. */
 	__be32 tun_ip;
+	/* Return code from the policy program CALI_POL_DENY/ALLOW etc. */
 	__s32 pol_rc;
+	/* Source port of the packet; updated on the CALI_CT_ESTABLISHED_SNAT path or when doing encap.
+	 * zeroed out on the ICMP response path. */
 	__u16 sport;
 	union
 	{
+		/* dport is the destination port of the packet; it may be pre or post NAT */
 		__u16 dport;
 		struct
 		{
@@ -50,12 +69,35 @@ struct cali_tc_state {
 			__u8 icmp_code;
 		};
 	};
+	/* Pre-NAT dest port; set similarly to pre_nat_ip_dst. */
+	__u16 pre_nat_dport;
+	/* Post-NAT dest port; set similarly to post_nat_ip_dst. */
 	__u16 post_nat_dport;
+	/* Packet IP proto; updated to UDP when we encap. */
 	__u8 ip_proto;
+	/* Flags from enum cali_state_flags. */
 	__u8 flags;
+
+	/* Result of the conntrack lookup. */
 	struct calico_ct_result ct_result;
+	/* Result of the NAT calculation.  Zeroed if there is no DNAT. */
 	struct calico_nat_dest nat_dest;
 	__u64 prog_start_time;
+};
+
+enum cali_state_flags {
+	/* CALI_ST_NAT_OUTGOING is set if this packet is from a NAT-outgoing IP pool and is leaving the
+	 * Calico network. Such packets are dropped through to iptables for SNAT. */
+	CALI_ST_NAT_OUTGOING	= (1 << 0),
+	/* CALI_ST_SKIP_FIB is set if the BPF FIB lookup should be skipped for this packet (for example, to
+	 * allow for the kernel RPF check to run. */
+	CALI_ST_SKIP_FIB	= (1 << 1),
+	/* CALI_ST_DEST_IS_HOST is set if the packet is towards the host namespace and the destination
+	 * belongs to the host. */
+	CALI_ST_DEST_IS_HOST	= (1 << 2),
+	/* CALI_ST_SRC_IS_HOST is set if the packet is heading away from the host namespace and the source
+	 * belongs to the host. */
+	CALI_ST_SRC_IS_HOST	= (1 << 3),
 };
 
 struct fwd {

--- a/bpf/bpf_syscall.go
+++ b/bpf/bpf_syscall.go
@@ -312,6 +312,15 @@ func DeleteMapEntry(mapFD MapFD, k []byte, valueSize int) error {
 	return nil
 }
 
+func DeleteMapEntryIfExists(mapFD MapFD, k []byte, valueSize int) error {
+	err := DeleteMapEntry(mapFD, k, valueSize)
+	if err == unix.ENOENT {
+		// Delete failed because entry did not exist.
+		err = nil
+	}
+	return err
+}
+
 // Batch size established by trial and error; 8-32 seemed to be the sweet spot for the conntrack map.
 const MapIteratorNumKeys = 16
 

--- a/bpf/bpf_syscall_stub.go
+++ b/bpf/bpf_syscall_stub.go
@@ -62,6 +62,10 @@ func DeleteMapEntry(mapFD MapFD, k []byte, valueSize int) error {
 	panic("BPF syscall stub")
 }
 
+func DeleteMapEntryIfExists(mapFD MapFD, k []byte, valueSize int) error {
+	panic("BPF syscall stub")
+}
+
 func GetMapNextKey(mapFD MapFD, k []byte, keySize int) ([]byte, error) {
 	panic("BPF syscall stub")
 }

--- a/bpf/bpf_test.go
+++ b/bpf/bpf_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	bpfDP       BPFDataplane
+	bpfDP BPFDataplane
 )
 
 func cleanup(calicoDir string) error {

--- a/bpf/failsafes/failsafe_test.go
+++ b/bpf/failsafes/failsafe_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2021  All rights reserved.
+
+package failsafes
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/bpf/mock"
+	"github.com/projectcalico/felix/config"
+	"github.com/projectcalico/felix/logutils"
+)
+
+const zeroValue = "\x00\x00\x00\x00"
+
+type failsafeTest struct {
+	Name                string
+	InitialMapContents  map[string]string
+	In, Out             []config.ProtoPort
+	ExpectedMapContents map[string]string
+}
+
+func (f *failsafeTest) Run(t *testing.T) {
+	RegisterTestingT(t)
+	mockMap := mock.NewMockMap(MapParams)
+	if f.InitialMapContents != nil {
+		mockMap.Contents = f.InitialMapContents
+	}
+
+	opReporter := logutils.NewSummarizer("test")
+	mgr := NewManager(mockMap, f.In, f.Out, opReporter)
+
+	err := mgr.CompleteDeferredWork()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(Equal(f.ExpectedMapContents))
+
+	opCount := mockMap.OpCount()
+	err = mgr.CompleteDeferredWork()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.OpCount()).To(Equal(opCount), "failsafes manager should only execute if not in sync")
+}
+
+var tests = []failsafeTest{
+	{
+		Name:                "EmptyShouldGiveEmptyMap",
+		ExpectedMapContents: map[string]string{},
+	},
+	{
+		Name: "ShouldFillEmptyMap",
+		In: []config.ProtoPort{
+			{Protocol: "tcp", Port: 22},
+			{Protocol: "udp", Port: 1234},
+		},
+		Out: []config.ProtoPort{
+			{Protocol: "tcp", Port: 443},
+			{Protocol: "udp", Port: 53},
+		},
+		ExpectedMapContents: map[string]string{
+			string(Key{Port: 22, IPProto: 6}.ToSlice()):                       zeroValue,
+			string(Key{Port: 1234, IPProto: 17}.ToSlice()):                    zeroValue,
+			string(Key{Port: 443, IPProto: 6, Flags: FlagOutbound}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound}.ToSlice()): zeroValue,
+		},
+	},
+	{
+		Name: "ShouldResyncDirtyMap",
+		In: []config.ProtoPort{
+			{Protocol: "tcp", Port: 22},
+			{Protocol: "udp", Port: 1234},
+		},
+		Out: []config.ProtoPort{
+			{Protocol: "tcp", Port: 443},
+			{Protocol: "udp", Port: 53},
+		},
+		InitialMapContents: map[string]string{
+			string(Key{Port: 22, IPProto: 6}.ToSlice()):                        zeroValue,
+			string(Key{Port: 2345, IPProto: 17}.ToSlice()):                     zeroValue,
+			string(Key{Port: 1443, IPProto: 6, Flags: FlagOutbound}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound}.ToSlice()):  zeroValue,
+			string(Key{Port: 57, IPProto: 17, Flags: FlagOutbound}.ToSlice()):  zeroValue,
+		},
+		ExpectedMapContents: map[string]string{
+			string(Key{Port: 22, IPProto: 6}.ToSlice()):                       zeroValue,
+			string(Key{Port: 1234, IPProto: 17}.ToSlice()):                    zeroValue,
+			string(Key{Port: 443, IPProto: 6, Flags: FlagOutbound}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound}.ToSlice()): zeroValue,
+		},
+	},
+	{
+		Name: "ShouldRemoveAll",
+		InitialMapContents: map[string]string{
+			string(Key{Port: 22, IPProto: 6}.ToSlice()):                        zeroValue,
+			string(Key{Port: 2345, IPProto: 17}.ToSlice()):                     zeroValue,
+			string(Key{Port: 1443, IPProto: 6, Flags: FlagOutbound}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound}.ToSlice()):  zeroValue,
+			string(Key{Port: 57, IPProto: 17, Flags: FlagOutbound}.ToSlice()):  zeroValue,
+		},
+		ExpectedMapContents: map[string]string{},
+	},
+}
+
+func TestManager(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.Name, test.Run)
+	}
+}

--- a/bpf/failsafes/failsafes.go
+++ b/bpf/failsafes/failsafes.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2021  All rights reserved.
+
+package failsafes
+
+import (
+	"errors"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/set"
+
+	"github.com/projectcalico/felix/bpf"
+	"github.com/projectcalico/felix/config"
+	"github.com/projectcalico/felix/logutils"
+)
+
+type Manager struct {
+	// failsafesMap is the BPF map containing host enpodint failsafe ports.
+	failsafesMap bpf.Map
+	// failsafesInSync is set to true if the failsafe map is in sync.
+	failsafesInSync bool
+	// failsafesIn the inbound failsafe ports, from configuration.
+	failsafesIn []config.ProtoPort
+	// failsafesOut the outbound failsafe ports, from configuration.
+	failsafesOut []config.ProtoPort
+
+	opReporter logutils.OpRecorder
+}
+
+func (m *Manager) OnUpdate(_ interface{}) {
+}
+
+func NewManager(
+	failsafesMap bpf.Map,
+	failsafesIn, failsafesOut []config.ProtoPort,
+	opReporter logutils.OpRecorder,
+) *Manager {
+	return &Manager{
+		failsafesMap: failsafesMap,
+		failsafesIn:  failsafesIn,
+		failsafesOut: failsafesOut,
+		opReporter:   opReporter,
+	}
+}
+
+func (m *Manager) CompleteDeferredWork() error {
+	if !m.failsafesInSync {
+		return m.ResyncFailsafes()
+	}
+	return nil
+}
+
+func (m *Manager) ResyncFailsafes() error {
+	m.opReporter.RecordOperation("resync-failsafes")
+	err := m.failsafesMap.EnsureExists()
+	if err != nil {
+		// Shouldn't happen because int_dataplane opens the map already.
+		log.WithError(err).Panic("Failed to open failsafe port map.")
+	}
+
+	syncFailed := false
+	unknownKeys := set.New()
+	err = m.failsafesMap.Iter(func(rawKey, _ []byte) bpf.IteratorAction {
+		key := KeyFromSlice(rawKey)
+		unknownKeys.Add(key)
+		return bpf.IterNone
+	})
+	if err != nil {
+		log.WithError(err).Panic("Failed to iterate failsafe ports map.")
+	}
+
+	addPort := func(p config.ProtoPort, outbound bool) {
+		var ipProto uint8
+		switch strings.ToLower(p.Protocol) {
+		case "tcp":
+			ipProto = 6
+		case "udp":
+			ipProto = 17
+		default:
+			log.WithField("proto", p.Protocol).Warn("Ignoring failsafe port; protocol not supported in BPF mode.")
+			return
+		}
+		k := MakeKey(ipProto, p.Port, outbound)
+		unknownKeys.Discard(k)
+		err := m.failsafesMap.Update(k.ToSlice(), Value())
+		if err != nil {
+			log.WithError(err).Error("Failed to update failsafe port.")
+			syncFailed = true
+		}
+	}
+
+	for _, p := range m.failsafesIn {
+		addPort(p, false)
+	}
+	for _, p := range m.failsafesOut {
+		addPort(p, true)
+	}
+
+	unknownKeys.Iter(func(item interface{}) error {
+		k := item.(Key)
+		err := m.failsafesMap.Delete(k.ToSlice())
+		if err != nil {
+			log.WithError(err).WithField("key", k).Warn("Failed to remove failsafe port from map.")
+			syncFailed = true
+		}
+		return nil
+	})
+
+	m.failsafesInSync = !syncFailed
+	if syncFailed {
+		return errors.New("failed to sync failsafe ports")
+	}
+	return nil
+}

--- a/bpf/failsafes/failsafes_map.go
+++ b/bpf/failsafes/failsafes_map.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2021  All rights reserved.
+
+package failsafes
+
+import (
+	"encoding/binary"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/projectcalico/felix/bpf"
+)
+
+const (
+	KeySize   = 4
+	ValueSize = 4
+
+	FlagOutbound = 1
+)
+
+type Key struct {
+	Port    uint16
+	IPProto uint8
+	Flags   uint8
+}
+
+var MapParams = bpf.MapParameters{
+	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_fsafes",
+	Type:       "hash",
+	KeySize:    KeySize,
+	ValueSize:  ValueSize,
+	MaxEntries: 65536,
+	Name:       "cali_v4_fsafes",
+	Flags:      unix.BPF_F_NO_PREALLOC,
+}
+
+func Map(mc *bpf.MapContext) bpf.Map {
+	return mc.NewPinnedMap(MapParams)
+}
+
+func MakeKey(ipProto uint8, port uint16, outbound bool) Key {
+	var flags uint8
+	if outbound {
+		flags |= FlagOutbound
+	}
+	return Key{
+		Port:    port,
+		IPProto: ipProto,
+		Flags:   flags,
+	}
+}
+
+func (k Key) ToSlice() []byte {
+	key := make([]byte, KeySize)
+	binary.LittleEndian.PutUint16(key[:2], k.Port)
+	key[2] = k.IPProto
+	key[3] = k.Flags
+	return key
+}
+
+func KeyFromSlice(data []byte) Key {
+	var k Key
+	k.Port = binary.LittleEndian.Uint16(data[:2])
+	k.IPProto = data[2]
+	k.Flags = data[3]
+	return k
+}
+
+func Value() []byte {
+	return make([]byte, ValueSize) // value is unused for now.
+}

--- a/bpf/nat/connecttime.go
+++ b/bpf/nat/connecttime.go
@@ -37,6 +37,11 @@ type cgroupProgs struct {
 }
 
 func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
+	if os.Getenv("FELIX_DebugSkipCTLBCleanup") == "true" {
+		log.Info("FV special case: skipping CTLB cleanup")
+		return nil
+	}
+
 	cgroupPath, err := ensureCgroupPath(cgroupv2)
 	if err != nil {
 		return errors.Wrap(err, "failed to set-up cgroupv2")

--- a/bpf/nat/connecttime.go
+++ b/bpf/nat/connecttime.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -142,13 +142,19 @@ func InstallConnectTimeLoadBalancer(frontendMap, backendMap, rtMap bpf.Map, cgro
 	sendrecvMap := SendRecvMsgMap(&bpf.MapContext{
 		RepinningEnabled: repin,
 	})
-
 	err = sendrecvMap.EnsureExists()
 	if err != nil {
 		return errors.WithMessage(err, "failed to create sendrecv BPF Map")
 	}
+	allNATsMap := AllNATsMsgMap(&bpf.MapContext{
+		RepinningEnabled: repin,
+	})
+	err = allNATsMap.EnsureExists()
+	if err != nil {
+		return errors.WithMessage(err, "failed to create all-NATs BPF Map")
+	}
 
-	maps := []bpf.Map{frontendMap, backendMap, rtMap, sendrecvMap}
+	maps := []bpf.Map{frontendMap, backendMap, rtMap, sendrecvMap, allNATsMap}
 
 	err = installProgram("connect", "4", bpfMount, cgroupPath, logLevel, maps...)
 	if err != nil {

--- a/bpf/nat/maps.go
+++ b/bpf/nat/maps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -519,6 +519,7 @@ func AffinityMapMemIter(m AffinityMapMem) bpf.IterCallback {
 // };
 
 const sendRecvMsgKeySize = 16
+const ctNATsMsgKeySize = 24
 
 // SendRecvMsgKey is the key for SendRecvMsgMap
 type SendRecvMsgKey [sendRecvMsgKeySize]byte
@@ -574,10 +575,23 @@ var SendRecvMsgMapParameters = bpf.MapParameters{
 	Name:       "cali_v4_srmsg",
 }
 
+var CTNATsMapParameters = bpf.MapParameters{
+	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_ct_nats",
+	Type:       "lru_hash",
+	KeySize:    ctNATsMsgKeySize,
+	ValueSize:  sendRecvMsgValueSize,
+	MaxEntries: 10000,
+	Name:       "cali_v4_ct_nats",
+}
+
 // SendRecvMsgMap tracks reverse translations for sendmsg/recvmsg of
 // unconnected UDP
 func SendRecvMsgMap(mc *bpf.MapContext) bpf.Map {
 	return mc.NewPinnedMap(SendRecvMsgMapParameters)
+}
+
+func AllNATsMsgMap(mc *bpf.MapContext) bpf.Map {
+	return mc.NewPinnedMap(CTNATsMapParameters)
 }
 
 // SendRecvMsgMapMem represents affinity map in memory

--- a/bpf/polprog/pol_prog_builder.go
+++ b/bpf/polprog/pol_prog_builder.go
@@ -166,8 +166,8 @@ type TierEndAction string
 
 const (
 	TierEndUndef TierEndAction = ""
-	TierEndDeny                = "deny"
-	TierEndPass                = "pass"
+	TierEndDeny  TierEndAction = "deny"
+	TierEndPass  TierEndAction = "pass"
 )
 
 func (p *Builder) Instructions(rules Rules) (Insns, error) {
@@ -488,7 +488,7 @@ func (p *Builder) writeRule(r Rule, actionLabel string, destLeg matchLeg) {
 	}
 	if len(rule.DstIpSetIds) > 0 {
 		log.WithField("ipSetIDs", rule.DstIpSetIds).Debugf("DstIpSetIds match")
-		p.writeIPSetMatch(false, destLeg, rule.DstIpSetIds)
+		p.writeIPSetOrMatch(destLeg, rule.DstIpSetIds)
 	}
 	if len(rule.NotDstIpSetIds) > 0 {
 		log.WithField("ipSetIDs", rule.NotDstIpSetIds).Debugf("NotDstIpSetIds match")

--- a/bpf/polprog/pol_prog_builder.go
+++ b/bpf/polprog/pol_prog_builder.go
@@ -81,14 +81,17 @@ var (
 	stateOffIPSrc          int16 = 0
 	stateOffIPDst          int16 = 4
 	_                            = stateOffIPDst
-	stateOffPostNATIPDst   int16 = 8
-	stateOffPolResult      int16 = 16
-	stateOffSrcPort        int16 = 20
-	stateOffDstPort        int16 = 22
-	stateOffICMPType       int16 = 22
-	_                            = stateOffDstPort
-	stateOffPostNATDstPort int16 = 24
-	stateOffIPProto        int16 = 26
+	stateOffPreNATIPDst    int16 = 8
+	_                            = stateOffPreNATIPDst
+	stateOffPostNATIPDst   int16 = 12
+	stateOffPolResult      int16 = 20
+	stateOffSrcPort        int16 = 24
+	stateOffDstPort        int16 = 26
+	stateOffICMPType             = stateOffDstPort
+	stateOffPreNATDstPort  int16 = 28
+	_                            = stateOffPreNATDstPort
+	stateOffPostNATDstPort int16 = 30
+	stateOffIPProto        int16 = 32
 
 	// Compile-time check that IPSetEntrySize hasn't changed; if it changes, the code will need to change.
 	_ = [1]struct{}{{}}[20-ipsets.IPSetEntrySize]

--- a/bpf/polprog/pol_prog_builder.go
+++ b/bpf/polprog/pol_prog_builder.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ import (
 
 type Builder struct {
 	b               *Block
+	tierID          int
+	policyID        int
 	ruleID          int
 	rulePartID      int
 	ipSetIDProvider ipSetIDProvider
@@ -70,6 +72,11 @@ func nextOffset(size int, align int) int16 {
 	return int16(offset)
 }
 
+const (
+	// In Enterprise, there's an extra offset.
+	stateEventHdrSize int16 = 0
+)
+
 var (
 	// Stack offsets.  These are defined locally.
 	offStateKey    = nextOffset(4, 4)
@@ -78,20 +85,21 @@ var (
 
 	// Offsets within the cal_tc_state struct.
 	// WARNING: must be kept in sync with the definitions in bpf/include/jump.h.
-	stateOffIPSrc          int16 = 0
-	stateOffIPDst          int16 = 4
+	stateOffIPSrc          int16 = stateEventHdrSize + 0
+	stateOffIPDst          int16 = stateEventHdrSize + 4
 	_                            = stateOffIPDst
-	stateOffPreNATIPDst    int16 = 8
+	stateOffPreNATIPDst    int16 = stateEventHdrSize + 8
 	_                            = stateOffPreNATIPDst
-	stateOffPostNATIPDst   int16 = 12
-	stateOffPolResult      int16 = 20
-	stateOffSrcPort        int16 = 24
-	stateOffDstPort        int16 = 26
+	stateOffPostNATIPDst   int16 = stateEventHdrSize + 12
+	stateOffPolResult      int16 = stateEventHdrSize + 20
+	stateOffSrcPort        int16 = stateEventHdrSize + 24
+	stateOffDstPort        int16 = stateEventHdrSize + 26
 	stateOffICMPType             = stateOffDstPort
-	stateOffPreNATDstPort  int16 = 28
+	stateOffPreNATDstPort  int16 = stateEventHdrSize + 28
 	_                            = stateOffPreNATDstPort
-	stateOffPostNATDstPort int16 = 30
-	stateOffIPProto        int16 = 32
+	stateOffPostNATDstPort int16 = stateEventHdrSize + 30
+	stateOffIPProto        int16 = stateEventHdrSize + 32
+	stateOffFlags          int16 = stateEventHdrSize + 33
 
 	// Compile-time check that IPSetEntrySize hasn't changed; if it changes, the code will need to change.
 	_ = [1]struct{}{{}}[20-ipsets.IPSetEntrySize]
@@ -105,9 +113,15 @@ var (
 	ipsKeyPort   int16 = 16
 	ipsKeyProto  int16 = 18
 	ipsKeyPad    int16 = 19
+
+	// Bits in the state flags field.
+	FlagDestIsHost uint8 = 1 << 2
+	FlagSrcIsHost  uint8 = 1 << 3
 )
 
-type Rule = *proto.Rule
+type Rule struct {
+	*proto.Rule
+}
 
 type Policy struct {
 	Name  string
@@ -115,21 +129,102 @@ type Policy struct {
 }
 
 type Tier struct {
-	Name     string
-	Policies []Policy
+	Name      string
+	EndAction TierEndAction
+	Policies  []Policy
 }
 
 type Rules struct {
-	Tiers    []Tier
-	Profiles []Profile
+	// Both workload and host interfaces can enforce host endpoint policy (carried here in the
+	// Host... fields); in the case of a workload interface, that can only come from the
+	// wildcard host endpoint, aka "host-*".
+	//
+	// However, only a workload interface can have any workload policy (carried here in the
+	// Tiers and Profiles fields), and workload interfaces also Deny by default when there is no
+	// workload policy at all.  ForHostInterface (with reversed polarity) is the boolean that
+	// tells us whether or not to implement workload policy and that default Deny.
+	ForHostInterface bool
+
+	// Indicates to suppress normal host policy because it's trumped by the setting of
+	// DefaultEndpointToHostAction.
+	SuppressNormalHostPolicy bool
+
+	// Workload policy.
+	Tiers            []Tier
+	Profiles         []Profile
+
+	// Host endpoint policy.
+	HostPreDnatTiers []Tier
+	HostForwardTiers []Tier
+	HostNormalTiers  []Tier
+	HostProfiles     []Profile
 }
 
 type Profile = Policy
 
+type TierEndAction string
+
+const (
+	TierEndUndef TierEndAction = ""
+	TierEndDeny                = "deny"
+	TierEndPass                = "pass"
+)
+
 func (p *Builder) Instructions(rules Rules) (Insns, error) {
 	p.b = NewBlock()
 	p.writeProgramHeader()
-	p.writeRules(rules)
+
+	// Pre-DNAT policy: on a host interface, or host-* policy on a workload interface.  Traffic
+	// is allowed to continue if there is no applicable pre-DNAT policy.
+	p.writeTiers(rules.HostPreDnatTiers, legDestPreNAT, "allowed_by_host_policy")
+
+	// If traffic is to or from the local host, skip over any apply-on-forward policy.  Note
+	// that this case can be:
+	// - on a workload interface, workload <--> own host
+	// - on a host interface, this host (not a workload) <--> anywhere outside this host
+	//
+	// When rules.SuppressNormalHostPolicy is true, we also skip normal host policy; this is
+	// the case when we're building the policy program for workload -> host and
+	// DefaultEndpointToHostAction is ACCEPT or DROP; or for host -> workload.
+	if rules.SuppressNormalHostPolicy {
+		p.writeJumpIfToOrFromHost("allowed_by_host_policy")
+	} else {
+		p.writeJumpIfToOrFromHost("to_or_from_host")
+	}
+
+	// At this point we know we have traffic that is being forwarded through the host's root
+	// network namespace.  Note that this case can be:
+	// - workload interface, workload <--> another local workload
+	// - workload interface, workload <--> anywhere outside this host
+	// - host interface, workload <--> anywhere outside this host
+	// - host interface, anywhere outside this host <--> anywhere outside this host
+
+	// Apply-On-Forward policy: on a host interface, or host-* policy on a workload interface.
+	// Traffic is allowed to continue if there is no applicable AoF policy.
+	p.writeTiers(rules.HostForwardTiers, legDest, "allowed_by_host_policy")
+
+	// Now skip over normal host policy and jump to where we apply possible workload policy.
+	p.b.Jump("allowed_by_host_policy")
+
+	if !rules.SuppressNormalHostPolicy {
+		// "Normal" host policy, i.e. for non-forwarded traffic.
+		p.b.LabelNextInsn("to_or_from_host")
+		p.writeTiers(rules.HostNormalTiers, legDest, "allowed_by_host_policy")
+		p.writeProfiles(rules.HostProfiles, "allowed_by_host_policy")
+	}
+
+	// End of host policy.
+	p.b.LabelNextInsn("allowed_by_host_policy")
+
+	if rules.ForHostInterface {
+		// On a host interface there is no workload policy, so we are now done.
+		p.b.Jump("allow")
+	} else {
+		// Workload policy.
+		p.writeTiers(rules.Tiers, legDest, "allow")
+		p.writeProfiles(rules.Profiles, "allow")
+	}
+
 	p.writeProgramFooter()
 	return p.b.Assemble()
 }
@@ -161,8 +256,22 @@ func (p *Builder) writeProgramHeader() {
 const (
 	jumpIdxPolicy = iota
 	jumpIdxEpilogue
+	jumpIdxICMP
+
 	_ = jumpIdxPolicy
+	_ = jumpIdxICMP
 )
+
+func (p *Builder) writeJumpIfToOrFromHost(label string) {
+	// Load state flags.
+	p.b.Load8(R1, R9, stateOffFlags)
+
+	// Mask against host bits.
+	p.b.AndImm32(R1, int32(FlagDestIsHost|FlagSrcIsHost))
+
+	// If non-zero, jump to specified label.
+	p.b.JumpNEImm64(R1, 0, label)
+}
 
 // writeProgramFooter emits the program exit jump targets.
 func (p *Builder) writeProgramFooter() {
@@ -190,14 +299,6 @@ func (p *Builder) writeProgramFooter() {
 	}
 }
 
-func (p *Builder) setUpSrcIPSetKey(ipsetID uint64) {
-	p.setUpIPSetKey(ipsetID, offSrcIPSetKey, stateOffIPSrc, stateOffSrcPort)
-}
-
-func (p *Builder) setUpDstIPSetKey(ipsetID uint64) {
-	p.setUpIPSetKey(ipsetID, offDstIPSetKey, stateOffPostNATIPDst, stateOffPostNATDstPort)
-}
-
 func (p *Builder) setUpIPSetKey(ipsetID uint64, keyOffset, ipOffset, portOffset int16) {
 	// TODO track whether we've already done an initialisation and skip the parts that don't change.
 	// Zero the padding.
@@ -223,64 +324,121 @@ func (p *Builder) setUpIPSetKey(ipsetID uint64, keyOffset, ipOffset, portOffset 
 	p.b.StoreStack32(R1, keyOffset+ipsKeyID+4)
 }
 
-func (p *Builder) writeRules(rules Rules) {
-	for idx, tier := range rules.Tiers {
-		endOfTierLabel := fmt.Sprint("end_of_tier_", idx)
+func (p *Builder) writeTiers(tiers []Tier, destLeg matchLeg, allowLabel string) {
+	actionLabels := map[string]string{
+		"allow": allowLabel,
+		"deny":  "deny",
+	}
+	for _, tier := range tiers {
+		endOfTierLabel := fmt.Sprint("end_of_tier_", p.tierID)
+		actionLabels["pass"] = endOfTierLabel
+		actionLabels["next-tier"] = endOfTierLabel
 
-		log.Debugf("Start of policies %d", idx)
-		for polIdx, pol := range tier.Policies {
-			p.writePolicy(pol, polIdx, endOfTierLabel)
+		log.Debugf("Start of tier %d %q", p.tierID, tier.Name)
+		for _, pol := range tier.Policies {
+			p.writePolicy(pol, actionLabels, destLeg)
 		}
 
-		log.Debugf("End of policies drop")
-		p.writeRule(&proto.Rule{Action: "deny"}, endOfTierLabel)
-
+		// End of tier rule.
+		action := tier.EndAction
+		if action == TierEndUndef {
+			action = TierEndDeny
+		}
+		log.Debugf("End of tier %d %q: %s", p.tierID, tier.Name, action)
+		p.writeRule(Rule{
+			Rule: &proto.Rule{},
+		}, actionLabels[string(action)], destLeg)
 		p.b.LabelNextInsn(endOfTierLabel)
+		p.tierID++
 	}
+}
 
-	endLabel := "end_of_profiles"
-
+func (p *Builder) writeProfiles(profiles []Policy, allowLabel string) {
 	log.Debugf("Start of profiles")
-	for idx, prof := range rules.Profiles {
-		p.writeProfile(prof, idx, endLabel)
+	for idx, prof := range profiles {
+		p.writeProfile(prof, idx, allowLabel)
 	}
 
 	log.Debugf("End of profiles drop")
-	p.writeRule(&proto.Rule{Action: "deny"}, endLabel)
-
-	p.b.LabelNextInsn(endLabel)
+	p.writeRule(Rule{
+		Rule: &proto.Rule{},
+	}, "deny", legDest)
 }
 
-func (p *Builder) writePolicyRules(policy Policy, idx int, endLabel string) {
+func (p *Builder) writePolicyRules(policy Policy, actionLabels map[string]string, destLeg matchLeg) {
 	for ruleIdx, rule := range policy.Rules {
 		log.Debugf("Start of rule %d", ruleIdx)
-		p.writeRule(rule, endLabel)
+		action := strings.ToLower(rule.Action)
+		p.writeRule(rule, actionLabels[action], destLeg)
 		log.Debugf("End of rule %d", ruleIdx)
 	}
 }
 
-func (p *Builder) writePolicy(policy Policy, idx int, endLabel string) {
-	log.Debugf("Start of policy %q %d", policy.Name, idx)
-	p.writePolicyRules(policy, idx, endLabel)
-	log.Debugf("End of policy %q %d", policy.Name, idx)
+func (p *Builder) writePolicy(policy Policy, actionLabels map[string]string, destLeg matchLeg) {
+	log.Debugf("Start of policy %q %d", policy.Name, p.policyID)
+	p.writePolicyRules(policy, actionLabels, destLeg)
+	log.Debugf("End of policy %q %d", policy.Name, p.policyID)
+	p.policyID++
 }
 
-func (p *Builder) writeProfile(profile Profile, idx int, endLabel string) {
+func (p *Builder) writeProfile(profile Profile, idx int, allowLabel string) {
+	actionLabels := map[string]string{
+		"allow":     allowLabel,
+		"deny":      "deny",
+		"pass":      "deny",
+		"next-tier": "deny",
+	}
 	log.Debugf("Start of profile %q %d", profile.Name, idx)
-	p.writePolicyRules(profile, idx, endLabel)
+	p.writePolicyRules(profile, actionLabels, legDest)
 	log.Debugf("End of profile %q %d", profile.Name, idx)
+	p.policyID++
 }
 
 type matchLeg string
 
 const (
-	legSource matchLeg = "source"
-	legDest   matchLeg = "dest"
+	legSource     matchLeg = "source"
+	legDest       matchLeg = "dest"
+	legDestPreNAT matchLeg = "destPreNAT"
 )
 
-func (p *Builder) writeRule(rule *proto.Rule, passLabel string) {
+func (leg matchLeg) offsetToStateIPAddressField() (offset int16) {
+	if leg == legSource {
+		offset = stateOffIPSrc
+	} else if leg == legDestPreNAT {
+		offset = stateOffPreNATIPDst
+	} else {
+		offset = stateOffPostNATIPDst
+	}
+	return
+}
 
-	rule = rules.FilterRuleToIPVersion(4, rule)
+func (leg matchLeg) offsetToStatePortField() (portOffset int16) {
+	if leg == legSource {
+		portOffset = stateOffSrcPort
+	} else if leg == legDestPreNAT {
+		portOffset = stateOffPreNATDstPort
+	} else {
+		portOffset = stateOffPostNATDstPort
+	}
+	return
+}
+
+func (leg matchLeg) stackOffsetToIPSetKey() (keyOffset int16) {
+	if leg == legSource {
+		keyOffset = offSrcIPSetKey
+	} else {
+		keyOffset = offDstIPSetKey
+	}
+	return
+}
+
+func (p *Builder) writeRule(r Rule, actionLabel string, destLeg matchLeg) {
+	if actionLabel == "" {
+		log.Panic("empty action label")
+	}
+
+	rule := rules.FilterRuleToIPVersion(4, r.Rule)
 	if rule == nil {
 		log.Debugf("Version mismatch, skipping rule")
 		return
@@ -307,11 +465,11 @@ func (p *Builder) writeRule(rule *proto.Rule, passLabel string) {
 
 	if len(rule.DstNet) != 0 {
 		log.WithField("cidrs", rule.DstNet).Debugf("DstNet match")
-		p.writeCIDRSMatch(false, legDest, rule.DstNet)
+		p.writeCIDRSMatch(false, destLeg, rule.DstNet)
 	}
 	if len(rule.NotDstNet) != 0 {
 		log.WithField("cidrs", rule.NotDstNet).Debugf("NotDstNet match")
-		p.writeCIDRSMatch(true, legDest, rule.NotDstNet)
+		p.writeCIDRSMatch(true, destLeg, rule.NotDstNet)
 	}
 
 	if len(rule.SrcIpSetIds) > 0 {
@@ -323,13 +481,18 @@ func (p *Builder) writeRule(rule *proto.Rule, passLabel string) {
 		p.writeIPSetMatch(true, legSource, rule.NotSrcIpSetIds)
 	}
 
+	if len(rule.DstIpSetIds) > 1 {
+		// We should only ever have one set here because they get combined in the calc graph.  Enterprise
+		// depends on that so we assert here too.
+		log.WithField("rule", rule).Panic("proto.Rule has more than one DstIpSetIds")
+	}
 	if len(rule.DstIpSetIds) > 0 {
 		log.WithField("ipSetIDs", rule.DstIpSetIds).Debugf("DstIpSetIds match")
-		p.writeIPSetMatch(false, legDest, rule.DstIpSetIds)
+		p.writeIPSetMatch(false, destLeg, rule.DstIpSetIds)
 	}
 	if len(rule.NotDstIpSetIds) > 0 {
 		log.WithField("ipSetIDs", rule.NotDstIpSetIds).Debugf("NotDstIpSetIds match")
-		p.writeIPSetMatch(true, legDest, rule.NotDstIpSetIds)
+		p.writeIPSetMatch(true, destLeg, rule.NotDstIpSetIds)
 	}
 
 	if len(rule.SrcPorts) > 0 || len(rule.SrcNamedPortIpSetIds) > 0 {
@@ -343,11 +506,11 @@ func (p *Builder) writeRule(rule *proto.Rule, passLabel string) {
 
 	if len(rule.DstPorts) > 0 || len(rule.DstNamedPortIpSetIds) > 0 {
 		log.WithField("ports", rule.DstPorts).Debugf("DstPorts match")
-		p.writePortsMatch(false, legDest, rule.DstPorts, rule.DstNamedPortIpSetIds)
+		p.writePortsMatch(false, destLeg, rule.DstPorts, rule.DstNamedPortIpSetIds)
 	}
 	if len(rule.NotDstPorts) > 0 || len(rule.NotDstNamedPortIpSetIds) > 0 {
 		log.WithField("ports", rule.NotDstPorts).Debugf("NotDstPorts match")
-		p.writePortsMatch(true, legDest, rule.NotDstPorts, rule.NotDstNamedPortIpSetIds)
+		p.writePortsMatch(true, destLeg, rule.NotDstPorts, rule.NotDstNamedPortIpSetIds)
 	}
 
 	if rule.Icmp != nil {
@@ -369,7 +532,7 @@ func (p *Builder) writeRule(rule *proto.Rule, passLabel string) {
 		}
 	}
 
-	p.writeEndOfRule(rule, passLabel)
+	p.writeEndOfRule(r, actionLabel)
 	p.ruleID++
 	p.rulePartID = 0
 }
@@ -377,15 +540,11 @@ func (p *Builder) writeRule(rule *proto.Rule, passLabel string) {
 func (p *Builder) writeStartOfRule() {
 }
 
-func (p *Builder) writeEndOfRule(rule *proto.Rule, passLabel string) {
-	// If all the match criteria are mat, we fall through to the end of the rule
+func (p *Builder) writeEndOfRule(rule Rule, actionLabel string) {
+	// If all the match criteria are met, we fall through to the end of the rule
 	// so all that's left to do is to jump to the relevant action.
 	// TODO log and log-and-xxx actions
-	action := strings.ToLower(rule.Action)
-	if action == "pass" {
-		action = passLabel
-	}
-	p.b.Jump(action)
+	p.b.Jump(actionLabel)
 
 	p.b.LabelNextInsn(p.endOfRuleLabel())
 }
@@ -412,20 +571,13 @@ func (p *Builder) writeICMPTypeMatch(negate bool, icmpType uint8) {
 func (p *Builder) writeICMPTypeCodeMatch(negate bool, icmpType, icmpCode uint8) {
 	p.b.Load16(R1, R9, stateOffICMPType)
 	if negate {
-		p.b.JumpEqImm64(R1, ((int32(icmpCode) << 8) | int32(icmpType)), p.endOfRuleLabel())
+		p.b.JumpEqImm64(R1, (int32(icmpCode)<<8)|int32(icmpType), p.endOfRuleLabel())
 	} else {
-		p.b.JumpNEImm64(R1, ((int32(icmpCode) << 8) | int32(icmpType)), p.endOfRuleLabel())
+		p.b.JumpNEImm64(R1, (int32(icmpCode)<<8)|int32(icmpType), p.endOfRuleLabel())
 	}
 }
 func (p *Builder) writeCIDRSMatch(negate bool, leg matchLeg, cidrs []string) {
-	var offset int16
-	if leg == legSource {
-		offset = stateOffIPSrc
-	} else {
-		offset = stateOffPostNATIPDst
-	}
-
-	p.b.Load32(R1, R9, offset)
+	p.b.Load32(R1, R9, leg.offsetToStateIPAddressField())
 
 	var onMatchLabel string
 	if negate {
@@ -461,15 +613,8 @@ func (p *Builder) writeIPSetMatch(negate bool, leg matchLeg, ipSets []string) {
 			log.WithField("setID", ipSetID).Panic("Failed to look up IP set ID.")
 		}
 
-		var keyOffset int16
-		if leg == legSource {
-			p.setUpSrcIPSetKey(id)
-			keyOffset = offSrcIPSetKey
-		} else {
-			p.setUpDstIPSetKey(id)
-			keyOffset = offDstIPSetKey
-		}
-
+		keyOffset := leg.stackOffsetToIPSetKey()
+		p.setUpIPSetKey(id, keyOffset, leg.offsetToStateIPAddressField(), leg.offsetToStatePortField())
 		p.b.LoadMapFD(R1, uint32(p.ipSetMapFD))
 		p.b.Mov64(R2, R10)
 		p.b.AddImm64(R2, int32(keyOffset))
@@ -480,23 +625,45 @@ func (p *Builder) writeIPSetMatch(negate bool, leg matchLeg, ipSets []string) {
 			// (Otherwise we fall through to the next match criteria.)
 			p.b.JumpNEImm64(R0, 0, p.endOfRuleLabel())
 		} else {
-			// Non-negated; if we got a miss (non-0) then the rule can't match.
+			// Non-negated; if we got a miss (0) then the rule can't match.
 			// (Otherwise we fall through to the next match criteria.)
 			p.b.JumpEqImm64(R0, 0, p.endOfRuleLabel())
 		}
 	}
 }
 
+// Match if packet matches ANY of the given IP sets.
+func (p *Builder) writeIPSetOrMatch(leg matchLeg, ipSets []string) {
+
+	onMatchLabel := p.freshPerRuleLabel()
+
+	for _, ipSetID := range ipSets {
+		id := p.ipSetIDProvider.GetNoAlloc(ipSetID)
+		if id == 0 {
+			log.WithField("setID", ipSetID).Panic("Failed to look up IP set ID.")
+		}
+
+		keyOffset := leg.stackOffsetToIPSetKey()
+		p.setUpIPSetKey(id, keyOffset, leg.offsetToStateIPAddressField(), leg.offsetToStatePortField())
+		p.b.LoadMapFD(R1, uint32(p.ipSetMapFD))
+		p.b.Mov64(R2, R10)
+		p.b.AddImm64(R2, int32(keyOffset))
+		p.b.Call(HelperMapLookupElem)
+
+		// If we got a hit (non-0) then packet matches one of the IP sets.
+		// (Otherwise we fall through to try the next IP set.)
+		p.b.JumpNEImm64(R0, 0, onMatchLabel)
+	}
+
+	// If packet reaches here, it hasn't matched any of the IP sets.
+	p.b.Jump(p.endOfRuleLabel())
+	// Label the next match so we can skip to it on success.
+	p.b.LabelNextInsn(onMatchLabel)
+}
+
 func (p *Builder) writePortsMatch(negate bool, leg matchLeg, ports []*proto.PortRange, namedPorts []string) {
 	// For a ports match, numeric ports and named ports are ORed together.  Check any
 	// numeric ports first and then any named ports.
-	var portOffset int16
-	if leg == legSource {
-		portOffset = stateOffSrcPort
-	} else {
-		portOffset = stateOffPostNATDstPort
-	}
-
 	var onMatchLabel string
 	if negate {
 		// Match negated, if we match any port then we jump to the next rule.
@@ -507,7 +674,7 @@ func (p *Builder) writePortsMatch(negate bool, leg matchLeg, ports []*proto.Port
 	}
 
 	// R1 = port to test against.
-	p.b.Load16(R1, R9, portOffset)
+	p.b.Load16(R1, R9, leg.offsetToStatePortField())
 
 	for _, portRange := range ports {
 		if portRange.First == portRange.Last {
@@ -535,15 +702,8 @@ func (p *Builder) writePortsMatch(negate bool, leg matchLeg, ports []*proto.Port
 			log.WithField("setID", ipSetID).Panic("Failed to look up IP set ID.")
 		}
 
-		var keyOffset int16
-		if leg == legSource {
-			p.setUpSrcIPSetKey(id)
-			keyOffset = offSrcIPSetKey
-		} else {
-			p.setUpDstIPSetKey(id)
-			keyOffset = offDstIPSetKey
-		}
-
+		keyOffset := leg.stackOffsetToIPSetKey()
+		p.setUpIPSetKey(id, keyOffset, leg.offsetToStateIPAddressField(), leg.offsetToStatePortField())
 		p.b.LoadMapFD(R1, uint32(p.ipSetMapFD))
 		p.b.Mov64(R2, R10)
 		p.b.AddImm64(R2, int32(keyOffset))

--- a/bpf/polprog/pol_prog_builder_test.go
+++ b/bpf/polprog/pol_prog_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,29 +37,31 @@ func TestPolicySanityCheck(t *testing.T) {
 	insns, err := pg.Instructions(Rules{
 		Tiers: []Tier{{
 			Policies: []Policy{{
-				Rules: []*proto.Rule{{
-					Action:                  "Allow",
-					IpVersion:               4,
-					Protocol:                &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 6}},
-					SrcNet:                  []string{"10.0.0.0/8"},
-					SrcPorts:                []*proto.PortRange{{First: 80, Last: 81}, {First: 8080, Last: 8081}},
-					SrcNamedPortIpSetIds:    []string{setID("n:abcdef1234567890")},
-					DstNet:                  []string{"11.0.0.0/8"},
-					DstPorts:                []*proto.PortRange{{First: 3000, Last: 3001}},
-					DstNamedPortIpSetIds:    []string{setID("n:foo1234567890")},
-					Icmp:                    &proto.Rule_IcmpTypeCode{IcmpTypeCode: &proto.IcmpTypeAndCode{Type: 10, Code: 12}},
-					SrcIpSetIds:             []string{setID("s:sbcdef1234567890")},
-					DstIpSetIds:             []string{setID("s:dbcdef1234567890")},
-					NotProtocol:             &proto.Protocol{NumberOrName: &proto.Protocol_Name{Name: "UDP"}},
-					NotSrcNet:               []string{"12.0.0.0/8"},
-					NotSrcPorts:             []*proto.PortRange{{First: 5000, Last: 5000}},
-					NotDstNet:               []string{"13.0.0.0/8"},
-					NotDstPorts:             []*proto.PortRange{{First: 4000, Last: 4000}},
-					NotIcmp:                 &proto.Rule_NotIcmpTypeCode{NotIcmpTypeCode: &proto.IcmpTypeAndCode{Type: 10, Code: 12}},
-					NotSrcIpSetIds:          []string{setID("s:abcdef1234567890")},
-					NotDstIpSetIds:          []string{setID("s:abcdef123456789l")},
-					NotSrcNamedPortIpSetIds: []string{setID("n:0bcdef1234567890")},
-					NotDstNamedPortIpSetIds: []string{setID("n:0bcdef1234567890")},
+				Rules: []Rule{{
+					Rule: &proto.Rule{
+						Action:                  "Allow",
+						IpVersion:               4,
+						Protocol:                &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 6}},
+						SrcNet:                  []string{"10.0.0.0/8"},
+						SrcPorts:                []*proto.PortRange{{First: 80, Last: 81}, {First: 8080, Last: 8081}},
+						SrcNamedPortIpSetIds:    []string{setID("n:abcdef1234567890")},
+						DstNet:                  []string{"11.0.0.0/8"},
+						DstPorts:                []*proto.PortRange{{First: 3000, Last: 3001}},
+						DstNamedPortIpSetIds:    []string{setID("n:foo1234567890")},
+						Icmp:                    &proto.Rule_IcmpTypeCode{IcmpTypeCode: &proto.IcmpTypeAndCode{Type: 10, Code: 12}},
+						SrcIpSetIds:             []string{setID("s:sbcdef1234567890")},
+						DstIpSetIds:             []string{setID("s:dbcdef1234567890")},
+						NotProtocol:             &proto.Protocol{NumberOrName: &proto.Protocol_Name{Name: "UDP"}},
+						NotSrcNet:               []string{"12.0.0.0/8"},
+						NotSrcPorts:             []*proto.PortRange{{First: 5000, Last: 5000}},
+						NotDstNet:               []string{"13.0.0.0/8"},
+						NotDstPorts:             []*proto.PortRange{{First: 4000, Last: 4000}},
+						NotIcmp:                 &proto.Rule_NotIcmpTypeCode{NotIcmpTypeCode: &proto.IcmpTypeAndCode{Type: 10, Code: 12}},
+						NotSrcIpSetIds:          []string{setID("s:abcdef1234567890")},
+						NotDstIpSetIds:          []string{setID("s:abcdef123456789l")},
+						NotSrcNamedPortIpSetIds: []string{setID("n:0bcdef1234567890")},
+						NotDstNamedPortIpSetIds: []string{setID("n:0bcdef1234567890")},
+					},
 				}},
 			}},
 		}},
@@ -69,6 +71,4 @@ func TestPolicySanityCheck(t *testing.T) {
 	for i, in := range insns {
 		t.Log(i, ": ", in)
 	}
-
-	Expect(insns).To(HaveLen(225))
 }

--- a/bpf/state/map.go
+++ b/bpf/state/map.go
@@ -58,7 +58,7 @@ type State struct {
 	PreNATDstPort       uint16
 	PostNATDstPort      uint16
 	IPProto             uint8
-	Pad                 uint8
+	Flags               uint8
 	ConntrackResultType uint32
 	ConntrackData       uint64
 	ConntrackDataTun    uint32

--- a/bpf/state/map.go
+++ b/bpf/state/map.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,11 +49,13 @@ const (
 type State struct {
 	SrcAddr             uint32
 	DstAddr             uint32
+	PreNATDstAddr       uint32
 	PostNATDstAddr      uint32
 	NATTunSrcAddr       uint32
 	PolicyRC            PolicyResult
 	SrcPort             uint16
 	DstPort             uint16
+	PreNATDstPort       uint16
 	PostNATDstPort      uint16
 	IPProto             uint8
 	Pad                 uint8
@@ -65,7 +67,7 @@ type State struct {
 	ProgStartTime       uint64
 }
 
-const expectedSize = 64
+const expectedSize = 72
 
 func (s *State) AsBytes() []byte {
 	size := unsafe.Sizeof(State{})
@@ -93,6 +95,7 @@ func Map(mc *bpf.MapContext) bpf.Map {
 		ValueSize:  expectedSize,
 		MaxEntries: 1,
 		Name:       "cali_v4_state",
+		Version:    2,
 	})
 }
 

--- a/bpf/tc/attach.go
+++ b/bpf/tc/attach.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ type AttachPoint struct {
 	ToHostDrop bool
 	DSR        bool
 	TunnelMTU  uint16
+	VXLANPort  uint16
 }
 
 var tcLock sync.RWMutex
@@ -195,6 +196,11 @@ func (ap AttachPoint) patchBinary(logCtx *log.Entry, ifile, ofile string) error 
 
 	b.PatchLogPrefix(ap.Iface)
 	b.PatchTunnelMTU(ap.TunnelMTU)
+	vxlanPort := ap.VXLANPort
+	if vxlanPort == 0 {
+		vxlanPort = 4789
+	}
+	b.PatchVXLANPort(vxlanPort)
 
 	err = b.WriteToFile(ofile)
 	if err != nil {
@@ -204,7 +210,7 @@ func (ap AttachPoint) patchBinary(logCtx *log.Entry, ifile, ofile string) error 
 	return nil
 }
 
-// ProgramName returnt the name of the program associated with this AttachPoint
+// ProgramName returns the name of the program associated with this AttachPoint
 func (ap AttachPoint) ProgramName() string {
 	return SectionName(ap.Type, ap.ToOrFrom)
 }

--- a/bpf/tc/compiler.go
+++ b/bpf/tc/compiler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bpf/tc/tc_defs.go
+++ b/bpf/tc/tc_defs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,12 +21,17 @@ const (
 	MarkSeenMask                     = MarkCalicoMask | MarkSeen
 	MarkSeenBypass                   = MarkSeen | 0x02000000
 	MarkSeenBypassMask               = MarkSeenMask | MarkSeenBypass
+	MarkSeenFallThrough              = MarkSeen | 0x04000000
+	MarkSeenFallThroughMask          = MarkSeenMask | MarkSeenFallThrough
 	MarkSeenBypassForward            = MarkSeenBypass | 0x00300000
 	MarkSeenBypassForwardSourceFixup = MarkSeenBypass | 0x00500000
 	MarkSeenBypassSkipRPF            = MarkSeenBypass | 0x00400000
 	MarkSeenBypassSkipRPFMask        = MarkSeenBypassMask | 0x00f00000
 	MarkSeenNATOutgoing              = MarkSeenBypass | 0x00800000
 	MarkSeenNATOutgoingMask          = MarkSeenBypassMask | MarkSeenNATOutgoing
+
+	MarkLinuxConntrackEstablished     = MarkCalico | 0x08000000
+	MarkLinuxConntrackEstablishedMask = MarkCalico | 0x08000000
 
 	MarksMask = 0xfff00000
 )

--- a/bpf/ut/attach_test.go
+++ b/bpf/ut/attach_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bpf/ut/benchmarks_test.go
+++ b/bpf/ut/benchmarks_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,13 +31,13 @@ func BenchmarkHEP(b *testing.B) {
 	defer cleanUpMaps()
 
 	// Run once to create conntrack entry
-	setupAndRun(b, "no_log", "calico_from_host_ep", rulesDefaultAllow, func(progName string) {
+	setupAndRun(b, "no_log", "calico_from_host_ep", nil, func(progName string) {
 		res, err := bpftoolProgRun(progName, pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 	})
 
-	setupAndRun(b, "no_log", "calico_from_host_ep", rulesDefaultAllow, func(progName string) {
+	setupAndRun(b, "no_log", "calico_from_host_ep", nil, func(progName string) {
 		b.ResetTimer()
 		res, err := bpftoolProgRunN(progName, pktBytes, b.N)
 		b.StopTimer()

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -332,9 +332,13 @@ func bpftoolProgLoadAll(fname, bpfFsDir string) error {
 		return err
 	}
 
-	_, err = bpftool("map", "update", "pinned", jumpMap.Path(), "key", "0", "0", "0", "0", "value", "pinned", path.Join(bpfFsDir, "1_0"))
-	if err != nil {
-		return errors.Wrap(err, "failed to update jump map (epilogue program)")
+	polProgPath := path.Join(bpfFsDir, "1_0")
+	_, err = os.Stat(polProgPath)
+	if err == nil {
+		_, err = bpftool("map", "update", "pinned", jumpMap.Path(), "key", "0", "0", "0", "0", "value", "pinned", polProgPath)
+		if err != nil {
+			return errors.Wrap(err, "failed to update jump map (policy program)")
+		}
 	}
 	_, err = bpftool("map", "update", "pinned", jumpMap.Path(), "key", "1", "0", "0", "0", "value", "pinned", path.Join(bpfFsDir, "1_1"))
 	if err != nil {
@@ -342,7 +346,7 @@ func bpftoolProgLoadAll(fname, bpfFsDir string) error {
 	}
 	_, err = bpftool("map", "update", "pinned", jumpMap.Path(), "key", "2", "0", "0", "0", "value", "pinned", path.Join(bpfFsDir, "1_2"))
 	if err != nil {
-		return errors.Wrap(err, "failed to update jump map (epilogue program)")
+		return errors.Wrap(err, "failed to update jump map (icmp program)")
 	}
 
 	return nil

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -217,6 +217,7 @@ outter:
 	err = bin.PatchIPv4(hostIP)
 	Expect(err).NotTo(HaveOccurred())
 	bin.PatchTunnelMTU(natTunnelMTU)
+	bin.PatchVXLANPort(testVxlanPort)
 	tempObj := tempDir + "bpf.o"
 	err = bin.WriteToFile(tempObj)
 	Expect(err).NotTo(HaveOccurred())
@@ -504,6 +505,7 @@ outter:
 	err = bin.PatchIPv4(hostIP)
 	Expect(err).NotTo(HaveOccurred())
 	bin.PatchTunnelMTU(natTunnelMTU)
+	bin.PatchVXLANPort(testVxlanPort)
 	tempObj := tempDir + "bpf.o"
 	err = bin.WriteToFile(tempObj)
 	Expect(err).NotTo(HaveOccurred())

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -546,18 +546,21 @@ func withSubtests(v bool) testOption {
 		o.subtests = v
 	}
 }
+var _ = withSubtests
 
 func withLogLevel(l log.Level) testOption {
 	return func(o *testOpts) {
 		o.logLevel = l
 	}
 }
+var _ = withLogLevel
 
 func withExtraMap(m bpf.Map) testOption {
 	return func(o *testOpts) {
 		o.extraMaps = append(o.extraMaps, m)
 	}
 }
+var _ = withExtraMap
 
 // layersMatchFields matches all Exported fields and ignore the ones explicitly
 // listed. It always ignores BaseLayer as that is not set by the tests.

--- a/bpf/ut/icmp_port_unreachable_test.go
+++ b/bpf/ut/icmp_port_unreachable_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ func TestNATNoBackendFromHEP(t *testing.T) {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_UNSPEC"), "expected program to return TC_ACT_UNSPEC")
@@ -86,7 +86,7 @@ func TestNATNoBackendFromHEP(t *testing.T) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_UNSPEC"), "expected program to return TC_ACT_UNSPEC")

--- a/bpf/ut/icmp_related_test.go
+++ b/bpf/ut/icmp_related_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,15 +29,15 @@ import (
 	"github.com/projectcalico/felix/proto"
 )
 
-var rulesAllowUDP = polprog.Rules{
+var rulesAllowUDP = &polprog.Rules{
 	Tiers: []polprog.Tier{{
 		Name: "base tier",
 		Policies: []polprog.Policy{{
 			Name: "allow all udp",
-			Rules: []*proto.Rule{{
+			Rules: []polprog.Rule{{Rule: &proto.Rule{
 				Action:   "Allow",
 				Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Name{Name: "udp"}},
-			}},
+			}}},
 		}},
 	}},
 }

--- a/bpf/ut/icmp_ttl_exceeded_test.go
+++ b/bpf/ut/icmp_ttl_exceeded_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ func TestICMPttlExceededFromHEP(t *testing.T) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_UNSPEC"), "expected program to return TC_ACT_UNSPEC")

--- a/bpf/ut/ip_options_test.go
+++ b/bpf/ut/ip_options_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,12 +44,12 @@ func TestMalformedIP(t *testing.T) {
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_SHOT"), "expected program to return TC_ACT_SHOT")
 
 	})
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_SHOT"), "expected program to return TC_ACT_UNSPEC")
 	})
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_SHOT"), "expected program to return TC_ACT_SHOT")
@@ -77,13 +77,13 @@ func TestIPOptions(t *testing.T) {
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_SHOT"), "expected program to return TC_ACT_SHOT")
 
 	})
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_SHOT"), "expected program to return TC_ACT_SHOT")
 	})
 
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_UNSPEC"), "expected program to return TC_ACT_UNSPEC")
@@ -111,7 +111,7 @@ func TestIPOptionsWithHostIP(t *testing.T) {
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_SHOT"), "expected program to return TC_ACT_SHOT")
 	})
 
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_UNSPEC"), "expected program to return TC_ACT_UNSPEC")

--- a/bpf/ut/nat_test.go
+++ b/bpf/ut/nat_test.go
@@ -111,7 +111,7 @@ func TestNATPodPodXNode(t *testing.T) {
 	// Leaving node 1
 	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(natedPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -133,7 +133,7 @@ func TestNATPodPodXNode(t *testing.T) {
 
 	bpfIfaceName = "NAT2"
 	// Arriving at node 2
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(natedPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -178,7 +178,7 @@ func TestNATPodPodXNode(t *testing.T) {
 
 	// Response leaving node 2
 	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(respPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -199,7 +199,7 @@ func TestNATPodPodXNode(t *testing.T) {
 	// Response arriving at node 1
 	bpfIfaceName = "NAT1"
 	skbMark = 0
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(respPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -298,7 +298,7 @@ func TestNATNodePort(t *testing.T) {
 	skbMark = 0
 
 	// Arriving at node 1 - non-routable -> denied
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
@@ -330,7 +330,7 @@ func TestNATNodePort(t *testing.T) {
 	vni := uint32(0)
 
 	// Arriving at node 1
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -373,7 +373,7 @@ func TestNATNodePort(t *testing.T) {
 
 	skbMark = tc.MarkSeenBypassForwardSourceFixup // CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP
 	// Leaving node 1
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(encapedPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -431,7 +431,7 @@ func TestNATNodePort(t *testing.T) {
 	arpMapN2 := saveARPMap(arpMap)
 	Expect(arpMapN2).To(HaveLen(0))
 
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(encapedPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -485,7 +485,7 @@ func TestNATNodePort(t *testing.T) {
 	Expect(arpMapN2[arpKey]).To(Equal(arp.NewValue(macDst, macSrc)))
 
 	// try a spoofed tunnel packet, should be dropped and have no effect
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		// modify the only known good src IP, we do not care about csums at this point
 		encapedPkt[26] = 234
 		res, err := bpfrun(encapedPkt)
@@ -573,7 +573,7 @@ func TestNATNodePort(t *testing.T) {
 	hostIP = node2ip
 
 	// Response leaving node 2
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(encapedPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -608,7 +608,7 @@ func TestNATNodePort(t *testing.T) {
 	// Response arriving at node 1
 	bpfIfaceName = "NP-1"
 
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(encapedPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -638,7 +638,7 @@ func TestNATNodePort(t *testing.T) {
 	dumpCTMap(ctMap)
 
 	// try a spoofed tunnel packet returnign back, should be dropped and have no effect
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		// modify the only known good src IP, we do not care about csums at this point
 		encapedPkt[26] = 235
 		res, err := bpfrun(encapedPkt)
@@ -649,7 +649,7 @@ func TestNATNodePort(t *testing.T) {
 	skbMark = tc.MarkSeenBypassForward // CALI_SKB_MARK_BYPASS_FWD
 
 	// Response leaving to original source
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(recvPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -680,7 +680,7 @@ func TestNATNodePort(t *testing.T) {
 	dumpCTMap(ctMap)
 
 	// Another pkt arriving at node 1 - uses existing CT entries
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -742,7 +742,7 @@ func TestNATNodePort(t *testing.T) {
 		// Arriving at node 2
 		bpfIfaceName = "NP-2"
 
-		runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 			res, err := bpfrun(encapedPktArrivesAtNode2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -789,7 +789,7 @@ func TestNATNodePort(t *testing.T) {
 		skbMark = 0
 
 		// Response leaving workload at node 2
-		runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 			respPkt := udpResposeRaw(recvPkt)
 
 			// Change the MAC addresses so that we can observe that the right
@@ -890,7 +890,7 @@ func TestNATNodePortNoFWD(t *testing.T) {
 	dumpRTMap(rtMap)
 
 	// Arriving at node
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -949,7 +949,7 @@ func TestNATNodePortNoFWD(t *testing.T) {
 	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 
 	// Response leaving to original source
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(respPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -1052,7 +1052,7 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 	dumpRTMap(rtMap)
 
 	// Arriving at node 1 through 10.10.2.x
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -1098,7 +1098,7 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 	var encapedGoPkt gopacket.Packet
 
 	// Leaving node 1 through 10.10.0.x
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(encapedPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -1126,7 +1126,7 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 	var recvPkt []byte
 
 	// Response arriving at node 1 through 10.10.0.x
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(respPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -1158,7 +1158,7 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 	skbMark = tc.MarkSeenBypassForward // CALI_SKB_MARK_BYPASS_FWD
 
 	// Response leaving to original source
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(recvPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -1296,7 +1296,7 @@ func TestNATNodePortICMPTooBig(t *testing.T) {
 	hostIP = node1ip
 
 	// Arriving at node but is rejected because of MTU, expect ICMP too big reply
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.RetvalStr()).To(Equal("TC_ACT_UNSPEC"), "expected program to return TC_ACT_UNSPEC")
@@ -1536,7 +1536,7 @@ func TestNATNodePortIngressDSR(t *testing.T) {
 	dumpRTMap(rtMap)
 
 	// Arriving at node 1
-	runBpfTest(t, "calico_from_host_ep_dsr", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep_dsr", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))

--- a/bpf/ut/precompilation_test.go
+++ b/bpf/ut/precompilation_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 						for _, dsr := range []bool{false, true} {
 							if dsr && !((epType == tc.EpTypeWorkload && toOrFrom == tc.FromEp) ||
 								(epType == tc.EpTypeHost)) {
-								log.Debug("DST only affects from WEP and HEP")
+								log.Debug("DSR only affects from WEP and HEP")
 								continue
 							}
 

--- a/bpf/ut/to_host_allowed_test.go
+++ b/bpf/ut/to_host_allowed_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ func TestToHostAllowedCTFull(t *testing.T) {
 
 	// No route - should not pass
 	bpfIfaceName = "ctNO"
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(synPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
@@ -109,7 +109,7 @@ func TestToHostAllowedCTFull(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	bpfIfaceName = "ctLW"
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(synPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
@@ -123,7 +123,7 @@ func TestToHostAllowedCTFull(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	bpfIfaceName = "ctRW"
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(synPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
@@ -137,7 +137,7 @@ func TestToHostAllowedCTFull(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	bpfIfaceName = "ctRH"
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(synPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
@@ -151,7 +151,7 @@ func TestToHostAllowedCTFull(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	bpfIfaceName = "ctLH"
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(synPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -172,7 +172,7 @@ func TestToHostAllowedCTFull(t *testing.T) {
 	_, _, _, _, synAckPkt, err := testPacket(nil, &ipv4Ret, tcpSynAck, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(synAckPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -189,7 +189,7 @@ func TestToHostAllowedCTFull(t *testing.T) {
 	_, _, _, _, ackPkt, err := testPacket(nil, nil, tcpAck, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(ackPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -199,7 +199,7 @@ func TestToHostAllowedCTFull(t *testing.T) {
 	err = ctMap.Delete(firstCTKey[:])
 	Expect(err).NotTo(HaveOccurred())
 
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(ackPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -259,7 +259,7 @@ func TestToHostAllowedCTFull(t *testing.T) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(synPkt)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))

--- a/bpf/ut/to_host_allowed_test.go
+++ b/bpf/ut/to_host_allowed_test.go
@@ -205,17 +205,8 @@ func TestToHostAllowedCTFull(t *testing.T) {
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 	})
 
-	// Conntrack created - the table is full again
-	err = ctMap.Update(firstCTKey[:], firstCTVal[:])
-	Expect(err).To(Equal(unix.E2BIG))
-
-	// Delete the newly created key to allow the rest of the tests pass - they
-	// expect full table and no match
-	key := conntrack.NewKey(6, ipv4.SrcIP, uint16(tcpAck.SrcPort), ipv4.DstIP, uint16(tcpAck.DstPort))
-	err = ctMap.Delete(key[:])
-	Expect(err).NotTo(HaveOccurred())
-
-	// Refill the table
+	// No conntrack created for non-SYN packet (should fall through to iptables).  We test by
+	// trying to create an entry, which should succeed.
 	err = ctMap.Update(firstCTKey[:], firstCTVal[:])
 	Expect(err).NotTo(HaveOccurred())
 

--- a/bpf/ut/whitelist_test.go
+++ b/bpf/ut/whitelist_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ func TestWhitelistFromWorkloadExitHost(t *testing.T) {
 	// Leaving node 1
 	skbMark = tc.MarkSeen // CALI_SKB_MARK_SEEN
 
-	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
@@ -123,7 +123,7 @@ func TestWhitelistEnterHostToWorkload(t *testing.T) {
 	ctKey := conntrack.NewKey(uint8(ipv4.Protocol),
 		ipv4.SrcIP, uint16(udp.SrcPort), ipv4.DstIP, uint16(udp.DstPort))
 
-	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))

--- a/cmd/calico-bpf/commands/conntrack.go
+++ b/cmd/calico-bpf/commands/conntrack.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ func (cmd *conntrackDumpCmd) Run(c *cobra.Command, _ []string) {
 	mc := &bpf.MapContext{}
 	ctMap := conntrack.Map(mc)
 	if err := ctMap.Open(); err != nil {
-		log.WithError(err).Error("Failed to access ConntrackMap")
+		log.WithError(err).Fatal("Failed to access ConntrackMap")
 	}
 	err := ctMap.Iter(func(k, v []byte) bpf.IteratorAction {
 		var ctKey conntrack.Key

--- a/cmd/calico-bpf/commands/root.go
+++ b/cmd/calico-bpf/commands/root.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.SetOut(os.Stdout)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -257,6 +257,7 @@ func StartDataplaneDriver(configParams *config.Config,
 			},
 			IPIPMTU:                        configParams.IpInIpMtu,
 			VXLANMTU:                       configParams.VXLANMTU,
+			VXLANPort:                      configParams.VXLANPort,
 			IptablesBackend:                configParams.IptablesBackend,
 			IptablesRefreshInterval:        configParams.IptablesRefreshInterval,
 			RouteRefreshInterval:           configParams.RouteRefreshInterval,

--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -117,6 +117,7 @@ type bpfEndpointManager struct {
 	ipSetIDAlloc       *idalloc.IDAllocator
 	epToHostAction     string
 	vxlanMTU           int
+	vxlanPort          uint16
 	dsrEnabled         bool
 
 	ipSetMap bpf.Map
@@ -150,6 +151,7 @@ func newBPFEndpointManager(
 	workloadIfaceRegex *regexp.Regexp,
 	ipSetIDAlloc *idalloc.IDAllocator,
 	vxlanMTU int,
+	vxlanPort uint16,
 	dsrEnabled bool,
 	ipSetMap bpf.Map,
 	stateMap bpf.Map,
@@ -178,6 +180,7 @@ func newBPFEndpointManager(
 		ipSetIDAlloc:        ipSetIDAlloc,
 		epToHostAction:      epToHostAction,
 		vxlanMTU:            vxlanMTU,
+		vxlanPort:           vxlanPort,
 		dsrEnabled:          dsrEnabled,
 		ipSetMap:            ipSetMap,
 		stateMap:            stateMap,
@@ -1007,6 +1010,7 @@ func (m *bpfEndpointManager) calculateTCAttachPoint(policyDirection PolDirection
 	ap.FIB = m.fibLookupEnabled
 	ap.DSR = m.dsrEnabled
 	ap.LogLevel = m.bpfLogLevel
+	ap.VXLANPort = m.vxlanPort
 
 	return ap
 }

--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -34,8 +34,6 @@ import (
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/sys/unix"
 
-	"github.com/projectcalico/libcalico-go/lib/set"
-
 	"github.com/projectcalico/felix/bpf"
 	"github.com/projectcalico/felix/bpf/polprog"
 	"github.com/projectcalico/felix/bpf/tc"
@@ -44,6 +42,7 @@ import (
 	"github.com/projectcalico/felix/iptables"
 	"github.com/projectcalico/felix/proto"
 	"github.com/projectcalico/felix/ratelimited"
+	"github.com/projectcalico/libcalico-go/lib/set"
 )
 
 const jumpMapCleanupInterval = 10 * time.Second
@@ -116,8 +115,9 @@ type bpfEndpointManager struct {
 	vxlanMTU           int
 	dsrEnabled         bool
 
-	ipSetMap            bpf.Map
-	stateMap            bpf.Map
+	ipSetMap bpf.Map
+	stateMap bpf.Map
+
 	ruleRenderer        bpfAllowChainRenderer
 	iptablesFilterTable *iptables.Table
 

--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -874,7 +874,7 @@ func (m *bpfEndpointManager) updatePolicyProgram(jumpMapFD bpf.MapFD, rules polp
 
 func (m *bpfEndpointManager) removePolicyProgram(jumpMapFD bpf.MapFD) error {
 	k := make([]byte, 4)
-	err := bpf.DeleteMapEntry(jumpMapFD, k, 4)
+	err := bpf.DeleteMapEntryIfExists(jumpMapFD, k, 4)
 	if err != nil {
 		return fmt.Errorf("failed to update jump map: %w", err)
 	}

--- a/dataplane/linux/bpf_ep_mgr.go
+++ b/dataplane/linux/bpf_ep_mgr.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// +build !windows
+
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +25,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"reflect"
 	"regexp"
 	"runtime"
 	"strings"
@@ -34,6 +37,8 @@ import (
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/sys/unix"
 
+	"github.com/projectcalico/libcalico-go/lib/set"
+
 	"github.com/projectcalico/felix/bpf"
 	"github.com/projectcalico/felix/bpf/polprog"
 	"github.com/projectcalico/felix/bpf/tc"
@@ -42,7 +47,6 @@ import (
 	"github.com/projectcalico/felix/iptables"
 	"github.com/projectcalico/felix/proto"
 	"github.com/projectcalico/felix/ratelimited"
-	"github.com/projectcalico/libcalico-go/lib/set"
 )
 
 const jumpMapCleanupInterval = 10 * time.Second
@@ -111,7 +115,7 @@ type bpfEndpointManager struct {
 	dataIfaceRegex     *regexp.Regexp
 	workloadIfaceRegex *regexp.Regexp
 	ipSetIDAlloc       *idalloc.IDAllocator
-	epToHostDrop       bool
+	epToHostAction     string
 	vxlanMTU           int
 	dsrEnabled         bool
 
@@ -126,6 +130,11 @@ type bpfEndpointManager struct {
 
 	// onStillAlive is called from loops to reset the watchdog.
 	onStillAlive func()
+
+	// HEP processing.
+	hostIfaceToEpMap     map[string]proto.HostEndpoint
+	wildcardHostEndpoint proto.HostEndpoint
+	wildcardExists       bool
 }
 
 type bpfAllowChainRenderer interface {
@@ -136,7 +145,7 @@ func newBPFEndpointManager(
 	bpfLogLevel string,
 	hostname string,
 	fibLookupEnabled bool,
-	epToHostDrop bool,
+	epToHostAction string,
 	dataIfaceRegex *regexp.Regexp,
 	workloadIfaceRegex *regexp.Regexp,
 	ipSetIDAlloc *idalloc.IDAllocator,
@@ -167,7 +176,7 @@ func newBPFEndpointManager(
 		dataIfaceRegex:      dataIfaceRegex,
 		workloadIfaceRegex:  workloadIfaceRegex,
 		ipSetIDAlloc:        ipSetIDAlloc,
-		epToHostDrop:        epToHostDrop,
+		epToHostAction:      epToHostAction,
 		vxlanMTU:            vxlanMTU,
 		dsrEnabled:          dsrEnabled,
 		ipSetMap:            ipSetMap,
@@ -178,7 +187,8 @@ func newBPFEndpointManager(
 			log.Debug("Jump map cleanup triggered.")
 			tc.CleanUpJumpMaps()
 		}),
-		onStillAlive: livenessCallback,
+		onStillAlive:     livenessCallback,
+		hostIfaceToEpMap: map[string]proto.HostEndpoint{},
 	}
 }
 
@@ -198,7 +208,7 @@ func (m *bpfEndpointManager) withIface(ifaceName string, fn func(iface *bpfInter
 		logCtx.Debug("Interface info is now empty.")
 		delete(m.nameToIface, ifaceName)
 	} else {
-		// Always store the result (rather than checking hte dirty flag) because dirty only covers the info..
+		// Always store the result (rather than checking the dirty flag) because dirty only covers the info..
 		m.nameToIface[ifaceName] = iface
 	}
 
@@ -316,7 +326,7 @@ func (m *bpfEndpointManager) onPolicyUpdate(msg *proto.ActivePolicyUpdate) {
 	polID := *msg.Id
 	log.WithField("id", polID).Debug("Policy update")
 	m.policies[polID] = msg.Policy
-	m.markPolicyUsersDirty(polID)
+	m.markEndpointsDirty(m.policiesToWorkloads[polID], "policy")
 }
 
 // onPolicyRemove removes the policy from the cache and marks any endpoints using it dirty.
@@ -324,7 +334,7 @@ func (m *bpfEndpointManager) onPolicyUpdate(msg *proto.ActivePolicyUpdate) {
 func (m *bpfEndpointManager) onPolicyRemove(msg *proto.ActivePolicyRemove) {
 	polID := *msg.Id
 	log.WithField("id", polID).Debug("Policy removed")
-	m.markPolicyUsersDirty(polID)
+	m.markEndpointsDirty(m.policiesToWorkloads[polID], "policy")
 	delete(m.policies, polID)
 	delete(m.policiesToWorkloads, polID)
 }
@@ -334,7 +344,7 @@ func (m *bpfEndpointManager) onProfileUpdate(msg *proto.ActiveProfileUpdate) {
 	profID := *msg.Id
 	log.WithField("id", profID).Debug("Profile update")
 	m.profiles[profID] = msg.Profile
-	m.markProfileUsersDirty(profID)
+	m.markEndpointsDirty(m.profilesToWorkloads[profID], "profile")
 }
 
 // onProfileRemove removes the profile from the cache and marks any endpoints that were using it as dirty.
@@ -342,33 +352,33 @@ func (m *bpfEndpointManager) onProfileUpdate(msg *proto.ActiveProfileUpdate) {
 func (m *bpfEndpointManager) onProfileRemove(msg *proto.ActiveProfileRemove) {
 	profID := *msg.Id
 	log.WithField("id", profID).Debug("Profile removed")
-	m.markProfileUsersDirty(profID)
+	m.markEndpointsDirty(m.profilesToWorkloads[profID], "profile")
 	delete(m.profiles, profID)
 	delete(m.profilesToWorkloads, profID)
 }
 
-func (m *bpfEndpointManager) markPolicyUsersDirty(id proto.PolicyID) {
-	wls := m.policiesToWorkloads[id]
-	if wls == nil {
-		// Hear about the policy before the endpoint.
+func (m *bpfEndpointManager) markEndpointsDirty(ids set.Set, kind string) {
+	if ids == nil {
+		// Hear about the policy/profile before the endpoint.
 		return
 	}
-	wls.Iter(func(item interface{}) error {
-		wlID := item.(proto.WorkloadEndpointID)
-		m.markExistingWEPDirty(wlID, "policy")
-		return nil
-	})
-}
-
-func (m *bpfEndpointManager) markProfileUsersDirty(id proto.ProfileID) {
-	wls := m.profilesToWorkloads[id]
-	if wls == nil {
-		// Hear about the policy before the endpoint.
-		return
-	}
-	wls.Iter(func(item interface{}) error {
-		wlID := item.(proto.WorkloadEndpointID)
-		m.markExistingWEPDirty(wlID, "profile")
+	ids.Iter(func(item interface{}) error {
+		switch id := item.(type) {
+		case proto.WorkloadEndpointID:
+			m.markExistingWEPDirty(id, kind)
+		case string:
+			if id == allInterfaces {
+				for ifaceName := range m.nameToIface {
+					if m.isWorkloadIface(ifaceName) {
+						log.Debugf("Mark WEP iface dirty, for host-* endpoint %v change", kind)
+						m.dirtyIfaceNames.Add(ifaceName)
+					}
+				}
+			} else {
+				log.Debugf("Mark host iface dirty, for host %v change", kind)
+				m.dirtyIfaceNames.Add(id)
+			}
+		}
 		return nil
 	})
 }
@@ -456,14 +466,19 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 				return
 			}
 
+			var hepPtr *proto.HostEndpoint
+			if hep, hepExists := m.hostIfaceToEpMap[iface]; hepExists {
+				hepPtr = &hep
+			}
+
 			var ingressWG sync.WaitGroup
 			var ingressErr error
 			ingressWG.Add(1)
 			go func() {
 				defer ingressWG.Done()
-				ingressErr = m.attachDataIfaceProgram(iface, PolDirnIngress)
+				ingressErr = m.attachDataIfaceProgram(iface, hepPtr, PolDirnIngress)
 			}()
-			err = m.attachDataIfaceProgram(iface, PolDirnEgress)
+			err = m.attachDataIfaceProgram(iface, hepPtr, PolDirnEgress)
 			ingressWG.Wait()
 			if err == nil {
 				err = ingressErr
@@ -670,7 +685,7 @@ func (m *bpfEndpointManager) applyPolicy(ifaceName string) error {
 var calicoRouterIP = net.IPv4(169, 254, 1, 1).To4()
 
 func (m *bpfEndpointManager) attachWorkloadProgram(ifaceName string, endpoint *proto.WorkloadEndpoint, polDirection PolDirection) error {
-	ap := m.calculateTCAttachPoint(tc.EpTypeWorkload, polDirection, ifaceName)
+	ap := m.calculateTCAttachPoint(polDirection, ifaceName)
 	// Host side of the veth is always configured as 169.254.1.1.
 	ap.HostIP = calicoRouterIP
 	// * VXLAN MTU should be the host ifaces MTU -50, in order to allow space for VXLAN.
@@ -680,8 +695,13 @@ func (m *bpfEndpointManager) attachWorkloadProgram(ifaceName string, endpoint *p
 	//   when we cannot encap the packet - non-GSO & too close to veth MTU
 	ap.TunnelMTU = uint16(m.vxlanMTU - 50)
 
-	var tier *proto.TierInfo
+	jumpMapFD, err := m.ensureProgramAttached(&ap, polDirection)
+	if err != nil {
+		return err
+	}
+
 	var profileIDs []string
+	var tier *proto.TierInfo
 	if endpoint != nil {
 		profileIDs = endpoint.ProfileIds
 		if len(endpoint.Tiers) != 0 {
@@ -696,20 +716,41 @@ func (m *bpfEndpointManager) attachWorkloadProgram(ifaceName string, endpoint *p
 	// drop rule, giving us default drop behaviour in that case.
 	rules := m.extractRules(tier, profileIDs, polDirection)
 
-	jumpMapFD := m.getJumpMapFD(ifaceName, polDirection)
+	// If host-* endpoint is configured, add in its policy.
+	if m.wildcardExists {
+		m.addHostPolicy(&rules, &m.wildcardHostEndpoint, polDirection.Inverse())
+	}
+
+	// If workload egress and DefaultEndpointToHostAction is ACCEPT or DROP, suppress the normal
+	// host-* endpoint policy.
+	if polDirection == PolDirnEgress && m.epToHostAction != "RETURN" {
+		rules.SuppressNormalHostPolicy = true
+	}
+
+	// If host -> workload, always suppress the normal host-* endpoint policy.
+	if polDirection == PolDirnIngress {
+		rules.SuppressNormalHostPolicy = true
+	}
+
+	return m.updatePolicyProgram(jumpMapFD, rules)
+}
+
+// Ensure TC program is attached to the specified interface and return its jump map FD.
+func (m *bpfEndpointManager) ensureProgramAttached(ap *tc.AttachPoint, polDirection PolDirection) (bpf.MapFD, error) {
+	jumpMapFD := m.getJumpMapFD(ap.Iface, polDirection)
 	if jumpMapFD != 0 {
 		if attached, err := ap.IsAttached(); err != nil {
-			return fmt.Errorf("failed to check if interface %s had BPF program; %w", ifaceName, err)
+			return jumpMapFD, fmt.Errorf("failed to check if interface %s had BPF program; %w", ap.Iface, err)
 		} else if !attached {
 			// BPF program is missing; maybe we missed a notification of the interface being recreated?
 			// Close the now-defunct jump map.
-			log.WithField("iface", ifaceName).Info(
+			log.WithField("iface", ap.Iface).Info(
 				"Detected that BPF program no longer attached to interface.")
 			err := jumpMapFD.Close()
 			if err != nil {
 				log.WithError(err).Warn("Failed to close jump map FD. Ignoring.")
 			}
-			m.setJumpMapFD(ifaceName, polDirection, 0)
+			m.setJumpMapFD(ap.Iface, polDirection, 0)
 			jumpMapFD = 0 // Trigger program to be re-added below.
 		}
 	}
@@ -718,17 +759,39 @@ func (m *bpfEndpointManager) attachWorkloadProgram(ifaceName string, endpoint *p
 		// We don't have a program attached to this interface yet, attach one now.
 		err := ap.AttachProgram()
 		if err != nil {
-			return err
+			return 0, err
 		}
 
 		jumpMapFD, err = FindJumpMap(ap)
 		if err != nil {
-			return fmt.Errorf("failed to look up jump map: %w", err)
+			return 0, fmt.Errorf("failed to look up jump map: %w", err)
 		}
-		m.setJumpMapFD(ifaceName, polDirection, jumpMapFD)
+		m.setJumpMapFD(ap.Iface, polDirection, jumpMapFD)
 	}
 
-	return m.updatePolicyProgram(jumpMapFD, rules)
+	return jumpMapFD, nil
+}
+
+func (m *bpfEndpointManager) addHostPolicy(rules *polprog.Rules, hostEndpoint *proto.HostEndpoint, polDirection PolDirection) {
+
+	// When there is applicable pre-DNAT policy that does not explicitly Allow or Deny traffic,
+	// we continue on to subsequent tiers and normal or AoF policy.
+	if len(hostEndpoint.PreDnatTiers) == 1 {
+		rules.HostPreDnatTiers = m.extractTiers(hostEndpoint.PreDnatTiers[0], polDirection, NoEndTierDrop)
+	}
+
+	// When there is applicable apply-on-forward policy that does not explicitly Allow or Deny
+	// traffic, traffic is dropped.
+	if len(hostEndpoint.ForwardTiers) == 1 {
+		rules.HostForwardTiers = m.extractTiers(hostEndpoint.ForwardTiers[0], polDirection, EndTierDrop)
+	}
+
+	// When there is applicable normal policy that does not explicitly Allow or Deny traffic,
+	// traffic is dropped.
+	if len(hostEndpoint.Tiers) == 1 {
+		rules.HostNormalTiers = m.extractTiers(hostEndpoint.Tiers[0], polDirection, EndTierDrop)
+	}
+	rules.HostProfiles = m.extractProfiles(hostEndpoint.ProfileIds, polDirection)
 }
 
 func (m *bpfEndpointManager) getJumpMapFD(ifaceName string, direction PolDirection) (fd bpf.MapFD) {
@@ -788,7 +851,16 @@ func (m *bpfEndpointManager) updatePolicyProgram(jumpMapFD bpf.MapFD, rules polp
 	return nil
 }
 
-func FindJumpMap(ap tc.AttachPoint) (mapFD bpf.MapFD, err error) {
+func (m *bpfEndpointManager) removePolicyProgram(jumpMapFD bpf.MapFD) error {
+	k := make([]byte, 4)
+	err := bpf.DeleteMapEntry(jumpMapFD, k, 4)
+	if err != nil {
+		return fmt.Errorf("failed to update jump map: %w", err)
+	}
+	return nil
+}
+
+func FindJumpMap(ap *tc.AttachPoint) (mapFD bpf.MapFD, err error) {
 	logCtx := log.WithField("iface", ap.Iface)
 	logCtx.Debug("Looking up jump map.")
 	out, err := tc.ExecTC("filter", "show", "dev", ap.Iface, string(ap.Hook))
@@ -851,17 +923,25 @@ func FindJumpMap(ap tc.AttachPoint) (mapFD bpf.MapFD, err error) {
 	return 0, errors.New("failed to find TC program")
 }
 
-func (m *bpfEndpointManager) attachDataIfaceProgram(ifaceName string, polDirection PolDirection) error {
-	epType := tc.EpTypeHost
-	if ifaceName == "tunl0" {
-		epType = tc.EpTypeTunnel
-	} else if ifaceName == "wireguard.cali" {
-		epType = tc.EpTypeWireguard
-	}
-	ap := m.calculateTCAttachPoint(epType, polDirection, ifaceName)
+func (m *bpfEndpointManager) attachDataIfaceProgram(ifaceName string, ep *proto.HostEndpoint, polDirection PolDirection) error {
+	ap := m.calculateTCAttachPoint(polDirection, ifaceName)
 	ap.HostIP = m.hostIP
 	ap.TunnelMTU = uint16(m.vxlanMTU)
-	return ap.AttachProgram()
+
+	jumpMapFD, err := m.ensureProgramAttached(&ap, polDirection)
+	if err != nil {
+		return err
+	}
+
+	if ep != nil {
+		rules := polprog.Rules{
+			ForHostInterface: true,
+		}
+		m.addHostPolicy(&rules, ep, polDirection)
+		return m.updatePolicyProgram(jumpMapFD, rules)
+	}
+
+	return m.removePolicyProgram(jumpMapFD)
 }
 
 // PolDirection is the Calico datamodel direction of policy.  On a host endpoint, ingress is towards the host.
@@ -873,8 +953,29 @@ const (
 	PolDirnEgress
 )
 
-func (m *bpfEndpointManager) calculateTCAttachPoint(endpointType tc.EndpointType, policyDirection PolDirection, ifaceName string) tc.AttachPoint {
+func (polDirection PolDirection) Inverse() PolDirection {
+	if polDirection == PolDirnIngress {
+		return PolDirnEgress
+	}
+	return PolDirnIngress
+}
+
+func (m *bpfEndpointManager) calculateTCAttachPoint(policyDirection PolDirection, ifaceName string) tc.AttachPoint {
 	var ap tc.AttachPoint
+	var endpointType tc.EndpointType
+
+	// Determine endpoint type.
+	if m.isWorkloadIface(ifaceName) {
+		endpointType = tc.EpTypeWorkload
+	} else if ifaceName == "tunl0" {
+		endpointType = tc.EpTypeTunnel
+	} else if ifaceName == "wireguard.cali" {
+		endpointType = tc.EpTypeWireguard
+	} else if m.isDataIface(ifaceName) {
+		endpointType = tc.EpTypeHost
+	} else {
+		log.Panicf("Unsupported ifaceName %v", ifaceName)
+	}
 
 	if endpointType == tc.EpTypeWorkload {
 		// Policy direction is relative to the workload so, from the host namespace it's flipped.
@@ -902,7 +1003,7 @@ func (m *bpfEndpointManager) calculateTCAttachPoint(endpointType tc.EndpointType
 	ap.Iface = ifaceName
 	ap.Type = endpointType
 	ap.ToOrFrom = toOrFrom
-	ap.ToHostDrop = m.epToHostDrop
+	ap.ToHostDrop = (m.epToHostAction == "DROP")
 	ap.FIB = m.fibLookupEnabled
 	ap.DSR = m.dsrEnabled
 	ap.LogLevel = m.bpfLogLevel
@@ -910,58 +1011,95 @@ func (m *bpfEndpointManager) calculateTCAttachPoint(endpointType tc.EndpointType
 	return ap
 }
 
-func (m *bpfEndpointManager) extractRules(tier *proto.TierInfo, profileNames []string, direction PolDirection) polprog.Rules {
-	var r polprog.Rules
-	if tier != nil {
-		directionalPols := tier.IngressPolicies
-		if direction == PolDirnEgress {
-			directionalPols = tier.EgressPolicies
+const EndTierDrop = true
+const NoEndTierDrop = false
+
+func (m *bpfEndpointManager) extractTiers(tier *proto.TierInfo, direction PolDirection, endTierDrop bool) (rTiers []polprog.Tier) {
+	if tier == nil {
+		return
+	}
+
+	directionalPols := tier.IngressPolicies
+	if direction == PolDirnEgress {
+		directionalPols = tier.EgressPolicies
+	}
+
+	if len(directionalPols) > 0 {
+		polTier := polprog.Tier{
+			Name:     tier.Name,
+			Policies: make([]polprog.Policy, len(directionalPols)),
 		}
 
-		if len(directionalPols) > 0 {
-
-			polTier := polprog.Tier{
-				Name:     tier.Name,
-				Policies: make([]polprog.Policy, len(directionalPols)),
+		for i, polName := range directionalPols {
+			pol := m.policies[proto.PolicyID{Tier: tier.Name, Name: polName}]
+			var prules []*proto.Rule
+			if direction == PolDirnIngress {
+				prules = pol.InboundRules
+			} else {
+				prules = pol.OutboundRules
+			}
+			policy := polprog.Policy{
+				Name:  polName,
+				Rules: make([]polprog.Rule, len(prules)),
 			}
 
-			for i, polName := range directionalPols {
-				pol := m.policies[proto.PolicyID{Tier: tier.Name, Name: polName}]
-				if direction == PolDirnIngress {
-					polTier.Policies[i] = polprog.Policy{
-						Name:  polName,
-						Rules: pol.InboundRules,
-					}
-				} else {
-					polTier.Policies[i] = polprog.Policy{
-						Name:  polName,
-						Rules: pol.OutboundRules,
-					}
+			for ri, r := range prules {
+				policy.Rules[ri] = polprog.Rule{
+					Rule: r,
 				}
 			}
 
-			r.Tiers = []polprog.Tier{polTier}
+			polTier.Policies[i] = policy
 		}
-	}
 
+		if endTierDrop {
+			polTier.EndAction = polprog.TierEndDeny
+		} else {
+			polTier.EndAction = polprog.TierEndPass
+		}
+
+		rTiers = append(rTiers, polTier)
+	}
+	return
+}
+
+func (m *bpfEndpointManager) extractProfiles(profileNames []string, direction PolDirection) (rProfiles []polprog.Profile) {
 	if count := len(profileNames); count > 0 {
-		r.Profiles = make([]polprog.Profile, count)
+		rProfiles = make([]polprog.Profile, count)
 
 		for i, profName := range profileNames {
 			prof := m.profiles[proto.ProfileID{Name: profName}]
+			var prules []*proto.Rule
 			if direction == PolDirnIngress {
-				r.Profiles[i] = polprog.Profile{
-					Name:  profName,
-					Rules: prof.InboundRules,
-				}
+				prules = prof.InboundRules
 			} else {
-				r.Profiles[i] = polprog.Profile{
-					Name:  profName,
-					Rules: prof.OutboundRules,
+				prules = prof.OutboundRules
+			}
+			profile := polprog.Profile{
+				Name:  profName,
+				Rules: make([]polprog.Rule, len(prules)),
+			}
+
+			for ri, r := range prules {
+				profile.Rules[ri] = polprog.Rule{
+					Rule: r,
 				}
 			}
+
+			rProfiles[i] = profile
 		}
 	}
+	return
+}
+
+func (m *bpfEndpointManager) extractRules(tier *proto.TierInfo, profileNames []string, direction PolDirection) polprog.Rules {
+	var r polprog.Rules
+
+	// When there is applicable normal policy that does not explicitly Allow or Deny traffic,
+	// traffic is dropped.
+	r.Tiers = m.extractTiers(tier, direction, EndTierDrop)
+
+	r.Profiles = m.extractProfiles(profileNames, direction)
 
 	return r
 }
@@ -976,13 +1114,13 @@ func (m *bpfEndpointManager) isDataIface(iface string) bool {
 
 func (m *bpfEndpointManager) addWEPToIndexes(wlID proto.WorkloadEndpointID, wl *proto.WorkloadEndpoint) {
 	for _, t := range wl.Tiers {
-		m.addPolicyToWEPMappings(t.IngressPolicies, wlID)
-		m.addPolicyToWEPMappings(t.EgressPolicies, wlID)
+		m.addPolicyToEPMappings(t.IngressPolicies, wlID)
+		m.addPolicyToEPMappings(t.EgressPolicies, wlID)
 	}
-	m.addProfileToWEPMappings(wl.ProfileIds, wlID)
+	m.addProfileToEPMappings(wl.ProfileIds, wlID)
 }
 
-func (m *bpfEndpointManager) addPolicyToWEPMappings(polNames []string, wlID proto.WorkloadEndpointID) {
+func (m *bpfEndpointManager) addPolicyToEPMappings(polNames []string, id interface{}) {
 	for _, pol := range polNames {
 		polID := proto.PolicyID{
 			Tier: "default",
@@ -991,11 +1129,11 @@ func (m *bpfEndpointManager) addPolicyToWEPMappings(polNames []string, wlID prot
 		if m.policiesToWorkloads[polID] == nil {
 			m.policiesToWorkloads[polID] = set.New()
 		}
-		m.policiesToWorkloads[polID].Add(wlID)
+		m.policiesToWorkloads[polID].Add(id)
 	}
 }
 
-func (m *bpfEndpointManager) addProfileToWEPMappings(profileIds []string, wlID proto.WorkloadEndpointID) {
+func (m *bpfEndpointManager) addProfileToEPMappings(profileIds []string, id interface{}) {
 	for _, profName := range profileIds {
 		profID := proto.ProfileID{Name: profName}
 		profSet := m.profilesToWorkloads[profID]
@@ -1003,7 +1141,7 @@ func (m *bpfEndpointManager) addProfileToWEPMappings(profileIds []string, wlID p
 			profSet = set.New()
 			m.profilesToWorkloads[profID] = profSet
 		}
-		profSet.Add(wlID)
+		profSet.Add(id)
 	}
 }
 
@@ -1013,11 +1151,11 @@ func (m *bpfEndpointManager) removeWEPFromIndexes(wlID proto.WorkloadEndpointID,
 	}
 
 	for _, t := range wep.Tiers {
-		m.removePolicyToWEPMappings(t.IngressPolicies, wlID)
-		m.removePolicyToWEPMappings(t.EgressPolicies, wlID)
+		m.removePolicyToEPMappings(t.IngressPolicies, wlID)
+		m.removePolicyToEPMappings(t.EgressPolicies, wlID)
 	}
 
-	m.removeProfileToWEPMappings(wep.ProfileIds, wlID)
+	m.removeProfileToEPMappings(wep.ProfileIds, wlID)
 
 	m.withIface(wep.Name, func(iface *bpfInterface) bool {
 		iface.info.endpointID = nil
@@ -1025,7 +1163,7 @@ func (m *bpfEndpointManager) removeWEPFromIndexes(wlID proto.WorkloadEndpointID,
 	})
 }
 
-func (m *bpfEndpointManager) removePolicyToWEPMappings(polNames []string, wlID proto.WorkloadEndpointID) {
+func (m *bpfEndpointManager) removePolicyToEPMappings(polNames []string, id interface{}) {
 	for _, pol := range polNames {
 		polID := proto.PolicyID{
 			Tier: "default",
@@ -1035,7 +1173,7 @@ func (m *bpfEndpointManager) removePolicyToWEPMappings(polNames []string, wlID p
 		if polSet == nil {
 			continue
 		}
-		polSet.Discard(wlID)
+		polSet.Discard(id)
 		if polSet.Len() == 0 {
 			// Defensive; we also clean up when the profile is removed.
 			delete(m.policiesToWorkloads, polID)
@@ -1043,17 +1181,107 @@ func (m *bpfEndpointManager) removePolicyToWEPMappings(polNames []string, wlID p
 	}
 }
 
-func (m *bpfEndpointManager) removeProfileToWEPMappings(profileIds []string, wlID proto.WorkloadEndpointID) {
+func (m *bpfEndpointManager) removeProfileToEPMappings(profileIds []string, id interface{}) {
 	for _, profName := range profileIds {
 		profID := proto.ProfileID{Name: profName}
 		profSet := m.profilesToWorkloads[profID]
 		if profSet == nil {
 			continue
 		}
-		profSet.Discard(wlID)
+		profSet.Discard(id)
 		if profSet.Len() == 0 {
 			// Defensive; we also clean up when the policy is removed.
 			delete(m.profilesToWorkloads, profID)
 		}
 	}
+}
+
+func (m *bpfEndpointManager) OnHEPUpdate(hostIfaceToEpMap map[string]proto.HostEndpoint) {
+	// Pre-process the map for the host-* endpoint: if there is a host-* endpoint, any host
+	// interface without its own HEP should use the host-* endpoint's policy.
+	wildcardHostEndpoint, wildcardExists := hostIfaceToEpMap[allInterfaces]
+	if wildcardExists {
+		log.Info("Host-* endpoint is configured")
+		for ifaceName := range m.nameToIface {
+			if _, specificExists := hostIfaceToEpMap[ifaceName]; m.isDataIface(ifaceName) && !specificExists {
+				log.Infof("Use host-* endpoint policy for %v", ifaceName)
+				hostIfaceToEpMap[ifaceName] = wildcardHostEndpoint
+			}
+		}
+		delete(hostIfaceToEpMap, allInterfaces)
+	}
+
+	// If there are parts of proto.HostEndpoint that do not affect us, we could mask those out
+	// here so that they can't cause spurious updates - at the cost of having different
+	// proto.HostEndpoint data here than elsewhere.  For example, the ExpectedIpv4Addrs and
+	// ExpectedIpv6Addrs fields.  But currently there are no fields that are sufficiently likely
+	// to change as to make this worthwhile.
+
+	// If the host-* endpoint is changing, mark all workload interfaces as dirty.
+	if !reflect.DeepEqual(wildcardHostEndpoint, m.wildcardHostEndpoint) {
+		log.Infof("Host-* endpoint is changing; was %v, now %v", m.wildcardHostEndpoint, wildcardHostEndpoint)
+		m.removeHEPFromIndexes(allInterfaces, &m.wildcardHostEndpoint)
+		m.wildcardHostEndpoint = wildcardHostEndpoint
+		m.wildcardExists = wildcardExists
+		m.addHEPToIndexes(allInterfaces, &wildcardHostEndpoint)
+		for ifaceName := range m.nameToIface {
+			if m.isWorkloadIface(ifaceName) {
+				log.Info("Mark WEP iface dirty, for host-* endpoint change")
+				m.dirtyIfaceNames.Add(ifaceName)
+			}
+		}
+	}
+
+	// Loop through existing host endpoints, in case they are changing or disappearing.
+	for ifaceName, existingEp := range m.hostIfaceToEpMap {
+		newEp, stillExists := hostIfaceToEpMap[ifaceName]
+		if stillExists && reflect.DeepEqual(newEp, existingEp) {
+			log.Debugf("No change to host endpoint for ifaceName=%v", ifaceName)
+		} else {
+			m.removeHEPFromIndexes(ifaceName, &existingEp)
+			if stillExists {
+				log.Infof("Host endpoint changing for ifaceName=%v", ifaceName)
+				m.addHEPToIndexes(ifaceName, &newEp)
+				m.hostIfaceToEpMap[ifaceName] = newEp
+			} else {
+				log.Infof("Host endpoint deleted for ifaceName=%v", ifaceName)
+				delete(m.hostIfaceToEpMap, ifaceName)
+			}
+			m.dirtyIfaceNames.Add(ifaceName)
+		}
+		delete(hostIfaceToEpMap, ifaceName)
+	}
+
+	// Now anything remaining in hostIfaceToEpMap must be a new host endpoint.
+	for ifaceName, newEp := range hostIfaceToEpMap {
+		if !m.isDataIface(ifaceName) {
+			log.Warningf("Host endpoint configured for ifaceName=%v, but that doesn't match BPFDataIfacePattern; ignoring", ifaceName)
+			continue
+		}
+		log.Infof("Host endpoint added for ifaceName=%v", ifaceName)
+		m.addHEPToIndexes(ifaceName, &newEp)
+		m.hostIfaceToEpMap[ifaceName] = newEp
+		m.dirtyIfaceNames.Add(ifaceName)
+	}
+}
+
+func (m *bpfEndpointManager) addHEPToIndexes(ifaceName string, ep *proto.HostEndpoint) {
+	for _, tiers := range [][]*proto.TierInfo{ep.Tiers, ep.UntrackedTiers, ep.PreDnatTiers, ep.ForwardTiers} {
+		for _, t := range tiers {
+			m.addPolicyToEPMappings(t.IngressPolicies, ifaceName)
+			m.addPolicyToEPMappings(t.EgressPolicies, ifaceName)
+		}
+	}
+	m.addProfileToEPMappings(ep.ProfileIds, ifaceName)
+}
+
+func (m *bpfEndpointManager) removeHEPFromIndexes(ifaceName string, ep *proto.HostEndpoint) {
+	for _, tiers := range [][]*proto.TierInfo{ep.Tiers, ep.UntrackedTiers, ep.PreDnatTiers, ep.ForwardTiers} {
+		for _, t := range tiers {
+			m.removePolicyToEPMappings(t.IngressPolicies, ifaceName)
+			m.removePolicyToEPMappings(t.EgressPolicies, ifaceName)
+		}
+	}
+
+	m.removeProfileToEPMappings(ep.ProfileIds, ifaceName)
 }

--- a/dataplane/linux/bpf_ep_mgr_test.go
+++ b/dataplane/linux/bpf_ep_mgr_test.go
@@ -1,0 +1,202 @@
+// +build !windows
+
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	"regexp"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/bpf"
+	bpfipsets "github.com/projectcalico/felix/bpf/ipsets"
+	"github.com/projectcalico/felix/bpf/state"
+	"github.com/projectcalico/felix/idalloc"
+	"github.com/projectcalico/felix/ifacemonitor"
+	"github.com/projectcalico/felix/ipsets"
+	"github.com/projectcalico/felix/proto"
+	"github.com/projectcalico/felix/rules"
+)
+
+var _ = Describe("BPF Endpoint Manager", func() {
+
+	var (
+		bpfEpMgr *bpfEndpointManager
+	)
+
+	fibLookupEnabled := true
+	endpointToHostAction := "DROP"
+	dataIfacePattern := "^((en|wl|ww|sl|ib)[opsx].*|(eth|wlan|wwan).*|tunl0$|wireguard.cali$)"
+	workloadIfaceRegex := "cali"
+	ipSetIDAllocator := idalloc.New()
+	vxlanMTU := 0
+	nodePortDSR := true
+	bpfMapContext := &bpf.MapContext{
+		RepinningEnabled: true,
+	}
+	ipSetsMap := bpfipsets.Map(bpfMapContext)
+	stateMap := state.Map(bpfMapContext)
+	rrConfigNormal := rules.Config{
+		IPIPEnabled:                 true,
+		IPIPTunnelAddress:           nil,
+		IPSetConfigV4:               ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, "cali", nil, nil),
+		IPSetConfigV6:               ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, "cali", nil, nil),
+		IptablesMarkAccept:          0x8,
+		IptablesMarkPass:            0x10,
+		IptablesMarkScratch0:        0x20,
+		IptablesMarkScratch1:        0x40,
+		IptablesMarkEndpoint:        0xff00,
+		IptablesMarkNonCaliEndpoint: 0x0100,
+		KubeIPVSSupportEnabled:      true,
+		WorkloadIfacePrefixes:       []string{"cali", "tap"},
+		VXLANPort:                   4789,
+		VXLANVNI:                    4096,
+	}
+	ruleRenderer := rules.NewRenderer(rrConfigNormal)
+	filterTableV4 := newMockTable("filter")
+
+	BeforeEach(func() {
+		bpfEpMgr = newBPFEndpointManager(
+			"info", // config.BPFLogLevel,
+			"uthost",
+			fibLookupEnabled,
+			endpointToHostAction,
+			regexp.MustCompile(dataIfacePattern),
+			regexp.MustCompile(workloadIfaceRegex),
+			ipSetIDAllocator,
+			vxlanMTU,
+			uint16(rrConfigNormal.VXLANPort),
+			nodePortDSR,
+			ipSetsMap,
+			stateMap,
+			ruleRenderer,
+			filterTableV4,
+			nil,
+		)
+	})
+
+	It("exists", func() {
+		Expect(bpfEpMgr).NotTo(BeNil())
+	})
+
+	genIfaceUpdate := func(name string, state ifacemonitor.State, index int) func() {
+		return func() {
+			bpfEpMgr.OnUpdate(&ifaceUpdate{Name: name, State: state, Index: index})
+			bpfEpMgr.CompleteDeferredWork()
+		}
+	}
+
+	genHEPUpdate := func(heps ...interface{}) func() {
+		return func() {
+			hostIfaceToEp := make(map[string]proto.HostEndpoint)
+			for i := 0; i < len(heps); i += 2 {
+				log.Infof("%v = %v", heps[i], heps[i+1])
+				hostIfaceToEp[heps[i].(string)] = heps[i+1].(proto.HostEndpoint)
+			}
+			log.Infof("2 hostIfaceToEp = %v", hostIfaceToEp)
+			bpfEpMgr.OnHEPUpdate(hostIfaceToEp)
+			bpfEpMgr.CompleteDeferredWork()
+		}
+	}
+
+	hostEp := proto.HostEndpoint{
+		Name: "uthost-eth0",
+		PreDnatTiers: []*proto.TierInfo{
+			&proto.TierInfo{
+				Name:            "mytier",
+				IngressPolicies: []string{"mypolicy"},
+			},
+		},
+	}
+
+	It("does not have HEP in initial state", func() {
+		Expect(bpfEpMgr.hostIfaceToEpMap["eth0"]).NotTo(Equal(hostEp))
+	})
+
+	Context("with eth0 up", func() {
+		BeforeEach(genIfaceUpdate("eth0", ifacemonitor.StateUp, 10))
+
+		Context("with eth0 host endpoint", func() {
+			BeforeEach(genHEPUpdate("eth0", hostEp))
+
+			It("stores host endpoint for eth0", func() {
+				Expect(bpfEpMgr.hostIfaceToEpMap["eth0"]).To(Equal(hostEp))
+				Expect(bpfEpMgr.policiesToWorkloads[proto.PolicyID{
+					Tier: "default",
+					Name: "mypolicy",
+				}]).To(HaveKey("eth0"))
+			})
+		})
+
+		Context("with host-* endpoint", func() {
+			BeforeEach(genHEPUpdate(allInterfaces, hostEp))
+
+			It("stores host endpoint for eth0", func() {
+				Expect(bpfEpMgr.hostIfaceToEpMap["eth0"]).To(Equal(hostEp))
+				Expect(bpfEpMgr.policiesToWorkloads[proto.PolicyID{
+					Tier: "default",
+					Name: "mypolicy",
+				}]).To(HaveKey("eth0"))
+			})
+		})
+	})
+
+	Context("with eth0 host endpoint", func() {
+		BeforeEach(genHEPUpdate("eth0", hostEp))
+
+		Context("with eth0 up", func() {
+			BeforeEach(genIfaceUpdate("eth0", ifacemonitor.StateUp, 10))
+
+			It("stores host endpoint for eth0", func() {
+				Expect(bpfEpMgr.hostIfaceToEpMap["eth0"]).To(Equal(hostEp))
+				Expect(bpfEpMgr.policiesToWorkloads[proto.PolicyID{
+					Tier: "default",
+					Name: "mypolicy",
+				}]).To(HaveKey("eth0"))
+			})
+		})
+	})
+
+	Context("with host-* endpoint", func() {
+		BeforeEach(genHEPUpdate(allInterfaces, hostEp))
+
+		Context("with eth0 up", func() {
+			BeforeEach(genIfaceUpdate("eth0", ifacemonitor.StateUp, 10))
+
+			It("stores host endpoint for eth0", func() {
+				Expect(bpfEpMgr.hostIfaceToEpMap["eth0"]).To(Equal(hostEp))
+				Expect(bpfEpMgr.policiesToWorkloads[proto.PolicyID{
+					Tier: "default",
+					Name: "mypolicy",
+				}]).To(HaveKey("eth0"))
+			})
+
+			Context("with eth0 down", func() {
+				BeforeEach(genIfaceUpdate("eth0", ifacemonitor.StateDown, 10))
+
+				It("clears host endpoint for eth0", func() {
+					Expect(bpfEpMgr.hostIfaceToEpMap).To(BeEmpty())
+					Expect(bpfEpMgr.policiesToWorkloads[proto.PolicyID{
+						Tier: "default",
+						Name: "mypolicy",
+					}]).NotTo(HaveKey("eth0"))
+				})
+			})
+		})
+	})
+})

--- a/dataplane/linux/bpf_ep_mgr_test.go
+++ b/dataplane/linux/bpf_ep_mgr_test.go
@@ -97,7 +97,8 @@ var _ = Describe("BPF Endpoint Manager", func() {
 	genIfaceUpdate := func(name string, state ifacemonitor.State, index int) func() {
 		return func() {
 			bpfEpMgr.OnUpdate(&ifaceUpdate{Name: name, State: state, Index: index})
-			bpfEpMgr.CompleteDeferredWork()
+			err := bpfEpMgr.CompleteDeferredWork()
+			Expect(err).NotTo(HaveOccurred())
 		}
 	}
 
@@ -110,7 +111,8 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			}
 			log.Infof("2 hostIfaceToEp = %v", hostIfaceToEp)
 			bpfEpMgr.OnHEPUpdate(hostIfaceToEp)
-			bpfEpMgr.CompleteDeferredWork()
+			err := bpfEpMgr.CompleteDeferredWork()
+			Expect(err).NotTo(HaveOccurred())
 		}
 	}
 

--- a/dataplane/linux/endpoint_mgr.go
+++ b/dataplane/linux/endpoint_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -187,6 +187,7 @@ type endpointManager struct {
 	activeHostEpIDToIfaceNames map[proto.HostEndpointID][]string
 	// activeIfaceNameToHostEpID records which endpoint we resolved each host interface to.
 	activeIfaceNameToHostEpID map[string]proto.HostEndpointID
+	newIfaceNameToHostEpID    map[string]proto.HostEndpointID
 
 	needToCheckDispatchChains     bool
 	needToCheckEndpointMarkChains bool
@@ -195,6 +196,7 @@ type endpointManager struct {
 	OnEndpointStatusUpdate EndpointStatusUpdateCallback
 	callbacks              endpointManagerCallbacks
 	bpfEnabled             bool
+	bpfEndpointManager     *bpfEndpointManager
 }
 
 type EndpointStatusUpdateCallback func(ipVersion uint8, id interface{}, status string)
@@ -213,6 +215,7 @@ func newEndpointManager(
 	wlInterfacePrefixes []string,
 	onWorkloadEndpointStatusUpdate EndpointStatusUpdateCallback,
 	bpfEnabled bool,
+	bpfEndpointManager *bpfEndpointManager,
 	callbacks *callbacks,
 ) *endpointManager {
 	return newEndpointManagerWithShims(
@@ -229,6 +232,7 @@ func newEndpointManager(
 		writeProcSys,
 		os.Stat,
 		bpfEnabled,
+		bpfEndpointManager,
 		callbacks,
 	)
 }
@@ -247,6 +251,7 @@ func newEndpointManagerWithShims(
 	procSysWriter procSysWriter,
 	osStat func(name string) (os.FileInfo, error),
 	bpfEnabled bool,
+	bpfEndpointManager *bpfEndpointManager,
 	callbacks *callbacks,
 ) *endpointManager {
 	wlIfacesPattern := "^(" + strings.Join(wlInterfacePrefixes, "|") + ").*"
@@ -257,6 +262,7 @@ func newEndpointManagerWithShims(
 		wlIfacesRegexp:         wlIfacesRegexp,
 		kubeIPVSSupportEnabled: kubeIPVSSupportEnabled,
 		bpfEnabled:             bpfEnabled,
+		bpfEndpointManager:     bpfEndpointManager,
 
 		rawTable:     rawTable,
 		mangleTable:  mangleTable,
@@ -345,7 +351,7 @@ func (m *endpointManager) OnUpdate(protoBufMsg interface{}) {
 	}
 }
 
-func (m *endpointManager) CompleteDeferredWork() error {
+func (m *endpointManager) ResolveUpdateBatch() error {
 	// Copy the pending interface state to the active set and mark any interfaces that have
 	// changed state for reconfiguration by resolveWorkload/HostEndpoints()
 	for ifaceName, state := range m.pendingIfaceUpdates {
@@ -368,11 +374,21 @@ func (m *endpointManager) CompleteDeferredWork() error {
 		delete(m.pendingIfaceUpdates, ifaceName)
 	}
 
+	if m.hostEndpointsDirty {
+		log.Debug("Host endpoints updated, resolving them.")
+		m.newIfaceNameToHostEpID = m.resolveHostEndpoints()
+	}
+
+	return nil
+}
+
+func (m *endpointManager) CompleteDeferredWork() error {
+
 	m.resolveWorkloadEndpoints()
 
 	if m.hostEndpointsDirty {
 		log.Debug("Host endpoints updated, resolving them.")
-		m.resolveHostEndpoints()
+		m.updateHostEndpoints()
 		m.hostEndpointsDirty = false
 	}
 
@@ -722,7 +738,7 @@ func (m *endpointManager) resolveEndpointMarks() {
 	m.updateDispatchChains(m.activeEPMarkDispatchChains, newEndpointMarkDispatchChains, m.filterTable)
 }
 
-func (m *endpointManager) resolveHostEndpoints() {
+func (m *endpointManager) resolveHostEndpoints() map[string]proto.HostEndpointID {
 
 	// Host endpoint resolution
 	// ------------------------
@@ -751,16 +767,12 @@ func (m *endpointManager) resolveHostEndpoints() {
 	// seeing which of them are matched by the current set of HostEndpoints as a
 	// whole.
 	newIfaceNameToHostEpID := map[string]proto.HostEndpointID{}
-	newPreDNATIfaceNameToHostEpID := map[string]proto.HostEndpointID{}
-	newUntrackedIfaceNameToHostEpID := map[string]proto.HostEndpointID{}
-	newHostEpIDToIfaceNames := map[proto.HostEndpointID][]string{}
 	for ifaceName, ifaceAddrs := range m.hostIfaceToAddrs {
 		ifaceCxt := log.WithFields(log.Fields{
 			"ifaceName":  ifaceName,
 			"ifaceAddrs": ifaceAddrs,
 		})
 		bestHostEpId := proto.HostEndpointID{}
-		var bestHostEp proto.HostEndpoint
 	HostEpLoop:
 		for id, hostEp := range m.rawHostEndpoints {
 			logCxt := ifaceCxt.WithField("id", id)
@@ -780,7 +792,6 @@ func (m *endpointManager) resolveHostEndpoints() {
 				// interface.
 				logCxt.Debug("Match on explicit iface name")
 				bestHostEpId = id
-				bestHostEp = *hostEp
 				continue
 			} else if hostEp.Name != "" {
 				// The HostEndpoint has an explicit name that isn't this
@@ -797,7 +808,6 @@ func (m *endpointManager) resolveHostEndpoints() {
 						// that is on this interface.
 						logCxt.Debug("Match on address")
 						bestHostEpId = id
-						bestHostEp = *hostEp
 						continue HostEpLoop
 					}
 				}
@@ -810,28 +820,80 @@ func (m *endpointManager) resolveHostEndpoints() {
 			})
 			logCxt.Debug("Got HostEp for interface")
 			newIfaceNameToHostEpID[ifaceName] = bestHostEpId
-			if len(bestHostEp.UntrackedTiers) > 0 {
-				// Optimisation: only add the endpoint chains to the raw (untracked)
-				// table if there's some untracked policy to apply.  This reduces
-				// per-packet latency since every packet has to traverse the raw
-				// table.
-				logCxt.Debug("Endpoint has untracked policies.")
-				newUntrackedIfaceNameToHostEpID[ifaceName] = bestHostEpId
-			}
-			if len(bestHostEp.PreDnatTiers) > 0 {
-				// Similar optimisation (or neatness) for pre-DNAT policy.
-				logCxt.Debug("Endpoint has pre-DNAT policies.")
-				newPreDNATIfaceNameToHostEpID[ifaceName] = bestHostEpId
-			}
-			// Record that this host endpoint is in use, for status reporting.
-			newHostEpIDToIfaceNames[bestHostEpId] = append(
-				newHostEpIDToIfaceNames[bestHostEpId], ifaceName)
 		}
+	}
 
+	// Similar loop to find the best all-interfaces host endpoint.
+	bestHostEpId := proto.HostEndpointID{}
+	for id, hostEp := range m.rawHostEndpoints {
+		logCxt := log.WithField("id", id)
+		if !forAllInterfaces(hostEp) {
+			logCxt.Debug("Skip interface-specific host endpoint")
+			continue
+		}
+		if (bestHostEpId.EndpointId != "") && (bestHostEpId.EndpointId < id.EndpointId) {
+			// We already have a HostEndpointId that is better than
+			// this one, so no point looking any further.
+			logCxt.Debug("No better than existing match")
+			continue
+		}
+		logCxt.Debug("New best all-interfaces host endpoint")
+		bestHostEpId = id
+	}
+
+	if bestHostEpId.EndpointId != "" {
+		log.WithField("bestHostEpId", bestHostEpId).Debug("Got all interfaces HostEp")
+		newIfaceNameToHostEpID[allInterfaces] = bestHostEpId
+	}
+
+	if m.bpfEnabled && m.bpfEndpointManager != nil {
+		// Construct map of interface names to host endpoints, and pass to the BPF endpoint
+		// manager.
+		hostIfaceToEpMap := map[string]proto.HostEndpoint{}
+		for ifaceName, id := range newIfaceNameToHostEpID {
+			// Note, dereference the proto.HostEndpoint here so that the data lifetime
+			// is decoupled from the validity of the pointer here.
+			hostIfaceToEpMap[ifaceName] = *m.rawHostEndpoints[id]
+		}
+		m.bpfEndpointManager.OnHEPUpdate(hostIfaceToEpMap)
+	}
+
+	return newIfaceNameToHostEpID
+}
+
+func (m *endpointManager) updateHostEndpoints() {
+
+	// Calculate filtered name/id maps for untracked and pre-DNAT policy, and a reverse map from
+	// each active host endpoint to the interfaces it is in use for.
+	newIfaceNameToHostEpID := m.newIfaceNameToHostEpID
+	newPreDNATIfaceNameToHostEpID := map[string]proto.HostEndpointID{}
+	newUntrackedIfaceNameToHostEpID := map[string]proto.HostEndpointID{}
+	newHostEpIDToIfaceNames := map[proto.HostEndpointID][]string{}
+	for ifaceName, id := range newIfaceNameToHostEpID {
+		logCxt := log.WithField("id", id).WithField("ifaceName", ifaceName)
+		ep := m.rawHostEndpoints[id]
+		if len(ep.UntrackedTiers) > 0 {
+			// Optimisation: only add the endpoint chains to the raw (untracked)
+			// table if there's some untracked policy to apply.  This reduces
+			// per-packet latency since every packet has to traverse the raw
+			// table.
+			logCxt.Debug("Endpoint has untracked policies.")
+			newUntrackedIfaceNameToHostEpID[ifaceName] = id
+		}
+		if len(ep.PreDnatTiers) > 0 {
+			// Similar optimisation (or neatness) for pre-DNAT policy.
+			logCxt.Debug("Endpoint has pre-DNAT policies.")
+			newPreDNATIfaceNameToHostEpID[ifaceName] = id
+		}
+		// Record that this host endpoint is in use, for status reporting.
+		newHostEpIDToIfaceNames[id] = append(
+			newHostEpIDToIfaceNames[id], ifaceName)
+
+		// Also determine endpoints for which we need to review status.
 		oldID, wasKnown := m.activeIfaceNameToHostEpID[ifaceName]
 		newID, isKnown := newIfaceNameToHostEpID[ifaceName]
 		if oldID != newID {
-			logCxt := ifaceCxt.WithFields(log.Fields{
+			logCxt := logCxt.WithFields(log.Fields{
 				"oldID": m.activeIfaceNameToHostEpID[ifaceName],
 				"newID": newIfaceNameToHostEpID[ifaceName],
 			})
@@ -847,40 +909,6 @@ func (m *endpointManager) resolveHostEndpoints() {
 		}
 	}
 
-	// Similar loop to find the best all-interfaces host endpoint.
-	bestHostEpId := proto.HostEndpointID{}
-	var bestHostEp proto.HostEndpoint
-	for id, hostEp := range m.rawHostEndpoints {
-		logCxt := log.WithField("id", id)
-		if !forAllInterfaces(hostEp) {
-			logCxt.Debug("Skip interface-specific host endpoint")
-			continue
-		}
-		if (bestHostEpId.EndpointId != "") && (bestHostEpId.EndpointId < id.EndpointId) {
-			// We already have a HostEndpointId that is better than
-			// this one, so no point looking any further.
-			logCxt.Debug("No better than existing match")
-			continue
-		}
-		logCxt.Debug("New best all-interfaces host endpoint")
-		bestHostEpId = id
-		bestHostEp = *hostEp
-	}
-
-	if bestHostEpId.EndpointId != "" {
-		logCxt := log.WithField("bestHostEpId", bestHostEpId)
-		logCxt.Debug("Got all interfaces HostEp")
-		if len(bestHostEp.PreDnatTiers) > 0 {
-			logCxt.Debug("Endpoint has pre-DNAT policies.")
-			newPreDNATIfaceNameToHostEpID[allInterfaces] = bestHostEpId
-		}
-
-		newIfaceNameToHostEpID[allInterfaces] = bestHostEpId
-
-		// Record that this host endpoint is in use, for status reporting.
-		newHostEpIDToIfaceNames[bestHostEpId] = append(
-			newHostEpIDToIfaceNames[bestHostEpId], allInterfaces)
-	}
 	if !m.bpfEnabled {
 		// Set up programming for the host endpoints that are now to be used.
 		newHostIfaceFiltChains := map[string][]*iptables.Chain{}
@@ -1006,6 +1034,8 @@ func (m *endpointManager) resolveHostEndpoints() {
 	m.activeHostEpIDToIfaceNames = newHostEpIDToIfaceNames
 
 	if m.bpfEnabled {
+		// Code after this point is for dispatch chains and IPVS endpoint marking, which
+		// aren't needed in BPF mode.
 		return
 	}
 

--- a/dataplane/linux/endpoint_mgr_test.go
+++ b/dataplane/linux/endpoint_mgr_test.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
-//
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -700,6 +700,7 @@ func endpointManagerTests(ipVersion uint8) func() {
 				mockProcSys.write,
 				mockProcSys.stat,
 				false,
+				nil,
 				newCallbacks(),
 			)
 		})
@@ -768,7 +769,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 						ExpectedIpv6Addrs: spec.ipv6Addrs,
 					},
 				})
-				err := epMgr.CompleteDeferredWork()
+				err := epMgr.ResolveUpdateBatch()
+				Expect(err).ToNot(HaveOccurred())
+				err = epMgr.CompleteDeferredWork()
 				Expect(err).ToNot(HaveOccurred())
 			}
 		}
@@ -813,7 +816,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 						EndpointId: id,
 					},
 				})
-				err := epMgr.CompleteDeferredWork()
+				err := epMgr.ResolveUpdateBatch()
+				Expect(err).ToNot(HaveOccurred())
+				err = epMgr.CompleteDeferredWork()
 				Expect(err).ToNot(HaveOccurred())
 			}
 		}
@@ -836,7 +841,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 					Name:  "lo",
 					Addrs: loAddrs,
 				})
-				err := epMgr.CompleteDeferredWork()
+				err := epMgr.ResolveUpdateBatch()
+				Expect(err).ToNot(HaveOccurred())
+				err = epMgr.CompleteDeferredWork()
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -1137,7 +1144,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 							Name:  "eth1",
 							Addrs: eth1Addrs,
 						})
-						err := epMgr.CompleteDeferredWork()
+						err := epMgr.ResolveUpdateBatch()
+						Expect(err).ToNot(HaveOccurred())
+						err = epMgr.CompleteDeferredWork()
 						Expect(err).ToNot(HaveOccurred())
 					})
 
@@ -1341,7 +1350,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 						Name:  "eth0",
 						Addrs: eth0Addrs,
 					})
-					err := epMgr.CompleteDeferredWork()
+					err := epMgr.ResolveUpdateBatch()
+					Expect(err).ToNot(HaveOccurred())
+					err = epMgr.CompleteDeferredWork()
 					Expect(err).ToNot(HaveOccurred())
 				})
 				It("should have expected chains", expectChainsFor("eth0"))
@@ -1394,7 +1405,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 							Ipv6Nets:   []string{"2001:db8:2::2/128"},
 						},
 					})
-					err := epMgr.CompleteDeferredWork()
+					err := epMgr.ResolveUpdateBatch()
+					Expect(err).ToNot(HaveOccurred())
+					err = epMgr.CompleteDeferredWork()
 					Expect(err).ToNot(HaveOccurred())
 				})
 
@@ -1428,7 +1441,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 									Ipv6Nets:   []string{"2001:db8:2::2/128"},
 								},
 							})
-							err := epMgr.CompleteDeferredWork()
+							err := epMgr.ResolveUpdateBatch()
+							Expect(err).ToNot(HaveOccurred())
+							err = epMgr.CompleteDeferredWork()
 							Expect(err).ToNot(HaveOccurred())
 						})
 
@@ -1440,7 +1455,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 								epMgr.OnUpdate(&proto.WorkloadEndpointRemove{
 									Id: &wlEPID1,
 								})
-								err := epMgr.CompleteDeferredWork()
+								err := epMgr.ResolveUpdateBatch()
+								Expect(err).ToNot(HaveOccurred())
+								err = epMgr.CompleteDeferredWork()
 								Expect(err).ToNot(HaveOccurred())
 							})
 
@@ -1456,7 +1473,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 											EndpointId:     "endpoint-id-11",
 										},
 									})
-									err := epMgr.CompleteDeferredWork()
+									err := epMgr.ResolveUpdateBatch()
+									Expect(err).ToNot(HaveOccurred())
+									err = epMgr.CompleteDeferredWork()
 									Expect(err).ToNot(HaveOccurred())
 								})
 
@@ -1484,7 +1503,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 									Ipv6Nets:   []string{"2001:db8:2::2/128"},
 								},
 							})
-							err := epMgr.CompleteDeferredWork()
+							err := epMgr.ResolveUpdateBatch()
+							Expect(err).ToNot(HaveOccurred())
+							err = epMgr.CompleteDeferredWork()
 							Expect(err).ToNot(HaveOccurred())
 						})
 
@@ -1496,7 +1517,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 								epMgr.OnUpdate(&proto.WorkloadEndpointRemove{
 									Id: &wlEPID1,
 								})
-								err := epMgr.CompleteDeferredWork()
+								err := epMgr.ResolveUpdateBatch()
+								Expect(err).ToNot(HaveOccurred())
+								err = epMgr.CompleteDeferredWork()
 								Expect(err).ToNot(HaveOccurred())
 							})
 
@@ -1512,7 +1535,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 											EndpointId:     "endpoint-id-11",
 										},
 									})
-									err := epMgr.CompleteDeferredWork()
+									err := epMgr.ResolveUpdateBatch()
+									Expect(err).ToNot(HaveOccurred())
+									err = epMgr.CompleteDeferredWork()
 									Expect(err).ToNot(HaveOccurred())
 								})
 
@@ -1576,7 +1601,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 							Name:  "cali12345-ab",
 							Addrs: set.New(),
 						})
-						err := epMgr.CompleteDeferredWork()
+						err := epMgr.ResolveUpdateBatch()
+						Expect(err).ToNot(HaveOccurred())
+						err = epMgr.CompleteDeferredWork()
 						Expect(err).ToNot(HaveOccurred())
 					})
 					It("should report the interface in error", func() {
@@ -1596,7 +1623,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 							Name:  "cali12345-ab",
 							Addrs: set.New(),
 						})
-						err := epMgr.CompleteDeferredWork()
+						err := epMgr.ResolveUpdateBatch()
+						Expect(err).ToNot(HaveOccurred())
+						err = epMgr.CompleteDeferredWork()
 						Expect(err).ToNot(HaveOccurred())
 					})
 
@@ -1647,7 +1676,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 									},
 								},
 							})
-							err := epMgr.CompleteDeferredWork()
+							err := epMgr.ResolveUpdateBatch()
+							Expect(err).ToNot(HaveOccurred())
+							err = epMgr.CompleteDeferredWork()
 							Expect(err).ToNot(HaveOccurred())
 						})
 
@@ -1693,7 +1724,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 							epMgr.OnUpdate(&proto.WorkloadEndpointRemove{
 								Id: &wlEPID1,
 							})
-							err := epMgr.CompleteDeferredWork()
+							err := epMgr.ResolveUpdateBatch()
+							Expect(err).ToNot(HaveOccurred())
+							err = epMgr.CompleteDeferredWork()
 							Expect(err).ToNot(HaveOccurred())
 						})
 
@@ -1729,7 +1762,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 									Ipv6Nets:   []string{"2001:db8:2::2/128"},
 								},
 							})
-							err := epMgr.CompleteDeferredWork()
+							err := epMgr.ResolveUpdateBatch()
+							Expect(err).ToNot(HaveOccurred())
+							err = epMgr.CompleteDeferredWork()
 							Expect(err).ToNot(HaveOccurred())
 						})
 
@@ -1780,7 +1815,9 @@ func endpointManagerTests(ipVersion uint8) func() {
 							Ipv6Nets:   []string{"2001:db8:2::2/128"},
 						},
 					})
-					err := epMgr.CompleteDeferredWork()
+					err := epMgr.ResolveUpdateBatch()
+					Expect(err).ToNot(HaveOccurred())
+					err = epMgr.CompleteDeferredWork()
 					Expect(err).ToNot(HaveOccurred())
 				})
 

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -557,6 +557,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			ipSetsConfigV4,
 			ipSetIDAllocator,
 			ipSetsMap,
+			dp.loopSummarizer,
 		)
 		dp.ipSets = append(dp.ipSets, ipSetsV4)
 		dp.RegisterManager(newIPSetsManager(ipSetsV4, config.MaxIPSetSize, callbacks))

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -548,7 +548,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		)
 		dp.ipSets = append(dp.ipSets, ipSetsV4)
 		dp.RegisterManager(newIPSetsManager(ipSetsV4, config.MaxIPSetSize, callbacks))
-		bpfRTMgr := newBPFRouteManager(config.Hostname, bpfMapContext)
+		bpfRTMgr := newBPFRouteManager(config.Hostname, config.ExternalNodesCidrs, bpfMapContext)
 		dp.RegisterManager(bpfRTMgr)
 
 		// Forwarding into a tunnel seems to fail silently, disable FIB lookup if tunnel is enabled for now.

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -120,6 +120,7 @@ type Config struct {
 	RuleRendererOverride rules.RuleRenderer
 	IPIPMTU              int
 	VXLANMTU             int
+	VXLANPort            int
 
 	MaxIPSetSize int
 
@@ -603,6 +604,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			workloadIfaceRegex,
 			ipSetIDAllocator,
 			config.VXLANMTU,
+			uint16(config.VXLANPort),
 			config.BPFNodePortDSREnabled,
 			ipSetsMap,
 			stateMap,

--- a/docker-image/calico-felix-wrapper
+++ b/docker-image/calico-felix-wrapper
@@ -29,6 +29,11 @@ if [ "$SET_CORE_PATTERN" == "true" ]; then
   echo '/tmp/core_%h_%e.%p' > /proc/sys/kernel/core_pattern
 fi
 
+# When Felix is run in a non-root netns (for FV testing) the conntrack subsystem doesn't
+# start tracking packets until it is used in some way.  This means that Felix's datastore
+# connection ends up being untracked, causing it to be dropped in BPF mode.
+iptables -A FORWARD -m conntrack --ctstate ESTABLISHED -m comment --comment "cali:workaround"
+
 while true; do
   if [ "$DELAY_FELIX_START" == "true" ]; then
     while [ ! -e /start-trigger ]; do

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -2766,18 +2766,11 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Wait for BPF to be active.
-				numTCProgramsOnEth0 := func() int {
-					total := 0
-					for i, f := range felixes {
-						for _, dir := range []string{"ingress", "egress"} {
-							out, err := f.ExecOutput("tc", "filter", "show", "dev", "eth0", dir)
-							Expect(err).NotTo(HaveOccurred())
-							count := strings.Count(out, "direct-action")
-							log.Debugf("Output from tc filter show for felix %d, dir=%s: %q (count=%d)", i, dir, out, count)
-							total += count
-						}
+				numTCProgramsOnEth0 := func() (total int) {
+					for _, f := range felixes {
+						total += f.NumTCBPFProgs("eth0")
 					}
-					return total
+					return
 				}
 				Eventually(numTCProgramsOnEth0, "10s").Should(Equal(len(felixes) * 2))
 			}

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -306,9 +306,12 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				}
 				f.Stop()
 			}
-			infra.Stop()
 			externalClient.Stop()
 			log.Info("AfterEach done")
+		})
+
+		AfterEach(func() {
+			infra.Stop()
 		})
 
 		createPolicy := func(policy *api.GlobalNetworkPolicy) *api.GlobalNetworkPolicy {

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -518,7 +518,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 					expJumpMaps := func(numWorkloads int) int {
 						numHostIfaces := 1
-						expectedNumMaps := 2*numWorkloads + 1*numHostIfaces
+						expectedNumMaps := 2*numWorkloads + 2*numHostIfaces
 						return expectedNumMaps
 					}
 

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -206,7 +206,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 		testOpts.protocol, protoExt, testOpts.connTimeEnabled,
 		testOpts.bpfLogLevel, testOpts.tunnel, testOpts.dsr,
 	)
-
 	return infrastructure.DatastoreDescribe(desc, []apiconfig.DatastoreType{apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
 		var (
 			infra              infrastructure.DatastoreInfra
@@ -2717,6 +2716,105 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					})
 				})
 			})
+		})
+
+		Describe("with BPF disabled to begin with", func() {
+			var pc *PersistentConnection
+
+			BeforeEach(func() {
+				options.TestManagesBPF = true
+				setupCluster()
+
+				// Default to Allow...
+				pol := api.NewGlobalNetworkPolicy()
+				pol.Namespace = "fv"
+				pol.Name = "policy-1"
+				pol.Spec.Ingress = []api.Rule{{Action: "Allow"}}
+				pol.Spec.Egress = []api.Rule{{Action: "Allow"}}
+				pol.Spec.Selector = "all()"
+				pol = createPolicy(pol)
+
+				pc = nil
+			})
+
+			AfterEach(func() {
+				if pc != nil {
+					pc.Stop()
+				}
+			})
+
+			enableBPF := func() {
+				By("Enabling BPF")
+				// Some tests start with a felix config pre-created, try to update it...
+				fc, err := calicoClient.FelixConfigurations().Get(context.Background(), "default", options2.GetOptions{})
+				bpfEnabled := true
+				if err == nil {
+					fc.Spec.BPFEnabled = &bpfEnabled
+					_, err := calicoClient.FelixConfigurations().Update(context.Background(), fc, options2.SetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					return
+				}
+
+				// Fall back on creating it...
+				fc = api.NewFelixConfiguration()
+				fc.Name = "default"
+				fc.Spec.BPFEnabled = &bpfEnabled
+				fc, err = calicoClient.FelixConfigurations().Create(context.Background(), fc, options2.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Wait for BPF to be active.
+				numTCProgramsOnEth0 := func() int {
+					total := 0
+					for i, f := range felixes {
+						for _, dir := range []string{"ingress", "egress"} {
+							out, err := f.ExecOutput("tc", "filter", "show", "dev", "eth0", dir)
+							Expect(err).NotTo(HaveOccurred())
+							count := strings.Count(out, "direct-action")
+							log.Debugf("Output from tc filter show for felix %d, dir=%s: %q (count=%d)", i, dir, out, count)
+							total += count
+						}
+					}
+					return total
+				}
+				Eventually(numTCProgramsOnEth0, "10s").Should(Equal(len(felixes) * 2))
+			}
+
+			expectPongs := func() {
+				EventuallyWithOffset(1, pc.SinceLastPong, "5s").Should(
+					BeNumerically("<", time.Second),
+					"Expected to see pong responses on the connection but didn't receive any")
+				log.Info("Pongs received within last 1s")
+			}
+
+			if testOpts.protocol == "tcp" && testOpts.dsr {
+				verifyConnectivityWhileEnablingBPF := func(from, to *workload.Workload) {
+					By("Starting persistent connection")
+					pc = from.StartPersistentConnection(to.IP, 8055, workload.PersistentConnectionOpts{
+						MonitorConnectivity: true,
+					})
+
+					By("having initial connectivity", expectPongs)
+					By("enabling BPF mode", enableBPF) // Waits for BPF programs to be installed
+					time.Sleep(2 * time.Second)        // pongs time out after 1s, make sure we look for fresh pongs.
+					By("still having connectivity on the existing connection", expectPongs)
+				}
+
+				It("should keep a connection up between hosts when BPF is enabled", func() {
+					verifyConnectivityWhileEnablingBPF(hostW[0], hostW[1])
+				})
+
+				It("should keep a connection up between workloads on different hosts when BPF is enabled", func() {
+					verifyConnectivityWhileEnablingBPF(w[0][0], w[1][0])
+				})
+
+				It("should keep a connection up between hosts and remote workloads when BPF is enabled", func() {
+					verifyConnectivityWhileEnablingBPF(hostW[0], w[1][0])
+				})
+
+				It("should keep a connection up between hosts and local workloads when BPF is enabled", func() {
+					verifyConnectivityWhileEnablingBPF(hostW[0], w[0][0])
+				})
+			}
 		})
 
 		Describe("3rd party CNI", func() {

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -669,4 +670,44 @@ func (c *Container) CanConnectTo(ip, port, protocol string, opts ...connectivity
 // AttachTCPDump returns tcpdump attached to the container
 func (c *Container) AttachTCPDump(iface string) *tcpdump.TCPDump {
 	return tcpdump.AttachUnavailable(c.Name, c.GetID(), iface)
+}
+
+// NumTCBPFProgs Returns the number of TC BPF programs attached to the given interface.  Only direct-action
+// programs are listed (i.e. the type that we use).
+func (c *Container) NumTCBPFProgs(ifaceName string) int {
+	var total int
+	for _, dir := range []string{"ingress", "egress"} {
+		out, err := c.ExecOutput("tc", "filter", "show", "dev", ifaceName, dir)
+		Expect(err).NotTo(HaveOccurred())
+		count := strings.Count(out, "direct-action")
+		log.Debugf("Output from tc filter show for %s, dir=%s: %q (count=%d)", c.Name, dir, out, count)
+		total += count
+	}
+	return total
+}
+
+// NumTCBPFProgs Returns the number of TC BPF programs attached to eth0.  Only direct-action programs are
+// listed (i.e. the type that we use).
+func (c *Container) NumTCBPFProgsEth0() int {
+	return c.NumTCBPFProgs("eth0")
+}
+
+// BPFRoutes returns the output of calico-bpf routes dump, trimmed of whitespace and sorted.
+func (c *Container) BPFRoutes() string {
+	out, err := c.ExecOutput("calico-bpf", "routes", "dump")
+	if err != nil {
+		log.WithError(err).Error("Failed to run calico-bpf")
+	}
+
+	lines := strings.Split(out, "\n")
+	var filteredLines []string
+	for _, l := range lines {
+		l = strings.TrimLeft(l, " ")
+		if len(l) == 0 {
+			continue
+		}
+		filteredLines = append(filteredLines, l)
+	}
+	sort.Strings(filteredLines)
+	return strings.Join(filteredLines, "\n")
 }

--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -720,7 +720,7 @@ func (c *Container) BPFNATDump() map[string][]string {
 		log.WithError(err).Error("Failed to run calico-bpf")
 	}
 
-	feMatch := regexp.MustCompile("(.* port \\d+ proto \\d+) id (\\d+) count.*")
+	feMatch := regexp.MustCompile(`(.* port \d+ proto \d+) id (\d+) count.*`)
 
 	lines := strings.Split(out, "\n")
 	front := ""

--- a/fv/host_port_test.go
+++ b/fv/host_port_test.go
@@ -33,7 +33,11 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 )
 
-func MetricsPortReachable(felix *infrastructure.Felix) bool {
+func MetricsPortReachable(felix *infrastructure.Felix, bpf bool) bool {
+	if bpf {
+		felix.Exec("calico-bpf", "conntrack", "clean")
+	}
+
 	// Delete existing conntrack state for the metrics port.
 	felix.Exec("conntrack", "-L")
 	felix.Exec("conntrack", "-L", "-p", "tcp", "--dport", metrics.PortString())
@@ -84,7 +88,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ host-port tests", []apiconf
 		felix, client = infrastructure.StartSingleNodeTopology(options, infra)
 
 		metricsPortReachable = func() bool {
-			return MetricsPortReachable(felix)
+			return MetricsPortReachable(felix, bpfEnabled)
 		}
 
 		if bpfEnabled {

--- a/fv/infrastructure/felix.go
+++ b/fv/infrastructure/felix.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -102,7 +102,12 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 
 	containerName := containers.UniqueName(fmt.Sprintf("felix-%d", id))
 	if os.Getenv("FELIX_FV_ENABLE_BPF") == "true" {
-		envVars["FELIX_BPFENABLED"] = "true"
+		if !options.TestManagesBPF {
+			log.Info("FELIX_FV_ENABLE_BPF=true, enabling BPF with env var")
+			envVars["FELIX_BPFENABLED"] = "true"
+		} else {
+			log.Info("FELIX_FV_ENABLE_BPF=true but test manages BPF state itself, not using env var")
+		}
 
 		// Disable map repinning by default since BPF map names are global and we don't want our simulated instances to
 		// share maps.

--- a/fv/infrastructure/felix.go
+++ b/fv/infrastructure/felix.go
@@ -83,7 +83,9 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 	args := infra.GetDockerArgs()
 	args = append(args, "--privileged")
 
-	// Add in the environment variables.
+	// Collect the environment variables for starting this particular container.  Note: we
+	// are called concurrently with other instances of RunFelix so it's important to only
+	// read from options.*.
 	envVars := map[string]string{
 		// Enable core dumps.
 		"GOTRACEBACK": "crash",
@@ -99,8 +101,14 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 		// Disable log dropping, because it can cause flakes in tests that look for particular logs.
 		"FELIX_DEBUGDISABLELOGDROPPING": "true",
 	}
+	// Collect the volumes for this container.
+	volumes := map[string]string{
+		"/lib/modules": "/lib/modules",
+		"/tmp":         "/tmp",
+	}
 
 	containerName := containers.UniqueName(fmt.Sprintf("felix-%d", id))
+
 	if os.Getenv("FELIX_FV_ENABLE_BPF") == "true" {
 		if !options.TestManagesBPF {
 			log.Info("FELIX_FV_ENABLE_BPF=true, enabling BPF with env var")
@@ -119,7 +127,7 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 	}
 
 	if options.DelayFelixStart {
-		args = append(args, "-e", "DELAY_FELIX_START=true")
+		envVars["DELAY_FELIX_START"] = "true"
 	}
 
 	for k, v := range options.ExtraEnvVars {
@@ -131,10 +139,6 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 	}
 
 	// Add in the volumes.
-	volumes := map[string]string{
-		"/lib/modules": "/lib/modules",
-		"/tmp":         "/tmp",
-	}
 	for k, v := range options.ExtraVolumes {
 		volumes[k] = v
 	}

--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -29,8 +29,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/onsi/ginkgo"
 
-	"github.com/projectcalico/libcalico-go/lib/backend/model"
-
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -42,6 +40,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	client "github.com/projectcalico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/libcalico-go/lib/names"
 	"github.com/projectcalico/libcalico-go/lib/options"
@@ -445,8 +444,6 @@ func (kds *K8sDatastoreInfra) EnsureReady() {
 }
 
 func (kds *K8sDatastoreInfra) Stop() {
-	kds.bpfLog.Stop()
-
 	// We don't tear down and recreate the Kubernetes infra between tests because it's
 	// too expensive.  We don't even, immediately, clean up any resources that may
 	// have been left behind by the test that has just finished.  Instead, mark all
@@ -456,6 +453,8 @@ func (kds *K8sDatastoreInfra) Stop() {
 	log.Info("K8sDatastoreInfra told to stop, deferring cleanup...")
 	kds.needsCleanup = true
 	kds.runningTest = ""
+
+	kds.bpfLog.Stop()
 }
 
 type cleanupFunc func(clientset *kubernetes.Clientset, calicoClient client.Interface)

--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -196,12 +196,25 @@ func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (feli
 	for i := 0; i < n; i++ {
 		// Then start Felix and create a node for it.
 		opts.ExtraEnvVars["BPF_LOG_PFX"] = fmt.Sprintf("%d-", i)
+		// Arrange for only the first Felix to enable the BPF connect-time load balancer, as
+		// we get unpredictable behaviour if more than one Felix enables it on the same
+		// host.
+		optsFirstFelix := opts
+		opts.ExtraEnvVars = map[string]string{}
+		for k, v := range optsFirstFelix.ExtraEnvVars {
+			opts.ExtraEnvVars[k] = v
+		}
+		opts.ExtraEnvVars["FELIX_BPFConnectTimeLoadBalancingEnabled"] = "false"
+		opts.ExtraEnvVars["FELIX_DebugSkipCTLBCleanup"] = "true"
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 			defer ginkgo.GinkgoRecover()
-			felix := RunFelix(infra, i, opts)
-			felixes[i] = felix
+			if i == 0 {
+				felixes[i] = RunFelix(infra, i, optsFirstFelix)
+			} else {
+				felixes[i] = RunFelix(infra, i, opts)
+			}
 		}(i)
 	}
 	wg.Wait()

--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -42,6 +42,7 @@ type TopologyOptions struct {
 	ExtraVolumes              map[string]string
 	WithTypha                 bool
 	WithFelixTyphaTLS         bool
+	TestManagesBPF            bool
 	TyphaLogSeverity          string
 	IPIPEnabled               bool
 	IPIPRoutesEnabled         bool

--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -252,14 +252,14 @@ func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (feli
 				`"IpInIpTunnelAddr":"` + regexp.QuoteMeta(felix.ExpectedIPIPTunnelAddr) + `"`))
 		} else if opts.NeedNodeIP {
 			w = felix.WatchStdoutFor(regexp.MustCompile(
-				`Host config update for this host`))
+				`Host config update for this host|Host IP changed`))
 		}
 		infra.AddNode(felix, i, bool(n > 1 || opts.NeedNodeIP))
 		if w != nil {
 			// Wait for any Felix restart...
 			log.Info("Wait for Felix to restart")
 			Eventually(w, "10s").Should(BeClosed(),
-				"Timed out waiting for Felix to restart")
+				fmt.Sprintf("Timed out waiting for %s to restart", felix.Name))
 		}
 
 		if opts.AutoHEPsEnabled {

--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,40 +17,43 @@
 package fv_test
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/felix/fv/connectivity"
 	"github.com/projectcalico/felix/fv/utils"
 
-	"context"
-	"errors"
-	"fmt"
-	"strings"
-	"time"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
-	"github.com/projectcalico/felix/fv/containers"
-	"github.com/projectcalico/felix/fv/infrastructure"
-	"github.com/projectcalico/felix/fv/workload"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	client "github.com/projectcalico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	"github.com/projectcalico/libcalico-go/lib/options"
+
+	"github.com/projectcalico/felix/fv/containers"
+	"github.com/projectcalico/felix/fv/infrastructure"
+	"github.com/projectcalico/felix/fv/workload"
 )
 
 var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs to IP sets", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
 
 	var (
-		infra   infrastructure.DatastoreInfra
-		felixes []*infrastructure.Felix
-		client  client.Interface
-		w       [2]*workload.Workload
-		hostW   [2]*workload.Workload
-		cc      *connectivity.Checker
+		bpfEnabled = os.Getenv("FELIX_FV_ENABLE_BPF") == "true"
+		infra      infrastructure.DatastoreInfra
+		felixes    []*infrastructure.Felix
+		client     client.Interface
+		w          [2]*workload.Workload
+		hostW      [2]*workload.Workload
+		cc         *connectivity.Checker
 	)
 
 	BeforeEach(func() {
@@ -318,7 +321,11 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 		BeforeEach(func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel()
-			l, err := client.Nodes().List(ctx, options.ListOptions{})
+			listOptions := options.ListOptions{}
+			if bpfEnabled {
+				listOptions.Name = felixes[0].Hostname
+			}
+			l, err := client.Nodes().List(ctx, listOptions)
 			Expect(err).NotTo(HaveOccurred())
 			for _, node := range l.Items {
 				node.Spec.BGP = nil
@@ -326,13 +333,17 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			// Removing the BGP config triggers a Felix restart and Felix has a 2s timer during
-			// a config restart to ensure that it doesn't tight loop.  Wait for the ipset to be
-			// updated as a signal that Felix has restarted.
-			for _, f := range felixes {
-				Eventually(func() int {
-					return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
-				}, "5s", "200ms").Should(BeZero())
+			if bpfEnabled {
+				Eventually(felixes[1].NumTCBPFProgsEth0, "5s", "200ms").Should(Equal(2))
+			} else {
+				for _, f := range felixes {
+					// Removing the BGP config triggers a Felix restart and Felix has a 2s timer during
+					// a config restart to ensure that it doesn't tight loop.  Wait for the ipset to be
+					// updated as a signal that Felix has restarted.
+					Eventually(func() int {
+						return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
+					}, "5s", "200ms").Should(BeZero())
+				}
 			}
 		})
 
@@ -363,10 +374,12 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 			}
 			// Removing the BGP config triggers a Felix restart. Wait for the ipset to be updated as a signal that Felix
 			// has restarted.
-			for _, f := range felixes {
-				Eventually(func() int {
-					return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
-				}, "5s", "200ms").Should(Equal(1))
+			if !bpfEnabled {
+				for _, f := range felixes {
+					Eventually(func() int {
+						return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
+					}, "5s", "200ms").Should(Equal(1))
+				}
 			}
 
 			updateConfig := func(addr string) {
@@ -380,12 +393,18 @@ var _ = infrastructure.DatastoreDescribe("IPIP topology before adding host IPs t
 				Expect(err).NotTo(HaveOccurred())
 			}
 			updateConfig(prevBGPSpec.IPv4Address)
+
 			// Wait for the config to take
 			for _, f := range felixes {
-				Eventually(func() int {
-					return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
-				}, "5s", "200ms").Should(Equal(3))
+				if bpfEnabled {
+					Eventually(f.BPFRoutes, "5s", "200ms").Should(ContainSubstring("1.1.1.1/32"))
+				} else {
+					Eventually(func() int {
+						return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
+					}, "5s", "200ms").Should(Equal(3))
+				}
 			}
+
 		})
 
 		It("should have all-hosts-net ipset configured with the external hosts and workloads connect", func() {

--- a/fv/utils/utils.go
+++ b/fv/utils/utils.go
@@ -104,7 +104,8 @@ var _ = BeforeEach(func() {
 
 var _ = AfterEach(func() {
 	if CurrentGinkgoTestDescription().Failed {
-		os.Stdout.WriteString("\n===== begin output from failed test =====\n")
+		os.Stdout.WriteString(fmt.Sprintf("\n===== begin output from failed test %s =====\n",
+			CurrentGinkgoTestDescription().FullTestText))
 		for _, output := range currentTestOutput {
 			os.Stdout.WriteString(output)
 		}

--- a/fv/vxlan_test.go
+++ b/fv/vxlan_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/options"
 )
 
-var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs to IP sets", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before adding host IPs to IP sets", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
 	for _, vxlanM := range []api.VXLANMode{api.VXLANModeCrossSubnet} {
 		vxlanMode := vxlanM
 		for _, routeSource := range []string{"CalicoIPAM", "WorkloadIPs"} {

--- a/rules/static.go
+++ b/rules/static.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -816,7 +816,7 @@ func (r *DefaultRuleRenderer) StaticManglePreroutingChain(ipVersion uint8) *Chai
 		},
 	)
 
-	// Now (=> not from a workload) dispatch to host endpoint chain for the incoming interface.
+	// Now dispatch to host endpoint chain for the incoming interface.
 	rules = append(rules,
 		Rule{
 			Action: JumpAction{Target: ChainDispatchFromHostEndpoint},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Implement host endpoint support for eBPF mode.

* Change the data interface programs to support policy.  Where no policy program is provided, fall back to current behaviour.
* Cooperate between BPF and Linux conntrack to ease upgrade to BPF mode.
* Add support for failsafe ports.
* Implement IPIP/VXLAN policing and bypass.
* Collect the pre-DNAT information about the packet along with Booleans for "to/from host" and pass those to the policy program.
* In the policy program, implement pre-DNAT/AoF and wildcard host endpoint policy. (doNotTrack policy is not yet implemented)
* Upstream various fixes and tweaks from the Enterprise codebase that the HEP work depends on.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF mode now supports host endpoints.  Wildcard host endpoints, pre-DNAT policy and apply on forward policy is supported but doNotTrack policy is not yet supported.  Wildcard host endpoints do not apply to the loopback device in eBPF mode.  This change also adds IPIP and VXLAN bypass and policing and failsafe ports, bringing the eBPF dataplane into line with iptables.
```
