### PR TITLE
bpf/conntrack: scanners IterationEnd called in reverse order

### DIFF
--- a/bpf/conntrack/scanner.go
+++ b/bpf/conntrack/scanner.go
@@ -160,7 +160,8 @@ func (s *Scanner) iterStart() {
 }
 
 func (s *Scanner) iterEnd() {
-	for _, scanner := range s.scanners {
+	for i := len(s.scanners) - 1; i >= 0; i-- {
+		scanner := s.scanners[i]
 		if synced, ok := scanner.(EntryScannerSynced); ok {
 			synced.IterationEnd()
 		}


### PR DESCRIPTION
To minimize the danger of scanners deadlocking, call the IterationEnd()
in a reverse order than the IterationStart so that if scanners acquire
locks and resources, they release them in the LIFO way.

Atm the only scanner that acquires a lock is the StaleNATScanner, which
calls into the kubeproxy, which internally grabs a lock.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
