### PR TITLE
Exclude network from failsafe rules for IPv6

### DIFF
--- a/rules/static.go
+++ b/rules/static.go
@@ -40,7 +40,7 @@ func (r *DefaultRuleRenderer) StaticFilterInputChains(ipVersion uint8) []*Chain 
 	result = append(result,
 		r.filterInputChain(ipVersion),
 		r.filterWorkloadToHostChain(ipVersion),
-		r.failsafeInChain("filter"),
+		r.failsafeInChain("filter", ipVersion),
 	)
 	if r.KubeIPVSSupportEnabled {
 		result = append(result, r.StaticFilterInputForwardCheckChain(ipVersion))
@@ -397,17 +397,24 @@ func (r *DefaultRuleRenderer) filterWorkloadToHostChain(ipVersion uint8) *Chain 
 	}
 }
 
-func (r *DefaultRuleRenderer) failsafeInChain(table string) *Chain {
+func (r *DefaultRuleRenderer) failsafeInChain(table string, ipVersion uint8) *Chain {
 	rules := []Rule{}
 
 	for _, protoPort := range r.Config.FailsafeInboundHostPorts {
-		rules = append(rules, Rule{
+		rule := Rule{
 			Match: Match().
 				Protocol(protoPort.Protocol).
-				DestPorts(protoPort.Port).
-				SourceNet(protoPort.Net),
+				DestPorts(protoPort.Port),
 			Action: AcceptAction{},
-		})
+		}
+		// Add a network for IPv4 failsafes
+		if ipVersion == 4 {
+			rule.Match = Match().
+				Protocol(protoPort.Protocol).
+				DestPorts(protoPort.Port).
+				SourceNet(protoPort.Net)
+		}
+		rules = append(rules, rule)
 	}
 
 	if table == "raw" {
@@ -432,17 +439,24 @@ func (r *DefaultRuleRenderer) failsafeInChain(table string) *Chain {
 	}
 }
 
-func (r *DefaultRuleRenderer) failsafeOutChain(table string) *Chain {
+func (r *DefaultRuleRenderer) failsafeOutChain(table string, ipVersion uint8) *Chain {
 	rules := []Rule{}
 
+	dstRule := Rule{
+		Match: Match().
+			Protocol(protoPort.Protocol).
+			DestPorts(protoPort.Port),
+		Action: AcceptAction{},
+	}
+	// Add a network for IPv4 failsafes
+	if ipVersion == 4 {
+		dstRule.Match = Match().
+			Protocol(protoPort.Protocol).
+			DestPorts(protoPort.Port).
+			DestNet(protoPort.Net)
+	}
 	for _, protoPort := range r.Config.FailsafeOutboundHostPorts {
-		rules = append(rules, Rule{
-			Match: Match().
-				Protocol(protoPort.Protocol).
-				DestPorts(protoPort.Port).
-				DestNet(protoPort.Net),
-			Action: AcceptAction{},
-		})
+		rules = append(rules, dstRule)
 	}
 
 	if table == "raw" {
@@ -450,14 +464,21 @@ func (r *DefaultRuleRenderer) failsafeOutChain(table string) *Chain {
 		// Otherwise, it could fall through to some doNotTrack policy and half of the connection
 		// would get untracked.  If we ACCEPT here then the traffic falls through to the filter
 		// table, where it'll only be accepted if there's a conntrack entry.
+		srcRule := Rule{
+			Match: Match().
+				Protocol(protoPort.Protocol).
+				SourcePorts(protoPort.Port),
+			Action: AcceptAction{},
+		}
+		// Add a network for IPv4 failsafes
+		if ipVersion == 4 {
+			srcRule.Match = Match().
+				Protocol(protoPort.Protocol).
+				SourcePorts(protoPort.Port).
+				SourceNet(protoPort.Net)
+		}
 		for _, protoPort := range r.Config.FailsafeInboundHostPorts {
-			rules = append(rules, Rule{
-				Match: Match().
-					Protocol(protoPort.Protocol).
-					SourcePorts(protoPort.Port).
-					SourceNet(protoPort.Net),
-				Action: AcceptAction{},
-			})
+			rules = append(rules, srcRule)
 		}
 	}
 
@@ -553,7 +574,7 @@ func (r *DefaultRuleRenderer) StaticFilterOutputChains(ipVersion uint8) []*Chain
 	result := []*Chain{}
 	result = append(result,
 		r.filterOutputChain(ipVersion),
-		r.failsafeOutChain("filter"),
+		r.failsafeOutChain("filter", ipVersion),
 	)
 
 	if r.KubeIPVSSupportEnabled {
@@ -784,8 +805,8 @@ func (r *DefaultRuleRenderer) StaticMangleTableChains(ipVersion uint8) []*Chain 
 	var chains []*Chain
 
 	chains = append(chains,
-		r.failsafeInChain("mangle"),
-		r.failsafeOutChain("mangle"),
+		r.failsafeInChain("mangle", ipVersion),
+		r.failsafeOutChain("mangle", ipVersion),
 		r.StaticManglePreroutingChain(ipVersion),
 		r.StaticManglePostroutingChain(ipVersion),
 	)
@@ -919,8 +940,8 @@ func (r *DefaultRuleRenderer) StaticManglePostroutingChain(ipVersion uint8) *Cha
 
 func (r *DefaultRuleRenderer) StaticRawTableChains(ipVersion uint8) []*Chain {
 	return []*Chain{
-		r.failsafeInChain("raw"),
-		r.failsafeOutChain("raw"),
+		r.failsafeInChain("raw", ipVersion),
+		r.failsafeOutChain("raw", ipVersion),
 		r.StaticRawPreroutingChain(ipVersion),
 		r.StaticRawOutputChain(),
 	}

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -160,37 +160,75 @@ var _ = Describe("Static", func() {
 					expRawFailsafeIn := &Chain{
 						Name: "cali-failsafe-in",
 						Rules: []Rule{
-							{Match: Match().Protocol("tcp").DestPorts(22).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").DestPorts(1022).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").SourcePorts(23).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").SourcePorts(1023).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(22), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(1022), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").SourcePorts(23), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").SourcePorts(1023), Action: AcceptAction{}},
 						},
 					}
 
 					expRawFailsafeOut := &Chain{
 						Name: "cali-failsafe-out",
 						Rules: []Rule{
-							{Match: Match().Protocol("tcp").DestPorts(23).DestNet("0.0.0.0/0"), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").DestPorts(1023).DestNet("0.0.0.0/0"), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").SourcePorts(22).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").SourcePorts(1022).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(23), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(1023), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").SourcePorts(22), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").SourcePorts(1022), Action: AcceptAction{}},
 						},
 					}
 
 					expFailsafeIn := &Chain{
 						Name: "cali-failsafe-in",
 						Rules: []Rule{
-							{Match: Match().Protocol("tcp").DestPorts(22).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").DestPorts(1022).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(22), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(1022), Action: AcceptAction{}},
 						},
 					}
 
 					expFailsafeOut := &Chain{
 						Name: "cali-failsafe-out",
 						Rules: []Rule{
-							{Match: Match().Protocol("tcp").DestPorts(23).DestNet("0.0.0.0/0"), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").DestPorts(1023).DestNet("0.0.0.0/0"), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(23), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(1023), Action: AcceptAction{}},
 						},
+					}
+
+					if ipVersion == 4 {
+						expRawFailsafeIn = &Chain{
+							Name: "cali-failsafe-in",
+							Rules: []Rule{
+								{Match: Match().Protocol("tcp").DestPorts(22).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").DestPorts(1022).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").SourcePorts(23).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").SourcePorts(1023).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+							},
+						}
+
+						expRawFailsafeOut = &Chain{
+							Name: "cali-failsafe-out",
+							Rules: []Rule{
+								{Match: Match().Protocol("tcp").DestPorts(23).DestNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").DestPorts(1023).DestNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").SourcePorts(22).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").SourcePorts(1022).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+							},
+						}
+
+						expFailsafeIn = &Chain{
+							Name: "cali-failsafe-in",
+							Rules: []Rule{
+								{Match: Match().Protocol("tcp").DestPorts(22).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").DestPorts(1022).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+							},
+						}
+
+						expFailsafeOut = &Chain{
+							Name: "cali-failsafe-out",
+							Rules: []Rule{
+								{Match: Match().Protocol("tcp").DestPorts(23).DestNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").DestPorts(1023).DestNet("0.0.0.0/0"), Action: AcceptAction{}},
+							},
+						}
 					}
 
 					expForwardCheck := &Chain{


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Fixes a bug where IPv4 addresses from the failsafe rules were injected into IPv6 failsafe rules.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
