### PR TITLE
Do not forward incoming VXLAN packets.

### DIFF
--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -154,6 +154,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 		case -2:
 			/* Non-BPF VXLAN packet from another Calico node. */
 			CALI_DEBUG("VXLAN packet from known Calico host, allow.");
+			fwd_fib_set(&ctx.fwd, false);
 			goto allow;
 		}
 	}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Disable the FIB when we detect a VXLAN packet to the local host.  The FIB lookup is not helpful and on that code path the FIB input datastructure hasn't be initialised so we end up sending the packet to the default gateway.

Bug was introduced by interaction between #2666 and #2669.  Only seems to show up in E2Es; perhaps the FIB is failing for another reason in the FVs?

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
