### PR TITLE
XDP parser

### DIFF
--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -68,6 +68,8 @@ struct bpf_map_def_extended {
 #define CALI_TC_DSR		(1<<4)
 // CALI_TC_WIREGUARD is set for the programs attached to the wireguard interface.
 #define CALI_TC_WIREGUARD	(1<<5)
+// CALI_XDP_PROG is set for programs attached to the XDP hook
+#define CALI_XDP_PROG 	(1<<6)
 
 #ifndef CALI_DROP_WORKLOAD_TO_HOST
 #define CALI_DROP_WORKLOAD_TO_HOST false
@@ -84,6 +86,8 @@ struct bpf_map_def_extended {
 #define CALI_F_WEP     	 (!CALI_F_HEP)
 #define CALI_F_TUNNEL  	 ((CALI_COMPILE_FLAGS) & CALI_TC_TUNNEL)
 #define CALI_F_WIREGUARD ((CALI_COMPILE_FLAGS) & CALI_TC_WIREGUARD)
+
+#define CALI_F_XDP ((CALI_COMPILE_FLAGS) & CALI_XDP_PROG)
 
 #define CALI_F_FROM_HEP (CALI_F_HEP && CALI_F_INGRESS)
 #define CALI_F_TO_HEP   (CALI_F_HEP && !CALI_F_INGRESS)
@@ -122,7 +126,7 @@ static CALI_BPF_INLINE void __compile_asserts(void) {
 	COMPILE_TIME_ASSERT(
 		CALI_COMPILE_FLAGS == 0 ||
 		!!(CALI_COMPILE_FLAGS & CALI_CGROUP) !=
-		!!(CALI_COMPILE_FLAGS & (CALI_TC_HOST_EP | CALI_TC_INGRESS | CALI_TC_TUNNEL | CALI_TC_DSR))
+		!!(CALI_COMPILE_FLAGS & (CALI_TC_HOST_EP | CALI_TC_INGRESS | CALI_TC_TUNNEL | CALI_TC_DSR | CALI_XDP_PROG))
 	);
 	COMPILE_TIME_ASSERT(!CALI_F_DSR || (CALI_F_DSR && CALI_F_FROM_WEP) || (CALI_F_DSR && CALI_F_HEP));
 	COMPILE_TIME_ASSERT(CALI_F_TO_HOST || CALI_F_FROM_HOST);

--- a/bpf-gpl/parsing.h
+++ b/bpf-gpl/parsing.h
@@ -53,7 +53,7 @@ static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
 			goto deny;
 		} else {
 			CALI_DEBUG("Unknown ethertype on host interface (%x), allow\n",
-								protocol);
+									protocol);
 			goto allow_no_fib;
 		}
 	}

--- a/bpf-gpl/parsing.h
+++ b/bpf-gpl/parsing.h
@@ -67,7 +67,7 @@ static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
 	}
 
 	// In TC programs, parse packet and validate its size. This is
