### PR TITLE
[v3.18] backport syncer fix

### DIFF
--- a/bpf/cachingmap/caching_map.go
+++ b/bpf/cachingmap/caching_map.go
@@ -1,0 +1,398 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cachingmap
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/bpf"
+)
+
+// CachingMap provides a caching layer around a bpf.Map, when one of the Apply methods is called, it applies
+// a minimal set of changes to the dataplane map to bring it into sync with the desired state.  Updating the
+// desired state in and of itself has no effect on the dataplane.
+//
+// CachingMap will load a cache of the dataplane state on the first call to ApplyXXX, or the cache can be loaded
+// explicitly by calling LoadCacheFromDataplane().  This allows for client code to inspect the dataplane cache
+// with IterDataplaneCache and GetDataplaneCache.
+type CachingMap struct {
+	// dataplaneMap is the backing map in the dataplane
+	dataplaneMap bpf.Map
+	params       bpf.MapParameters
+
+	// desiredStateOfDataplane stores the complete set of key/value pairs that we _want_ to
+	// be in the dataplane.  Calling ApplyAllChanges attempts to bring the dataplane into
+	// sync.
+	//
+	// For occupancy's sake we may want to drop this copy and instead maintain the invariant:
+	// desiredStateOfDataplane = cacheOfDataplane - pendingDeletions + pendingUpdates.
+	desiredStateOfDataplane *ByteArrayToByteArrayMap
+
+	cacheOfDataplane *ByteArrayToByteArrayMap
+	pendingUpdates   *ByteArrayToByteArrayMap
+	pendingDeletions *ByteArrayToByteArrayMap
+}
+
+func New(mapParams bpf.MapParameters, dataplaneMap bpf.Map) *CachingMap {
+	cm := &CachingMap{
+		params:                  mapParams,
+		dataplaneMap:            dataplaneMap,
+		desiredStateOfDataplane: NewByteArrayToByteArrayMap(mapParams.KeySize, mapParams.ValueSize),
+	}
+	return cm
+}
+
+// LoadCacheFromDataplane loads the contents of the BPF map into the dataplane cache, allowing it to be queried with
+// GetDataplaneCache and IterDataplaneCache.
+func (c *CachingMap) LoadCacheFromDataplane() error {
+	logrus.WithField("name", c.params.Name).Debug("Loading cache of dataplane state.")
+	c.initCache()
+	err := c.dataplaneMap.Iter(func(k, v []byte) bpf.IteratorAction {
+		c.cacheOfDataplane.Set(k, v)
+		return bpf.IterNone
+	})
+	if err != nil {
+		logrus.WithError(err).WithField("name", c.params.Name).Warn("Failed to load cache of BPF map")
+		c.clearCache()
+		return err
+	}
+	logrus.WithField("name", c.params.Name).WithField("count", c.cacheOfDataplane.Len()).Info(
+		"Loaded cache of BPF map")
+	c.recalculatePendingOperations()
+	return nil
+}
+
+func (c *CachingMap) initCache() {
+	c.cacheOfDataplane = NewByteArrayToByteArrayMap(c.params.KeySize, c.params.ValueSize)
+	c.pendingUpdates = NewByteArrayToByteArrayMap(c.params.KeySize, c.params.ValueSize)
+	c.pendingDeletions = NewByteArrayToByteArrayMap(c.params.KeySize, c.params.ValueSize)
+}
+
+func (c *CachingMap) clearCache() {
+	logrus.WithField("name", c.params.Name).Debug("Clearing cache of BPF map")
+	c.cacheOfDataplane = nil
+	c.pendingDeletions = nil
+	c.pendingUpdates = nil
+}
+
+// recalculatePendingOperations compares the dataplane cache against he desired state and adds entries to
+// pendingUpdates/pendingDeletions that would bring the dataplane into sync with the desired state.
+func (c *CachingMap) recalculatePendingOperations() {
+	debug := logrus.GetLevel() >= logrus.DebugLevel
+
+	// Look for any discrepancies and queue up updates.
+	c.desiredStateOfDataplane.Iter(func(k, desiredVal []byte) {
+		actualVal := c.cacheOfDataplane.Get(k)
+		if slicesEqual(actualVal, desiredVal) {
+			return
+		}
+		c.pendingUpdates.Set(k, desiredVal)
+	})
+
+	// Scan for any dataplane keys that are not in the desired map at all and
+	// queue up deletions.
+	c.cacheOfDataplane.Iter(func(k, actualVal []byte) {
+		desiredVal := c.desiredStateOfDataplane.Get(k)
+		if debug {
+			logrus.WithFields(logrus.Fields{
+				"k":        k,
+				"v":        actualVal,
+				"expected": desiredVal,
+			}).Debug("Checking cache against desired")
+		}
+		if desiredVal == nil {
+			c.pendingDeletions.Set(k, actualVal)
+			return
+		}
+	})
+
+	logrus.WithFields(logrus.Fields{
+		"cached":         c.cacheOfDataplane.Len(),
+		"pendingDels":    c.pendingDeletions.Len(),
+		"pendingUpdates": c.pendingUpdates.Len(),
+		"name":           c.params.Name,
+	}).Info("Recalculated pending operations")
+}
+
+// SetDesired sets the desired state of the given key to the given value. This is an in-memory operation,
+// it doesn't actually touch the dataplane.
+func (c *CachingMap) SetDesired(k, v []byte) {
+	if logrus.GetLevel() >= logrus.DebugLevel {
+		logrus.WithFields(logrus.Fields{"name": c.params.Name, "k": k, "v": v}).Debug("SetDesired")
+	}
+	c.desiredStateOfDataplane.Set(k, v)
+	if c.cacheOfDataplane == nil {
+		logrus.Debug("SetDesired: initial sync pending.")
+		return // Initial sync is pending, we're not tracking deltas yet.
+	}
+	c.pendingDeletions.Delete(k)
+
+	// Check if we think we need to update the dataplane as a result.
+	currentVal := c.cacheOfDataplane.Get(k)
+	if slicesEqual(currentVal, v) {
+		// Dataplane already agrees with the new value so clear any pending update.
+		logrus.Debug("SetDesired: Key in dataplane already, ignoring.")
+		c.pendingUpdates.Delete(k)
+		return
+	}
+	c.pendingUpdates.Set(k, v)
+}
+
+func slicesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// DeleteDesired deletes the given key from the desired state of the dataplane. This is an in-memory operation,
+// it doesn't actually touch the dataplane.
+func (c *CachingMap) DeleteDesired(k []byte) {
+	if logrus.GetLevel() >= logrus.DebugLevel {
+		logrus.WithFields(logrus.Fields{"name": c.params.Name, "k": k}).Debug("DeleteDesired")
+	}
+	c.desiredStateOfDataplane.Delete(k)
+	if c.cacheOfDataplane == nil {
+		logrus.Debug("DeleteDesired: initial sync pending.")
+		return // Initial sync is pending, we're not tracking deltas yet.
+	}
+	c.pendingUpdates.Delete(k)
+
+	// Check if we need to update the dataplane.
+	currentVal := c.cacheOfDataplane.Get(k)
+	if currentVal == nil {
+		// We don't think this value is in the dataplane so clear any pending delete.
+		logrus.Debug("DeleteDesired: Key not in dataplane, ignoring.")
+		c.pendingDeletions.Delete(k)
+		return
+	}
+	c.pendingDeletions.Set(k, currentVal)
+}
+
+// DeleteAllDesired deletes all entries from the in-memory desired state of the map.  It doesn't actually touch
+// the dataplane.
+func (c *CachingMap) DeleteAllDesired() {
+	logrus.WithField("name", c.params.Name).Debug("DeleteAll")
+	c.desiredStateOfDataplane.Iter(func(k, v []byte) {
+		c.DeleteDesired(k)
+	})
+}
+
+// IterDataplaneCache iterates over the cache of the dataplane. The cache must have previously been loaded with
+// a successful call to LoadCacheFromDataplane() or one of the ApplyXXX methods.
+func (c *CachingMap) IterDataplaneCache(f func(k, v []byte)) {
+	c.cacheOfDataplane.Iter(f)
+}
+
+// GetDataplaneCache gets a single value from the cache of the dataplane. The cache must have previously been
+// loaded with a successful call to LoadCacheFromDataplane() or one of the ApplyXXX methods.
+func (c *CachingMap) GetDataplaneCache(k []byte) []byte {
+	return c.cacheOfDataplane.Get(k)
+}
+
+// ApplyAllChanges attempts to bring the dataplane map into sync with the desired state.
+func (c *CachingMap) ApplyAllChanges() error {
+	var errs ErrSlice
+	err := c.ApplyDeletionsOnly()
+	if err != nil {
+		errs = append(errs, err)
+	}
+	err = c.ApplyUpdatesOnly()
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return errs
+	}
+	return nil
+}
+
+func (c *CachingMap) maybeLoadCache() error {
+	if c.cacheOfDataplane == nil {
+		err := c.LoadCacheFromDataplane()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ApplyUpdatesOnly applies any pending adds/updates to the dataplane map.  It doesn't delete any keys that are no
+// longer wanted.
+func (c *CachingMap) ApplyUpdatesOnly() error {
+	logrus.WithField("name", c.params.Name).Debug("Applying updates to BPF map.")
+	err := c.maybeLoadCache()
+	if err != nil {
+		return err
+	}
+	var errs ErrSlice
+	c.pendingUpdates.Iter(func(k, v []byte) {
+		err := c.dataplaneMap.Update(k, v)
+		if err != nil {
+			logrus.WithError(err).Warn("Error while updating BPF map")
+			errs = append(errs, err)
+		} else {
+			c.pendingUpdates.Delete(k)
+			c.cacheOfDataplane.Set(k, v)
+		}
+	})
+	if len(errs) > 0 {
+		return errs
+	}
+	return nil
+}
+
+// ApplyDeletionsOnly applies any pending deletions to the dataplane map.  It doesn't add or update any keys that
+// are new/changed.
+func (c *CachingMap) ApplyDeletionsOnly() error {
+	logrus.WithField("name", c.params.Name).Debug("Applying deletions to BPF map.")
+	err := c.maybeLoadCache()
+	if err != nil {
+		return err
+	}
+	var errs ErrSlice
+	c.pendingDeletions.Iter(func(k, v []byte) {
+		err := c.dataplaneMap.Delete(k)
+		if err != nil && !bpf.IsNotExists(err) {
+			logrus.WithError(err).Warn("Error while deleting from BPF map")
+			errs = append(errs, err)
+		} else {
+			c.pendingDeletions.Delete(k)
+			c.cacheOfDataplane.Delete(k)
+		}
+	})
+	if len(errs) > 0 {
+		return errs
+	}
+	return nil
+}
+
+type ErrSlice []error
+
+func (e ErrSlice) Error() string {
+	return fmt.Sprintf("multiple errors while updating dataplane (%d)", len(e))
+}
+
+// ByteArrayToByteArrayMap uses reflection to implements a map from a fixed size array of bytes to
+// a fixed size array of bytes where the key and value sizes are set at map creation time.  It exposes
+// an API that uses slices for Get/Set/Delete, making it much more convenient to interact with.
+// All operations panic if passed a slice of incorrect size.
+type ByteArrayToByteArrayMap struct {
+	keySize   int
+	valueSize int
+	keyType   reflect.Type
+	valueType reflect.Type
+
+	m reflect.Value // map[[keySize]byte][valueSize]byte
+
+	// key and value that we reuse when reading/writing the map.  Since the map uses value types (not
+	// pointers), we can reuse the same key/value to read/write the map and the map will save the
+	// actual key/value internally rather than sharing storage with our reflect.Value.
+	key        reflect.Value
+	value      reflect.Value
+	keySlice   []byte // Slice backed by key
+	valueSlice []byte // Slice backed by value
+}
+
+func NewByteArrayToByteArrayMap(keySize, valueSize int) *ByteArrayToByteArrayMap {
+	// Effectively make(map[[keySize]byte][valueSize]byte)
+	keyType := reflect.ArrayOf(keySize, reflect.TypeOf(byte(0)))
+	valueType := reflect.ArrayOf(valueSize, reflect.TypeOf(byte(0)))
+	mapType := reflect.MapOf(keyType, valueType)
+	mapVal := reflect.MakeMap(mapType)
+
+	key := reflect.New(keyType).Elem()
+	value := reflect.New(valueType).Elem()
+	return &ByteArrayToByteArrayMap{
+		keySize:    keySize,
+		valueSize:  valueSize,
+		keyType:    keyType,
+		valueType:  valueType,
+		m:          mapVal,
+		key:        key,
+		value:      value,
+		keySlice:   key.Slice(0, keySize).Interface().([]byte),
+		valueSlice: value.Slice(0, valueSize).Interface().([]byte),
+	}
+}
+
+func (b *ByteArrayToByteArrayMap) Set(k, v []byte) {
+	if len(k) != b.keySize {
+		log.Panic("ByteArrayToByteArrayMap.Set() called with incorrect key length")
+	}
+	if len(v) != b.valueSize {
+		log.Panic("ByteArrayToByteArrayMap.Set() called with incorrect key length")
+	}
+
+	copy(b.keySlice, k)
+	copy(b.valueSlice, v)
+	b.m.SetMapIndex(b.key, b.value)
+}
+
+func (b *ByteArrayToByteArrayMap) Get(k []byte) []byte {
+	if len(k) != b.keySize {
+		log.Panic("ByteArrayToByteArrayMap.Get() called with incorrect key length")
+	}
+
+	copy(b.keySlice, k)
+	valVal := b.m.MapIndex(b.key)
+	if !valVal.IsValid() {
+		return nil
+	}
+	valSlice := make([]byte, b.valueSize)
+	reflect.Copy(reflect.ValueOf(valSlice), valVal)
+	return valSlice
+}
+
+func (b *ByteArrayToByteArrayMap) Delete(k []byte) {
+	if len(k) != b.keySize {
+		log.Panic("ByteArrayToByteArrayMap.Delete() called with incorrect key length")
+	}
+
+	copy(b.keySlice, k)
+	var zeroVal reflect.Value
+	b.m.SetMapIndex(b.key, zeroVal)
+}
+
+// Iter iterates over the map, passing each key/value to the given func as a slice.  For performance,
+// The slice is reused between iterations and should not be retained.  As with a normal map, it is safe
+// to delete from the map during iteration.
+func (b *ByteArrayToByteArrayMap) Iter(f func(k, v []byte)) {
+	iter := b.m.MapRange()
+	// Since it's valid for a user to call Get/Set while we're iterating, make sure we have our own
+	// values for key/value to avoid aliasing.
+	key := reflect.New(b.keyType).Elem()
+	val := reflect.New(b.valueType).Elem()
+	keySlice := key.Slice(0, b.keySize).Interface().([]byte)
+	valSlice := val.Slice(0, b.valueSize).Interface().([]byte)
+	for iter.Next() {
+		reflect.Copy(key, iter.Key())
+		reflect.Copy(val, iter.Value())
+		f(keySlice, valSlice)
+	}
+}
+
+func (b *ByteArrayToByteArrayMap) Len() int {
+	return b.m.Len()
+}

--- a/bpf/cachingmap/caching_map_test.go
+++ b/bpf/cachingmap/caching_map_test.go
@@ -1,0 +1,370 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cachingmap
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/bpf"
+	"github.com/projectcalico/felix/bpf/mock"
+	"github.com/projectcalico/felix/logutils"
+)
+
+func init() {
+	logutils.ConfigureEarlyLogging()
+	logrus.SetLevel(logrus.DebugLevel)
+}
+
+var cachingMapParams = bpf.MapParameters{
+	Name:      "mock-map",
+	KeySize:   2,
+	ValueSize: 4,
+}
+
+// TestCachingMap_Empty verifies loading of an empty map with no changes queued.
+func TestCachingMap_Empty(t *testing.T) {
+	mockMap, cm := setupCachingMapTest(t)
+	err := cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(BeEmpty())
+}
+
+var ErrFail = fmt.Errorf("fail")
+
+// TestCachingMap_Errors tests returning of errors from the underlying map.
+func TestCachingMap_Errors(t *testing.T) {
+	mockMap, cm := setupCachingMapTest(t)
+	mockMap.IterErr = ErrFail
+	err := cm.ApplyAllChanges()
+	Expect(err).To(HaveOccurred())
+
+	// Failure should have cleared the cache again so next Apply should see this new entry.
+	mockMap.Contents = map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+	}
+	mockMap.IterErr = nil
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(BeEmpty())
+
+	// Now check errors on update
+	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 4})
+	mockMap.UpdateErr = ErrFail
+	err = cm.ApplyAllChanges()
+	Expect(err).To(HaveOccurred())
+
+	// And then success
+	mockMap.UpdateErr = nil
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(Equal(map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 4}),
+	}))
+
+	// And delete.
+	mockMap.DeleteErr = ErrFail
+	cm.DeleteAllDesired()
+	err = cm.ApplyAllChanges()
+	Expect(err).To(HaveOccurred())
+
+	mockMap.DeleteErr = nil
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(BeEmpty())
+}
+
+// TestCachingMap_CleanUp verifies cleaning up of a whole map.
+func TestCachingMap_CleanUp(t *testing.T) {
+	mockMap, cm := setupCachingMapTest(t)
+	_ = mockMap.Update([]byte{1, 2}, []byte{1, 2, 3, 4})
+	_ = mockMap.Update([]byte{1, 3}, []byte{1, 2, 4, 4})
+
+	err := cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(BeEmpty())
+}
+
+// TestCachingMap_ApplyAll mainline test using separate Apply calls for adds and deletes.
+func TestCachingMap_SplitUpdateAndDelete(t *testing.T) {
+	mockMap, cm := setupCachingMapTest(t)
+	mockMap.Contents = map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+		string([]byte{1, 2}): string([]byte{1, 2, 3, 4}),
+		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}),
+	}
+
+	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 3}) // Same value for existing key.
+	cm.SetDesired([]byte{1, 2}, []byte{1, 2, 3, 6}) // New value for existing key.
+	cm.SetDesired([]byte{1, 4}, []byte{1, 2, 3, 5}) // New K/V
+	// Shouldn't do anything until we hit apply.
+	Expect(mockMap.OpCount()).To(Equal(0))
+
+	err := cm.ApplyUpdatesOnly()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(Equal(map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}), // No change
+		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}), // Updated
+		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}), // Not desired but should be left alone
+		string([]byte{1, 4}): string([]byte{1, 2, 3, 5}), // Added
+	}))
+	// Two updates and an iteration to load the map initially.
+	Expect(mockMap.UpdateCount).To(Equal(2))
+	Expect(mockMap.DeleteCount).To(Equal(0))
+	Expect(mockMap.GetCount).To(Equal(0))
+	Expect(mockMap.IterCount).To(Equal(1))
+
+	err = cm.ApplyDeletionsOnly()
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(mockMap.Contents).To(Equal(map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}),
+		string([]byte{1, 4}): string([]byte{1, 2, 3, 5}),
+	}))
+	// No new updates or iterations but should get one extra deletion.
+	Expect(mockMap.UpdateCount).To(Equal(2))
+	Expect(mockMap.GetCount).To(Equal(0))
+	Expect(mockMap.DeleteCount).To(Equal(1))
+	Expect(mockMap.IterCount).To(Equal(1))
+
+	// Doing an extra apply should make no changes.
+	preApplyOpCount := mockMap.OpCount()
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.OpCount()).To(Equal(preApplyOpCount))
+}
+
+// TestCachingMap_ApplyAll mainline test using ApplyAll() to update the dataplane.
+func TestCachingMap_ApplyAll(t *testing.T) {
+	mockMap, cm := setupCachingMapTest(t)
+	mockMap.Contents = map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+		string([]byte{1, 2}): string([]byte{1, 2, 3, 4}),
+		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}),
+	}
+
+	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 3}) // Same value for existing key.
+	cm.SetDesired([]byte{1, 2}, []byte{1, 2, 3, 6}) // New value for existing key.
+	cm.SetDesired([]byte{1, 4}, []byte{1, 2, 3, 5}) // New K/V
+	// Shouldn't do anything until we hit apply.
+	Expect(mockMap.OpCount()).To(Equal(0))
+
+	err := cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(Equal(map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}),
+		string([]byte{1, 4}): string([]byte{1, 2, 3, 5}),
+	}))
+	// Two updates and an iteration to load the map initially.
+	Expect(mockMap.UpdateCount).To(Equal(2))
+	Expect(mockMap.DeleteCount).To(Equal(1))
+	Expect(mockMap.GetCount).To(Equal(0))
+	Expect(mockMap.IterCount).To(Equal(1))
+
+	// Doing an extra apply should make no changes.
+	preApplyOpCount := mockMap.OpCount()
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.OpCount()).To(Equal(preApplyOpCount))
+
+	// Finish with a DeleteAll()
+	cm.DeleteAllDesired()
+	Expect(mockMap.OpCount()).To(Equal(preApplyOpCount)) // No immediate change
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(BeEmpty())
+	Expect(mockMap.DeleteCount).To(Equal(4))
+
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(BeEmpty())
+	Expect(mockMap.DeleteCount).To(Equal(4))
+}
+
+// TestCachingMap_DeleteBeforeLoad does some set and delete calls before loading from
+// the dataplane.
+func TestCachingMap_DeleteBeforeLoad(t *testing.T) {
+	mockMap, cm := setupCachingMapTest(t)
+	mockMap.Contents = map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+		string([]byte{1, 2}): string([]byte{1, 2, 3, 4}),
+		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}),
+	}
+
+	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 3}) // Same value for existing key.
+	cm.SetDesired([]byte{1, 2}, []byte{1, 2, 3, 6}) // New value for existing key.
+	cm.SetDesired([]byte{1, 4}, []byte{1, 2, 3, 5}) // New K/V
+	cm.DeleteDesired([]byte{1, 2})                  // Changed my mind.
+	cm.DeleteDesired([]byte{1, 4})                  // Changed my mind.
+	cm.DeleteDesired([]byte{1, 8})                  // Delete of non-existent key is a no-op.
+	// Shouldn't do anything until we hit apply.
+	Expect(mockMap.OpCount()).To(Equal(0))
+
+	err := cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(Equal(map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+	}))
+	// Just the two deletes.
+	Expect(mockMap.UpdateCount).To(Equal(0))
+	Expect(mockMap.DeleteCount).To(Equal(2))
+	Expect(mockMap.GetCount).To(Equal(0))
+	Expect(mockMap.IterCount).To(Equal(1))
+
+	// Doing an extra apply should make no changes.
+	preApplyOpCount := mockMap.OpCount()
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.OpCount()).To(Equal(preApplyOpCount))
+}
+
+// TestCachingMap_PreLoad verifies calling LoadCacheFromDataplane before setting values.
+func TestCachingMap_PreLoad(t *testing.T) {
+	mockMap, cm := setupCachingMapTest(t)
+	mockMap.Contents = map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+		string([]byte{1, 2}): string([]byte{1, 2, 3, 4}),
+		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}),
+	}
+	err := cm.LoadCacheFromDataplane()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.IterCount).To(Equal(1))
+	Expect(mockMap.OpCount()).To(Equal(1))
+
+	// Check we can query the cache.
+	Expect(cm.GetDataplaneCache([]byte{1, 1})).To(Equal([]byte{1, 2, 4, 3}))
+	seenValues := make(map[string]string)
+	cm.IterDataplaneCache(func(k, v []byte) {
+		seenValues[string(k)] = string(v)
+	})
+	Expect(seenValues).To(Equal(mockMap.Contents))
+
+	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 3}) // Same value for existing key.
+	cm.SetDesired([]byte{1, 2}, []byte{1, 2, 3, 6}) // New value for existing key.
+	cm.SetDesired([]byte{1, 4}, []byte{1, 2, 3, 5}) // New K/V
+	cm.DeleteDesired([]byte{1, 8})                  // Delete of non-existent key is a no-op.
+
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(Equal(map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}),
+		string([]byte{1, 4}): string([]byte{1, 2, 3, 5}),
+	}))
+	// Two updates and an iteration to load the map initially.
+	Expect(mockMap.UpdateCount).To(Equal(2))
+	Expect(mockMap.DeleteCount).To(Equal(1))
+	Expect(mockMap.GetCount).To(Equal(0))
+	Expect(mockMap.IterCount).To(Equal(1))
+
+	// Doing an extra apply should make no changes.
+	preApplyOpCount := mockMap.OpCount()
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.OpCount()).To(Equal(preApplyOpCount))
+}
+
+// TestCachingMap_Resync verifies handling of a dataplane reload while there are pending
+// changes.  Pending changes should be dropped if the reload finds that they've already
+// been made.
+func TestCachingMap_Resync(t *testing.T) {
+	mockMap, cm := setupCachingMapTest(t)
+	mockMap.Contents = map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+		string([]byte{1, 2}): string([]byte{1, 2, 3, 4}),
+		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}),
+	}
+	err := cm.LoadCacheFromDataplane()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.IterCount).To(Equal(1))
+	Expect(mockMap.OpCount()).To(Equal(1))
+
+	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 3}) // Same value for existing key.
+	cm.SetDesired([]byte{1, 2}, []byte{1, 2, 3, 6}) // New value for existing key.
+	cm.SetDesired([]byte{1, 4}, []byte{1, 2, 3, 5}) // New K/V
+
+	// At this point we've got some updates and a deletion queued up. Change the contents
+	// of the map:
+	// - Remove the key that was already correct.
+	// - Remove the key that we were about to delete.
+	// - Correct the value of the other key.
+	mockMap.Contents = map[string]string{
+		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}),
+	}
+
+	err = cm.LoadCacheFromDataplane()
+	Expect(err).NotTo(HaveOccurred())
+
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.Contents).To(Equal(map[string]string{
+		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}),
+		string([]byte{1, 4}): string([]byte{1, 2, 3, 5}),
+	}))
+	// Two updates and an iteration to load the map initially.
+	Expect(mockMap.UpdateCount).To(Equal(2))
+	Expect(mockMap.DeleteCount).To(Equal(0))
+	Expect(mockMap.GetCount).To(Equal(0))
+	Expect(mockMap.IterCount).To(Equal(2))
+
+	// Doing an extra apply should make no changes.
+	preApplyOpCount := mockMap.OpCount()
+	err = cm.ApplyAllChanges()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mockMap.OpCount()).To(Equal(preApplyOpCount))
+}
+
+func setupCachingMapTest(t *testing.T) (*mock.Map, *CachingMap) {
+	RegisterTestingT(t)
+	mockMap := mock.NewMockMap(cachingMapParams)
+	cm := New(cachingMapParams, mockMap)
+	return mockMap, cm
+}
+
+func TestByteArrayToByteArrayMap(t *testing.T) {
+	RegisterTestingT(t)
+
+	m := NewByteArrayToByteArrayMap(2, 4)
+
+	Expect(m.Get([]byte{1, 2})).To(BeNil(), "New map should not contain a value")
+	m.Set([]byte{1, 2}, []byte{1, 2, 3, 4})
+	Expect(m.Get([]byte{1, 2})).To(Equal([]byte{1, 2, 3, 4}), "Map should contain set value")
+	m.Set([]byte{1, 2}, []byte{1, 2, 3, 5})
+	Expect(m.Get([]byte{1, 2})).To(Equal([]byte{1, 2, 3, 5}), "Map should record updates")
+	m.Set([]byte{3, 4}, []byte{1, 2, 3, 6})
+	Expect(m.Get([]byte{3, 4})).To(Equal([]byte{1, 2, 3, 6}), "Map should record updates")
+
+	seenValues := map[string][]byte{}
+	m.Iter(func(k, v []byte) {
+		Expect(k).To(HaveLen(2))
+		Expect(v).To(HaveLen(4))
+		vCopy := make([]byte, len(v))
+		copy(vCopy, v)
+		seenValues[string(k)] = vCopy
+	})
+	Expect(seenValues).To(Equal(map[string][]byte{
+		string([]byte{1, 2}): {1, 2, 3, 5},
+		string([]byte{3, 4}): {1, 2, 3, 6},
+	}))
+
+	m.Delete([]byte{1, 2})
+	Expect(m.Get([]byte{1, 2})).To(BeNil(), "Deletion should remove the value")
+}

