### PR TITLE
[v3.16] Handle failure of netlink channel.  Reconnect and resync

### DIFF
--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -51,6 +51,7 @@ import (
 func StartDataplaneDriver(configParams *config.Config,
 	healthAggregator *health.HealthAggregator,
 	configChangedRestartCallback func(),
+	fatalErrorCallback func(error),
 	k8sClientSet *kubernetes.Clientset) (DataplaneDriver, *exec.Cmd) {
 
 	if !configParams.IsLeader() {
@@ -66,7 +67,7 @@ func StartDataplaneDriver(configParams *config.Config,
 		if kubeIPVSSupportEnabled {
 			log.Info("Kube-proxy in ipvs mode, enabling felix kube-proxy ipvs support.")
 		}
-		if configChangedRestartCallback == nil {
+		if configChangedRestartCallback == nil || fatalErrorCallback == nil {
 			log.Panic("Starting dataplane with nil callback func.")
 		}
 
@@ -247,6 +248,7 @@ func StartDataplaneDriver(configParams *config.Config,
 			NetlinkTimeout: configParams.NetlinkTimeoutSecs,
 
 			ConfigChangedRestartCallback: configChangedRestartCallback,
+			FatalErrorRestartCallback:    fatalErrorCallback,
 
 			PostInSyncCallback: func() {
 				// The initial resync uses a lot of scratch space so now is

--- a/dataplane/driver_windows.go
+++ b/dataplane/driver_windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import (
 func StartDataplaneDriver(configParams *config.Config,
 	healthAggregator *health.HealthAggregator,
 	configChangedRestartCallback func(),
+	fatalErrorCallback func(error),
 	k8sClientSet *kubernetes.Clientset) (DataplaneDriver, *exec.Cmd) {
 	log.Info("Using Windows dataplane driver.")
 

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -146,6 +146,7 @@ type Config struct {
 	StatusReportingInterval time.Duration
 
 	ConfigChangedRestartCallback func()
+	FatalErrorRestartCallback    func(error)
 
 	PostInSyncCallback func()
 	HealthAggregator   *health.HealthAggregator
@@ -283,7 +284,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		toDataplane:      make(chan interface{}, msgPeekLimit),
 		fromDataplane:    make(chan interface{}, 100),
 		ruleRenderer:     ruleRenderer,
-		ifaceMonitor:     ifacemonitor.New(config.IfaceMonitorConfig),
+		ifaceMonitor:     ifacemonitor.New(config.IfaceMonitorConfig, config.FatalErrorRestartCallback),
 		ifaceUpdates:     make(chan *ifaceUpdate, 100),
 		ifaceAddrUpdates: make(chan *ifaceAddrsUpdate, 100),
 		config:           config,

--- a/ifacemonitor/ifacemonitor_test.go
+++ b/ifacemonitor/ifacemonitor_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package ifacemonitor_test
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -45,6 +46,7 @@ type netlinkTest struct {
 	linkUpdates    chan netlink.LinkUpdate
 	routeUpdates   chan netlink.RouteUpdate
 	userSubscribed chan int
+	cancel         chan struct{}
 
 	nextIndex int
 	links     map[string]linkModel
@@ -53,7 +55,8 @@ type netlinkTest struct {
 	// possible after we've read and/or written that data - instead of using defer - because we
 	// don't want to hold the mutex when writing to a channel (which is often what happens next
 	// in the same function).
-	linksMutex sync.Mutex
+	linksMutex  sync.Mutex
+	LinkListErr error
 }
 
 type addrState struct {
@@ -222,14 +225,19 @@ func (nl *netlinkTest) signalAddr(name string, addr string, exists bool) {
 func (nl *netlinkTest) Subscribe(
 	linkUpdates chan netlink.LinkUpdate,
 	routeUpdates chan netlink.RouteUpdate,
-) error {
+) (chan struct{}, error) {
 	nl.linkUpdates = linkUpdates
 	nl.routeUpdates = routeUpdates
+	nl.cancel = make(chan struct{})
 	nl.userSubscribed <- 1
-	return nil
+	return nl.cancel, nil
 }
 
 func (nl *netlinkTest) LinkList() ([]netlink.Link, error) {
+	if nl.LinkListErr != nil {
+		return nil, nl.LinkListErr
+	}
+
 	links := []netlink.Link{}
 	nl.linksMutex.Lock()
 	for name, link := range nl.links {
@@ -383,9 +391,12 @@ func (dp *mockDataplane) expectAddrStateCb(ifaceName string, addr string, presen
 	}
 }
 
+var errFatal = errors.New("fatal error")
+
 var _ = Describe("ifacemonitor", func() {
 	var nl *netlinkTest
 	var resyncC chan time.Time
+	var fatalErrC chan struct{}
 	var im *ifacemonitor.InterfaceMonitor
 	var dp *mockDataplane
 
@@ -405,7 +416,13 @@ var _ = Describe("ifacemonitor", func() {
 				regexp.MustCompile("dummy"),
 			},
 		}
-		im = ifacemonitor.NewWithStubs(config, nl, resyncC)
+		fatalErrC = make(chan struct{})
+		fatalErrCallback := func(err error) {
+			log.WithError(err).Info("Fatal error reported")
+			close(fatalErrC) // Signal to test code that we saw the fatal error callback.
+			panic(errFatal)  // Break out of the MonitorInterfaces goroutine (this panic is recovered below).
+		}
+		im = ifacemonitor.NewWithStubs(config, nl, resyncC, fatalErrCallback)
 
 		// Register this test code's callbacks, which (a) log; and (b) send to a 1- or
 		// 2-buffered channel, so that the test code _must_ explicitly indicate when it
@@ -421,11 +438,35 @@ var _ = Describe("ifacemonitor", func() {
 		}
 		im.StateCallback = dp.linkStateCallback
 		im.AddrCallback = dp.addrStateCallback
+	})
 
+	JustBeforeEach(func() {
 		// Start the monitor running, and wait until it has subscribed to our test netlink
 		// stub.
-		go im.MonitorInterfaces()
-		<-nl.userSubscribed
+		go func() {
+			defer GinkgoRecover()
+			defer func() {
+				v := recover()
+				if v == errFatal { // Our expected fatal error.
+					return
+				}
+				panic(v)
+			}()
+			im.MonitorInterfaces()
+		}()
+		Eventually(nl.userSubscribed).Should(Receive())
+		log.Info("Monitor interfaces subscribed")
+	})
+
+	Context("with an error from LinkList", func() {
+		BeforeEach(func() {
+			nl.LinkListErr = fmt.Errorf("dummy err")
+		})
+
+		It("should report a fatal error", func() {
+			log.Info("Waiting for fatal error...")
+			Eventually(fatalErrC).Should(BeClosed())
+		})
 	})
 
 	It("should skip netlink address updates for ipvs", func() {
@@ -475,6 +516,8 @@ var _ = Describe("ifacemonitor", func() {
 
 		// Repeat test for third interface exclude entry
 		netlinkUpdates("0dummy1")
+
+		Expect(fatalErrC).ToNot(BeClosed())
 	})
 
 	It("should handle mainline netlink updates", func() {
@@ -534,6 +577,8 @@ var _ = Describe("ifacemonitor", func() {
 		// ready to read it.)
 		resyncC <- time.Time{}
 		resyncC <- time.Time{}
+
+		Expect(fatalErrC).ToNot(BeClosed())
 	})
 
 	It("should handle an interface rename", func() {
@@ -570,6 +615,8 @@ var _ = Describe("ifacemonitor", func() {
 		// ready to read it.)
 		resyncC <- time.Time{}
 		resyncC <- time.Time{}
+
+		Expect(fatalErrC).ToNot(BeClosed())
 	})
 
 	It("should handle link flap", func() {
@@ -603,5 +650,23 @@ var _ = Describe("ifacemonitor", func() {
 
 		// Now we should see an address callback again.
 		dp.expectAddrStateCb("eth0", "10.0.240.10", true)
+
+		Expect(fatalErrC).ToNot(BeClosed())
+	})
+
+	It("should reconnect to netlink if channel goes down", func() {
+		oldCancel := nl.cancel
+		close(nl.linkUpdates)
+		Eventually(oldCancel).Should(BeClosed())
+		Eventually(nl.userSubscribed).Should(Receive())
+		Expect(fatalErrC).ToNot(BeClosed())
+	})
+
+	It("should report a fatal error if routes channel goes down", func() {
+		oldCancel := nl.cancel
+		close(nl.routeUpdates)
+		Eventually(oldCancel).Should(BeClosed())
+		Eventually(nl.userSubscribed).Should(Receive())
+		Expect(fatalErrC).ToNot(BeClosed())
 	})
 })

--- a/ifacemonitor/update_filter_test.go
+++ b/ifacemonitor/update_filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,6 +34,26 @@ const (
 	chanPollTime  = "10ms"
 	chanPollIntvl = "100us"
 )
+
+func TestUpdateFilter_FilterUpdates_LinkCClosed(t *testing.T) {
+	t.Log("Link channel closure should be propagated to output channel")
+	harness, cancel := setUpFilterTest(t)
+	defer cancel()
+
+	close(harness.LinkIn)
+	Eventually(harness.LinkOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+	Eventually(harness.RouteOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+}
+
+func TestUpdateFilter_FilterUpdates_RouteCClosed(t *testing.T) {
+	t.Log("Link channel closure should be propagated to output channel")
+	harness, cancel := setUpFilterTest(t)
+	defer cancel()
+
+	close(harness.RouteIn)
+	Eventually(harness.LinkOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+	Eventually(harness.RouteOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+}
 
 func TestUpdateFilter_FilterUpdates_LinkUpdateDelay(t *testing.T) {
 	t.Log("Link updates should be delayed")


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Cherry pick of #2710.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that, after a netlink read failure, Felix would tight loop reading from a closed channel.  Restart the event poll in that case.
```
