### PR TITLE
Add CIDR handling for failsafes in bpf

### DIFF
--- a/bpf-gpl/failsafe.h
+++ b/bpf-gpl/failsafe.h
@@ -22,9 +22,11 @@
 #include "types.h"
 
 struct failsafe_key {
+	__u32 prefixlen;
 	__u16 port;
 	__u8 ip_proto;
 	__u8 flags;
+	__u32 addr;
 };
 
 struct failsafe_val {
@@ -32,7 +34,7 @@ struct failsafe_val {
 };
 
 CALI_MAP_V1(cali_v4_fsafes,
-		BPF_MAP_TYPE_HASH,
+		BPF_MAP_TYPE_LPM_TRIE,
 		struct failsafe_key, struct failsafe_val,
 		65536,
 		BPF_F_NO_PREALLOC,
@@ -40,11 +42,20 @@ CALI_MAP_V1(cali_v4_fsafes,
 
 #define CALI_FSAFE_OUT 1
 
-static CALI_BPF_INLINE bool is_failsafe_in(__u8 ip_proto, __u16 dport) {
+
+/* Prefix len = (port + protocol + addr) in bits. */
+#define FSAFE_PREFIX_LEN  (sizeof(struct failsafe_key) - \
+				sizeof(((struct failsafe_key*)0)->prefixlen))
+
+#define FSAFE_PREFIX_LEN_IN_BITS (FSAFE_PREFIX_LEN * 8)
+
+static CALI_BPF_INLINE bool is_failsafe_in(__u8 ip_proto, __u16 dport, __be32 ip) {
 	struct failsafe_key key = {
+		.prefixlen = FSAFE_PREFIX_LEN_IN_BITS,
 		.ip_proto = ip_proto,
 		.port = dport,
 		.flags = 0,
+		.addr = ip,
 	};
 	if (cali_v4_fsafes_lookup_elem(&key)) {
 		return true;
@@ -52,11 +63,13 @@ static CALI_BPF_INLINE bool is_failsafe_in(__u8 ip_proto, __u16 dport) {
 	return false;
 }
 
-static CALI_BPF_INLINE bool is_failsafe_out(__u8 ip_proto, __u16 dport) {
+static CALI_BPF_INLINE bool is_failsafe_out(__u8 ip_proto, __u16 dport, __be32 ip) {
 	struct failsafe_key key = {
+		.prefixlen = FSAFE_PREFIX_LEN_IN_BITS,
 		.ip_proto = ip_proto,
 		.port = dport,
 		.flags = CALI_FSAFE_OUT,
+		.addr = ip,
 	};
 	if (cali_v4_fsafes_lookup_elem(&key)) {
 		return true;

--- a/bpf-gpl/failsafe.h
+++ b/bpf-gpl/failsafe.h
@@ -33,7 +33,7 @@ struct failsafe_val {
 	__u32 unused;
 };
 
-CALI_MAP_V1(cali_v4_fsafes,
+CALI_MAP(cali_v4_fsafes, 2,
 		BPF_MAP_TYPE_LPM_TRIE,
 		struct failsafe_key, struct failsafe_val,
 		65536,

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -427,7 +427,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 skip_pre_dnat_default:
 	if (rt_addr_is_local_host(ctx.state->post_nat_ip_dst)) {
 		CALI_DEBUG("Post-NAT dest IP is local host.\n");
-		if (CALI_F_FROM_HEP && is_failsafe_in(ctx.state->ip_proto, ctx.state->post_nat_dport)) {
+		if (CALI_F_FROM_HEP && is_failsafe_in(ctx.state->ip_proto, ctx.state->post_nat_dport, ctx.state->ip_src)) {
 			CALI_DEBUG("Inbound failsafe port: %d. Skip policy.\n", ctx.state->post_nat_dport);
 			ctx.state->pol_rc = CALI_POL_ALLOW;
 			goto skip_policy;
@@ -436,7 +436,7 @@ skip_pre_dnat_default:
 	}
 	if (rt_addr_is_local_host(ctx.state->ip_src)) {
 		CALI_DEBUG("Source IP is local host.\n");
-		if (CALI_F_TO_HEP && is_failsafe_out(ctx.state->ip_proto, ctx.state->post_nat_dport)) {
+		if (CALI_F_TO_HEP && is_failsafe_out(ctx.state->ip_proto, ctx.state->post_nat_dport, ctx.state->post_nat_ip_dst)) {
 			CALI_DEBUG("Outbound failsafe port: %d. Skip policy.\n", ctx.state->post_nat_dport);
 			ctx.state->pol_rc = CALI_POL_ALLOW;
 			goto skip_policy;

--- a/bpf/failsafes/failsafe_test.go
+++ b/bpf/failsafes/failsafe_test.go
@@ -17,7 +17,6 @@
 package failsafes
 
 import (
-	"net"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -27,7 +26,7 @@ import (
 	"github.com/projectcalico/felix/logutils"
 )
 
-const zeroValue = "\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+const zeroValue = "\x00\x00\x00\x00"
 
 type failsafeTest struct {
 	Name                string
@@ -72,10 +71,10 @@ var tests = []failsafeTest{
 			{Protocol: "udp", Port: 53, Net: "0.0.0.0/0"},
 		},
 		ExpectedMapContents: map[string]string{
-			string(Key{Port: 22, IPProto: 6, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                       zeroValue,
-			string(Key{Port: 1234, IPProto: 17, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                    zeroValue,
-			string(Key{Port: 443, IPProto: 6, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
-			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
+			string(Key{Port: 22, IPProto: 6, IP: "0.0.0.0", IPMask: 0}.ToSlice()):                       zeroValue,
+			string(Key{Port: 1234, IPProto: 17, IP: "0.0.0.0", IPMask: 0}.ToSlice()):                    zeroValue,
+			string(Key{Port: 443, IPProto: 6, Flags: FlagOutbound, IP: "0.0.0.0", IPMask: 0}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: "0.0.0.0", IPMask: 0}.ToSlice()): zeroValue,
 		},
 	},
 	{
@@ -89,27 +88,27 @@ var tests = []failsafeTest{
 			{Protocol: "udp", Port: 53, Net: "0.0.0.0/0"},
 		},
 		InitialMapContents: map[string]string{
-			string(Key{Port: 22, IPProto: 6, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                        zeroValue,
-			string(Key{Port: 2345, IPProto: 17, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                     zeroValue,
-			string(Key{Port: 1443, IPProto: 6, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
-			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):  zeroValue,
-			string(Key{Port: 57, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):  zeroValue,
+			string(Key{Port: 22, IPProto: 6, IP: "0.0.0.0", IPMask: 0}.ToSlice()):                        zeroValue,
+			string(Key{Port: 2345, IPProto: 17, IP: "0.0.0.0", IPMask: 0}.ToSlice()):                     zeroValue,
+			string(Key{Port: 1443, IPProto: 6, Flags: FlagOutbound, IP: "0.0.0.0", IPMask: 0}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: "0.0.0.0", IPMask: 0}.ToSlice()):  zeroValue,
+			string(Key{Port: 57, IPProto: 17, Flags: FlagOutbound, IP: "0.0.0.0", IPMask: 0}.ToSlice()):  zeroValue,
 		},
 		ExpectedMapContents: map[string]string{
-			string(Key{Port: 22, IPProto: 6, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                       zeroValue,
-			string(Key{Port: 1234, IPProto: 17, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                    zeroValue,
-			string(Key{Port: 443, IPProto: 6, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
-			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
+			string(Key{Port: 22, IPProto: 6, IP: "0.0.0.0", IPMask: 0}.ToSlice()):                       zeroValue,
+			string(Key{Port: 1234, IPProto: 17, IP: "0.0.0.0", IPMask: 0}.ToSlice()):                    zeroValue,
+			string(Key{Port: 443, IPProto: 6, Flags: FlagOutbound, IP: "0.0.0.0", IPMask: 0}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: "0.0.0.0", IPMask: 0}.ToSlice()): zeroValue,
 		},
 	},
 	{
 		Name: "ShouldRemoveAll",
 		InitialMapContents: map[string]string{
-			string(Key{Port: 22, IPProto: 6, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                        zeroValue,
-			string(Key{Port: 2345, IPProto: 17, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                     zeroValue,
-			string(Key{Port: 1443, IPProto: 6, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
-			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):  zeroValue,
-			string(Key{Port: 57, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):  zeroValue,
+			string(Key{Port: 22, IPProto: 6, IP: "0.0.0.0", IPMask: 0}.ToSlice()):                        zeroValue,
+			string(Key{Port: 2345, IPProto: 17, IP: "0.0.0.0", IPMask: 0}.ToSlice()):                     zeroValue,
+			string(Key{Port: 1443, IPProto: 6, Flags: FlagOutbound, IP: "0.0.0.0", IPMask: 0}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: "0.0.0.0", IPMask: 0}.ToSlice()):  zeroValue,
+			string(Key{Port: 57, IPProto: 17, Flags: FlagOutbound, IP: "0.0.0.0", IPMask: 0}.ToSlice()):  zeroValue,
 		},
 		ExpectedMapContents: map[string]string{},
 	},

--- a/bpf/failsafes/failsafe_test.go
+++ b/bpf/failsafes/failsafe_test.go
@@ -17,6 +17,7 @@
 package failsafes
 
 import (
+	"net"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -26,7 +27,7 @@ import (
 	"github.com/projectcalico/felix/logutils"
 )
 
-const zeroValue = "\x00\x00\x00\x00"
+const zeroValue = "\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 
 type failsafeTest struct {
 	Name                string
@@ -63,52 +64,52 @@ var tests = []failsafeTest{
 	{
 		Name: "ShouldFillEmptyMap",
 		In: []config.ProtoPort{
-			{Protocol: "tcp", Port: 22},
-			{Protocol: "udp", Port: 1234},
+			{Protocol: "tcp", Port: 22, Net: "0.0.0.0/0"},
+			{Protocol: "udp", Port: 1234, Net: "0.0.0.0/0"},
 		},
 		Out: []config.ProtoPort{
-			{Protocol: "tcp", Port: 443},
-			{Protocol: "udp", Port: 53},
+			{Protocol: "tcp", Port: 443, Net: "0.0.0.0/0"},
+			{Protocol: "udp", Port: 53, Net: "0.0.0.0/0"},
 		},
 		ExpectedMapContents: map[string]string{
-			string(Key{Port: 22, IPProto: 6}.ToSlice()):                       zeroValue,
-			string(Key{Port: 1234, IPProto: 17}.ToSlice()):                    zeroValue,
-			string(Key{Port: 443, IPProto: 6, Flags: FlagOutbound}.ToSlice()): zeroValue,
-			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound}.ToSlice()): zeroValue,
+			string(Key{Port: 22, IPProto: 6, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                       zeroValue,
+			string(Key{Port: 1234, IPProto: 17, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                    zeroValue,
+			string(Key{Port: 443, IPProto: 6, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
 		},
 	},
 	{
 		Name: "ShouldResyncDirtyMap",
 		In: []config.ProtoPort{
-			{Protocol: "tcp", Port: 22},
-			{Protocol: "udp", Port: 1234},
+			{Protocol: "tcp", Port: 22, Net: "0.0.0.0/0"},
+			{Protocol: "udp", Port: 1234, Net: "0.0.0.0/0"},
 		},
 		Out: []config.ProtoPort{
-			{Protocol: "tcp", Port: 443},
-			{Protocol: "udp", Port: 53},
+			{Protocol: "tcp", Port: 443, Net: "0.0.0.0/0"},
+			{Protocol: "udp", Port: 53, Net: "0.0.0.0/0"},
 		},
 		InitialMapContents: map[string]string{
-			string(Key{Port: 22, IPProto: 6}.ToSlice()):                        zeroValue,
-			string(Key{Port: 2345, IPProto: 17}.ToSlice()):                     zeroValue,
-			string(Key{Port: 1443, IPProto: 6, Flags: FlagOutbound}.ToSlice()): zeroValue,
-			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound}.ToSlice()):  zeroValue,
-			string(Key{Port: 57, IPProto: 17, Flags: FlagOutbound}.ToSlice()):  zeroValue,
+			string(Key{Port: 22, IPProto: 6, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                        zeroValue,
+			string(Key{Port: 2345, IPProto: 17, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                     zeroValue,
+			string(Key{Port: 1443, IPProto: 6, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):  zeroValue,
+			string(Key{Port: 57, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):  zeroValue,
 		},
 		ExpectedMapContents: map[string]string{
-			string(Key{Port: 22, IPProto: 6}.ToSlice()):                       zeroValue,
-			string(Key{Port: 1234, IPProto: 17}.ToSlice()):                    zeroValue,
-			string(Key{Port: 443, IPProto: 6, Flags: FlagOutbound}.ToSlice()): zeroValue,
-			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound}.ToSlice()): zeroValue,
+			string(Key{Port: 22, IPProto: 6, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                       zeroValue,
+			string(Key{Port: 1234, IPProto: 17, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                    zeroValue,
+			string(Key{Port: 443, IPProto: 6, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
 		},
 	},
 	{
 		Name: "ShouldRemoveAll",
 		InitialMapContents: map[string]string{
-			string(Key{Port: 22, IPProto: 6}.ToSlice()):                        zeroValue,
-			string(Key{Port: 2345, IPProto: 17}.ToSlice()):                     zeroValue,
-			string(Key{Port: 1443, IPProto: 6, Flags: FlagOutbound}.ToSlice()): zeroValue,
-			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound}.ToSlice()):  zeroValue,
-			string(Key{Port: 57, IPProto: 17, Flags: FlagOutbound}.ToSlice()):  zeroValue,
+			string(Key{Port: 22, IPProto: 6, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                        zeroValue,
+			string(Key{Port: 2345, IPProto: 17, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):                     zeroValue,
+			string(Key{Port: 1443, IPProto: 6, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()): zeroValue,
+			string(Key{Port: 53, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):  zeroValue,
+			string(Key{Port: 57, IPProto: 17, Flags: FlagOutbound, IP: net.ParseIP("0.0.0.0"), IPMask: 0}.ToSlice()):  zeroValue,
 		},
 		ExpectedMapContents: map[string]string{},
 	},

--- a/bpf/failsafes/failsafes.go
+++ b/bpf/failsafes/failsafes.go
@@ -108,7 +108,7 @@ func (m *Manager) ResyncFailsafes() error {
 		ipv4 := ip.To4()
 		if ipv4 == nil || len(ipv4) != 4 {
 			// If ipv4 is nil, then the IP is not an IPv4 address. Only IPv4 addresses are supported in failsafes.
-			log.Error("Invalid IPv4 address configured in the failsafe ports")
+			log.Errorf("Invalid IPv4 address configured in the failsafe ports: %s", p.Net)
 			syncFailed = true
 			return
 		}

--- a/bpf/failsafes/failsafes.go
+++ b/bpf/failsafes/failsafes.go
@@ -98,7 +98,11 @@ func (m *Manager) ResyncFailsafes() error {
 		}
 
 		// Parse the CIDR and split out the IP and mask
-		ip, ipnet, err := cnet.ParseCIDROrIP(p.Net)
+		cidr := p.Net
+		if p.Net == "" {
+			cidr = "0.0.0.0/0"
+		}
+		ip, ipnet, err := cnet.ParseCIDROrIP(cidr)
 		if err != nil {
 			log.WithError(err).Error("Failed to parse CIDR for failsafe port")
 			syncFailed = true
@@ -108,7 +112,7 @@ func (m *Manager) ResyncFailsafes() error {
 		ipv4 := ip.To4()
 		if ipv4 == nil || len(ipv4) != 4 {
 			// If ipv4 is nil, then the IP is not an IPv4 address. Only IPv4 addresses are supported in failsafes.
-			log.Errorf("Invalid IPv4 address configured in the failsafe ports: %s", p.Net)
+			log.Errorf("Invalid IPv4 address configured in the failsafe ports: %s", cidr)
 			syncFailed = true
 			return
 		}

--- a/bpf/failsafes/failsafes.go
+++ b/bpf/failsafes/failsafes.go
@@ -121,7 +121,7 @@ func (m *Manager) ResyncFailsafes() error {
 		// Mask the IP
 		ip := parsedIP.Mask(net.CIDRMask(mask, 32))
 
-		k := MakeKey(ipProto, p.Port, outbound, ip, mask)
+		k := MakeKey(ipProto, p.Port, outbound, ip.String(), mask)
 		unknownKeys.Discard(k)
 		err = m.failsafesMap.Update(k.ToSlice(), Value())
 		if err != nil {

--- a/bpf/failsafes/failsafes_map.go
+++ b/bpf/failsafes/failsafes_map.go
@@ -52,6 +52,7 @@ var MapParams = bpf.MapParameters{
 	MaxEntries: 65536,
 	Name:       "cali_v4_fsafes",
 	Flags:      unix.BPF_F_NO_PREALLOC,
+	Version:    2,
 }
 
 func Map(mc *bpf.MapContext) bpf.Map {

--- a/bpf/failsafes/failsafes_map.go
+++ b/bpf/failsafes/failsafes_map.go
@@ -18,6 +18,7 @@ package failsafes
 
 import (
 	"encoding/binary"
+	"net"
 
 	"golang.org/x/sys/unix"
 
@@ -25,21 +26,27 @@ import (
 )
 
 const (
-	KeySize   = 4
+	// PrefixLen (4) + Port (2) + Proto (1) + Flags (1) + IP (4)
+	KeySize   = 12
 	ValueSize = 4
 
 	FlagOutbound = 1
+
+	// sizeof(port) + sizeof(proto) + sizeof(flags)
+	ZeroCIDRPrefixLen = 32
 )
 
 type Key struct {
 	Port    uint16
 	IPProto uint8
 	Flags   uint8
+	IP      net.IP
+	IPMask  int
 }
 
 var MapParams = bpf.MapParameters{
 	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_fsafes",
-	Type:       "hash",
+	Type:       "lpm_trie",
 	KeySize:    KeySize,
 	ValueSize:  ValueSize,
 	MaxEntries: 65536,
@@ -51,7 +58,7 @@ func Map(mc *bpf.MapContext) bpf.Map {
 	return mc.NewPinnedMap(MapParams)
 }
 
-func MakeKey(ipProto uint8, port uint16, outbound bool) Key {
+func MakeKey(ipProto uint8, port uint16, outbound bool, ip net.IP, mask int) Key {
 	var flags uint8
 	if outbound {
 		flags |= FlagOutbound
@@ -60,22 +67,38 @@ func MakeKey(ipProto uint8, port uint16, outbound bool) Key {
 		Port:    port,
 		IPProto: ipProto,
 		Flags:   flags,
+		IP:      ip,
+		IPMask:  mask,
 	}
 }
 
 func (k Key) ToSlice() []byte {
 	key := make([]byte, KeySize)
-	binary.LittleEndian.PutUint16(key[:2], k.Port)
-	key[2] = k.IPProto
-	key[3] = k.Flags
+	binary.LittleEndian.PutUint32(key[:4], uint32(ZeroCIDRPrefixLen)+uint32(k.IPMask))
+	binary.LittleEndian.PutUint16(key[4:6], k.Port)
+	key[6] = k.IPProto
+	key[7] = k.Flags
+	maskedIP := k.IP.Mask(net.CIDRMask(k.IPMask, 32))
+	for i := 0; i < 4; i++ {
+		key[8+i] = maskedIP.To4()[i]
+	}
 	return key
 }
 
 func KeyFromSlice(data []byte) Key {
 	var k Key
-	k.Port = binary.LittleEndian.Uint16(data[:2])
-	k.IPProto = data[2]
-	k.Flags = data[3]
+	k.Port = binary.LittleEndian.Uint16(data[4:6])
+	k.IPProto = data[6]
+	k.Flags = data[7]
+
+	prefixLen := binary.LittleEndian.Uint32(data[:4])
+	k.IPMask = int(prefixLen) - ZeroCIDRPrefixLen
+	ipBytes := make([]byte, 4)
+	for i := 8; i < len(data); i++ {
+		ipBytes[i-8] = data[i]
+	}
+	k.IP = net.IPv4(ipBytes[0], ipBytes[1], ipBytes[2], ipBytes[3])
+
 	return k
 }
 

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -836,6 +836,7 @@ func testPacketUDPDefaultNP(destIP net.IP) (*layers.Ethernet, *layers.IPv4, gopa
 func resetBPFMaps() {
 	resetCTMap(ctMap)
 	resetRTMap(rtMap)
+	resetMap(fsafeMap)
 }
 
 func TestMapIterWithDelete(t *testing.T) {

--- a/bpf/ut/failsafes_test.go
+++ b/bpf/ut/failsafes_test.go
@@ -44,7 +44,7 @@ func TestFailsafes(t *testing.T) {
 
 	// Set up failsafe to accept incoming connections from srcIP (1.1.1.1/16)
 	err = fsafeMap.Update(
-		failsafes.MakeKey(17, 5678, false, srcIP, 16).ToSlice(),
+		failsafes.MakeKey(17, 5678, false, srcIP.String(), 16).ToSlice(),
 		failsafes.Value(),
 	)
 	Expect(err).NotTo(HaveOccurred())
@@ -52,7 +52,7 @@ func TestFailsafes(t *testing.T) {
 	// Set up failsafe to accept outgoing connections to 3.3.3.3/16
 	fsafeDstIP := net.IPv4(3, 3, 3, 3)
 	err = fsafeMap.Update(
-		failsafes.MakeKey(17, 5678, true, fsafeDstIP, 16).ToSlice(),
+		failsafes.MakeKey(17, 5678, true, fsafeDstIP.String(), 16).ToSlice(),
 		failsafes.Value(),
 	)
 	Expect(err).NotTo(HaveOccurred())

--- a/bpf/ut/failsafes_test.go
+++ b/bpf/ut/failsafes_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/gopacket/layers"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/bpf/failsafes"
+	"github.com/projectcalico/felix/bpf/polprog"
+	"github.com/projectcalico/felix/bpf/routes"
+	"github.com/projectcalico/felix/ip"
+	"github.com/projectcalico/felix/proto"
+)
+
+func TestFailsafes(t *testing.T) {
+	RegisterTestingT(t)
+
+	defer resetBPFMaps()
+
+	hostIP = dstIP // set host IP to the default dest
+	hostCIDR := ip.CIDRFromNetIP(hostIP).(ip.V4CIDR)
+
+	// Setup routing so that failsafe check knows it is localhost
+	rtKey := routes.NewKey(hostCIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalHost, 1).AsBytes()
+	err := rtMap.Update(rtKey, rtVal)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Set up failsafe to accept incoming connections from srcIP (1.1.1.1/16)
+	err = fsafeMap.Update(
+		failsafes.MakeKey(17, 5678, false, srcIP, 16).ToSlice(),
+		failsafes.Value(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Set up failsafe to accept outgoing connections to 3.3.3.3/16
+	fsafeDstIP := net.IPv4(3, 3, 3, 3)
+	err = fsafeMap.Update(
+		failsafes.MakeKey(17, 5678, true, fsafeDstIP, 16).ToSlice(),
+		failsafes.Value(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	denyAllRules := polprog.Rules{
+		ForHostInterface: true,
+		HostNormalTiers: []polprog.Tier{{
+			Policies: []polprog.Policy{{
+				Name: "deny all",
+				Rules: []polprog.Rule{{Rule: &proto.Rule{
+					Action: "Deny",
+				}}},
+			}},
+		}},
+	}
+
+	denyAllRulesWorkloads := polprog.Rules{
+		Tiers: []polprog.Tier{{
+			Policies: []polprog.Policy{{
+				Name: "deny all",
+				Rules: []polprog.Rule{{Rule: &proto.Rule{
+					Action: "Deny",
+				}}},
+			}},
+		}},
+	}
+
+	// Packet from 1.1.1.1 to 2.2.2.2
+	iphdr := *ipv4Default
+	_, _, _, _, pktBytesIn, err := testPacket(nil, &iphdr, nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+	// Packets from failsafe IP to localhost are allowed
+	runBpfTest(t, "calico_from_host_ep", &denyAllRules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytesIn)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RetvalStr()).To(Equal("TC_ACT_UNSPEC"), "expected program to return TC_ACT_UNSPEC")
+	})
+
+	// Packet from IP not in failsafe (4.4.4.4) to localhost (2.2.2.2)
+	ipHeaderInBlocked := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		Flags:    layers.IPv4DontFragment,
+		SrcIP:    net.IPv4(4, 4, 4, 4),
+		DstIP:    dstIP,
+		Protocol: layers.IPProtocolUDP,
+	}
+	_, _, _, _, pktBytesInBlocked, err := testPacket(nil, ipHeaderInBlocked, nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+	// Packets from non-failsafe IP to localhost are denied
+	runBpfTest(t, "calico_from_host_ep", &denyAllRules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytesInBlocked)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RetvalStr()).To(Equal("TC_ACT_SHOT"), "expected program to return TC_ACT_SHOT")
+	})
+
+	// Packet from 2.2.2.2 to 3.3.3.3
+	ipHeaderOut := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		Flags:    layers.IPv4DontFragment,
+		SrcIP:    dstIP,
+		DstIP:    fsafeDstIP,
+		Protocol: layers.IPProtocolUDP,
+	}
+	_, _, _, _, pktBytesOut, err := testPacket(nil, ipHeaderOut, nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+	// Packets from localhost to failsafe IP are allowed
+	runBpfTest(t, "calico_to_host_ep", &denyAllRules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytesOut)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RetvalStr()).To(Equal("TC_ACT_UNSPEC"), "expected program to return TC_ACT_UNSPEC")
+	})
+
+	// Packet from localhost (2.2.2.2) to IP not in failsafe (4.4.4.4)
+	ipHeaderOutBlocked := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		Flags:    layers.IPv4DontFragment,
+		SrcIP:    dstIP,
+		DstIP:    net.IPv4(4, 4, 4, 4),
+		Protocol: layers.IPProtocolUDP,
+	}
+	_, _, _, _, pktBytesOutBlocked, err := testPacket(nil, ipHeaderOutBlocked, nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+	// Packets from localhost to non-failsafe IP are denied
+	runBpfTest(t, "calico_from_host_ep", &denyAllRules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytesOutBlocked)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RetvalStr()).To(Equal("TC_ACT_SHOT"), "expected program to return TC_ACT_SHOT")
+	})
+
+	// Packet from an allowed outbound failsafe IP (3.3.3.3) to an allowed inbound failsafe IP (1.1.1.1)
+	ipHeaderSwappedFailsafes := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		Flags:    layers.IPv4DontFragment,
+		SrcIP:    fsafeDstIP,
+		DstIP:    srcIP,
+		Protocol: layers.IPProtocolUDP,
+	}
+	_, _, _, _, pktBytesSwappedFailsafes, err := testPacket(nil, ipHeaderSwappedFailsafes, nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+	// Packets from outbound failsafes to inbound failsafes are denied
+	runBpfTest(t, "calico_from_host_ep", &denyAllRulesWorkloads, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytesSwappedFailsafes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RetvalStr()).To(Equal("TC_ACT_SHOT"), "expected program to return TC_ACT_SHOT")
+	})
+
+	// Packet from unallowed IP (4.4.4.4) to failsafe IP (3.3.3.3)
+	ipHeaderToFailsafe := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		Flags:    layers.IPv4DontFragment,
+		SrcIP:    net.IPv4(4, 4, 4, 4),
+		DstIP:    fsafeDstIP,
+		Protocol: layers.IPProtocolUDP,
+	}
+	_, _, _, _, pktBytesToFailsafe, err := testPacket(nil, ipHeaderToFailsafe, nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+	// Packets from non-failsafe IP to failsafe IP are denied
+	runBpfTest(t, "calico_from_host_ep", &denyAllRulesWorkloads, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytesToFailsafe)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RetvalStr()).To(Equal("TC_ACT_SHOT"), "expected program to return TC_ACT_SHOT")
+	})
+
+	// Packet from failsafe IP (3.3.3.3) to unallowed IP (4.4.4.4)
+	ipHeaderFromFailsafe := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		Flags:    layers.IPv4DontFragment,
+		SrcIP:    fsafeDstIP,
+		DstIP:    net.IPv4(4, 4, 4, 4),
+		Protocol: layers.IPProtocolUDP,
+	}
+	_, _, _, _, pktBytesFromFailsafe, err := testPacket(nil, ipHeaderFromFailsafe, nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+	// Packets from failsafe IP to non-failsafe IP are denied
+	runBpfTest(t, "calico_from_host_ep", &denyAllRulesWorkloads, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytesFromFailsafe)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RetvalStr()).To(Equal("TC_ACT_SHOT"), "expected program to return TC_ACT_SHOT")
+	})
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Add logic for additional CIDRs in failsafe rules in BPF. This is to ensure that the BPF dataplane behaves similar to the iptables dataplane after https://github.com/projectcalico/felix/pull/2646 was merged.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add CIDRs to the failsafe rule handling in BPF.
```
