### PR TITLE
bpf: set rc to TC_ACT_UNSPEC if CALI_RES_REDIR_IFINDEX fails

### DIFF
--- a/bpf-gpl/fib.h
+++ b/bpf-gpl/fib.h
@@ -106,6 +106,7 @@ static CALI_BPF_INLINE int forward_or_drop(struct cali_tc_ctx *ctx)
 skip_redir_ifindex:
 		CALI_DEBUG("Redirect directly to interface (%d) failed.\n", iface);
 		/* fall through to FIB if enabled or the IP stack, don't give up yet. */
+		rc = TC_ACT_UNSPEC;
 	}
 
 #if CALI_FIB_ENABLED


### PR DESCRIPTION
If we fallback to fib/netstack we need to return a value that would let
the packet through.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
