### PR TITLE
Reduce log level to debug for selector ID check

### DIFF
--- a/labelindex/label_inheritance_index.go
+++ b/labelindex/label_inheritance_index.go
@@ -189,7 +189,7 @@ func (idx *InheritIndex) UpdateSelector(id interface{}, sel selector.Selector) {
 	// Since the selectorRoot struct has cache fields, the easiest way to compare two
 	// selectors is to compare their IDs.
 	if oldSel != nil && oldSel.UniqueID() == sel.UniqueID() {
-		log.WithField("selID", id).Info("Skipping unchanged selector")
+		log.WithField("selID", id).Debug("Skipping unchanged selector")
 		return
 	}
 	log.WithField("selID", id).Info("Updating selector")


### PR DESCRIPTION
Hi,

My team and I are happy users of Calico. We’re running into a minor issue around log verbosity that this PR aims to address.

Guidance on how to get this PR up to the projectcalico standards would be greatly appreciated.

## Description

**type**: bugfix
**summary**:  This PR changes the log level from `info` to `debug`.
**context**:

The `UpdateSelector(id interface{}, sel selector.Selector)` method on `InheritIndex` is very verbose when comparing selectors.

```go
if oldSel != nil && oldSel.UniqueID() == sel.UniqueID() {
		log.WithField("selID", id).Info("Skipping unchanged selector")
		return
}
```

In our cluster, the current `info` level on `UpdateSelector(id interface{}, sel selector.Selector)` produces ~500M log lines every day of questionable usefulness.

Example log line being produced:
```
2021-04-23 16:48:37.440 [INFO][177] label_inheritance_index.go 200: Skipping unchanged selector selID=Policy(name=knp.default.foo-ns.foo-netpol)
```


## Todos
- [x] Unit tests (full coverage) not needed
- [x] Integrations tests not needed
- [ ] Documentation
- [ ] Backport
- [ ] Release note
