### PR TITLE
[v3.17] ignore log rules in eBPF mode

### DIFF
--- a/bpf/polprog/pol_prog_builder.go
+++ b/bpf/polprog/pol_prog_builder.go
@@ -216,6 +216,11 @@ func (p *Builder) writeRules(rules [][][]*proto.Rule) {
 			log.Debugf("Start of policy/profile %d", polIdx)
 			for ruleIdx, rule := range pol {
 				log.Debugf("Start of rule %d", ruleIdx)
+				action := strings.ToLower(rule.Action)
+				if action == "log" {
+					log.Debug("Skipping log rule.  Not supported in BPF mode.")
+					continue
+				}
 				p.writeRule(rule, endOfTierLabel)
 				log.Debugf("End of rule %d", ruleIdx)
 			}

--- a/bpf/polprog/pol_prog_builder_test.go
+++ b/bpf/polprog/pol_prog_builder_test.go
@@ -66,3 +66,19 @@ func TestPolicySanityCheck(t *testing.T) {
 
 	Expect(insns).To(HaveLen(225))
 }
+
+func TestLogActionIgnored(t *testing.T) {
+	RegisterTestingT(t)
+	alloc := idalloc.New()
+
+	pg := NewBuilder(alloc, 1, 2, 3)
+	insns, err := pg.Instructions([][][]*proto.Rule{{{{
+		Action: "Log",
+	}}}})
+	Expect(err).NotTo(HaveOccurred())
+
+	pg = NewBuilder(alloc, 1, 2, 3)
+	noOpInsns, err := pg.Instructions([][][]*proto.Rule{{{}}})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(noOpInsns).To(Equal(insns))
+}

--- a/bpf/ut/pol_prog_test.go
+++ b/bpf/ut/pol_prog_test.go
@@ -868,7 +868,7 @@ var polProgramTests = []polProgramTest{
 			"setB": {"123.0.0.1/32,udp:1024"},
 		},
 	},
-	//ICMP tests
+	// ICMP tests
 	{
 		PolicyName: "allow icmp packet with type 8",
 		Policy: [][][]*proto.Rule{{{{


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Backport of https://github.com/projectcalico/felix/pull/2682

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that, in eBPF mode, a Log rule would result in an error instead of being ignored.  Log rules are not supported but they should be ignored, not cause a failure.
```
