### PR TITLE
Update IPIP FV connectivity behavior expectation

### DIFF
--- a/fv/ipip_test.go
+++ b/fv/ipip_test.go
@@ -343,84 +343,20 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ IPIP topology before adding
 				Eventually(felixes[1].NumTCBPFProgsEth0, "5s", "200ms").Should(Equal(2))
 			} else {
 				for _, f := range felixes {
-					// Removing the BGP config triggers a Felix restart and Felix has a 2s timer during
-					// a config restart to ensure that it doesn't tight loop.  Wait for the ipset to be
-					// updated as a signal that Felix has restarted.
-					Eventually(func() int {
-						return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
-					}, "5s", "200ms").Should(BeZero())
+					// Removing the BGP config doesn't trigger a restart anymore as we copy
+					// and fill out the HostIPKey always.
+					f.Restart()
 				}
 			}
 		})
 
-		It("should have no workload to workload connectivity", func() {
-			cc.ExpectNone(w[0], w[1])
-			cc.ExpectNone(w[1], w[0])
-			cc.CheckConnectivity()
-		})
-	})
-
-	Context("external nodes configured", func() {
-		BeforeEach(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-			defer cancel()
-			l, err := client.Nodes().List(ctx, options.ListOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			// Now remove the BGP configuration for felixes[0]
-			var prevBGPSpec api.NodeBGPSpec
-			for _, node := range l.Items {
-				log.Infof("node: %v", node)
-				if node.Name == felixes[0].Name {
-					// save the old spec
-					prevBGPSpec = *node.Spec.BGP
-					node.Spec.BGP = nil
-					_, err = client.Nodes().Update(ctx, &node, options.SetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-				}
-			}
-			// Removing the BGP config triggers a Felix restart. Wait for the ipset to be updated as a signal that Felix
-			// has restarted.
-			if !bpfEnabled {
-				for _, f := range felixes {
-					Eventually(func() int {
-						return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
-					}, "5s", "200ms").Should(Equal(1))
-				}
-			}
-
-			updateConfig := func(addr string) {
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-				defer cancel()
-				c, err := client.FelixConfigurations().Get(ctx, "default", options.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				c.Spec.ExternalNodesCIDRList = &[]string{addr, "1.1.1.1"}
-				log.WithFields(log.Fields{"felixconfiguration": c, "adding Addr": addr}).Info("Updating FelixConfiguration ")
-				_, err = client.FelixConfigurations().Update(ctx, c, options.SetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-			}
-			updateConfig(prevBGPSpec.IPv4Address)
-
-			// Wait for the config to take
-			for _, f := range felixes {
-				if bpfEnabled {
-					Eventually(f.BPFRoutes, "5s", "200ms").Should(ContainSubstring("1.1.1.1/32"))
-				} else {
-					Eventually(func() int {
-						return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
-					}, "5s", "200ms").Should(Equal(3))
-				}
-			}
-
-		})
-
-		It("should have all-hosts-net ipset configured with the external hosts and workloads connect", func() {
-			f := felixes[0]
-			// Add the ip route via tunnel back on the Felix for which we nuked when we removed its BGP spec.
-			f.Exec("ip", "route", "add", w[1].IP, "via", felixes[1].IP, "dev", "tunl0", "onlink")
+		It("should continue to have all-hosts-net ipset configured with the hosts and workloads connect", func() {
 			cc.ExpectSome(w[0], w[1])
+			cc.ExpectSome(w[1], w[0])
 			cc.CheckConnectivity()
 		})
 	})
+
 })
 
 func getNumIPSetMembers(c *containers.Container, ipSetName string) int {


### PR DESCRIPTION
## Description

In projectcalico/libcalico-go#1387 we've changed how we populate IP address information in the `HostIPKey`.  This means that workload connectivity continues to exist despite the removal of BGP. This PR updates the FV to match the new behavior. 
If this isn't the expected behavior then this PR isn't valid and the behavior should be fixed.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
