### PR TITLE
Handle failure of netlink channel.  Reconnect and resync

### DIFF
--- a/dataplane/driver_windows.go
+++ b/dataplane/driver_windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import (
 func StartDataplaneDriver(configParams *config.Config,
 	healthAggregator *health.HealthAggregator,
 	configChangedRestartCallback func(),
+	fatalErrorCallback func(error),
 	k8sClientSet *kubernetes.Clientset) (DataplaneDriver, *exec.Cmd) {
 	log.Info("Using Windows dataplane driver.")
 

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -149,6 +149,7 @@ type Config struct {
 	StatusReportingInterval time.Duration
 
 	ConfigChangedRestartCallback func()
+	FatalErrorRestartCallback    func(error)
 
 	PostInSyncCallback func()
 	HealthAggregator   *health.HealthAggregator
@@ -326,7 +327,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		toDataplane:      make(chan interface{}, msgPeekLimit),
 		fromDataplane:    make(chan interface{}, 100),
 		ruleRenderer:     ruleRenderer,
-		ifaceMonitor:     ifacemonitor.New(config.IfaceMonitorConfig),
+		ifaceMonitor:     ifacemonitor.New(config.IfaceMonitorConfig, config.FatalErrorRestartCallback),
 		ifaceUpdates:     make(chan *ifaceUpdate, 100),
 		ifaceAddrUpdates: make(chan *ifaceAddrsUpdate, 100),
 		config:           config,

--- a/dataplane/windows/policysets/static_rules.go
+++ b/dataplane/windows/policysets/static_rules.go
@@ -22,8 +22,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/projectcalico/felix/dataplane/windows/hns"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/dataplane/windows/hns"
 )
 
 const (

--- a/ifacemonitor/ifacemonitor_test.go
+++ b/ifacemonitor/ifacemonitor_test.go
@@ -419,8 +419,8 @@ var _ = Describe("ifacemonitor", func() {
 		fatalErrC = make(chan struct{})
 		fatalErrCallback := func(err error) {
 			log.WithError(err).Info("Fatal error reported")
-			close(fatalErrC)
-			panic(errFatal)
+			close(fatalErrC) // Signal to test code that we saw the fatal error callback.
+			panic(errFatal)  // Break out of the MonitorInterfaces goroutine (this panic is recovered below).
 		}
 		im = ifacemonitor.NewWithStubs(config, nl, resyncC, fatalErrCallback)
 

--- a/ifacemonitor/netlink_real.go
+++ b/ifacemonitor/netlink_real.go
@@ -18,7 +18,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
-	//"syscall"
 )
 
 type netlinkReal struct {
@@ -27,7 +26,7 @@ type netlinkReal struct {
 func (nl *netlinkReal) Subscribe(
 	linkUpdates chan netlink.LinkUpdate,
 	routeUpdates chan netlink.RouteUpdate,
-) error {
+) (chan struct{}, error) {
 	cancel := make(chan struct{})
 
 	if err := netlink.LinkSubscribeWithOptions(linkUpdates, cancel, netlink.LinkSubscribeOptions{
@@ -36,8 +35,9 @@ func (nl *netlinkReal) Subscribe(
 			log.WithError(err).Warn("Netlink reported an error.")
 		},
 	}); err != nil {
-		log.WithError(err).Panic("Failed to subscribe to link updates")
-		return err
+		log.WithError(err).Error("Failed to subscribe to link updates")
+		close(cancel)
+		return nil, err
 	}
 	if err := netlink.RouteSubscribeWithOptions(routeUpdates, cancel, netlink.RouteSubscribeOptions{
 		ErrorCallback: func(err error) {
@@ -45,11 +45,12 @@ func (nl *netlinkReal) Subscribe(
 			log.WithError(err).Warn("Netlink reported an error.")
 		},
 	}); err != nil {
-		log.WithError(err).Panic("Failed to subscribe to addr updates")
-		return err
+		log.WithError(err).Error("Failed to subscribe to route updates")
+		close(cancel)
+		return nil, err
 	}
 
-	return nil
+	return cancel, nil
 }
 
 func (nl *netlinkReal) LinkList() ([]netlink.Link, error) {

--- a/ifacemonitor/netlink_real.go
+++ b/ifacemonitor/netlink_real.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017,2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,11 +30,21 @@ func (nl *netlinkReal) Subscribe(
 ) error {
 	cancel := make(chan struct{})
 
-	if err := netlink.LinkSubscribe(linkUpdates, cancel); err != nil {
+	if err := netlink.LinkSubscribeWithOptions(linkUpdates, cancel, netlink.LinkSubscribeOptions{
+		ErrorCallback: func(err error) {
+			// Not necessarily fatal (can be an unexpected message, which the library will drop).
+			log.WithError(err).Warn("Netlink reported an error.")
+		},
+	}); err != nil {
 		log.WithError(err).Panic("Failed to subscribe to link updates")
 		return err
 	}
-	if err := netlink.RouteSubscribe(routeUpdates, cancel); err != nil {
+	if err := netlink.RouteSubscribeWithOptions(routeUpdates, cancel, netlink.RouteSubscribeOptions{
+		ErrorCallback: func(err error) {
+			// Not necessarily fatal (can be an unexpected message, which the library will drop).
+			log.WithError(err).Warn("Netlink reported an error.")
+		},
+	}); err != nil {
 		log.WithError(err).Panic("Failed to subscribe to addr updates")
 		return err
 	}

--- a/ifacemonitor/update_filter_test.go
+++ b/ifacemonitor/update_filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,6 +34,26 @@ const (
 	chanPollTime  = "10ms"
 	chanPollIntvl = "100us"
 )
+
+func TestUpdateFilter_FilterUpdates_LinkCClosed(t *testing.T) {
+	t.Log("Link channel closure should be propagated to output channel")
+	harness, cancel := setUpFilterTest(t)
+	defer cancel()
+
+	close(harness.LinkIn)
+	Eventually(harness.LinkOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+	Eventually(harness.RouteOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+}
+
+func TestUpdateFilter_FilterUpdates_RouteCClosed(t *testing.T) {
+	t.Log("Link channel closure should be propagated to output channel")
+	harness, cancel := setUpFilterTest(t)
+	defer cancel()
+
+	close(harness.RouteIn)
+	Eventually(harness.LinkOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+	Eventually(harness.RouteOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+}
 
 func TestUpdateFilter_FilterUpdates_LinkUpdateDelay(t *testing.T) {
 	t.Log("Link updates should be delayed")


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

When I added the FilterUpdates mechanism, we lost error checking on the channel read.  Add that back and plumb through a failure reporting callback so that we shut down/restart gracefully instead of panicking.

Handle the failure to read gracefully and reconnect to netlink.  Initially, I reinstated the old behaviour that restarted felix but that made a consistent CI failure.  Let's go the whole hog and do the reconnection in-band...

## Todos
- [x] Unit tests (full coverage)
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that, after a netlink read failure, Felix would tight loop reading from a closed channel.  Restart the event poll in that case.
```
