### PR TITLE
Added support for programming static rules on Windows

### DIFF
--- a/dataplane/windows/policy_mgr_test.go
+++ b/dataplane/windows/policy_mgr_test.go
@@ -33,7 +33,7 @@ func TestPolicyManager(t *testing.T) {
 		IPSets: map[string][]string{},
 	}
 
-	ps := policysets.NewPolicySets(&h, []policysets.IPSetCache{&ipsc})
+	ps := policysets.NewPolicySets(&h, []policysets.IPSetCache{&ipsc}, mockReader(""))
 	policyMgr := newPolicyManager(ps)
 
 	//Apply policy update
@@ -142,4 +142,13 @@ type mockIPSetCache struct {
 
 func (c *mockIPSetCache) GetIPSetMembers(ipsetID string) []string {
 	return c.IPSets[ipsetID]
+}
+
+type mockReader string
+
+func (m mockReader) ReadData() ([]byte, error) {
+	if len(m) == 0 {
+		return []byte{}, policysets.ErrNoRuleSpecified
+	}
+	return []byte(string(m)), nil
 }

--- a/dataplane/windows/policysets/static_rules.go
+++ b/dataplane/windows/policysets/static_rules.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policysets
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/projectcalico/felix/dataplane/windows/hns"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// static rule file name
+	StaticFileName = "static-rules.json"
+)
+
+var (
+	ErrNoRuleSpecified = errors.New("no rule specified")
+)
+
+type staticACLRule struct {
+	Type            hns.PolicyType    `json:"Type"`
+	Id              string            `json:"ID"`
+	Protocol        uint16            `json:"Protocol"`
+	Action          hns.ActionType    `json:"Action"`
+	Direction       hns.DirectionType `json:"Direction"`
+	LocalAddresses  string            `json:"LocalAddresses,omitempty"`
+	RemoteAddresses string            `json:"RemoteAddresses,omitempty"`
+	LocalPorts      string            `json:"LocalPorts,omitempty"`
+	RemotePorts     string            `json:"RemotePorts,omitempty"`
+	RuleType        hns.RuleType      `json:"RuleType"`
+	Priority        uint16            `json:"Priority"`
+}
+
+func (p staticACLRule) ToHnsACLPolicy(prefix string) (*hns.ACLPolicy, error) {
+	if len(p.Id) == 0 {
+		return nil, fmt.Errorf("'Id' is missing")
+	}
+	if p.Priority == 0 {
+		return nil, fmt.Errorf("'Priority' should not be zero")
+	}
+	if p.Type != hns.ACL {
+		return nil, fmt.Errorf("'Type' is not ACL")
+	}
+	if (p.RuleType != hns.Host) && (p.RuleType != hns.Switch) {
+		return nil, fmt.Errorf("'RuleType' %s is invalid", p.RuleType)
+	}
+	if (p.Action != hns.Allow) && (p.Action != hns.Block) {
+		return nil, fmt.Errorf("'Action' %s is invalid", p.Action)
+	}
+	if (p.Direction != hns.In) && (p.Direction != hns.Out) {
+		return nil, fmt.Errorf("'Direction' %s is invalid", p.Direction)
+	}
+
+	return &hns.ACLPolicy{
+		Type:            p.Type,
+		Id:              prefix + "-" + p.Id,
+		Protocol:        p.Protocol,
+		Action:          p.Action,
+		Direction:       p.Direction,
+		LocalAddresses:  p.LocalAddresses,
+		RemoteAddresses: p.RemoteAddresses,
+		LocalPorts:      p.LocalPorts,
+		RemotePorts:     p.RemotePorts,
+		RuleType:        p.RuleType,
+		Priority:        p.Priority,
+	}, nil
+}
+
+type staticEndpointPolicy struct {
+	Name string        `json:"Name"`
+	Rule staticACLRule `json:"Rule"`
+}
+
+type staticEndpointPolicies struct {
+	Provider string                 `json:"Provider"`
+	Version  string                 `json:"Version"`
+	Rules    []staticEndpointPolicy `json:"Rules"`
+}
+
+// staticRulesReader is a wrapper to read a file.
+// So we can have a mock reader for UT.
+type StaticRulesReader interface {
+	ReadData() ([]byte, error)
+}
+
+type FileReader string
+
+func (f FileReader) ReadData() ([]byte, error) {
+	// The value of os.Args[0] is "c:\CalicoWindows\calico-node.exe" which
+	// is the executable for CalicoFelix service. The static rules file is located
+	// at same directory with "calico-node.exe".
+	rootDir := filepath.Dir(os.Args[0])
+	ruleFile := filepath.Join(rootDir, string(f))
+
+	if _, err := os.Stat(ruleFile); os.IsNotExist(err) {
+		return []byte{}, ErrNoRuleSpecified
+	}
+	return ioutil.ReadFile(ruleFile)
+}
+
+// Read ACL policy rules from static rule file.
+func readStaticRules(r StaticRulesReader) (policies []*hns.ACLPolicy) {
+	data, err := r.ReadData()
+	if err == ErrNoRuleSpecified {
+		log.Info("Ignoring absent static rules file")
+		return
+	}
+
+	// If anything wrong with static rules file, Felix should panic.
+	if err != nil {
+		log.WithError(err).Panic("Failed to read static rules file.")
+	}
+
+	staticPolicies := staticEndpointPolicies{}
+
+	if err = json.Unmarshal(data, &staticPolicies); err != nil {
+		log.WithError(err).Panicf("Failed to unmarshal static rules file <provider %s, version %s>.",
+			staticPolicies.Provider, staticPolicies.Version)
+	}
+
+	if len(staticPolicies.Provider) == 0 {
+		log.WithError(err).Panic("Provider is not specified")
+	}
+
+	for _, r := range staticPolicies.Rules {
+		if r.Rule.Type != hns.ACL {
+			log.WithField("static rules", r.Rule).Panic("Incorrect static rule")
+		}
+		hnsRule, err := r.Rule.ToHnsACLPolicy(staticPolicies.Provider)
+		if err != nil {
+			log.WithError(err).Panic("Failed to convert static rule to ACL rule.")
+		}
+		log.WithField("static ACL rules", hnsRule).Info("Reading static ACL rules")
+		policies = append(policies, hnsRule)
+	}
+
+	return
+}