--- a/bpf/mock/map.go
+++ b/bpf/mock/map.go
@@ -29,19 +29,24 @@ type Map struct {
 
 	UpdateCount int
 	GetCount    int
+	DeleteCount int
 	IterCount   int
+
+	IterErr   error
+	UpdateErr error
+	DeleteErr error
 }
 
-func (m Map) MapFD() bpf.MapFD {
+func (m *Map) MapFD() bpf.MapFD {
 	panic("implement me")
 }
 
-func (m Map) Open() error {
+func (m *Map) Open() error {
 	m.logCxt.Info("Open called")
 	return nil
 }
 
-func (m Map) EnsureExists() error {
+func (m *Map) EnsureExists() error {
 	m.logCxt.Info("EnsureExists called")
 	return nil
 }
@@ -54,8 +59,13 @@ func (m *Map) Path() string {
 	return m.Filename
 }
 
-func (m Map) Iter(f bpf.IterCallback) error {
+func (m *Map) Iter(f bpf.IterCallback) error {
 	m.IterCount++
+
+	if m.IterErr != nil {
+		return m.IterErr
+	}
+
 	for kstr, vstr := range m.Contents {
 		action := f([]byte(kstr), []byte(vstr))
 		if action == bpf.IterDelete {
@@ -65,8 +75,12 @@ func (m Map) Iter(f bpf.IterCallback) error {
 	return nil
 }
 
-func (m Map) Update(k, v []byte) error {
+func (m *Map) Update(k, v []byte) error {
 	m.UpdateCount++
+	if m.UpdateErr != nil {
+		return m.UpdateErr
+	}
+
 	if len(k) != m.KeySize {
 		m.logCxt.Panicf("Key had wrong size (%d)", len(k))
 	}
@@ -78,7 +92,7 @@ func (m Map) Update(k, v []byte) error {
 	return nil
 }
 
-func (m Map) Get(k []byte) ([]byte, error) {
+func (m *Map) Get(k []byte) ([]byte, error) {
 	m.GetCount++
 
 	vstr, ok := m.Contents[string(k)]
@@ -88,7 +102,12 @@ func (m Map) Get(k []byte) ([]byte, error) {
 	return []byte(vstr), nil
 }
 
-func (m Map) Delete(k []byte) error {
+func (m *Map) Delete(k []byte) error {
+	m.DeleteCount++
+	if m.DeleteErr != nil {
+		return m.DeleteErr
+	}
+
 	if len(k) != m.KeySize {
 		m.logCxt.Panicf("Key had wrong size (%d)", len(k))
 	}
@@ -96,8 +115,8 @@ func (m Map) Delete(k []byte) error {
 	return nil
 }
 
-func (m Map) OpCount() int {
-	return m.UpdateCount + m.IterCount + m.GetCount
+func (m *Map) OpCount() int {
+	return m.UpdateCount + m.IterCount + m.GetCount + m.DeleteCount
 }
 
 func NewMockMap(params bpf.MapParameters) *Map {

--- a/bpf/proxy/health_check_nodeport_test.go
+++ b/bpf/proxy/health_check_nodeport_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -236,6 +236,9 @@ var _ = Describe("BPF Proxy healthCheckNodeport", func() {
 
 type mockDummySyncer struct {
 	syncerConntrackAPIDummy
+}
+
+func (s *mockDummySyncer) SetTriggerFn(f func()) {
 }
 
 func (*mockDummySyncer) Stop() {}

--- a/bpf/proxy/proxy.go
+++ b/bpf/proxy/proxy.go
@@ -61,6 +61,7 @@ type DPSyncer interface {
 	ConntrackScanEnd()
 	ConntrackFrontendHasBackend(ip net.IP, port uint16, backendIP net.IP, backendPort uint16, proto uint8) bool
 	Stop()
+	SetTriggerFn(func())
 }
 
 type proxy struct {
@@ -139,6 +140,7 @@ func New(k8s kubernetes.Interface, dp DPSyncer, hostname string, opts ...Option)
 	// will kick it
 	p.runner = async.NewBoundedFrequencyRunner("dp-sync-runner",
 		p.invokeDPSyncer, p.minDPSyncPeriod, time.Hour /* XXX might be infinite? */, 1)
+	dp.SetTriggerFn(p.runner.Run)
 
 	p.svcHealthServer = healthcheck.NewServiceHealthServer(p.hostname, p.recorder)
 	isIPv6 := false

--- a/bpf/proxy/proxy_bench_test.go
+++ b/bpf/proxy/proxy_bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,10 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/projectcalico/felix/bpf/cachingmap"
+
+	"github.com/projectcalico/felix/bpf/nat"
+
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,10 +45,13 @@ func benchmarkProxyUpdates(b *testing.B, svcN, epsN int) {
 		eps := makeEps(svcN, epsN)
 		k8s := fake.NewSimpleClientset(append(svcs, eps...)...)
 
+		feCache := cachingmap.New(nat.FrontendMapParameters, &mock.DummyMap{})
+		beCache := cachingmap.New(nat.BackendMapParameters, &mock.DummyMap{})
+
 		syncer, err := proxy.NewSyncer(
 			[]net.IP{net.IPv4(1, 1, 1, 1)},
-			&mock.DummyMap{},
-			&mock.DummyMap{},
+			feCache,
+			beCache,
 			&mock.DummyMap{},
 			proxy.NewRTCache(),
 		)

--- a/bpf/proxy/proxy_test.go
+++ b/bpf/proxy/proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -589,6 +589,9 @@ type mockSyncer struct {
 	out  chan proxy.DPSyncerState
 	in   chan error
 	stop chan struct{}
+}
+
+func (s *mockSyncer) SetTriggerFn(f func()) {
 }
 
 func newMockSyncer(stop chan struct{}) *mockSyncer {

--- a/bpf/proxy/service_type_change_test.go
+++ b/bpf/proxy/service_type_change_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -131,7 +131,6 @@ var _ = Describe("BPF service type change", func() {
 				}
 				return false
 			}).Should(BeTrue())
-
 		})
 
 		By("Remove ExternalIP", func() {

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -1275,6 +1275,26 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						cc.ExpectSome(externalClient, TargetIP(ip[0]), port)
 						cc.CheckConnectivity()
 					})
+
+					It("should handle temporary overlap of external IPs", func() {
+						By("Having connectivity to external IP initially")
+						cc.ExpectSome(externalClient, TargetIP(ip[0]), port)
+						cc.CheckConnectivity()
+
+						By("Adding second service with same external IP")
+						testSvc = k8sCreateLBServiceWithEndPoints(k8sClient, testSvcName+"-2", "10.101.0.11", w[0][0], 80, tgtPort,
+							testOpts.protocol, externalIP, srcIPRange)
+
+						By("Deleting first service")
+						err := k8sClient.CoreV1().Services(testSvc.ObjectMeta.Namespace).Delete(context.Background(), testSvcName, metav1.DeleteOptions{})
+						Expect(err).NotTo(HaveOccurred())
+
+						By("Sleeping")
+						time.Sleep(20 * time.Second)
+						By("And still having connectivity...")
+						cc.ExpectSome(externalClient, TargetIP(ip[0]), port)
+						cc.CheckConnectivity()
+					})
 				})
 
 				Context("Test load balancer service with src ranges", func() {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Cherry pick pull request #2770 from fasaxc/fix-proxy-syncer

(cherry picked from commit fbe51d56c9f2a1106a8a433cb9617d264dc0bdbd)

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Backport
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In BPF mode: Fix that changing the type of a service or having multiple services with overlapping external IPs would result in incorrect load balancing, even after the overlap was resolved.
```
