### PR TITLE
Reduce FV verbosity

### DIFF
--- a/fv/infrastructure/infra_etcd.go
+++ b/fv/infrastructure/infra_etcd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -198,6 +198,8 @@ func (eds *EtcdDatastoreInfra) DumpErrorData() {
 }
 
 func (eds *EtcdDatastoreInfra) Stop() {
+	eds.bpfLog.StopLogs()
+	eds.etcdContainer.StopLogs()
 	eds.bpfLog.Stop()
 	eds.etcdContainer.Stop()
 }

--- a/fv/named_ports_test.go
+++ b/fv/named_ports_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -156,37 +156,37 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 
 			profiles, err := client.Profiles().List(context.Background(), options.ListOptions{})
 			if err == nil {
-				utils.AddToTestOutput("Calico Profiles\n")
+				log.Info("DIAGS: Calico Profiles:")
 				for _, profile := range profiles.Items {
-					utils.AddToTestOutput(fmt.Sprintf("%v\n", profile))
+					log.Info(profile)
 				}
 			}
 			policies, err := client.NetworkPolicies().List(context.Background(), options.ListOptions{})
 			if err == nil {
-				utils.AddToTestOutput("Calico NetworkPolicies\n")
+				log.Info("DIAGS: Calico NetworkPolicies:")
 				for _, policy := range policies.Items {
-					utils.AddToTestOutput(fmt.Sprintf("%v\n", policy))
+					log.Info(policy)
 				}
 			}
 			gnps, err := client.GlobalNetworkPolicies().List(context.Background(), options.ListOptions{})
 			if err == nil {
-				utils.AddToTestOutput("Calico GlobalNetworkPolicies\n")
+				log.Info("DIAGS: Calico GlobalNetworkPolicies:")
 				for _, gnp := range gnps.Items {
-					utils.AddToTestOutput(fmt.Sprintf("%v\n", gnp))
+					log.Info(gnp)
 				}
 			}
 			workloads, err := client.WorkloadEndpoints().List(context.Background(), options.ListOptions{})
 			if err == nil {
-				utils.AddToTestOutput("Calico WorkloadEndpoints\n")
+				log.Info("DIAGS: Calico WorkloadEndpoints:")
 				for _, w := range workloads.Items {
-					utils.AddToTestOutput(fmt.Sprintf("%v\n", w))
+					log.Info(w)
 				}
 			}
 			nodes, err := client.Nodes().List(context.Background(), options.ListOptions{})
 			if err == nil {
-				utils.AddToTestOutput("Calico Nodes\n")
+				log.Info("DIAGS: Calico Nodes:")
 				for _, n := range nodes.Items {
-					utils.AddToTestOutput(fmt.Sprintf("%v\n", n))
+					log.Info(n)
 				}
 			}
 

--- a/fv/utils/utils.go
+++ b/fv/utils/utils.go
@@ -84,14 +84,19 @@ func run(input []byte, checkNoError bool, command string, args ...string) error 
 	outputBytes, err := cmd.CombinedOutput()
 	output := string(outputBytes)
 	LastRunOutput = string(outputBytes)
+	formattedCmd := formatCommand(command, args)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"command": command,
-			"args":    args}).WithError(err).Warningf("Command failed:\n%s", output)
+		if len(output) == 0 {
+			log.WithError(err).Warningf("Command failed [%s]: <no output>", formattedCmd)
+		} else {
+			log.WithError(err).Warningf("Command failed [%s]:\n%s", formattedCmd, indent(output, "\t"))
+		}
 	} else {
-		log.WithFields(log.Fields{
-			"command": command,
-			"args":    args}).Infof("Command succeeded:\n%s", output)
+		if len(output) == 0 {
+			log.Infof("Command succeeded [%s]: <no output>", formattedCmd)
+		} else {
+			log.Infof("Command succeeded [%s]:\n%s", formattedCmd, indent(output, "\t"))
+		}
 	}
 	if checkNoError {
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Command failed\nCommand: %v args: %v\nOutput:\n\n%v",
@@ -102,6 +107,28 @@ func run(input []byte, checkNoError bool, command string, args ...string) error 
 			command, args, string(outputBytes), err)
 	}
 	return nil
