### PR TITLE
Fix ip rule logic to stop churning rules

### DIFF
--- a/fv/wireguard_test.go
+++ b/fv/wireguard_test.go
@@ -156,7 +156,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 			for _, felix := range felixes {
 				Eventually(func() string {
 					return getWireguardRoutingRule(felix)
-				}, "5s", "100ms").Should(MatchRegexp("\\d+:\\s+from all fwmark 0/0x\\d+ lookup \\d+"))
+				}, "5s", "100ms").Should(MatchRegexp("\\d+:\\s+not from all fwmark 0x\\d+/0x\\d+ lookup \\d+"))
 			}
 		})
 
@@ -353,7 +353,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 				// Check the rule exists.
 				Eventually(func() string {
 					return getWireguardRoutingRule(felix)
-				}, "10s", "100ms").Should(MatchRegexp("\\d+:\\s+from all fwmark 0/0x\\d+ lookup \\d+"))
+				}, "10s", "100ms").Should(MatchRegexp("\\d+:\\s+not from all fwmark 0x\\d+/0x\\d+ lookup \\d+"))
 			}
 
 			for i, felix := range felixes {
@@ -755,7 +755,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3 node 
 		for i := range []int{0, 1} {
 			Eventually(func() string {
 				return getWireguardRoutingRule(felixes[i])
-			}, "10s", "100ms").Should(MatchRegexp(fmt.Sprintf("\\d+:\\s+from all fwmark 0/0x\\d+ lookup \\d+")))
+			}, "10s", "100ms").Should(MatchRegexp(fmt.Sprintf("\\d+:\\s+not from all fwmark 0x\\d+/0x\\d+ lookup \\d+")))
 		}
 		// 3. by checking, Wireguard route table exist.
 		for i := range []int{0, 1} {
@@ -809,7 +809,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3 node 
 				// Check the rule exists.
 				Eventually(func() string {
 					return getWireguardRoutingRule(felixes[i])
-				}, "10s", "100ms").Should(MatchRegexp(fmt.Sprintf("\\d+:\\s+from all fwmark 0/0x\\d+ lookup \\d+")))
+				}, "10s", "100ms").Should(MatchRegexp(fmt.Sprintf("\\d+:\\s+not from all fwmark 0x\\d+/0x\\d+ lookup \\d+")))
 			}
 			for i := range []int{0, 1} {
 				// Check the route entry exists.
@@ -1052,7 +1052,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 		for _, felix := range felixes {
 			Eventually(func() string {
 				return getWireguardRoutingRule(felix)
-			}, "10s", "100ms").Should(MatchRegexp(fmt.Sprintf("\\d+:\\s+from all fwmark 0/0x\\d+ lookup \\d+")))
+			}, "10s", "100ms").Should(MatchRegexp(fmt.Sprintf("\\d+:\\s+not from all fwmark 0x\\d+/0x\\d+ lookup \\d+")))
 		}
 
 		By("Checking the routing table entries exist")

--- a/routerule/route_rule.go
+++ b/routerule/route_rule.go
@@ -238,6 +238,11 @@ func (r *RouteRules) Apply() error {
 		return ListFailed
 	}
 
+	// Set the Family onto the rules, the netlink lib does not populate this field.
+	for i := range nlRules {
+		nlRules[i].Family = r.netlinkFamily
+	}
+
 	// Work out two sets, rules to add and rules to remove.
 	toAdd := r.activeRules.Copy()
 	toRemove := set.New()

--- a/wireguard/wireguard.go
+++ b/wireguard/wireguard.go
@@ -1496,9 +1496,12 @@ func (w *Wireguard) ensureLinkAddressV4(netlinkClient netlinkshim.Interface) err
 
 // addRouteRule adds a routing rule to use the wireguard table.
 func (w *Wireguard) addRouteRule() {
+	// The netlink library has a bug where it returns -1 for the mark on a rule instead of 0.
+	// To work around this issue, the rule below was re-written to no longer use a mark of 0x0,
+	// instead matching the NOT of the actual wireguard mark.
 	w.routerule.SetRule(routerule.NewRule(ipVersion, w.config.RoutingRulePriority).
 		GoToTable(w.config.RoutingTableIndex).
-		MatchFWMarkWithMask(0, uint32(w.config.FirewallMark)))
+		Not().MatchFWMarkWithMask(uint32(w.config.FirewallMark), uint32(w.config.FirewallMark)))
 }
 
 // ensureDisabled ensures all calico-installed wireguard configuration is removed.

--- a/wireguard/wireguard_test.go
+++ b/wireguard/wireguard_test.go
@@ -180,7 +180,8 @@ var _ = Describe("Enable wireguard", func() {
 		rule.Family = netlink.FAMILY_V4
 		rule.Priority = rulePriority
 		rule.Table = tableIndex
-		rule.Mark = 0
+		rule.Invert = true
+		rule.Mark = firewallMark
 		rule.Mask = firewallMark
 	})
 
@@ -274,6 +275,7 @@ var _ = Describe("Enable wireguard", func() {
 
 			It("should delete invalid rules jumping to the wireguard table", func() {
 				incorrectRule := netlink.NewRule()
+				incorrectRule.Family = 2
 				incorrectRule.Priority = rulePriority + 10
 				incorrectRule.Table = tableIndex
 				incorrectRule.Mark = firewallMark + 10
@@ -1367,19 +1369,23 @@ var _ = Describe("Wireguard (disabled)", func() {
 				// Create a rule to route to the wireguard table.
 				rrDataplane.Rules = []netlink.Rule{
 					{
+						Family:   2,
 						Priority: 0,
 						Table:    255,
 					},
 					{
+						Family: 2,
 						Table:  tableIndex,
 						Mark:   firewallMark,
 						Invert: true,
 					},
 					{
+						Family:   2,
 						Priority: 32766,
 						Table:    254,
 					},
 					{
+						Family:   2,
 						Priority: 32767,
 						Table:    253,
 					},
@@ -1424,14 +1430,17 @@ var _ = Describe("Wireguard (disabled)", func() {
 				Expect(rrDataplane.NumRuleAddCalls).To(Equal(0))
 				Expect(rrDataplane.Rules).To(Equal([]netlink.Rule{
 					{
+						Family:   2,
 						Priority: 0,
 						Table:    255,
 					},
 					{
+						Family:   2,
 						Priority: 32766,
 						Table:    254,
 					},
 					{
+						Family:   2,
 						Priority: 32767,
 						Table:    253,
 					},


### PR DESCRIPTION
The netlink library has a couple of quirks when listing rules:
- it doesn't populate the family field, instead returning 0
- if a rule has fwmark of 0, netlink returns -1

These quirks were causing felix to determine that the wireguard ip
rule entry on the node was different to what should be present, and so
felix deleted the "incorrect" rule and re-created it.

To workaround these quirks:

- when listing the rules, we populate the family ourselves

- the wireguard ip rule was changed from:
  from all fwmark 0x0/0x100000 lookup 1
  to:
  not from all fwmark 0x100000/0x100000 lookup 1

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests Done

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that, with wireguard enabled, felix would delete and re-add the wireguard routing rule every 90 seconds causing occasional dropped packets.
```
