### PR TITLE
Stop ARP traffic being dropped due to RPF check

### DIFF
--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -1263,11 +1263,35 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 			rulesConfig.RouteSource == "WorkloadIPs" {
 			log.Debug("Adding Wireguard iptables rule")
 			rawRules = append(rawRules, iptables.Rule{
-				Match: iptables.Match().Protocol("udp").
-					DestPorts(uint16(rulesConfig.WireguardListeningPort)).
-					NotSrcAddrType(iptables.AddrTypeLocal, false),
+				Match:  nil,
+				Action: iptables.JumpAction{Target: rules.ChainSetWireguardIncomingMark},
+			})
+
+			wgRules := []iptables.Rule{
+				{
+					Match:  iptables.Match().InInterface("lo"),
+					Action: iptables.ReturnAction{}},
+				{
+					Match:  iptables.Match().InInterface(rulesConfig.WireguardInterfaceName),
+					Action: iptables.ReturnAction{}},
+			}
+
+			for _, ifacePrefix := range rulesConfig.WorkloadIfacePrefixes {
+				wgRules = append(wgRules, iptables.Rule{
+					Match:  iptables.Match().InInterface(fmt.Sprintf("%s+", ifacePrefix)),
+					Action: iptables.ReturnAction{}})
+			}
+
+			wgRules = append(wgRules, iptables.Rule{
+				Match:  nil,
 				Action: iptables.SetMarkAction{Mark: rulesConfig.WireguardIptablesMark},
 			})
+
+			setWireguardIncomingMarkChain := &iptables.Chain{
+				Name:  rules.ChainSetWireguardIncomingMark,
+				Rules: wgRules,
+			}
+			t.UpdateChain(setWireguardIncomingMarkChain)
 		}
 
 		rawRules = append(rawRules, iptables.Rule{

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -1258,40 +1258,16 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 		t.UpdateChains(rpfChain)
 
 		var rawRules []iptables.Rule
-		// Set a mark on encapsulated packets coming from WireGuard to ensure the RPF check allows it
 		if t.IPVersion == 4 && rulesConfig.WireguardEnabled && len(rulesConfig.WireguardInterfaceName) > 0 &&
 			rulesConfig.RouteSource == "WorkloadIPs" {
-			log.Debug("Adding Wireguard iptables rule")
+			// Set a mark on packets coming from any interface except for lo, wireguard, or pod veths to ensure the RPF
+			// check allows it.
+			log.Debug("Adding Wireguard iptables rule chain")
 			rawRules = append(rawRules, iptables.Rule{
 				Match:  nil,
 				Action: iptables.JumpAction{Target: rules.ChainSetWireguardIncomingMark},
 			})
-
-			wgRules := []iptables.Rule{
-				{
-					Match:  iptables.Match().InInterface("lo"),
-					Action: iptables.ReturnAction{}},
-				{
-					Match:  iptables.Match().InInterface(rulesConfig.WireguardInterfaceName),
-					Action: iptables.ReturnAction{}},
-			}
-
-			for _, ifacePrefix := range rulesConfig.WorkloadIfacePrefixes {
-				wgRules = append(wgRules, iptables.Rule{
-					Match:  iptables.Match().InInterface(fmt.Sprintf("%s+", ifacePrefix)),
-					Action: iptables.ReturnAction{}})
-			}
-
-			wgRules = append(wgRules, iptables.Rule{
-				Match:  nil,
-				Action: iptables.SetMarkAction{Mark: rulesConfig.WireguardIptablesMark},
-			})
-
-			setWireguardIncomingMarkChain := &iptables.Chain{
-				Name:  rules.ChainSetWireguardIncomingMark,
-				Rules: wgRules,
-			}
-			t.UpdateChain(setWireguardIncomingMarkChain)
+			t.UpdateChain(d.ruleRenderer.WireguardIncomingMarkChain())
 		}
 
 		rawRules = append(rawRules, iptables.Rule{

--- a/fv/wireguard_test.go
+++ b/fv/wireguard_test.go
@@ -1004,7 +1004,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 				felix.Exec("ip", "route", "show", "table", "all")
 				felix.Exec("ip", "route", "show", "cached")
 				felix.Exec("wg")
-				felix.Exec("iptables-save", "-t", "raw")
+				felix.Exec("iptables-save", "-c", "-t", "raw")
 				felix.Exec("iptables", "-L", "-vx")
 				felix.Exec("cat", "/proc/sys/net/ipv4/conf/all/src_valid_mark")
 			}
@@ -1073,6 +1073,14 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 			Eventually(func() []string {
 				return strings.Split(getWireguardRouteEntry(felixes[i]), "\n")
 			}, "10s", "100ms").Should(ContainElements(matchers))
+		}
+
+		By("Checking the iptables raw chain cali-wireguard-incoming-mark exists")
+		for _, felix := range felixes {
+			Eventually(func() string {
+				s, _ := felix.ExecCombinedOutput("iptables", "-L", "cali-wireguard-incoming-mark", "-t", "raw")
+				return s
+			}, "10s", "100ms").Should(ContainSubstring("Chain cali-wireguard-incoming-mark"))
 		}
 
 		By("Checking the proc/sys src valid mark entries")

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -224,6 +224,8 @@ type RuleRenderer interface {
 	DNATsToIptablesChains(dnats map[string]string) []*iptables.Chain
 	SNATsToIptablesChains(snats map[string]string) []*iptables.Chain
 	BlockedCIDRsToIptablesChains(cidrs []string, ipVersion uint8) []*iptables.Chain
+
+	WireguardIncomingMarkChain() *iptables.Chain
 }
 
 type DefaultRuleRenderer struct {

--- a/rules/rule_defs.go
+++ b/rules/rule_defs.go
@@ -86,6 +86,8 @@ const (
 	ChainForwardCheck        = ChainNamePrefix + "forward-check"
 	ChainForwardEndpointMark = ChainNamePrefix + "forward-endpoint-mark"
 
+	ChainSetWireguardIncomingMark = ChainNamePrefix + "wireguard-incoming-mark"
+
 	WorkloadToEndpointPfx   = ChainNamePrefix + "tw-"
 	WorkloadPfxSpecialAllow = "ALLOW"
 	WorkloadFromEndpointPfx = ChainNamePrefix + "fw-"

--- a/rules/static.go
+++ b/rules/static.go
@@ -980,7 +980,7 @@ func (r *DefaultRuleRenderer) StaticRawTableChains(ipVersion uint8) []*Chain {
 		r.failsafeInChain("raw", ipVersion),
 		r.failsafeOutChain("raw", ipVersion),
 		r.StaticRawPreroutingChain(ipVersion),
-		r.StaticRawWireguardIncomingMarkChain(),
+		r.WireguardIncomingMarkChain(),
 		r.StaticRawOutputChain(),
 	}
 }
@@ -1087,7 +1087,7 @@ func (r *DefaultRuleRenderer) allCalicoMarkBits() uint32 {
 		r.IptablesMarkScratch1
 }
 
-func (r *DefaultRuleRenderer) StaticRawWireguardIncomingMarkChain() *Chain {
+func (r *DefaultRuleRenderer) WireguardIncomingMarkChain() *Chain {
 	rules := []Rule{
 		{
 			Match:  Match().InInterface("lo"),

--- a/rules/static_test.go
+++ b/rules/static_test.go
@@ -473,7 +473,7 @@ var _ = Describe("Static", func() {
 						Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-failsafe-out")).To(Equal(expRawFailsafeOut))
 					})
 					It("should return only the expected raw chains", func() {
-						Expect(len(rr.StaticRawTableChains(ipVersion))).To(Equal(4))
+						Expect(len(rr.StaticRawTableChains(ipVersion))).To(Equal(5))
 					})
 				})
 			}
@@ -1385,10 +1385,8 @@ var _ = Describe("Static", func() {
 				Rules: []Rule{
 					{Match: nil,
 						Action: ClearMarkAction{Mark: 0xf0}},
-					{Match: Match().Protocol("udp").
-						DestPorts(51820).
-						NotSrcAddrType(AddrTypeLocal, false),
-						Action: SetMarkAction{Mark: 0x100000}},
+					{Match: nil,
+						Action: JumpAction{Target: "cali-wireguard-incoming-mark"}},
 					{Match: Match().InInterface("cali+"),
 						Action: SetMarkAction{Mark: 0x40}},
 					{Match: Match().MarkMatchesWithMask(0x40, 0x40).RPFCheckFailed(false),
@@ -1397,6 +1395,19 @@ var _ = Describe("Static", func() {
 						Action: JumpAction{Target: "cali-from-host-endpoint"}},
 					{Match: Match().MarkMatchesWithMask(0x10, 0x10),
 						Action: AcceptAction{}},
+				},
+			}))
+			Expect(findChain(rr.StaticRawTableChains(ipVersion), "cali-wireguard-incoming-mark")).To(Equal(&Chain{
+				Name: "cali-wireguard-incoming-mark",
+				Rules: []Rule{
+					{Match: Match().InInterface("lo"),
+						Action: ReturnAction{}},
+					{Match: Match().InInterface("wireguard.cali"),
+						Action: ReturnAction{}},
+					{Match: Match().InInterface("cali+"),
+						Action: ReturnAction{}},
+					{Match: nil,
+						Action: SetMarkAction{Mark: 0x100000}},
 				},
 			}))
 		})


### PR DESCRIPTION
ARP request packets were being dropped on the receiving node due to the
RPF check. This was because the incoming packets arrived on eth0, but
the RPF check determined that as the packets were not marked with the
wireguard fwmark, the return route would be through the wireguard
interface.

To fix this issue, iptables rules were introduced to mark all packets
which were not from the lo, wireguard, or cali+ interfaces with the
wireguard fwmark. This has the affect that these packets will then not
be routed through the wireguard interface and will pass the RPF
check.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests Done

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