+}
+
+func indent(s string, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i := range lines {
+		lines[i] = prefix + lines[i]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatCommand(command string, args []string) string {
+	out := command
+	for _, arg := range args {
+		// Only quote if there are actually some interesting characters in there, just to make it easier to read.
+		quoted := fmt.Sprintf("%q", arg)
+		if quoted == `"` + arg + `"` {
+			out += " " + arg
+		} else {
+			out += " " + quoted
+		}
+	}
+	return out
 }
 
 func GetCommandOutput(command string, args ...string) (string, error) {
@@ -118,10 +145,7 @@ func RunCommand(command string, args ...string) error {
 }
 
 func Command(name string, args ...string) *exec.Cmd {
-	log.WithFields(log.Fields{
-		"command":     name,
-		"commandArgs": args,
-	}).Debug("Creating Command.")
+	log.Debugf("Creating Command [%s].", formatCommand(name, args))
 
 	return exec.Command(name, args...)
 }

--- a/fv/utils/utils.go
+++ b/fv/utils/utils.go
@@ -19,14 +19,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 
@@ -76,8 +74,6 @@ func RunMayFail(command string, args ...string) error {
 	return run(nil, false, command, args...)
 }
 
-var currentTestOutput = []string{}
-
 var LastRunOutput string
 
 func run(input []byte, checkNoError bool, command string, args ...string) error {
@@ -86,14 +82,16 @@ func run(input []byte, checkNoError bool, command string, args ...string) error 
 		cmd.Stdin = bytes.NewReader(input)
 	}
 	outputBytes, err := cmd.CombinedOutput()
-	currentTestOutput = append(currentTestOutput, fmt.Sprintf("Command: %v %v\n", command, args))
-	currentTestOutput = append(currentTestOutput, string(outputBytes))
+	output := string(outputBytes)
 	LastRunOutput = string(outputBytes)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"command": command,
-			"args":    args,
-			"output":  string(outputBytes)}).WithError(err).Warning("Command failed")
+			"args":    args}).WithError(err).Warningf("Command failed:\n%s", output)
+	} else {
+		log.WithFields(log.Fields{
+			"command": command,
+			"args":    args}).Infof("Command succeeded:\n%s", output)
 	}
 	if checkNoError {
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Command failed\nCommand: %v args: %v\nOutput:\n\n%v",
@@ -105,25 +103,6 @@ func run(input []byte, checkNoError bool, command string, args ...string) error 
 	}
 	return nil
 }
-
-func AddToTestOutput(args ...string) {
-	currentTestOutput = append(currentTestOutput, args...)
-}
-
-var _ = BeforeEach(func() {
-	currentTestOutput = []string{}
-})
-
-var _ = AfterEach(func() {
-	if CurrentGinkgoTestDescription().Failed {
-		os.Stdout.WriteString(fmt.Sprintf("\n===== begin output from failed test %s =====\n",
-			CurrentGinkgoTestDescription().FullTestText))
-		for _, output := range currentTestOutput {
-			os.Stdout.WriteString(output)
-		}
-		os.Stdout.WriteString("===== end output from failed test =====\n\n")
-	}
-})
 
 func GetCommandOutput(command string, args ...string) (string, error) {
 	cmd := Command(command, args...)
@@ -142,7 +121,7 @@ func Command(name string, args ...string) *exec.Cmd {
 	log.WithFields(log.Fields{
 		"command":     name,
 		"commandArgs": args,
-	}).Info("Creating Command.")
+	}).Debug("Creating Command.")
 
 	return exec.Command(name, args...)
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
* Ignore infra logs during stop. (API server tends to log a few pages of "can't reach etcd", which is totally useless.)
* Log command output inline rather than buffer.  (Think the buffered approach was added before we understood we could route logrus to ginkgo's writer in a nice way...)
* Reduce k8s components log levels; I can't remember the last time we've hit a problem where those logs were useful.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
