### PR TITLE
Ignore log rules in BPF mode.

### DIFF
--- a/bpf/polprog/pol_prog_builder.go
+++ b/bpf/polprog/pol_prog_builder.go
@@ -369,6 +369,10 @@ func (p *Builder) writePolicyRules(policy Policy, actionLabels map[string]string
 	for ruleIdx, rule := range policy.Rules {
 		log.Debugf("Start of rule %d", ruleIdx)
 		action := strings.ToLower(rule.Action)
+		if action == "log" {
+			log.Debug("Skipping log rule.  Not supported in BPF mode.")
+			continue
+		}
 		p.writeRule(rule, actionLabels[action], destLeg)
 		log.Debugf("End of rule %d", ruleIdx)
 	}

--- a/bpf/polprog/pol_prog_builder_test.go
+++ b/bpf/polprog/pol_prog_builder_test.go
@@ -72,3 +72,30 @@ func TestPolicySanityCheck(t *testing.T) {
 		t.Log(i, ": ", in)
 	}
 }
+
+func TestLogActionIgnored(t *testing.T) {
+	RegisterTestingT(t)
+	alloc := idalloc.New()
+
+	pg := NewBuilder(alloc, 1, 2, 3)
+	insns, err := pg.Instructions(Rules{
+		Tiers: []Tier{{
+			Name: "default",
+			Policies: []Policy{{
+				Name: "test policy",
+				Rules: []Rule{{Rule: &proto.Rule{
+					Action: "Log",
+				}}},
+			}},
+		}}})
+	Expect(err).NotTo(HaveOccurred())
+
+	pg = NewBuilder(alloc, 1, 2, 3)
+	noOpInsns, err := pg.Instructions(Rules{
+		Tiers: []Tier{{
+			Name:     "default",
+			Policies: []Policy{},
+		}}})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(noOpInsns).To(Equal(insns))
+}

--- a/bpf/ut/pol_prog_test.go
+++ b/bpf/ut/pol_prog_test.go
@@ -1026,7 +1026,7 @@ var polProgramTests = []polProgramTest{
 			"setB": {"123.0.0.1/32,udp:1024"},
 		},
 	},
-	//ICMP tests
+	// ICMP tests
 	{
 		PolicyName: "allow icmp packet with type 8",
 		Policy: makeRulesSingleTier([]*proto.Rule{{


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Log rules are not suported but they were causing panics instead of being ignored.

Fixes https://github.com/projectcalico/calico/issues/4389

## Todos
- [x] Unit tests (full coverage)
- [ ] Backport
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that, in eBPF mode, a Log rule would result in an error instead of being ignored.  Log rules are not supported but they should be ignored, not cause a failure.
```
