### PR TITLE
Reduce organisation impact of semaphore job

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,9 +11,9 @@ agent:
 
 auto_cancel:
   running:
-    when: "branch != 'master'"
+    when: "true"
   queued:
-    when: "branch != 'master'"
+    when: "true"
 
 promotions:
 - name: Cleanup

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,18 +15,6 @@ auto_cancel:
   queued:
     when: "true"
 
-queue:
-  # Run PR builds in parallel excluding automated pin updates from being classed as PRs.
-  - when: "pull_request =~ '.+' AND branch !~ 'semaphore-auto.*'"
-    name: "PRs"
-    processing: parallel
-
-  # Run everything else serially on a second queue.  This means that master and release branch builds
-  # will be queued with automated pin updates.
-  - when: "true"
-    name: "Automated builds"
-    processing: serialized
-
 promotions:
 - name: Cleanup
   pipeline_file: cleanup.yml
@@ -115,7 +103,7 @@ blocks:
         - ./.semaphore/collect-artifacts
         - ./.semaphore/publish-artifacts
 - name: BPF UT/FV tests on new kernel
-  dependencies: ["Build"]
+  dependencies: []
   task:
     prologue:
       commands:
@@ -151,7 +139,7 @@ blocks:
     secrets:
     - name: google-service-account-for-gce
 - name: Static checks on e1-standard-8
-  dependencies: ["Build"]
+  dependencies: []
   task:
     agent:
       machine:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,6 +15,18 @@ auto_cancel:
   queued:
     when: "true"
 
+queue:
+  # Run PR builds in parallel excluding automated pin updates from being classed as PRs.
+  - when: "pull_request =~ '.+' AND branch !~ 'semaphore-auto.*'"
+    name: "PRs"
+    processing: parallel
+
+  # Run everything else serially on a second queue.  This means that master and release branch builds
+  # will be queued with automated pin updates.
+  - when: "true"
+    name: "Automated builds"
+    processing: serialized
+
 promotions:
 - name: Cleanup
   pipeline_file: cleanup.yml

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -47,7 +47,7 @@ blocks:
         type: e1-standard-4
         os_image: ubuntu1804
     jobs:
-    - name: Build
+    - name: Build and run UT, k8sfv
       execution_time_limit:
         minutes: 20
       commands:
@@ -55,13 +55,16 @@ blocks:
       - cache restore go-pkg-cache
       - cache restore go-mod-cache
       - >-
-        make image fv/fv.test bin/test-workload bin/test-connection
+        make image-all fv/fv.test bin/test-workload bin/test-connection
         bin/calico-felix
       - 'cache store bin-${SEMAPHORE_GIT_SHA} bin'
       - cache store go-pkg-cache .go-pkg-cache
       - 'cache store go-mod-cache ${HOME}/go/pkg/mod/cache'
       - docker save -o /tmp/calico-felix.tar calico/felix:latest-amd64
       - 'cache store felix-image-${SEMAPHORE_GIT_SHA} /tmp/calico-felix.tar'
+      - make ut
+      - make k8sfv-test JUST_A_MINUTE=true USE_TYPHA=true
+      - make k8sfv-test JUST_A_MINUTE=true USE_TYPHA=false
 - name: FV Tests
   dependencies: ["Build"]
   task:
@@ -100,7 +103,7 @@ blocks:
         - ./.semaphore/collect-artifacts
         - ./.semaphore/publish-artifacts
 - name: BPF UT/FV tests on new kernel
-  dependencies: []
+  dependencies: ["Build"]
   task:
     prologue:
       commands:
@@ -135,8 +138,8 @@ blocks:
         - gcloud --quiet compute instances delete ${VM_NAME} --zone=${ZONE}
     secrets:
     - name: google-service-account-for-gce
-- name: Static checks
-  dependencies: []
+- name: Static checks on e1-standard-8
+  dependencies: ["Build"]
   task:
     agent:
       machine:
@@ -154,35 +157,6 @@ blocks:
         minutes: 15
       commands:
       - make static-checks
-- name: Multi-arch builds, UT, k8sfv-tests
-  dependencies: []
-  task:
-    prologue:
-      commands:
-      - checkout
-      - cache restore go-pkg-cache
-      - cache restore go-mod-cache
-    jobs:
-    - name: Build All
-      execution_time_limit:
-        minutes: 60
-      commands:
-        - make image-all
-    - name: UT
-      execution_time_limit:
-        minutes: 60
-      commands:
-        - make ut
-    - name: K8sfv with Typha
-      execution_time_limit:
-        minutes: 60
-      commands:
-        - make k8sfv-test JUST_A_MINUTE=true USE_TYPHA=true
-    - name: K8sfv without Typha
-      execution_time_limit:
-        minutes: 60
-      commands:
-        - make k8sfv-test JUST_A_MINUTE=true USE_TYPHA=false
 - name: Trigger pin updates
   dependencies: []
   skip:


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Proposing a few changes to the semaphore job to increase efficiency at the expense of a slightly longer job times (and some other changes):

* Coalesce the build, UT, k8sfv, image-all jobs into one job that is run first.  Previously, the jobs took an aggregate of ~32minutes but combining them reduces that to 14 minutes due to being able to make use of the warm go build cache etc.
* Enable auto-cancel for master; I think it's pretty rare that we queue up multiple master builds but it might help when we're doing a lot of pin updates etc.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
