### PR TITLE
DebugBPFMapRepinEnabled -> false

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -132,7 +132,7 @@ type Config struct {
 	DebugBPFCgroupV2 string `config:"string;;local"`
 	// DebugBPFMapRepinEnabled can be used to prevent Felix from repinning its BPF maps at startup.  This is useful for
 	// testing with multiple Felix instances running on one host.
-	DebugBPFMapRepinEnabled bool `config:"bool;true;local"`
+	DebugBPFMapRepinEnabled bool `config:"bool;false;local"`
 
 	DatastoreType string `config:"oneof(kubernetes,etcdv3);etcdv3;non-zero,die-on-fail,local"`
 

--- a/fv/infrastructure/felix.go
+++ b/fv/infrastructure/felix.go
@@ -117,10 +117,6 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 			log.Info("FELIX_FV_ENABLE_BPF=true but test manages BPF state itself, not using env var")
 		}
 
-		// Disable map repinning by default since BPF map names are global and we don't want our simulated instances to
-		// share maps.
-		envVars["FELIX_DebugBPFMapRepinEnabled"] = "false"
-
 		if CreateCgroupV2 {
 			envVars["FELIX_DEBUGBPFCGROUPV2"] = containerName
 		}


### PR DESCRIPTION
There are now no use cases where we need map repinning, so let's
disable it by default.  After running with this for a while, if there
are no issues, we can remove the related code.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
In eBPF mode, disable Felix's BPF map repinning logic by default. This logic was intended to avoid the need to mount the BPF filesystem into the calico/node container but it was flawed because program maps are emptied by the kernel when they are not pinned.
```