### PR TITLE
[v3.15] Handle failure of netlink channel.  Reconnect and resync

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -48,6 +48,12 @@ blocks:
   task:
     prologue:
       commands:
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during the build.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
       # Free up space on the build machine.
       - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl
       - checkout

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -79,9 +79,13 @@ const (
 	// String sent on the failure report channel to indicate we're shutting down for config
 	// change.
 	reasonConfigChanged = "config changed"
+	reasonFatalError    = "fatal error"
 	// Process return code used to report a config change.  This is the same as the code used
 	// by SIGHUP, which means that the wrapper script also restarts Felix on a SIGHUP.
 	configChangedRC = 129
+
+	// Grace period we allow for graceful shutdown before panicking.
+	gracefulShutdownTimeout = 30 * time.Second
 )
 
 // Run is the entry point to run a Felix instance.
@@ -367,12 +371,23 @@ configRetry:
 	var dpDriverCmd *exec.Cmd
 
 	failureReportChan := make(chan string)
-	configChangedRestartCallback := func() { failureReportChan <- reasonConfigChanged }
+	configChangedRestartCallback := func() {
+		failureReportChan <- reasonConfigChanged
+		time.Sleep(gracefulShutdownTimeout)
+		log.Panic("Graceful shutdown took too long")
+	}
+	fatalErrorCallback := func(err error) {
+		log.WithError(err).Error("Shutting down due to fatal error")
+		failureReportChan <- reasonFatalError
+		time.Sleep(gracefulShutdownTimeout)
+		log.Panic("Graceful shutdown took too long")
+	}
 
 	dpDriver, dpDriverCmd = dp.StartDataplaneDriver(
 		configParams.Copy(), // Copy to avoid concurrent access.
 		healthAggregator,
 		configChangedRestartCallback,
+		fatalErrorCallback,
 		k8sClientSet)
 
 	// Initialise the glue logic that connects the calculation graph to/from the dataplane driver.

