### PR TITLE
upgrade clang version from clang-7 to clang-11 for bpf build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 #
 ###############################################################################
 PACKAGE_NAME?=github.com/projectcalico/felix
-GO_BUILD_VER?=master
+GO_BUILD_VER?=v0.54
 
 ORGANIZATION=projectcalico
 SEMAPHORE_PROJECT_ID?=$(SEMAPHORE_FELIX_PROJECT_ID)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 #
 ###############################################################################
 PACKAGE_NAME?=github.com/projectcalico/felix
-GO_BUILD_VER?=v0.53
+GO_BUILD_VER?=master
 
 ORGANIZATION=projectcalico
 SEMAPHORE_PROJECT_ID?=$(SEMAPHORE_FELIX_PROJECT_ID)

--- a/bpf-apache/Makefile
+++ b/bpf-apache/Makefile
@@ -34,8 +34,8 @@ CFLAGS +=  \
 TRIPLET := $(shell gcc -dumpmachine)
 CFLAGS += -I/usr/include/$(TRIPLET)
 
-CC := clang
-LD := llc
+CC := clang-11
+LD := llc-11
 
 C_FILES:=filter.c redir.c sockops.c
 OBJS:=$(addprefix bin/,$(C_FILES:.c=.o))

--- a/bpf-gpl/Makefile
+++ b/bpf-gpl/Makefile
@@ -55,8 +55,8 @@ CFLAGS +=  \
 TRIPLET := $(shell gcc -dumpmachine)
 CFLAGS += -I/usr/include/$(TRIPLET)
 
-CC := clang
-LD := llc
+CC := clang-11
+LD := llc-11
 
 UT_C_FILES:=$(shell find ut -name '*.c')
 UT_OBJS:=$(UT_C_FILES:.c=.o) $(shell ./list-ut-objs)


### PR DESCRIPTION
Upgrading BPF compiler clang's version from 7 to 11. 

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
