### PR TITLE
Allow felix build on 32 bits systems (armv7)

### DIFF
--- a/bpf/tc/tc_defs.go
+++ b/bpf/tc/tc_defs.go
@@ -33,5 +33,5 @@ const (
 	MarkLinuxConntrackEstablished     = MarkCalico | 0x08000000
 	MarkLinuxConntrackEstablishedMask = MarkCalico | 0x08000000
 
-	MarksMask = 0xfff00000
+	MarksMask uint32 = 0xfff00000
 )


### PR DESCRIPTION
## Description
A small patch allowing to build felix for 32 bits architecture 
- fix : change tc.MarksMask datatype to unsigned 32 bits integer. Somehow this 32 bits value is picked as 64 bits integer.
- required to build felix on armv7
- tested locally by cross compiling calico/node  for armv7 or amd64
- component affected: calico/felix & calico/node


## Todos
- [ ] Unit tests
- [ ] Integration tests:  Not needed ?

## Release Note

```release-note
None required
```