--- a/dataplane/driver.go
+++ b/dataplane/driver.go
@@ -47,6 +47,7 @@ import (
 func StartDataplaneDriver(configParams *config.Config,
 	healthAggregator *health.HealthAggregator,
 	configChangedRestartCallback func(),
+	fatalErrorCallback func(error),
 	k8sClientSet *kubernetes.Clientset) (DataplaneDriver, *exec.Cmd) {
 
 	if !configParams.IsLeader() {
@@ -62,7 +63,7 @@ func StartDataplaneDriver(configParams *config.Config,
 		if kubeIPVSSupportEnabled {
 			log.Info("Kube-proxy in ipvs mode, enabling felix kube-proxy ipvs support.")
 		}
-		if configChangedRestartCallback == nil {
+		if configChangedRestartCallback == nil || fatalErrorCallback == nil {
 			log.Panic("Starting dataplane with nil callback func.")
 		}
 
@@ -242,6 +243,7 @@ func StartDataplaneDriver(configParams *config.Config,
 			NetlinkTimeout: configParams.NetlinkTimeoutSecs,
 
 			ConfigChangedRestartCallback: configChangedRestartCallback,
+			FatalErrorRestartCallback:    fatalErrorCallback,
 
 			PostInSyncCallback: func() {
 				// The initial resync uses a lot of scratch space so now is

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,6 +145,7 @@ type Config struct {
 	StatusReportingInterval time.Duration
 
 	ConfigChangedRestartCallback func()
+	FatalErrorRestartCallback    func(error)
 
 	PostInSyncCallback func()
 	HealthAggregator   *health.HealthAggregator
@@ -283,7 +284,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		fromDataplane:     make(chan interface{}, 100),
 		ruleRenderer:      ruleRenderer,
 		interfacePrefixes: config.RulesConfig.WorkloadIfacePrefixes,
-		ifaceMonitor:      ifacemonitor.New(config.IfaceMonitorConfig),
+		ifaceMonitor:      ifacemonitor.New(config.IfaceMonitorConfig, config.FatalErrorRestartCallback),
 		ifaceUpdates:      make(chan *ifaceUpdate, 100),
 		ifaceAddrUpdates:  make(chan *ifaceAddrsUpdate, 100),
 		config:            config,

--- a/fv/wireguard_test.go
+++ b/fv/wireguard_test.go
@@ -19,11 +19,12 @@ package fv_test
 import (
 	"context"
 	"fmt"
-	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	"os"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -257,7 +258,7 @@ var _ = infrastructure.DatastoreDescribe("WireGuard-Supported", []apiconfig.Data
 	Context("traffic with Wireguard enabled", func() {
 		// Checks the TCP dump for a count value. Retries until count is correct, or fails after 1.5s.
 		waitForPackets := func(t *tcpdump.TCPDump, timeout time.Time, name string, num int) error {
-			for ;; time.Now().Before(timeout) {
+			for ; ; time.Now().Before(timeout) {
 				if num == 0 && t.MatchCount(name) > 0 {
 					// We expect no traffic, but got some.  Error immediately.
 					break
@@ -308,7 +309,7 @@ var _ = infrastructure.DatastoreDescribe("WireGuard-Supported", []apiconfig.Data
 			// Now check the packet counts are as expected. We should have no WL->WL traffic visible on eth0, but
 			// we should be able to see tunnel traffic. Since we want to verify
 			By("Checking the packet stats from tcpdump")
-			timeout := time.Now().Add(2*time.Second)
+			timeout := time.Now().Add(2 * time.Second)
 			for i := range felixes {
 				if err := waitForPackets(tcpdumps[i], timeout, "numInTunnelPackets", 10); err != nil {
 					return err

--- a/ifacemonitor/iface_monitor.go
+++ b/ifacemonitor/iface_monitor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package ifacemonitor
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"syscall"
 	"time"
@@ -31,7 +32,7 @@ type netlinkStub interface {
 	Subscribe(
 		linkUpdates chan netlink.LinkUpdate,
 		routeUpdates chan netlink.RouteUpdate,
-	) error
+	) (cancel chan struct{}, err error)
 	LinkList() ([]netlink.Link, error)
 	ListLocalRoutes(link netlink.Link, family int) ([]netlink.Route, error)
 }
@@ -54,29 +55,31 @@ type Config struct {
 type InterfaceMonitor struct {
 	Config
 
-	netlinkStub   netlinkStub
-	resyncC       <-chan time.Time
-	upIfaces      map[string]int // Map from interface name to index.
-	StateCallback InterfaceStateCallback
-	AddrCallback  AddrStateCallback
-	ifaceName     map[int]string
-	ifaceAddrs    map[int]set.Set
+	netlinkStub      netlinkStub
+	resyncC          <-chan time.Time
+	upIfaces         map[string]int // Map from interface name to index.
+	StateCallback    InterfaceStateCallback
+	AddrCallback     AddrStateCallback
+	ifaceName        map[int]string
+	ifaceAddrs       map[int]set.Set
+	fatalErrCallback func(error)
 }
 
-func New(config Config) *InterfaceMonitor {
+func New(config Config, fatalErrCallback func(error)) *InterfaceMonitor {
 	// Interface monitor using the real netlink, and resyncing every 10 seconds.
 	resyncTicker := time.NewTicker(10 * time.Second)
-	return NewWithStubs(config, &netlinkReal{}, resyncTicker.C)
+	return NewWithStubs(config, &netlinkReal{}, resyncTicker.C, fatalErrCallback)
 }
 
-func NewWithStubs(config Config, netlinkStub netlinkStub, resyncC <-chan time.Time) *InterfaceMonitor {
+func NewWithStubs(config Config, netlinkStub netlinkStub, resyncC <-chan time.Time, fatalErrCallback func(error)) *InterfaceMonitor {
 	return &InterfaceMonitor{
-		Config:      config,
-		netlinkStub: netlinkStub,
-		resyncC:     resyncC,
-		upIfaces:    map[string]int{},
-		ifaceName:   map[int]string{},
-		ifaceAddrs:  map[int]set.Set{},
+		Config:           config,
+		netlinkStub:      netlinkStub,
+		resyncC:          resyncC,
+		upIfaces:         map[string]int{},
+		ifaceName:        map[int]string{},
+		ifaceAddrs:       map[int]set.Set{},
+		fatalErrCallback: fatalErrCallback,
 	}
 }
 
@@ -88,55 +91,66 @@ func IsInterfacePresent(name string) bool {
 func (m *InterfaceMonitor) MonitorInterfaces() {
 	log.Info("Interface monitoring thread started.")
 
-	updates := make(chan netlink.LinkUpdate, 10)
-	routeUpdates := make(chan netlink.RouteUpdate, 10)
-	if err := m.netlinkStub.Subscribe(updates, routeUpdates); err != nil {
-		log.WithError(err).Panic("Failed to subscribe to netlink stub")
-	}
-	filteredUpdates := make(chan netlink.LinkUpdate, 10)
-	filteredRouteUpdates := make(chan netlink.RouteUpdate, 10)
-	go FilterUpdates(context.Background(), filteredRouteUpdates, routeUpdates, filteredUpdates, updates)
-	log.Info("Subscribed to netlink updates.")
-
-	// Start of day, do a resync to notify all our existing interfaces.  We also do periodic
-	// resyncs because it's not clear what the ordering guarantees are for our netlink
-	// subscription vs a list operation as used by resync().
-	err := m.resync()
-	if err != nil {
-		log.WithError(err).Panic("Failed to read link states from netlink.")
-	}
-
-readLoop:
+	// Reconnection loop.
 	for {
-		log.WithFields(log.Fields{
-			"updates":      filteredUpdates,
-			"routeUpdates": filteredRouteUpdates,
-			"resyncC":      m.resyncC,
-		}).Debug("About to select on possible triggers")
-		select {
-		case update, ok := <-filteredUpdates:
-			log.WithField("update", update).Debug("Link update")
-			if !ok {
-				log.Warn("Failed to read a link update")
-				break readLoop
+		var nlCancelC chan struct{}
+		filterUpdatesCtx, filterUpdatesCancel := context.WithCancel(context.Background())
+		filteredUpdates := make(chan netlink.LinkUpdate, 10)
+		filteredRouteUpdates := make(chan netlink.RouteUpdate, 10)
+		{
+			updates := make(chan netlink.LinkUpdate, 10)
+			routeUpdates := make(chan netlink.RouteUpdate, 10)
+			var err error
+			if nlCancelC, err = m.netlinkStub.Subscribe(updates, routeUpdates); err != nil {
+				// If we can't even subscribe, something must have gone very wrong.  Bail.
+				m.fatalErrCallback(fmt.Errorf("failed to subscribe to netlink: %w", err))
 			}
-			m.handleNetlinkUpdate(update)
-		case routeUpdate, ok := <-filteredRouteUpdates:
-			log.WithField("addrUpdate", routeUpdate).Debug("Address update")
-			if !ok {
-				log.Warn("Failed to read an address update")
-				break readLoop
-			}
-			m.handleNetlinkRouteUpdate(routeUpdate)
-		case <-m.resyncC:
-			log.Debug("Resync trigger")
-			err := m.resync()
-			if err != nil {
-				log.WithError(err).Panic("Failed to read link states from netlink.")
+			go FilterUpdates(filterUpdatesCtx, filteredRouteUpdates, routeUpdates, filteredUpdates, updates)
+		}
+		log.Info("Subscribed to netlink updates.")
+
+		// Do a resync to notify all our existing interfaces.  We also do periodic
+		// resyncs because it's not clear what the ordering guarantees are for our netlink
+		// subscription vs a list operation as used by resync().
+		err := m.resync()
+		if err != nil {
+			m.fatalErrCallback(fmt.Errorf("failed to read from netlink (initial resync): %w", err))
+		}
+
+	readLoop:
+		for {
+			log.WithFields(log.Fields{
+				"updates":      filteredUpdates,
+				"routeUpdates": filteredRouteUpdates,
+				"resyncC":      m.resyncC,
+			}).Debug("About to select on possible triggers")
+			select {
+			case update, ok := <-filteredUpdates:
+				log.WithField("update", update).Debug("Link update")
+				if !ok {
+					log.Warn("Failed to read a link update")
+					break readLoop
+				}
+				m.handleNetlinkUpdate(update)
+			case routeUpdate, ok := <-filteredRouteUpdates:
+				log.WithField("addrUpdate", routeUpdate).Debug("Address update")
+				if !ok {
+					log.Warn("Failed to read an address update")
+					break readLoop
+				}
+				m.handleNetlinkRouteUpdate(routeUpdate)
+			case <-m.resyncC:
+				log.Debug("Resync trigger")
+				err := m.resync()
+				if err != nil {
+					m.fatalErrCallback(fmt.Errorf("failed to read from netlink (resync): %w", err))
+				}
 			}
 		}
+		close(nlCancelC)
+		filterUpdatesCancel()
+		log.Warn("Reconnecting to netlink after a failure...")
 	}
-	log.Panic("Failed to read events from Netlink.")
 }
 
 func (m *InterfaceMonitor) isExcludedInterface(ifName string) bool {

--- a/ifacemonitor/ifacemonitor_test.go
+++ b/ifacemonitor/ifacemonitor_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package ifacemonitor_test
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -45,6 +46,7 @@ type netlinkTest struct {
 	linkUpdates    chan netlink.LinkUpdate
 	routeUpdates   chan netlink.RouteUpdate
 	userSubscribed chan int
+	cancel         chan struct{}
 
 	nextIndex int
 	links     map[string]linkModel
@@ -53,7 +55,8 @@ type netlinkTest struct {
 	// possible after we've read and/or written that data - instead of using defer - because we
 	// don't want to hold the mutex when writing to a channel (which is often what happens next
 	// in the same function).
-	linksMutex sync.Mutex
+	linksMutex  sync.Mutex
+	LinkListErr error
 }
 
 type addrState struct {
@@ -222,14 +225,19 @@ func (nl *netlinkTest) signalAddr(name string, addr string, exists bool) {
 func (nl *netlinkTest) Subscribe(
 	linkUpdates chan netlink.LinkUpdate,
 	routeUpdates chan netlink.RouteUpdate,
-) error {
+) (chan struct{}, error) {
 	nl.linkUpdates = linkUpdates
 	nl.routeUpdates = routeUpdates
+	nl.cancel = make(chan struct{})
 	nl.userSubscribed <- 1
-	return nil
+	return nl.cancel, nil
 }
 
 func (nl *netlinkTest) LinkList() ([]netlink.Link, error) {
+	if nl.LinkListErr != nil {
+		return nil, nl.LinkListErr
+	}
+
 	links := []netlink.Link{}
 	nl.linksMutex.Lock()
 	for name, link := range nl.links {
@@ -383,9 +391,12 @@ func (dp *mockDataplane) expectAddrStateCb(ifaceName string, addr string, presen
 	}
 }
 
+var errFatal = errors.New("fatal error")
+
 var _ = Describe("ifacemonitor", func() {
 	var nl *netlinkTest
 	var resyncC chan time.Time
+	var fatalErrC chan struct{}
 	var im *ifacemonitor.InterfaceMonitor
 	var dp *mockDataplane
 
@@ -405,7 +416,13 @@ var _ = Describe("ifacemonitor", func() {
 				regexp.MustCompile("dummy"),
 			},
 		}
-		im = ifacemonitor.NewWithStubs(config, nl, resyncC)
+		fatalErrC = make(chan struct{})
+		fatalErrCallback := func(err error) {
+			log.WithError(err).Info("Fatal error reported")
+			close(fatalErrC) // Signal to test code that we saw the fatal error callback.
+			panic(errFatal)  // Break out of the MonitorInterfaces goroutine (this panic is recovered below).
+		}
+		im = ifacemonitor.NewWithStubs(config, nl, resyncC, fatalErrCallback)
 
 		// Register this test code's callbacks, which (a) log; and (b) send to a 1- or
 		// 2-buffered channel, so that the test code _must_ explicitly indicate when it
@@ -421,11 +438,35 @@ var _ = Describe("ifacemonitor", func() {
 		}
 		im.StateCallback = dp.linkStateCallback
 		im.AddrCallback = dp.addrStateCallback
+	})
 
+	JustBeforeEach(func() {
 		// Start the monitor running, and wait until it has subscribed to our test netlink
 		// stub.
-		go im.MonitorInterfaces()
-		<-nl.userSubscribed
+		go func() {
+			defer GinkgoRecover()
+			defer func() {
+				v := recover()
+				if v == errFatal { // Our expected fatal error.
+					return
+				}
+				panic(v)
+			}()
+			im.MonitorInterfaces()
+		}()
+		Eventually(nl.userSubscribed).Should(Receive())
+		log.Info("Monitor interfaces subscribed")
+	})
+
+	Context("with an error from LinkList", func() {
+		BeforeEach(func() {
+			nl.LinkListErr = fmt.Errorf("dummy err")
+		})
+
+		It("should report a fatal error", func() {
+			log.Info("Waiting for fatal error...")
+			Eventually(fatalErrC).Should(BeClosed())
+		})
 	})
 
 	It("should skip netlink address updates for ipvs", func() {
@@ -475,6 +516,8 @@ var _ = Describe("ifacemonitor", func() {
 
 		// Repeat test for third interface exclude entry
 		netlinkUpdates("0dummy1")
+
+		Expect(fatalErrC).ToNot(BeClosed())
 	})
 
 	It("should handle mainline netlink updates", func() {
@@ -534,6 +577,8 @@ var _ = Describe("ifacemonitor", func() {
 		// ready to read it.)
 		resyncC <- time.Time{}
 		resyncC <- time.Time{}
+
+		Expect(fatalErrC).ToNot(BeClosed())
 	})
 
 	It("should handle an interface rename", func() {
@@ -570,6 +615,8 @@ var _ = Describe("ifacemonitor", func() {
 		// ready to read it.)
 		resyncC <- time.Time{}
 		resyncC <- time.Time{}
+
+		Expect(fatalErrC).ToNot(BeClosed())
 	})
 
 	It("should handle link flap", func() {
@@ -603,5 +650,23 @@ var _ = Describe("ifacemonitor", func() {
 
 		// Now we should see an address callback again.
 		dp.expectAddrStateCb("eth0", "10.0.240.10", true)
+
+		Expect(fatalErrC).ToNot(BeClosed())
+	})
+
+	It("should reconnect to netlink if channel goes down", func() {
+		oldCancel := nl.cancel
+		close(nl.linkUpdates)
+		Eventually(oldCancel).Should(BeClosed())
+		Eventually(nl.userSubscribed).Should(Receive())
+		Expect(fatalErrC).ToNot(BeClosed())
+	})
+
+	It("should report a fatal error if routes channel goes down", func() {
+		oldCancel := nl.cancel
+		close(nl.routeUpdates)
+		Eventually(oldCancel).Should(BeClosed())
+		Eventually(nl.userSubscribed).Should(Receive())
+		Expect(fatalErrC).ToNot(BeClosed())
 	})
 })

--- a/ifacemonitor/update_filter.go
+++ b/ifacemonitor/update_filter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,9 +49,13 @@ func WithTimeShim(t timeshim.Time) UpdateFilterOp {
 // * When we see a potential flap (i.e. an IP deletion), defer processing the queue for a while.
 // * If the flap resolves itself (i.e. the IP is added back), suppress the IP deletion.
 func FilterUpdates(ctx context.Context,
-	addrOutC chan<- netlink.RouteUpdate, routeInC <-chan netlink.RouteUpdate,
+	routeOutC chan<- netlink.RouteUpdate, routeInC <-chan netlink.RouteUpdate,
 	linkOutC chan<- netlink.LinkUpdate, linkInC <-chan netlink.LinkUpdate,
-	options ...UpdateFilterOp) {
+	options ...UpdateFilterOp,
+) {
+	// Propagate failures to the downstream channels.
+	defer close(routeOutC)
+	defer close(linkOutC)
 
 	u := &updateFilter{
 		Time: timeshim.NewRealTime(),
@@ -76,7 +80,11 @@ mainLoop:
 		case <-ctx.Done():
 			logrus.Info("FilterUpdates: Context expired, stopping")
 			return
-		case linkUpd := <-linkInC:
+		case linkUpd, ok := <-linkInC:
+			if !ok {
+				logrus.Error("FilterUpdates: link input channel closed.")
+				return
+			}
 			idx := int(linkUpd.Index)
 			linkIsUp := linkUpd.Header.Type == syscall.RTM_NEWLINK && linkIsOperUp(linkUpd.Link)
 			var delay time.Duration
@@ -99,7 +107,11 @@ mainLoop:
 					ReadyAt: u.Time.Now().Add(delay),
 					Update:  linkUpd,
 				})
-		case routeUpd := <-routeInC:
+		case routeUpd, ok := <-routeInC:
+			if !ok {
+				logrus.Error("FilterUpdates: route input channel closed.")
+				return
+			}
 			logrus.WithField("route", routeUpd).Debug("Route update")
 			if routeUpd.Route.Type&unix.RTN_LOCAL == 0 {
 				logrus.WithField("route", routeUpd).Debug("Ignoring non-local route.")
@@ -121,7 +133,7 @@ mainLoop:
 					// Short circuit.  We care about flaps where IPs are temporarily removed so no need to
 					// delay an add.
 					logrus.Debug("FilterUpdates: add with empty queue, short circuit.")
-					addrOutC <- routeUpd
+					routeOutC <- routeUpd
 					continue
 				}
 
@@ -177,7 +189,7 @@ mainLoop:
 					logrus.WithField("update", firstUpd).Debug("FilterUpdates: update ready to send.")
 					switch u := firstUpd.Update.(type) {
 					case netlink.RouteUpdate:
-						addrOutC <- u
+						routeOutC <- u
 					case netlink.LinkUpdate:
 						linkOutC <- u
 					}

--- a/ifacemonitor/update_filter_test.go
+++ b/ifacemonitor/update_filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,26 @@ const (
 	chanPollTime  = "10ms"
 	chanPollIntvl = "100us"
 )
+
+func TestUpdateFilter_FilterUpdates_LinkCClosed(t *testing.T) {
+	t.Log("Link channel closure should be propagated to output channel")
+	harness, cancel := setUpFilterTest(t)
+	defer cancel()
+
+	close(harness.LinkIn)
+	Eventually(harness.LinkOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+	Eventually(harness.RouteOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+}
+
+func TestUpdateFilter_FilterUpdates_RouteCClosed(t *testing.T) {
+	t.Log("Link channel closure should be propagated to output channel")
+	harness, cancel := setUpFilterTest(t)
+	defer cancel()
+
+	close(harness.RouteIn)
+	Eventually(harness.LinkOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+	Eventually(harness.RouteOut, chanPollTime, chanPollIntvl).Should(BeClosed())
+}
 
 func TestUpdateFilter_FilterUpdates_LinkUpdateDelay(t *testing.T) {
 	t.Log("Link updates should be delayed")

--- a/proto/felixbackend.pb.go
+++ b/proto/felixbackend.pb.go
@@ -69,16 +69,21 @@
 */
 package proto
 
-import proto1 "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import context "golang.org/x/net/context"
-import grpc "google.golang.org/grpc"
+	proto1 "github.com/gogo/protobuf/proto"
 
-import binary "encoding/binary"
+	math "math"
 
-import io "io"
+	context "golang.org/x/net/context"
+
+	grpc "google.golang.org/grpc"
+
+	binary "encoding/binary"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto1.Marshal

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -57,9 +57,9 @@ const (
 	IPSetIDNATOutgoingAllPools  = "all-ipam-pools"
 	IPSetIDNATOutgoingMasqPools = "masq-ipam-pools"
 
-	IPSetIDAllHostNets          = "all-hosts-net"
-	IPSetIDAllVXLANSourceNets   = "all-vxlan-net"
-	IPSetIDThisHostIPs          = "this-host"
+	IPSetIDAllHostNets        = "all-hosts-net"
+	IPSetIDAllVXLANSourceNets = "all-vxlan-net"
+	IPSetIDThisHostIPs        = "this-host"
 
 	ChainFIPDnat = ChainNamePrefix + "fip-dnat"
 	ChainFIPSnat = ChainNamePrefix + "fip-snat"


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Cherry pick of #2710.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that, after a netlink read failure, Felix would tight loop reading from a closed channel.  Restart the event poll in that case.
```
