### PR TITLE
Dont panic when we see a sctp named port

### DIFF
--- a/bpf/ipsets/map.go
+++ b/bpf/ipsets/map.go
@@ -106,7 +106,8 @@ func ProtoIPSetMemberToBPFEntry(id uint64, member string) *IPSetEntry {
 		case "udp":
 			protocol = 17
 		default:
-			logrus.WithField("member", member).Panic("Unknown protocol in named port member")
+			logrus.WithField("member", member).Error("Unknown protocol in named port member")
+			return nil
 		}
 		port64, err := strconv.ParseUint(parts[1], 10, 16)
 		if err != nil {

--- a/bpf/ipsets/map.go
+++ b/bpf/ipsets/map.go
@@ -106,7 +106,7 @@ func ProtoIPSetMemberToBPFEntry(id uint64, member string) *IPSetEntry {
 		case "udp":
 			protocol = 17
 		default:
-			logrus.WithField("member", member).Error("Unknown protocol in named port member")
+			logrus.WithField("member", member).Warn("Unknown protocol in named port member")
 			return nil
 		}
 		port64, err := strconv.ParseUint(parts[1], 10, 16)


### PR DESCRIPTION
Do not panic in BPF when we see a named port other than TCP, UDP, just log the error and ignore/continue.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
