### PR TITLE
BPF: Two more steps towards reducing conntrack-specific context

### DIFF
--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -52,7 +52,7 @@ static CALI_BPF_INLINE void dump_ct_key(struct calico_ct_key *k)
 }
 
 static CALI_BPF_INLINE int calico_ct_v4_create_tracking(struct cali_tc_ctx *tc_ctx,
-							struct ct_create_ctx *ct_ctx,
+							const struct ct_create_ctx *ct_ctx,
 							struct calico_ct_key *k)
 {
 	__be32 ip_src = ct_ctx->src;
@@ -208,7 +208,7 @@ out:
 	return err;
 }
 
-static CALI_BPF_INLINE int calico_ct_v4_create_nat_fwd(struct ct_create_ctx *ct_ctx,
+static CALI_BPF_INLINE int calico_ct_v4_create_nat_fwd(const struct ct_create_ctx *ct_ctx,
 						       struct calico_ct_key *rk)
 {
 	__u8 ip_proto = ct_ctx->proto;
@@ -801,7 +801,7 @@ out_invalid:
 }
 
 /* creates connection tracking for tracked protocols */
-static CALI_BPF_INLINE int conntrack_create(struct cali_tc_ctx *ctx, struct ct_create_ctx *ct_ctx)
+static CALI_BPF_INLINE int conntrack_create(struct cali_tc_ctx *ctx, const struct ct_create_ctx *ct_ctx)
 {
 	struct calico_ct_key k;
 	int err;

--- a/bpf-gpl/conntrack_types.h
+++ b/bpf-gpl/conntrack_types.h
@@ -107,7 +107,6 @@ struct ct_lookup_ctx {
 };
 
 struct ct_create_ctx {
-	struct __sk_buff *skb;
 	__u8 proto;
 	__be32 src;
 	__be32 orig_dst;

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -702,7 +702,6 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 			goto deny;
 		}
 
-		ct_ctx_nat.skb = skb;
 		ct_ctx_nat.proto = state->ip_proto;
 		ct_ctx_nat.src = state->ip_src;
 		ct_ctx_nat.sport = state->sport;


### PR DESCRIPTION
ee0cf7b36 Remove skb field from ct_create_ctx
1a48dd52c Check and enforce that conntrack_create doesn't change ct_create_ctx
