### PR TITLE
Add support for generic IP protocols.

### DIFF
--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -820,23 +820,19 @@ out_invalid:
 }
 
 /* creates connection tracking for tracked protocols */
-static CALI_BPF_INLINE int conntrack_create(struct ct_ctx * ct_ctx, int nat)
+static CALI_BPF_INLINE int conntrack_create(struct cali_tc_ctx *ctx, struct ct_ctx * ct_ctx, int nat)
 {
-	switch (ct_ctx->proto) {
-	case IPPROTO_TCP:
-	case IPPROTO_UDP:
-	case IPPROTO_ICMP:
-		switch (nat) {
-		case CT_CREATE_NORMAL:
-			return calico_ct_v4_create(ct_ctx);
-		case CT_CREATE_NAT:
-		case CT_CREATE_NAT_FWD:
-			return calico_ct_v4_create_nat(ct_ctx, nat);
-		}
-		return 0;
-	default:
-		return 0;
+	// Workaround for verifier; make sure verifier sees the skb on all code paths.
+	ct_ctx->skb = ctx->skb;
+
+	switch (nat) {
+	case CT_CREATE_NORMAL:
+		return calico_ct_v4_create(ct_ctx);
+	case CT_CREATE_NAT:
+	case CT_CREATE_NAT_FWD:
+		return calico_ct_v4_create_nat(ct_ctx, nat);
 	}
+	return 0;
 }
 
 #endif /* __CALI_CONNTRACK_H__ */

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -236,21 +236,6 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 
 	ctx.state->pol_rc = CALI_POL_NO_MATCH;
 
-	switch (ctx.state->ip_proto) {
-	case IPPROTO_TCP:
-	case IPPROTO_UDP:
-	case IPPROTO_ICMP:
-		break;
-	default:
-		if (CALI_F_HEP) {
-			// TODO-HEPs allow unknown protocols through on host endpoints.
-			goto allow;
-		}
-		// FIXME non-port based conntrack.
-		CALI_DEBUG("Unknown protocol from workload.\n");
-		goto deny;
-	}
-
 	/* Do conntrack lookup before anything else */
 	ctx.state->ct_result = calico_ct_v4_lookup(&ctx);
 	CALI_DEBUG("conntrack entry flags 0x%x\n", ctx.state->ct_result.flags);

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -725,7 +725,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 		// If we get here, we've passed policy.
 
 		if (nat_dest == NULL) {
-			if (conntrack_create(&ct_ctx_nat, CT_CREATE_NORMAL)) {
+			if (conntrack_create(ctx, &ct_ctx_nat, CT_CREATE_NORMAL)) {
 				CALI_DEBUG("Creating normal conntrack failed\n");
 
 				if ((CALI_F_FROM_HEP && rt_addr_is_local_host(ct_ctx_nat.dst)) ||
@@ -798,8 +798,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 				}
 			}
 
-
-			if (conntrack_create(&ct_ctx_nat, nat_type)) {
+			if (conntrack_create(ctx, &ct_ctx_nat, nat_type)) {
 				CALI_DEBUG("Creating NAT conntrack failed\n");
 				goto deny;
 			}

--- a/bpf/conntrack/conntrack_test.go
+++ b/bpf/conntrack/conntrack_test.go
@@ -39,29 +39,34 @@ var (
 	tcpKey  = conntrack.NewKey(conntrack.ProtoTCP, ip1, 1234, ip2, 3456)
 	udpKey  = conntrack.NewKey(conntrack.ProtoUDP, ip1, 1234, ip2, 3456)
 	icmpKey = conntrack.NewKey(conntrack.ProtoICMP, ip1, 1234, ip2, 3456)
+	genericKey = conntrack.NewKey(253, ip1, 0, ip2, 0)
 
 	timeouts = conntrack.DefaultTimeouts()
 
-	udpJustCreated    = tcpEntry(now-1, now-1, conntrack.Leg{}, conntrack.Leg{})
-	udpAlmostTimedOut = tcpEntry(now-(2*time.Minute), now-(59*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
-	udpTimedOut       = tcpEntry(now-(2*time.Minute), now-(61*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
+	genericJustCreated    = makeValue(now-1, now-1, conntrack.Leg{}, conntrack.Leg{})
+	genericAlmostTimedOut = makeValue(now-(20*time.Minute), now-(599*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
+	genericTimedOut       = makeValue(now-(20*time.Minute), now-(601*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
+	
+	udpJustCreated    = makeValue(now-1, now-1, conntrack.Leg{}, conntrack.Leg{})
+	udpAlmostTimedOut = makeValue(now-(2*time.Minute), now-(59*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
+	udpTimedOut       = makeValue(now-(2*time.Minute), now-(61*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
 
-	icmpJustCreated    = tcpEntry(now-1, now-1, conntrack.Leg{}, conntrack.Leg{})
-	icmpAlmostTimedOut = tcpEntry(now-(2*time.Minute), now-(4*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
-	icmpTimedOut       = tcpEntry(now-(2*time.Minute), now-(6*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
+	icmpJustCreated    = makeValue(now-1, now-1, conntrack.Leg{}, conntrack.Leg{})
+	icmpAlmostTimedOut = makeValue(now-(2*time.Minute), now-(4*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
+	icmpTimedOut       = makeValue(now-(2*time.Minute), now-(6*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
 
-	tcpJustCreated        = tcpEntry(now-1, now-1, conntrack.Leg{SynSeen: true}, conntrack.Leg{})
-	tcpHandshakeTimeout   = tcpEntry(now-22*time.Second, now-21*time.Second, conntrack.Leg{SynSeen: true}, conntrack.Leg{})
-	tcpHandshakeTimeout2  = tcpEntry(now-22*time.Second, now-21*time.Second, conntrack.Leg{SynSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
-	tcpEstablished        = tcpEntry(now-(10*time.Second), now-1, conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
-	tcpEstablishedTimeout = tcpEntry(now-(3*time.Hour), now-(2*time.Hour), conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
-	tcpSingleFin          = tcpEntry(now-(3*time.Hour), now-(50*time.Minute), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
-	tcpSingleFinTimeout   = tcpEntry(now-(3*time.Hour), now-(2*time.Hour), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
-	tcpBothFin            = tcpEntry(now-(3*time.Hour), now-(29*time.Second), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true})
-	tcpBothFinTimeout     = tcpEntry(now-(3*time.Hour), now-(31*time.Second), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true})
+	tcpJustCreated        = makeValue(now-1, now-1, conntrack.Leg{SynSeen: true}, conntrack.Leg{})
+	tcpHandshakeTimeout   = makeValue(now-22*time.Second, now-21*time.Second, conntrack.Leg{SynSeen: true}, conntrack.Leg{})
+	tcpHandshakeTimeout2  = makeValue(now-22*time.Second, now-21*time.Second, conntrack.Leg{SynSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
+	tcpEstablished        = makeValue(now-(10*time.Second), now-1, conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
+	tcpEstablishedTimeout = makeValue(now-(3*time.Hour), now-(2*time.Hour), conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
+	tcpSingleFin          = makeValue(now-(3*time.Hour), now-(50*time.Minute), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
+	tcpSingleFinTimeout   = makeValue(now-(3*time.Hour), now-(2*time.Hour), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
+	tcpBothFin            = makeValue(now-(3*time.Hour), now-(29*time.Second), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true})
+	tcpBothFinTimeout     = makeValue(now-(3*time.Hour), now-(31*time.Second), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true})
 )
 
-func tcpEntry(created time.Duration, lastSeen time.Duration, legA conntrack.Leg, legB conntrack.Leg) conntrack.Value {
+func makeValue(created time.Duration, lastSeen time.Duration, legA conntrack.Leg, legB conntrack.Leg) conntrack.Value {
 	var e conntrack.Value
 	binary.LittleEndian.PutUint64(e[:8], uint64(created))
 	binary.LittleEndian.PutUint64(e[8:16], uint64(lastSeen))
@@ -138,6 +143,10 @@ var _ = Describe("BPF Conntrack LivenessCalculator", func() {
 		Entry("UDP just created", udpKey, udpJustCreated, false),
 		Entry("UDP almost timed out", udpKey, udpAlmostTimedOut, false),
 		Entry("UDP timed out", udpKey, udpTimedOut, true),
+		
+		Entry("Generic just created", genericKey, genericJustCreated, false),
+		Entry("Generic almost timed out", genericKey, genericAlmostTimedOut, false),
+		Entry("Generic timed out", genericKey, genericTimedOut, true),
 
 		Entry("icmp just created", icmpKey, icmpJustCreated, false),
 		Entry("icmp almost timed out", icmpKey, icmpAlmostTimedOut, false),

--- a/bpf/conntrack/conntrack_test.go
+++ b/bpf/conntrack/conntrack_test.go
@@ -34,11 +34,11 @@ import (
 var now = mocktime.StartKTime
 
 var (
-	ip1     = net.ParseIP("10.0.0.1")
-	ip2     = net.ParseIP("10.0.0.2")
-	tcpKey  = conntrack.NewKey(conntrack.ProtoTCP, ip1, 1234, ip2, 3456)
-	udpKey  = conntrack.NewKey(conntrack.ProtoUDP, ip1, 1234, ip2, 3456)
-	icmpKey = conntrack.NewKey(conntrack.ProtoICMP, ip1, 1234, ip2, 3456)
+	ip1        = net.ParseIP("10.0.0.1")
+	ip2        = net.ParseIP("10.0.0.2")
+	tcpKey     = conntrack.NewKey(conntrack.ProtoTCP, ip1, 1234, ip2, 3456)
+	udpKey     = conntrack.NewKey(conntrack.ProtoUDP, ip1, 1234, ip2, 3456)
+	icmpKey    = conntrack.NewKey(conntrack.ProtoICMP, ip1, 1234, ip2, 3456)
 	genericKey = conntrack.NewKey(253, ip1, 0, ip2, 0)
 
 	timeouts = conntrack.DefaultTimeouts()
@@ -46,7 +46,7 @@ var (
 	genericJustCreated    = makeValue(now-1, now-1, conntrack.Leg{}, conntrack.Leg{})
 	genericAlmostTimedOut = makeValue(now-(20*time.Minute), now-(599*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
 	genericTimedOut       = makeValue(now-(20*time.Minute), now-(601*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
-	
+
 	udpJustCreated    = makeValue(now-1, now-1, conntrack.Leg{}, conntrack.Leg{})
 	udpAlmostTimedOut = makeValue(now-(2*time.Minute), now-(59*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
 	udpTimedOut       = makeValue(now-(2*time.Minute), now-(61*time.Second), conntrack.Leg{Whitelisted: true}, conntrack.Leg{})
@@ -143,7 +143,7 @@ var _ = Describe("BPF Conntrack LivenessCalculator", func() {
 		Entry("UDP just created", udpKey, udpJustCreated, false),
 		Entry("UDP almost timed out", udpKey, udpAlmostTimedOut, false),
 		Entry("UDP timed out", udpKey, udpTimedOut, true),
-		
+
 		Entry("Generic just created", genericKey, genericJustCreated, false),
 		Entry("Generic almost timed out", genericKey, genericAlmostTimedOut, false),
 		Entry("Generic timed out", genericKey, genericTimedOut, true),

--- a/bpf/polprog/pol_prog_builder.go
+++ b/bpf/polprog/pol_prog_builder.go
@@ -150,8 +150,8 @@ type Rules struct {
 	SuppressNormalHostPolicy bool
 
 	// Workload policy.
-	Tiers            []Tier
-	Profiles         []Profile
+	Tiers    []Tier
+	Profiles []Profile
 
 	// Host endpoint policy.
 	HostPreDnatTiers []Tier

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -546,6 +546,7 @@ func withSubtests(v bool) testOption {
 		o.subtests = v
 	}
 }
+
 var _ = withSubtests
 
 func withLogLevel(l log.Level) testOption {
@@ -553,6 +554,7 @@ func withLogLevel(l log.Level) testOption {
 		o.logLevel = l
 	}
 }
+
 var _ = withLogLevel
 
 func withExtraMap(m bpf.Map) testOption {
@@ -560,6 +562,7 @@ func withExtraMap(m bpf.Map) testOption {
 		o.extraMaps = append(o.extraMaps, m)
 	}
 }
+
 var _ = withExtraMap
 
 // layersMatchFields matches all Exported fields and ignore the ones explicitly

--- a/bpf/ut/pol_prog_test.go
+++ b/bpf/ut/pol_prog_test.go
@@ -927,10 +927,10 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 		DroppedPackets: []packet{
 			packetNoPorts(253, "11.0.0.2", "10.0.0.2"), // Wrong proto, no ports
-			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080"), // Wrong port
-			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),   // Wrong proto
-			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),   // Src/dest confusion
-			tcpPkt("10.0.0.2:31245", "10.0.0.1:80"),   // Wrong dest
+			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080"),  // Wrong port
+			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),    // Wrong proto
+			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),    // Src/dest confusion
+			tcpPkt("10.0.0.2:31245", "10.0.0.1:80"),    // Wrong dest
 		},
 		IPSets: map[string][]string{
 			"setA": {"10.0.0.2/32,tcp:80", "123.0.0.1/32,udp:1024"},
@@ -947,10 +947,10 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 		DroppedPackets: []packet{
 			packetNoPorts(253, "11.0.0.2", "10.0.0.2"), // Wrong proto, no ports
-			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080"), // Wrong port
-			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),   // Wrong proto
-			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),   // Src/dest confusion
-			tcpPkt("10.0.0.2:31245", "10.0.0.1:80"),   // Wrong dest
+			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080"),  // Wrong port
+			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),    // Wrong proto
+			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),    // Src/dest confusion
+			tcpPkt("10.0.0.2:31245", "10.0.0.1:80"),    // Wrong dest
 		},
 		IPSets: map[string][]string{
 			"setA": {"10.0.0.2/32,tcp:80"},
@@ -975,10 +975,10 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:82")},
 		DroppedPackets: []packet{
 			packetNoPorts(253, "11.0.0.2", "10.0.0.2"), // Wrong proto, no ports
-			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080"), // Wrong port
-			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),   // Wrong proto
-			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),   // Src/dest confusion
-			tcpPkt("10.0.0.2:31245", "10.0.0.1:80"),   // Wrong dest
+			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080"),  // Wrong port
+			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),    // Wrong proto
+			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),    // Src/dest confusion
+			tcpPkt("10.0.0.2:31245", "10.0.0.1:80"),    // Wrong dest
 		},
 		IPSets: map[string][]string{
 			"setA": {"10.0.0.2/32,tcp:80"},
@@ -996,10 +996,10 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
 			packetNoPorts(253, "10.0.0.2", "10.0.0.2"), // Wrong proto, no ports
-			tcpPkt("10.0.0.2:8080", "11.0.0.1:12345"), // Wrong port
-			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),   // Wrong proto
-			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),   // Src/dest confusion
-			tcpPkt("10.0.0.1:80", "10.0.0.2:31245"),   // Wrong src
+			tcpPkt("10.0.0.2:8080", "11.0.0.1:12345"),  // Wrong port
+			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),    // Wrong proto
+			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),    // Src/dest confusion
+			tcpPkt("10.0.0.1:80", "10.0.0.2:31245"),    // Wrong src
 		},
 		IPSets: map[string][]string{
 			"setA": {"10.0.0.2/32,tcp:80", "123.0.0.1/32,udp:1024"},
@@ -1016,10 +1016,10 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
 			packetNoPorts(253, "10.0.0.2", "10.0.0.2"), // Wrong proto, no ports
-			tcpPkt("10.0.0.2:8080", "11.0.0.1:12345"), // Wrong port
-			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),   // Wrong proto
-			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),   // Src/dest confusion
-			tcpPkt("10.0.0.1:80", "10.0.0.2:31245"),   // Wrong src
+			tcpPkt("10.0.0.2:8080", "11.0.0.1:12345"),  // Wrong port
+			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),    // Wrong proto
+			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),    // Src/dest confusion
+			tcpPkt("10.0.0.1:80", "10.0.0.2:31245"),    // Wrong src
 		},
 		IPSets: map[string][]string{
 			"setA": {"10.0.0.2/32,tcp:80"},
@@ -1081,7 +1081,7 @@ var polProgramTests = []polProgramTest{
 	{
 		PolicyName: "Protocol match",
 		Policy: makeRulesSingleTier([]*proto.Rule{{
-			Action: "Allow",
+			Action:   "Allow",
 			Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 253}},
 		}}),
 		AllowedPackets: []packet{

--- a/bpf/ut/pol_prog_test.go
+++ b/bpf/ut/pol_prog_test.go
@@ -210,6 +210,7 @@ func udpPkt(src, dst string) packet {
 func icmpPkt(src, dst string) packet {
 	return packetWithPorts(1, src+":0", dst+":0")
 }
+
 func icmpPktWithTypeCode(src, dst string, icmpType, icmpCode int) packet {
 	return packet{
 		protocol: 1,
@@ -220,6 +221,14 @@ func icmpPktWithTypeCode(src, dst string, icmpType, icmpCode int) packet {
 	}
 }
 
+func packetNoPorts(proto int, src, dst string) packet {
+	return packet{
+		protocol: proto,
+		srcAddr:  src,
+		dstAddr:  dst,
+	}
+}
+
 var polProgramTests = []polProgramTest{
 	// Tests of actions and flow control.
 	{
@@ -227,7 +236,9 @@ var polProgramTests = []polProgramTest{
 		DroppedPackets: []packet{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
-			icmpPkt("10.0.0.1", "10.0.0.2")},
+			icmpPkt("10.0.0.1", "10.0.0.2"),
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
+		},
 	},
 	{
 		PolicyName: "empty tier has no impact",
@@ -251,7 +262,9 @@ var polProgramTests = []polProgramTest{
 		AllowedPackets: []packet{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
-			icmpPkt("10.0.0.1", "10.0.0.2")},
+			icmpPkt("10.0.0.1", "10.0.0.2"),
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
+		},
 	},
 	{
 		PolicyName: "unreachable tier",
@@ -278,6 +291,7 @@ var polProgramTests = []polProgramTest{
 			},
 		},
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			icmpPkt("10.0.0.1", "10.0.0.2")},
@@ -296,6 +310,7 @@ var polProgramTests = []polProgramTest{
 			},
 		},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			icmpPkt("10.0.0.1", "10.0.0.2")},
@@ -326,6 +341,7 @@ var polProgramTests = []polProgramTest{
 			},
 		},
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			icmpPkt("10.0.0.1", "10.0.0.2")},
@@ -356,6 +372,7 @@ var polProgramTests = []polProgramTest{
 			},
 		},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			icmpPkt("10.0.0.1", "10.0.0.2")},
@@ -366,6 +383,7 @@ var polProgramTests = []polProgramTest{
 			Action: "Allow",
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
@@ -397,6 +415,7 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			icmpPkt("10.0.0.1", "10.0.0.2")},
@@ -408,6 +427,7 @@ var polProgramTests = []polProgramTest{
 			NotProtocol: &proto.Protocol{NumberOrName: &proto.Protocol_Name{Name: "tcp"}},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			icmpPkt("10.0.0.1", "10.0.0.2")},
@@ -425,6 +445,7 @@ var polProgramTests = []polProgramTest{
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			icmpPkt("10.0.0.1", "10.0.0.2")},
@@ -439,10 +460,12 @@ var polProgramTests = []polProgramTest{
 			SrcNet: []string{"10.0.0.1/32"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			icmpPkt("10.0.0.1", "10.0.0.2")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.2"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 	},
@@ -453,12 +476,14 @@ var polProgramTests = []polProgramTest{
 			SrcNet: []string{"10.0.0.0/8"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			icmpPkt("10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "11.0.0.1", "10.0.0.2"),
 			icmpPkt("11.0.0.1", "10.0.0.2")},
 	},
 	{
@@ -468,9 +493,11 @@ var polProgramTests = []polProgramTest{
 			SrcNet: []string{"102.0.0.0/8", "10.0.0.1/32", "11.0.0.1/32"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			icmpPkt("11.0.0.1", "10.0.0.2"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.2"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 	},
 	{
@@ -480,8 +507,10 @@ var polProgramTests = []polProgramTest{
 			NotSrcNet: []string{"102.0.0.0/8", "10.0.0.1/32", "11.0.0.1/32"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.2"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			icmpPkt("11.0.0.1", "10.0.0.2"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 	},
@@ -492,8 +521,10 @@ var polProgramTests = []polProgramTest{
 			DstNet: []string{"102.0.0.0/8", "10.0.0.1/32", "11.0.0.1/32"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			udpPkt("10.0.0.2:12345", "123.0.0.1:1024")},
 	},
 	{
@@ -503,8 +534,10 @@ var polProgramTests = []polProgramTest{
 			NotDstNet: []string{"102.0.0.0/8", "10.0.0.1/32", "11.0.0.1/32"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "123.0.0.1"),
 			udpPkt("10.0.0.2:12345", "123.0.0.1:1024")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 	},
 	{
@@ -514,8 +547,10 @@ var polProgramTests = []polProgramTest{
 			NotSrcNet: []string{"10.0.0.0/8"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.0.0.1"),
 			icmpPkt("11.0.0.1", "10.0.0.2")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			icmpPkt("10.0.0.1", "10.0.0.2"),
@@ -529,9 +564,11 @@ var polProgramTests = []polProgramTest{
 			DstNet: []string{"10.0.0.1/32"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			icmpPkt("10.0.0.1", "10.0.0.2"),
@@ -544,6 +581,7 @@ var polProgramTests = []polProgramTest{
 			DstNet: []string{"10.0.0.0/8"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			icmpPkt("10.0.0.1", "10.0.0.2"),
@@ -551,6 +589,7 @@ var polProgramTests = []polProgramTest{
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			icmpPkt("11.0.0.1", "10.0.0.2")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "123.0.0.2"),
 			udpPkt("10.0.0.2:12345", "123.0.0.1:1024")},
 	},
 	{
@@ -560,8 +599,10 @@ var polProgramTests = []polProgramTest{
 			NotDstNet: []string{"10.0.0.0/8"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "123.0.0.2"),
 			udpPkt("10.0.0.2:12345", "123.0.0.1:1024")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			icmpPkt("10.0.0.1", "10.0.0.2"),
@@ -584,6 +625,7 @@ var polProgramTests = []polProgramTest{
 		AllowedPackets: []packet{
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
@@ -603,6 +645,7 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			tcpPkt("10.0.0.2:81", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.2:79", "10.0.0.1:31245"),
 			tcpPkt("10.0.0.2:82", "10.0.0.1:31245"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
@@ -622,6 +665,7 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.2:0", "10.0.0.1:31245"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.2:81", "10.0.0.1:31245")},
 	},
 	{
@@ -638,6 +682,7 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:65535")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:79")},
 	},
 	{
@@ -655,6 +700,7 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:81"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:90")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.1", "10.0.0.2"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:79"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:82"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:89"),
@@ -677,6 +723,7 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:89"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:91")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:81"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:90"),
@@ -695,6 +742,7 @@ var polProgramTests = []polProgramTest{
 		AllowedPackets: []packet{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
@@ -713,6 +761,7 @@ var polProgramTests = []polProgramTest{
 		AllowedPackets: []packet{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
@@ -732,6 +781,7 @@ var polProgramTests = []polProgramTest{
 		AllowedPackets: []packet{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:65535")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 	},
 	{
@@ -747,6 +797,7 @@ var polProgramTests = []polProgramTest{
 		AllowedPackets: []packet{
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
@@ -762,6 +813,7 @@ var polProgramTests = []polProgramTest{
 			SrcIpSetIds: []string{"setA"},
 		}}),
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
@@ -782,6 +834,7 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			icmpPkt("10.0.0.1", "10.0.0.2")},
@@ -796,12 +849,14 @@ var polProgramTests = []polProgramTest{
 			SrcIpSetIds: []string{"setA"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.2:12345", "123.0.0.1:1024"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),
 			icmpPkt("10.0.0.1", "10.0.0.2")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.0.0.1"),
 			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080")},
 		IPSets: map[string][]string{
 			"setA": {"10.0.0.0/8"},
@@ -814,8 +869,10 @@ var polProgramTests = []polProgramTest{
 			DstIpSetIds: []string{"setA"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "11.0.0.1"),
 			udpPkt("10.0.0.2:12345", "123.0.0.1:1024")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.0.0.1"),
 			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 		IPSets: map[string][]string{
@@ -829,8 +886,10 @@ var polProgramTests = []polProgramTest{
 			NotSrcIpSetIds: []string{"setA"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.0.0.1"),
 			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.1"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),
 			udpPkt("10.0.0.2:12345", "123.0.0.1:1024"),
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),
@@ -847,9 +906,11 @@ var polProgramTests = []polProgramTest{
 			NotDstIpSetIds: []string{"setA"},
 		}}),
 		AllowedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.0.0.1"),
 			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080"),
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "11.0.0.1"),
 			udpPkt("10.0.0.2:12345", "123.0.0.1:1024")},
 		IPSets: map[string][]string{
 			"setA": {"11.0.0.0/8", "123.0.0.1/32"},
@@ -865,6 +926,7 @@ var polProgramTests = []polProgramTest{
 			udpPkt("10.0.0.2:12345", "123.0.0.1:1024"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.0.0.2"), // Wrong proto, no ports
 			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080"), // Wrong port
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),   // Wrong proto
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),   // Src/dest confusion
@@ -884,6 +946,7 @@ var polProgramTests = []polProgramTest{
 			udpPkt("10.0.0.2:12345", "123.0.0.1:1024"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.0.0.2"), // Wrong proto, no ports
 			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080"), // Wrong port
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),   // Wrong proto
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),   // Src/dest confusion
@@ -911,6 +974,7 @@ var polProgramTests = []polProgramTest{
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:90"),
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:82")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.0.0.2"), // Wrong proto, no ports
 			tcpPkt("11.0.0.1:12345", "10.0.0.2:8080"), // Wrong port
 			udpPkt("10.0.0.1:31245", "10.0.0.2:80"),   // Wrong proto
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245"),   // Src/dest confusion
@@ -931,6 +995,7 @@ var polProgramTests = []polProgramTest{
 			udpPkt("123.0.0.1:1024", "10.0.0.2:12345"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.2"), // Wrong proto, no ports
 			tcpPkt("10.0.0.2:8080", "11.0.0.1:12345"), // Wrong port
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),   // Wrong proto
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),   // Src/dest confusion
@@ -950,6 +1015,7 @@ var polProgramTests = []polProgramTest{
 			udpPkt("123.0.0.1:1024", "10.0.0.2:12345"),
 			tcpPkt("10.0.0.2:80", "10.0.0.1:31245")},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "10.0.0.2", "10.0.0.2"), // Wrong proto, no ports
 			tcpPkt("10.0.0.2:8080", "11.0.0.1:12345"), // Wrong port
 			udpPkt("10.0.0.2:80", "10.0.0.1:31245"),   // Wrong proto
 			tcpPkt("10.0.0.1:31245", "10.0.0.2:80"),   // Src/dest confusion
@@ -970,6 +1036,7 @@ var polProgramTests = []polProgramTest{
 		AllowedPackets: []packet{
 			icmpPktWithTypeCode("10.0.0.1", "10.0.0.2", 8, 0)},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.0.0.2"), // Wrong proto
 			icmpPktWithTypeCode("10.0.0.1", "10.0.0.2", 10, 0)},
 	},
 	{
@@ -1010,6 +1077,23 @@ var polProgramTests = []polProgramTest{
 			icmpPktWithTypeCode("10.0.0.1", "10.0.0.2", 8, 3)},
 	},
 
+	// Generic protocol tests.
+	{
+		PolicyName: "Protocol match",
+		Policy: makeRulesSingleTier([]*proto.Rule{{
+			Action: "Allow",
+			Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 253}},
+		}}),
+		AllowedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.0.0.2"),
+		},
+		DroppedPackets: []packet{
+			icmpPktWithTypeCode("10.0.0.1", "10.0.0.2", 10, 0),
+			udpPkt("123.0.0.1:1024", "10.96.0.10:53"),
+			packetNoPorts(254, "11.0.0.2", "10.0.0.2"),
+		},
+	},
+
 	// Test cases with host policy.
 	{
 		PolicyName: "pre-DNAT",
@@ -1033,10 +1117,12 @@ var polProgramTests = []polProgramTest{
 			},
 		},
 		AllowedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.96.0.10"),
 			udpPkt("123.0.0.1:1024", "10.0.0.2:12345").preNAT("10.96.0.10:53"),
 			udpPkt("123.0.0.1:1024", "10.96.0.10:53"),
 		},
 		DroppedPackets: []packet{
+			packetNoPorts(253, "11.0.0.2", "10.0.0.10"),
 			udpPkt("123.0.0.1:1024", "10.0.0.2:12345").preNAT("10.96.0.11:53"),
 			udpPkt("123.0.0.1:1024", "10.96.0.10:53").preNAT("10.0.0.2:12345"),
 			udpPkt("123.0.0.1:1024", "10.96.0.11:53"),

--- a/fv/fv_infra_test.go
+++ b/fv/fv_infra_test.go
@@ -91,7 +91,7 @@ func describeConnCheckTests(protocol string) bool {
 				cc.ExpectSome(felixes[0], hostW[1])
 				if !strings.HasPrefix(protocol, "ip") {
 					cc.ExpectNone(felixes[0], hostW[1], 8066)
-				} 
+				}
 				cc.CheckConnectivity()
 			})
 

--- a/fv/fv_infra_test.go
+++ b/fv/fv_infra_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import (
 var _ = describeConnCheckTests("tcp")
 var _ = describeConnCheckTests("sctp")
 var _ = describeConnCheckTests("udp")
+var _ = describeConnCheckTests("253")
 var _ = describeConnCheckTests("udp-recvmsg")
 var _ = describeConnCheckTests("udp-noconn")
 
@@ -88,7 +89,9 @@ func describeConnCheckTests(protocol string) bool {
 
 			It("should have host-to-host on right port only", func() {
 				cc.ExpectSome(felixes[0], hostW[1])
-				cc.ExpectNone(felixes[0], hostW[1], 8066)
+				if protocol != "253" {
+					cc.ExpectNone(felixes[0], hostW[1], 8066)
+				}
 				cc.CheckConnectivity()
 			})
 

--- a/fv/fv_infra_test.go
+++ b/fv/fv_infra_test.go
@@ -39,7 +39,7 @@ import (
 var _ = describeConnCheckTests("tcp")
 var _ = describeConnCheckTests("sctp")
 var _ = describeConnCheckTests("udp")
-var _ = describeConnCheckTests("253")
+var _ = describeConnCheckTests("ip4:253")
 var _ = describeConnCheckTests("udp-recvmsg")
 var _ = describeConnCheckTests("udp-noconn")
 
@@ -89,9 +89,9 @@ func describeConnCheckTests(protocol string) bool {
 
 			It("should have host-to-host on right port only", func() {
 				cc.ExpectSome(felixes[0], hostW[1])
-				if protocol != "253" {
+				if !strings.HasPrefix(protocol, "ip") {
 					cc.ExpectNone(felixes[0], hostW[1], 8066)
-				}
+				} 
 				cc.CheckConnectivity()
 			})
 

--- a/fv/hostendpoints_test.go
+++ b/fv/hostendpoints_test.go
@@ -319,7 +319,7 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 			cc253.CheckConnectivity()
 			cc253.ResetExpectations()
 
-			By("Allowing raw IP from felix[1] -> felix[0]")
+			By("Allowing raw IP from felix[0] -> felix[1]")
 			cc253.Expect(connectivity.Some, felixes[0], rawIPHostW253[1])
 			cc253.CheckConnectivity()
 		})
@@ -361,7 +361,7 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 			// One-way check because conntrack for unknown protocols is symmetric so, once the
 			// felix[0] -> felix[1] packet goes through, we expect felix[1] -> felix[0] to work too
 			// (and the connetivity checker always does a request-response to check that).
-			cc253.Expect(connectivity.None, felixes[0], rawIPHostW253[1])
+			cc253.Expect(connectivity.Some, felixes[0], rawIPHostW253[1])
 			cc253.CheckConnectivity()
 
 			// 254 should still be blocked...

--- a/fv/hostendpoints_test.go
+++ b/fv/hostendpoints_test.go
@@ -23,14 +23,17 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/projectcalico/felix/fv/connectivity"
-	"github.com/projectcalico/felix/fv/infrastructure"
-	"github.com/projectcalico/felix/fv/utils"
-	"github.com/projectcalico/felix/fv/workload"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	client "github.com/projectcalico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/libcalico-go/lib/options"
+
+	"github.com/projectcalico/felix/fv/connectivity"
+	"github.com/projectcalico/felix/fv/infrastructure"
+	"github.com/projectcalico/felix/fv/utils"
+	"github.com/projectcalico/felix/fv/workload"
 )
 
 var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ named host endpoints",
@@ -47,13 +50,15 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ all-interfaces host endpoin
 // If allInterfaces, then interfaceName: "*". Otherwise, interfaceName: "eth0".
 func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfaces bool) {
 	var (
-		bpfEnabled = os.Getenv("FELIX_FV_ENABLE_BPF") == "true"
-		infra      infrastructure.DatastoreInfra
-		felixes    []*infrastructure.Felix
-		client     client.Interface
-		w          [2]*workload.Workload
-		hostW      [2]*workload.Workload
-		cc         *connectivity.Checker
+		bpfEnabled       = os.Getenv("FELIX_FV_ENABLE_BPF") == "true"
+		infra            infrastructure.DatastoreInfra
+		felixes          []*infrastructure.Felix
+		client           client.Interface
+		w                [2]*workload.Workload
+		hostW            [2]*workload.Workload
+		rawIPHostW253    [2]*workload.Workload
+		rawIPHostW254    [2]*workload.Workload
+		cc, cc253, cc254 *connectivity.Checker // Numbered checkers are for raw IP tests of specific protocols.
 	)
 
 	BeforeEach(func() {
@@ -71,9 +76,13 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 			w[ii].ConfigureInInfra(infra)
 
 			hostW[ii] = workload.Run(felixes[ii], fmt.Sprintf("host%d", ii), "", felixes[ii].IP, "8055", "tcp")
+			rawIPHostW253[ii] = workload.Run(felixes[ii], fmt.Sprintf("raw-host%d", ii), "", felixes[ii].IP, "", "ip4:253")
+			rawIPHostW254[ii] = workload.Run(felixes[ii], fmt.Sprintf("raw-host%d", ii), "", felixes[ii].IP, "", "ip4:254")
 		}
 
 		cc = &connectivity.Checker{}
+		cc253 = &connectivity.Checker{Protocol: "ip4:253"}
+		cc254 = &connectivity.Checker{Protocol: "ip4:254"}
 	})
 
 	AfterEach(func() {
@@ -213,6 +222,15 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 			cc.ResetExpectations()
 		})
 
+		It("should block raw IP", func() {
+			cc253.Expect(connectivity.None, felixes[0], rawIPHostW253[1])
+			cc253.Expect(connectivity.None, felixes[1], rawIPHostW253[0])
+			cc254.Expect(connectivity.None, felixes[0], rawIPHostW254[1])
+			cc254.Expect(connectivity.None, felixes[1], rawIPHostW254[0])
+			cc253.CheckConnectivity()
+			cc254.CheckConnectivity()
+		})
+
 		It("should allow connectivity from nodes to the Kubernetes API server", func() {
 			expectConnectivityToAPIServer()
 			cc.CheckConnectivity()
@@ -268,8 +286,14 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 			expectPodToPodTraffic()
 			expectHostToOwnPodTraffic()
 			cc.CheckConnectivity()
-
 			cc.ResetExpectations()
+
+			// Should block raw IP too.
+			By("Blocking raw IP from felix[0] <-> felix[1]")
+			cc253.Expect(connectivity.None, felixes[0], rawIPHostW253[1])
+			cc253.Expect(connectivity.None, felixes[1], rawIPHostW253[0])
+			cc253.CheckConnectivity()
+			cc253.ResetExpectations()
 
 			// Now add a policy selecting felix[1] that allows ingress.
 			policy = api.NewGlobalNetworkPolicy()
@@ -288,6 +312,60 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 			expectPodToPodTraffic()
 			expectHostToOwnPodTraffic()
 			cc.CheckConnectivity()
+
+			// Need to test this first because the conntrack is symmetric for portless protocols.
+			By("Blocking raw IP from felix[1] -> felix[0]")
+			cc253.Expect(connectivity.None, felixes[1], rawIPHostW253[0])
+			cc253.CheckConnectivity()
+			cc253.ResetExpectations()
+
+			By("Allowing raw IP from felix[1] -> felix[0]")
+			cc253.Expect(connectivity.Some, felixes[0], rawIPHostW253[1])
+			cc253.CheckConnectivity()
+		})
+
+		It("should allow raw IP with the right protocol only", func() {
+			// Create a policy selecting felix[0] that allows egress.
+			policy := api.NewGlobalNetworkPolicy()
+			policy.Name = "f0-egress"
+			proto253 := numorstring.ProtocolFromInt(253)
+			policy.Spec.Egress = []api.Rule{{
+				Action:   api.Allow,
+				Protocol: &proto253,
+			}}
+			policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[0].Hostname)
+			_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Should block all raw IP until we have the second policy in place.
+			By("Blocking raw IP from felix[0] <-> felix[1]")
+			cc253.Expect(connectivity.None, felixes[0], rawIPHostW253[1])
+			cc253.Expect(connectivity.None, felixes[1], rawIPHostW253[0])
+			cc253.CheckConnectivity()
+			cc253.ResetExpectations()
+			cc254.Expect(connectivity.None, felixes[0], rawIPHostW254[1])
+			cc254.Expect(connectivity.None, felixes[1], rawIPHostW254[0])
+			cc254.CheckConnectivity()
+
+			// Now add a policy selecting felix[1] that allows ingress.
+			policy = api.NewGlobalNetworkPolicy()
+			policy.Name = "f1-ingress"
+			policy.Spec.Ingress = []api.Rule{{
+				Action:   api.Allow,
+				Protocol: &proto253,
+			}}
+			policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[1].Hostname)
+			_, err = client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+			Expect(err).NotTo(HaveOccurred())
+
+			// One-way check because conntrack for unknown protocols is symmetric so, once the
+			// felix[0] -> felix[1] packet goes through, we expect felix[1] -> felix[0] to work too
+			// (and the connetivity checker always does a request-response to check that).
+			cc253.Expect(connectivity.None, felixes[0], rawIPHostW253[1])
+			cc253.CheckConnectivity()
+
+			// 254 should still be blocked...
+			cc254.CheckConnectivity()
 		})
 
 		It("should not deny host-to-own pod traffic even if an apply-on-forward deny policy is applied", func() {

--- a/fv/hostendpoints_test.go
+++ b/fv/hostendpoints_test.go
@@ -360,7 +360,7 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 
 			// One-way check because conntrack for unknown protocols is symmetric so, once the
 			// felix[0] -> felix[1] packet goes through, we expect felix[1] -> felix[0] to work too
-			// (and the connetivity checker always does a request-response to check that).
+			// (and the connectivity checker always does a request-response to check that).
 			cc253.Expect(connectivity.Some, felixes[0], rawIPHostW253[1])
 			cc253.CheckConnectivity()
 

--- a/fv/test-connection/test-connection.go
+++ b/fv/test-connection/test-connection.go
@@ -353,14 +353,42 @@ func tryConnect(remoteIPAddr, remotePort, sourceIPAddr, sourcePort, protocol str
 	if remotePort == "6443" {
 		// Testing for connectivity to the Kubernetes API server.  If we reach here, we're
 		// good.  Skip sending and receiving any data, as that would need TLS.
-		connectivity.Result{}.PrintToStdout()
+		connectivity.Result{
+			LastResponse: connectivity.Response{
+				Timestamp:  time.Now(),
+				SourceAddr: sourceIPAddr,
+				ServerAddr: remoteIPAddr,
+				Request:    connectivity.Request{
+					Payload:      "Dummy request: TCP handshake only for API server connection testing",
+				},
+			},
+			Stats: connectivity.Stats{
+				RequestsSent:      1,
+				ResponsesReceived: 1,
+			},
+			ClientMTU: connectivity.MTUPair{},
+		}.PrintToStdout()
 		return nil
 	}
 
 	if remotePort == "5473" {
 		// Testing for connectivity to Typha. If we reach here, we're good.
 		// Skip sending and receiving any data.
-		connectivity.Result{}.PrintToStdout()
+		connectivity.Result{
+			LastResponse: connectivity.Response{
+				Timestamp:  time.Now(),
+				SourceAddr: sourceIPAddr,
+				ServerAddr: remoteIPAddr,
+				Request:    connectivity.Request{
+					Payload:      "Dummy request: TCP handshake only for Typha connection testing",
+				},
+			},
+			Stats: connectivity.Stats{
+				RequestsSent:      1,
+				ResponsesReceived: 1,
+			},
+			ClientMTU: connectivity.MTUPair{},
+		}.PrintToStdout()
 		return nil
 	}
 

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -146,12 +146,8 @@ func (w *Workload) Start() error {
 	// Start the workload.
 	log.WithField("workload", w).Info("About to run workload")
 	var protoArg string
-	if w.Protocol == "253" {
-		protoArg = "--253"
-	} else if w.Protocol == "udp" {
-		protoArg = "--udp"
-	} else if w.Protocol == "sctp" {
-		protoArg = "--sctp"
+	if w.Protocol != "" {
+		protoArg = "--protocol=" + w.Protocol
 	}
 	w.runCmd = utils.Command("docker", "exec", w.C.Name,
 		"sh", "-c",

--- a/fv/workload/workload.go
+++ b/fv/workload/workload.go
@@ -146,7 +146,9 @@ func (w *Workload) Start() error {
 	// Start the workload.
 	log.WithField("workload", w).Info("About to run workload")
 	var protoArg string
-	if w.Protocol == "udp" {
+	if w.Protocol == "253" {
+		protoArg = "--253"
+	} else if w.Protocol == "udp" {
 		protoArg = "--udp"
 	} else if w.Protocol == "sctp" {
 		protoArg = "--sctp"


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
* Allow such packets through to policy.
* Add conntrack support with 10 min timer (based in Linux default).
* Add UTs for policy matches.
* Add FVs that verify protocol match and conntrack works as expected for host endpoints.
  * Extend `test-connection` and `test-workload` to support arbitrary protocols
  * Clean up `test-workload`'s protocol flags
  * Ignore ports for raw IP protocol tests

## Todos
- [x] Unit tests (full coverage)
- [x] FV tests
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In eBPF mode, generic IP protocols (i.e. everything apart from TCP, UDP and ICMP) are now supported in a limited fashion (similarly to iptables). Such protocols are connection-tracked based on IP and protocol number only.
```
