### PR TITLE
In BPF mode, enable the FIB lookup when VXLAN is enabled.

### DIFF
--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -565,8 +565,9 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		bpfRTMgr := newBPFRouteManager(config.Hostname, config.ExternalNodesCidrs, bpfMapContext)
 		dp.RegisterManager(bpfRTMgr)
 
-		// Forwarding into a tunnel seems to fail silently, disable FIB lookup if tunnel is enabled for now.
-		fibLookupEnabled := !config.RulesConfig.IPIPEnabled && !config.RulesConfig.VXLANEnabled
+		// Forwarding into an IPIP tunnel fails silently because IPIP tunnels are L3 devices and support for
+		// L3 devices in BPF is not available yet.  Disable the FIB lookup in that case.
+		fibLookupEnabled := !config.RulesConfig.IPIPEnabled
 		stateMap := state.Map(bpfMapContext)
 		err = stateMap.EnsureExists()
 		if err != nil {


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
This was previously disabled out of caution, but it appears to work fine so (now we have FV coverage of VXLAN with BPF mode) enable it.

## Todos
- [x] Integration tests (delete as appropriate)
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In eBPF mode, enable FIB lookup acceleration in VXLAN mode.  This should improve performance in VXLAN mode.  Previously, this was disabled whenever an overlay was enabled but that was due to a problem with IPIP so we can safely enable the FIB with VXLAN mode.
```