-	// already done for XDP programs at the beginning of function
+	// already done for XDP programs at the beginning of the function.
 	if (!CALI_F_XDP) {
 		if (skb_refresh_validate_ptrs(ctx, UDP_SIZE)) {
 			ctx->fwd.reason = CALI_REASON_SHORT;

--- a/bpf-gpl/parsing.h
+++ b/bpf-gpl/parsing.h
@@ -88,19 +88,9 @@ static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
 
 allow_no_fib:
 	fwd_fib_set(&ctx->fwd, false);
-	if (CALI_F_XDP) {
-		ctx->fwd.res = XDP_PASS;
-	} else {
-		ctx->fwd.res = TC_ACT_UNSPEC;
-	}
 	return -1;
 deny:
-	if (CALI_F_XDP) {
-		ctx->fwd.res = XDP_DROP;
-	} else {
-		ctx->fwd.res = TC_ACT_SHOT;
-	}
-	return -1;
+	return -2;
 }
 
 #endif /* __CALI_PARSING_H__ */

--- a/bpf-gpl/parsing.h
+++ b/bpf-gpl/parsing.h
@@ -97,7 +97,6 @@ static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
 	return 0;
 
 allow_no_fib:
-	fwd_fib_set(&ctx->fwd, false);
 	return -1;
 deny:
 	return -2;

--- a/bpf-gpl/parsing.h
+++ b/bpf-gpl/parsing.h
@@ -19,7 +19,20 @@
 #define __CALI_PARSING_H__
 
 static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
-	switch (bpf_htons(ctx->skb->protocol)) {
+	__u16 protocol = 0;
+
+	if (CALI_F_XDP) {
+		if (skb_refresh_validate_ptrs(ctx, UDP_SIZE)) {
+			ctx->fwd.reason = CALI_REASON_SHORT;
+			CALI_DEBUG("Too short\n");
+			goto deny;
+		}
+		protocol = bpf_ntohs(ctx->eth->h_proto);
+	} else {
+		protocol = bpf_ntohs(ctx->skb->protocol);
+	}
+
+	switch (protocol) {
 	case ETH_P_IP:
 		break;
 	case ETH_P_ARP:
@@ -36,19 +49,21 @@ static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
 		}
 	default:
 		if (CALI_F_WEP) {
-			CALI_DEBUG("Unknown ethertype (%x), drop\n", bpf_ntohs(ctx->skb->protocol));
+			CALI_DEBUG("Unknown ethertype (%x), drop\n", protocol);
 			goto deny;
 		} else {
 			CALI_DEBUG("Unknown ethertype on host interface (%x), allow\n",
-								bpf_ntohs(ctx->skb->protocol));
+								protocol);
 			goto allow_no_fib;
 		}
 	}
 
