### PR TITLE
Use new common cd formatting / pipeline

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,7 +34,9 @@ global_job_config:
   - name: docker-hub
   prologue:
     commands:
-    - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      # make some room on the disk
+      - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl
+      - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
 
 blocks:
 - name: Build


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

dry run output:
```
docker tag calico/felix:latest-amd64 calico/felix:master-amd64
docker tag calico/felix:latest-arm64 calico/felix:master-arm64
docker tag calico/felix:latest-ppc64le calico/felix:master-ppc64le
docker tag calico/felix:latest-amd64 quay.io/calico/felix:master
[DRY RUN] docker push calico/felix:master-amd64
[DRY RUN] docker push calico/felix:master-arm64
[DRY RUN] docker push calico/felix:master-ppc64le
[DRY RUN] docker push quay.io/calico/felix:master
[DRY RUN] docker run -t --entrypoint /bin/sh -v /home/brian/.docker/config.json:/root/.docker/config.json calico/go-build:v0.53 -c /usr/bin/manifest-tool push from-args --platforms linux/amd64,linux/arm64,linux/ppc64le --template /calico/felix:master-ARCHVARIANT --target /calico/felix:master
docker tag calico/felix:latest-amd64 calico/felix:v3.20.0-0.dev-1-g20be9fc0c20e-amd64
docker tag calico/felix:latest-arm64 calico/felix:v3.20.0-0.dev-1-g20be9fc0c20e-arm64
docker tag calico/felix:latest-ppc64le calico/felix:v3.20.0-0.dev-1-g20be9fc0c20e-ppc64le
docker tag calico/felix:latest-amd64 quay.io/calico/felix:v3.20.0-0.dev-1-g20be9fc0c20e
[DRY RUN] docker push calico/felix:v3.20.0-0.dev-1-g20be9fc0c20e-amd64
[DRY RUN] docker push calico/felix:v3.20.0-0.dev-1-g20be9fc0c20e-arm64
[DRY RUN] docker push calico/felix:v3.20.0-0.dev-1-g20be9fc0c20e-ppc64le
[DRY RUN] docker push quay.io/calico/felix:v3.20.0-0.dev-1-g20be9fc0c20e
[DRY RUN] docker run -t --entrypoint /bin/sh -v /home/brian/.docker/config.json:/root/.docker/config.json calico/go-build:v0.53 -c /usr/bin/manifest-tool push from-args --platforms linux/amd64,linux/arm64,linux/ppc64le --template /calico/felix:v3.20.0-0.dev-1-g20be9fc0c20e-ARCHVARIANT --target /calico/felix:v3.20.0-0.dev-1-g20be9fc0c20e

```

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
