### PR TITLE
Reduce felix FV log severity; add env var to override for debug 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ fv fv/latency.log fv/data-races.log: $(REMOTE_DEPS) image-test bin/iptables-lock
 	  FV_K8SIMAGE=$(FV_K8SIMAGE) \
 	  FV_NUM_BATCHES=$(FV_NUM_BATCHES) \
 	  FV_BATCHES_TO_RUN="$(FV_BATCHES_TO_RUN)" \
-	  FELIX_FV_FELIX_LOG_LEVEL="$(FELIX_FV_FELIX_LOG_LEVEL)" \
+	  FV_FELIX_LOG_LEVEL="$(FV_FELIX_LOG_LEVEL)" \
 	  PRIVATE_KEY=`pwd`/private.key \
 	  GINKGO_ARGS='$(GINKGO_ARGS)' \
 	  GINKGO_FOCUS="$(GINKGO_FOCUS)" \

--- a/Makefile
+++ b/Makefile
@@ -354,6 +354,7 @@ fv fv/latency.log fv/data-races.log: $(REMOTE_DEPS) image-test bin/iptables-lock
 	  FV_K8SIMAGE=$(FV_K8SIMAGE) \
 	  FV_NUM_BATCHES=$(FV_NUM_BATCHES) \
 	  FV_BATCHES_TO_RUN="$(FV_BATCHES_TO_RUN)" \
+	  FELIX_FV_FELIX_LOG_LEVEL="$(FELIX_FV_FELIX_LOG_LEVEL)" \
 	  PRIVATE_KEY=`pwd`/private.key \
 	  GINKGO_ARGS='$(GINKGO_ARGS)' \
 	  GINKGO_FOCUS="$(GINKGO_FOCUS)" \

--- a/fv/bpf_test.go
+++ b/fv/bpf_test.go
@@ -245,7 +245,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			}
 
 			options = infrastructure.DefaultTopologyOptions()
-			options.FelixLogSeverity = "debug"
 			options.NATOutgoingEnabled = true
 			options.AutoHEPsEnabled = true
 			// override IPIP being enabled by default

--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -17,6 +17,7 @@ package infrastructure
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"sync"
 	"time"
@@ -60,8 +61,13 @@ type TopologyOptions struct {
 }
 
 func DefaultTopologyOptions() TopologyOptions {
+	felixLogLevel := "info"
+	if envLogLevel := os.Getenv("FELIX_FV_FELIX_LOG_LEVEL"); envLogLevel != "" {
+		log.WithField("level", envLogLevel).Info("FELIX_FV_FELIX_LOG_LEVEL env var set; overriding felix log level")
+		felixLogLevel = envLogLevel
+	}
 	return TopologyOptions{
-		FelixLogSeverity:  "info",
+		FelixLogSeverity:  felixLogLevel,
 		EnableIPv6:        true,
 		ExtraEnvVars:      map[string]string{},
 		ExtraVolumes:      map[string]string{},

--- a/fv/infrastructure/topology.go
+++ b/fv/infrastructure/topology.go
@@ -62,8 +62,8 @@ type TopologyOptions struct {
 
 func DefaultTopologyOptions() TopologyOptions {
 	felixLogLevel := "info"
-	if envLogLevel := os.Getenv("FELIX_FV_FELIX_LOG_LEVEL"); envLogLevel != "" {
-		log.WithField("level", envLogLevel).Info("FELIX_FV_FELIX_LOG_LEVEL env var set; overriding felix log level")
+	if envLogLevel := os.Getenv("FV_FELIX_LOG_LEVEL"); envLogLevel != "" {
+		log.WithField("level", envLogLevel).Info("FV_FELIX_LOG_LEVEL env var set; overriding felix log level")
 		felixLogLevel = envLogLevel
 	}
 	return TopologyOptions{

--- a/fv/mtu_test.go
+++ b/fv/mtu_test.go
@@ -44,7 +44,6 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 			topologyOptions := infrastructure.DefaultTopologyOptions()
 			topologyOptions.VXLANMode = api.VXLANModeAlways
 			topologyOptions.IPIPEnabled = false
-			topologyOptions.FelixLogSeverity = "debug"
 
 			// Configure the interface pattern so that it doesn't match any host interfaces.
 			topologyOptions.ExtraEnvVars["FELIX_MTUIFACEPATTERN"] = "foo"

--- a/fv/sockmap_test.go
+++ b/fv/sockmap_test.go
@@ -143,7 +143,6 @@ func unmarshalBpfToolSockhashDumpOutput(output string) []mapEntry {
 func getSockmapOpts() infrastructure.TopologyOptions {
 	opts := infrastructure.DefaultTopologyOptions()
 	opts.EnableIPv6 = false
-	opts.FelixLogSeverity = "debug"
 	opts.ExtraEnvVars["FELIX_XDPENABLED"] = "0"
 	opts.ExtraEnvVars["FELIX_SIDECARACCELERATIONENABLED"] = "1"
 	return opts


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Debug logging generates a lot of output when a test fails and that can cause problems:
* Ginkgo uses a lot of RAM to buffer the logs.
* The log become unwieldy for Semaphore.

Change the default to be info everywhere but add an env var to override it 

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