--- a/dataplane/windows/policysets/static_rules_test.go
+++ b/dataplane/windows/policysets/static_rules_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policysets
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/dataplane/windows/hns"
+)
+
+var staticRules string = `
+{
+    "Provider": "MyPlatform",
+    "Rules": [
+        {
+            "Name": "EndpointPolicy",
+            "Rule": {
+                "Action": "Block",
+                "Direction": "Out",
+                "ID": "block-server",
+                "Priority": 200,
+                "Protocol": 6,
+                "RemoteAddresses": "10.0.0.1/32",
+                "RemotePorts": "80",
+                "RuleType": "Switch",
+                "Type": "ACL"
+            }
+        },
+        {
+            "Name": "EndpointPolicy",
+            "Rule": {
+                "Action": "Allow",
+                "Direction": "In",
+                "Id": "block-client",
+                "Priority": 300,
+                "Protocol": 17,
+                "RemoteAddresses": "10.0.0.2/32",
+                "RemotePorts": "90",
+                "RuleType": "Host",
+                "Type": "ACL"
+            }
+        }
+    ],
+    "version": "0.1.0"
+}
+`
+
+func TestStaticRuleRendering(t *testing.T) {
+	RegisterTestingT(t)
+
+	r := mockReader(staticRules)
+	// Should read rules.
+	Expect(readStaticRules(r)).To(Equal([]*hns.ACLPolicy{
+		// Default deny rule.
+		{Type: hns.ACL, Id: "MyPlatform-block-server", Protocol: 6, Action: hns.Block, Direction: hns.Out,
+			RuleType: hns.Switch, Priority: 200, RemoteAddresses: "10.0.0.1/32", RemotePorts: "80"},
+		{Type: hns.ACL, Id: "MyPlatform-block-client", Protocol: 17, Action: hns.Allow, Direction: hns.In,
+			RuleType: hns.Host, Priority: 300, RemoteAddresses: "10.0.0.2/32", RemotePorts: "90"},
+	}))
+}
+
+var secondRuleMissingDirection string = `
+{
+    "Provider": "MyPlatform",
+    "Rules": [
+        {
+            "Name": "EndpointPolicy",
+            "Rule": {
+                "Action": "Block",
+                "Direction": "Out",
+                "ID": "block-server",
+                "Priority": 200,
+                "Protocol": 6,
+                "RemoteAddresses": "10.0.0.1/32",
+                "RemotePorts": "80",
+                "RuleType": "Switch",
+                "Type": "ACL"
+            }
+        },
+        {
+            "Name": "EndpointPolicy",
+            "Rule": {
+                "Action": "Allow",
+                "Id": "block-client",
+                "Priority": 300,
+                "Protocol": 17,
+                "RemoteAddresses": "10.0.0.2/32",
+                "RemotePorts": "90",
+                "RuleType": "Host",
+                "Type": "ACL"
+            }
+        }
+    ],
+    "version": "0.1.0"
+}
+`
+
+func TestFailedRendering(t *testing.T) {
+	RegisterTestingT(t)
+
+	r := mockReader(secondRuleMissingDirection)
+	// Should not render any rule.
+	Expect(func() { readStaticRules(r) }).To(Panic())
+}
+
+type mockReader string
+
+func (m mockReader) ReadData() ([]byte, error) {
+	if len(m) == 0 {
+		return []byte{}, ErrNoRuleSpecified
+	}
+	return []byte(string(m)), nil
+}

--- a/dataplane/windows/win_dataplane.go
+++ b/dataplane/windows/win_dataplane.go
@@ -173,7 +173,7 @@ func NewWinDataplaneDriver(hns hns.API, config Config) *WindowsDataplane {
 	for _, i := range dp.ipSets {
 		ipsc = append(ipsc, i)
 	}
-	dp.policySets = policysets.NewPolicySets(hns, ipsc)
+	dp.policySets = policysets.NewPolicySets(hns, ipsc, policysets.FileReader(policysets.StaticFileName))
 
 	dp.RegisterManager(newIPSetsManager(ipSetsV4))
 	dp.RegisterManager(newPolicyManager(dp.policySets))


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

This PR allows Felix to program static ACL rules if needed. However, users should avoid using this feature unless it is a special requirement of the platform, since static rules are not visible and controlled by Calico datastore. 

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
