### PR TITLE
Ignore /32 routes when programming VXLAN blackhole routes.

### DIFF
--- a/dataplane/linux/vxlan_mgr_test.go
+++ b/dataplane/linux/vxlan_mgr_test.go
@@ -180,6 +180,16 @@ var _ = Describe("VXLANManager", func() {
 			SameSubnet:  true,
 		})
 
+		// Borrowed /32 should not be programmed as blackhole.
+		manager.OnUpdate(&proto.RouteUpdate{
+			Type:        proto.RouteType_LOCAL_WORKLOAD,
+			IpPoolType:  proto.IPPoolType_VXLAN,
+			Dst:         "172.0.0.1/32",
+			DstNodeName: "node1",
+			DstNodeIp:   "172.8.8.7",
+			SameSubnet:  true,
+		})
+
 		Expect(rt.currentRoutes["vxlan.calico"]).To(HaveLen(0))
 		Expect(brt.currentRoutes[routetable.InterfaceNone]).To(HaveLen(0))
 


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
/32 blackholes are inherently racey vs the CNI plugin adding a workload.
## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix race where felix programs a /32 blackhole route for a borrowed IP address concurrently with CNI plugin programming a "proper" route.
```
