### PR TITLE
Put logic for configuring network interfaces behind a configuration flag

### DIFF
--- a/config/config_params.go
+++ b/config/config_params.go
@@ -335,6 +335,9 @@ type Config struct {
 	// Configures MTU auto-detection.
 	MTUIfacePattern *regexp.Regexp `config:"regexp;^((en|wl|ww|sl|ib)[opsx].*|(eth|wlan|wwan).*)"`
 
+	// Provides information on whether Felix should maintain endpoints in the absence of Calico CNI
+	InterfaceConfigurationEnabled bool `config:"bool;true"`
+
 	// State tracking.
 
 	// internalOverrides contains our highest priority config source, generated from internal constraints

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -718,7 +718,8 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		dp.endpointStatusCombiner.OnEndpointStatusUpdate,
 		config.BPFEnabled,
 		bpfEndpointManager,
-		callbacks)
+		callbacks,
+		config.InterfaceConfigurationEnabled)
 	dp.RegisterManager(epManager)
 	dp.endpointsSourceV4 = epManager
 	dp.RegisterManager(newFloatingIPManager(natTableV4, ruleRenderer, 4))
@@ -815,7 +816,8 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			dp.endpointStatusCombiner.OnEndpointStatusUpdate,
 			config.BPFEnabled,
 			nil,
-			callbacks))
+			callbacks,
+			config.InterfaceConfigurationEnabled))
 		dp.RegisterManager(newFloatingIPManager(natTableV6, ruleRenderer, 6))
 		dp.RegisterManager(newMasqManager(ipSetsV6, natTableV6, ruleRenderer, config.MaxIPSetSize, 6))
 		dp.RegisterManager(newServiceLoopManager(filterTableV6, ruleRenderer, 6))


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
This hides the calls that configure sysctl values on the network interfaces behind a configuration flag. The intention is that in cases where we are using the Calico CNI, the Calico CNI will run these operations instead and this will remove the reliance on sysctl to make our normal node logic work (since sysctl requires privileged permissions to run).

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