-	if (skb_refresh_validate_ptrs(ctx, UDP_SIZE)) {
-		ctx->fwd.reason = CALI_REASON_SHORT;
-		CALI_DEBUG("Too short\n");
-		goto deny;
+	if (!CALI_F_XDP) {
+		if (skb_refresh_validate_ptrs(ctx, UDP_SIZE)) {
+			ctx->fwd.reason = CALI_REASON_SHORT;
+			CALI_DEBUG("Too short\n");
+			goto deny;
+		}
 	}
 
 	// Drop malformed IP packets
@@ -73,10 +88,18 @@ static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
 
 allow_no_fib:
 	fwd_fib_set(&ctx->fwd, false);
-	ctx->fwd.res = TC_ACT_UNSPEC;
+	if (CALI_F_XDP) {
+		ctx->fwd.res = XDP_PASS;
+	} else {
+		ctx->fwd.res = TC_ACT_UNSPEC;
+	}
 	return -1;
 deny:
-	ctx->fwd.res = TC_ACT_SHOT;
+	if (CALI_F_XDP) {
+		ctx->fwd.res = XDP_DROP;
+	} else {
+		ctx->fwd.res = TC_ACT_SHOT;
+	}
 	return -1;
 }
 

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -131,6 +131,7 @@ static CALI_BPF_INLINE int skb_refresh_validate_ptrs(struct cali_tc_ctx *ctx, lo
 	if (ctx->data_start + (min_size + nh_len) > ctx->data_end) {
 		// This is an XDP program and there is not enough data for next header.
 		if (CALI_F_XDP) {
+			CALI_DEBUG("Too short to have %d bytes for next header\n");
 			return -2;
 		}
 

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -131,7 +131,8 @@ static CALI_BPF_INLINE int skb_refresh_validate_ptrs(struct cali_tc_ctx *ctx, lo
 	if (ctx->data_start + (min_size + nh_len) > ctx->data_end) {
 		// This is an XDP program and there is not enough data for next header.
 		if (CALI_F_XDP) {
-			CALI_DEBUG("Too short to have %d bytes for next header\n");
+			CALI_DEBUG("Too short to have %d bytes for next header\n",
+							min_size + nh_len);
 			return -2;
 		}
 

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -66,8 +66,13 @@ static CALI_BPF_INLINE void *skb_end_ptr(struct __sk_buff *skb) {
  * Fresh values are loaded using skb_start/end_ptr.
  */
 static CALI_BPF_INLINE void skb_refresh_start_end(struct cali_tc_ctx *ctx) {
-	ctx->data_start = skb_start_ptr(ctx->skb);
-	ctx->data_end = skb_end_ptr(ctx->skb);
+	if (CALI_F_XDP) {
+		ctx->data_start = (void *)(long)ctx->xdp->data;
+		ctx->data_end = (void *)(long)ctx->xdp->data_end;
+	} else {
+		ctx->data_start = skb_start_ptr(ctx->skb);
+		ctx->data_end = skb_end_ptr(ctx->skb);
+	}
 }
 
 /* skb_iphdr_offset returns the expected offset of the IP header for this type of program.
@@ -118,12 +123,17 @@ static CALI_BPF_INLINE void skb_refresh_hdr_ptrs(struct cali_tc_ctx *ctx)
  * - ctx->data_start/end
  * - ctx->eth (if this BPF program has access to the L2 header)
  * - ctx->ip_header
- * - ctx->nh/tcp_header/udp_header/icp_header.
+ * - ctx->nh/tcp_header/udp_header/icmp_header.
  */
 static CALI_BPF_INLINE int skb_refresh_validate_ptrs(struct cali_tc_ctx *ctx, long nh_len) {
 	int min_size = skb_iphdr_offset(ctx->skb) + IP_SIZE;
 	skb_refresh_start_end(ctx);
 	if (ctx->data_start + (min_size + nh_len) > ctx->data_end) {
+		// This is an XDP program and there is not enough data for next header.
+		if (CALI_F_XDP) {
+			return -2;
+		}
+
 		// Try to pull in more data.  Ideally enough for TCP, or, failing that, the
 		// minimum we've been asked for.
 		if (nh_len > TCP_SIZE || bpf_skb_pull_data(ctx->skb, min_size + TCP_SIZE)) {

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -142,7 +142,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 		// A packet that we automatically let through
 		ctx.fwd.res = TC_ACT_UNSPEC;
 		goto finalize;
-	default:
+	case -2:
 		// A malformed packet or a packet we don't support
 		CALI_DEBUG("Drop malformed or unsupported packet\n");
 		ctx.fwd.res = TC_ACT_SHOT;

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -137,8 +137,15 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 
 	/* Parse the packet as far as the IP header; as a side-effect this validates the packet size
 	 * is large enough for UDP. */
-	if (parse_packet_ip(&ctx)) {
-		// Either a problem or a packet that we automatically let through.
+	switch (parse_packet_ip(&ctx)) {
+	case -1:
+		// A packet that we automatically let through
+		ctx.fwd.res = TC_ACT_UNSPEC;
+		goto finalize;
+	default:
+		// A malformed packet or a packet we don't support
+		CALI_DEBUG("Drop malformed or unsupported packet\n");
+		ctx.fwd.res = TC_ACT_SHOT;
 		goto finalize;
 	}
 

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -140,6 +140,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	switch (parse_packet_ip(&ctx)) {
 	case -1:
 		// A packet that we automatically let through
+		fwd_fib_set(&ctx.fwd, false);
 		ctx.fwd.res = TC_ACT_UNSPEC;
 		goto finalize;
 	case -2:

--- a/bpf-gpl/types.h
+++ b/bpf-gpl/types.h
@@ -115,6 +115,7 @@ struct fwd {
 
 struct cali_tc_ctx {
   struct __sk_buff *skb;
+  struct xdp_md *xdp;
 
   /* Our single copies of the data start/end pointers loaded from the skb. */
   union {

--- a/bpf-gpl/xdp.c
+++ b/bpf-gpl/xdp.c
@@ -1,0 +1,93 @@
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/in.h>
+#include <linux/icmp.h>
+#include <linux/tcp.h>
+#include <linux/udp.h>
+
+// stdbool.h has no deps so it's OK to include; stdint.h pulls in parts
+// of the std lib that aren't compatible with BPF.
+#include <stdbool.h>
+
+#include "bpf.h"
+#include "types.h"
+#include "log.h"
+#include "skb.h"
+#include "routes.h"
+#include "reasons.h"
+#include "icmp.h"
+#include "fib.h"
+#include "parsing.h"
+#include "failsafe.h"
+#include "jump.h"
+
+struct flow_tuple {
+	__be32 saddr;
+	__be32 daddr;
+	__be16 sport;
+	__be16 dport;
+	__u8 protocol;
+};
+
+struct bpf_map_def_extended SEC("maps") flowtracker = {
+	.type = BPF_MAP_TYPE_HASH,
+	.key_size = sizeof(struct flow_tuple),
+	.value_size = sizeof(__u64),
+	.max_entries = 32,
+#ifndef __BPFTOOL_LOADER__
+	.pinning_strategy = MAP_PIN_GLOBAL,
+#endif
+};
+
+SEC("prog")
+static CALI_BPF_INLINE int calico_xdp(struct xdp_md *xdp_ctx) {
+
+	struct cali_tc_ctx ctx = {
+		.state = state_get(),
+		.xdp = xdp_ctx,
+		.fwd = {
+			.res = XDP_PASS, // or XDP_DROP?
+			.reason = CALI_REASON_UNKNOWN,
+		},
+	};
+
+	if (!ctx.state) {
+		CALI_DEBUG("State map lookup failed: PASS\n");
+		return XDP_PASS; // or XDP_DROP?
+	}
+	__builtin_memset(ctx.state, 0, sizeof(*ctx.state));
+
+	if (CALI_LOG_LEVEL >= CALI_LOG_LEVEL_INFO) {
+		ctx.state->prog_start_time = bpf_ktime_get_ns();
+	}
+
+	// Packet is malformed or non an IPv4
+	if (parse_packet_ip(&ctx)) {
+		return ctx.fwd.res;
+	}
+
+	// no a TCP packet
+	if (ctx.ip_header->protocol != IPPROTO_TCP)
+		return XDP_PASS;
+	
+	struct flow_tuple flow = {};
+	flow.protocol = ctx.ip_header->protocol;
+	flow.saddr = ctx.ip_header->saddr;
+	flow.daddr = ctx.ip_header->daddr;
+	flow.sport = ctx.tcp_header->source;
+	flow.dport = ctx.tcp_header->dest;
+	
+	__u64 new_counter = 1;
+	__u64 *counter;
+	
+	counter = bpf_map_lookup_elem(&flowtracker, &flow);
+	if (counter) {
+		__sync_fetch_and_add(counter, 1);
+	} else {
+		bpf_map_update_elem(&flowtracker, &flow, &new_counter, BPF_ANY);
+	}
+
+	return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/bpf-gpl/xdp.c
+++ b/bpf-gpl/xdp.c
@@ -42,7 +42,7 @@
 #include "jump.h"
 
 SEC("prog")
-static CALI_BPF_INLINE int calico_xdp(struct xdp_md *xdp_ctx) {
+int calico_xdp(struct xdp_md *xdp_ctx) {
 
 	struct cali_tc_ctx ctx = {
 		.state = state_get(),

--- a/bpf-gpl/xdp.c
+++ b/bpf-gpl/xdp.c
@@ -63,9 +63,9 @@ int calico_xdp(struct xdp_md *xdp_ctx) {
 		ctx.state->prog_start_time = bpf_ktime_get_ns();
 	}
 
-	// Packet is malformed or non an IPv4
-	if (parse_packet_ip(&ctx)) {
-		return ctx.fwd.res;
+	// Parse packets and drop malformed and unsupported ones
+	if (parse_packet_ip(&ctx) == -2) {
+		return XDP_DROP;
 	}
 
 	return XDP_PASS;

--- a/bpf-gpl/xdp.c
+++ b/bpf-gpl/xdp.c
@@ -43,7 +43,8 @@
 
 SEC("prog")
 int calico_xdp(struct xdp_md *xdp_ctx) {
-
+	/* Initialise the context, which is stored on the stack, and the state, which
+	 * we use to pass data from one program to the next via tail calls. */
 	struct cali_tc_ctx ctx = {
 		.state = state_get(),
 		.xdp = xdp_ctx,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
This PR adds support for parsing packets in XDP programs. Most parts are similar to the parsing in TC programs, with few exceptions. For that the original parser in TC is used and differences are separated via a new flag named "CALI_F_XDP". This allows to compile XDP programs using 
"-DCALI_COMPILE_FLAGS=64"

The PR also includes a simple XDP program in xdp.c that can be used as a skeleton for XDP programs.


## Todos

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
