### PR TITLE
Fix XDP FV tests and add them to Semaphore CI

### DIFF
--- a/.semaphore/collect-artifacts-from-vms
+++ b/.semaphore/collect-artifacts-from-vms
@@ -16,6 +16,8 @@
 
 set -e
 
+source .semaphore/new-kernel-common.sh
+
 vm_name_prefix=$1
 project=unique-caldron-775
 zone=${ZONE:-europe-west3-c}
@@ -25,8 +27,6 @@ artifacts_dir="$repo_dir/artifacts"
 
 echo "Collecting artifacts..."
 
-num_fv_batches=${NUM_FV_BATCHES:-8}
-batches=(ut $(seq 1 ${num_fv_batches}))
 pids=()
 log_files=()
 for batch in "${batches[@]}"; do

--- a/.semaphore/create-test-vms
+++ b/.semaphore/create-test-vms
@@ -16,6 +16,8 @@
 
 set -e
 
+source .semaphore/new-kernel-common.sh
+
 vm_name_prefix=$1
 project=unique-caldron-775
 zone=${ZONE:-europe-west3-c}
@@ -23,8 +25,6 @@ my_dir="$(dirname $0)"
 repo_dir="."
 artifacts_dir="$repo_dir/artifacts"
 
-num_fv_batches=${NUM_FV_BATCHES:-8}
-batches=(ut $(seq 1 ${num_fv_batches}))
 pids=()
 for batch in "${batches[@]}"; do
   vm_name="$vm_name_prefix$batch"

--- a/.semaphore/new-kernel-common.sh
+++ b/.semaphore/new-kernel-common.sh
@@ -1,0 +1,5 @@
+# Common definitions for the tests that we run on VMs with a newer
+# kernel than Semaphore itself provides.
+
+num_fv_batches=${NUM_FV_BATCHES:-8}
+batches=(ut xdp $(seq 1 ${num_fv_batches}))

--- a/.semaphore/run-tests-on-vms
+++ b/.semaphore/run-tests-on-vms
@@ -20,7 +20,7 @@ vm_name_prefix=$1
 project=unique-caldron-775
 zone=${ZONE:-europe-west3-c}
 num_fv_batches=${NUM_FV_BATCHES:-8}
-batches=(ut $(seq 1 ${num_fv_batches}))
+batches=(ut xdp $(seq 1 ${num_fv_batches}))
 my_dir="$(dirname $0)"
 repo_dir="."
 artifacts_dir="$repo_dir/artifacts"
@@ -38,6 +38,10 @@ for batch in "${batches[@]}"; do
   log_files+=( $log_file )
   if [ $batch = "ut" ]; then
     VM_NAME=$vm_name $my_dir/on-test-vm make --directory=${REPO_NAME} ut-bpf check-wireguard >& "$log_file" &
+    pid=$!
+    pids+=( $pid )
+  elif [ $batch = "xdp" ]; then
+    VM_NAME=$vm_name ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv GINKGO_FOCUS="XDP tests" >& "$log_file" &
     pid=$!
     pids+=( $pid )
   else

--- a/.semaphore/run-tests-on-vms
+++ b/.semaphore/run-tests-on-vms
@@ -16,11 +16,11 @@
 
 set -e
 
+source .semaphore/new-kernel-common.sh
+
 vm_name_prefix=$1
 project=unique-caldron-775
 zone=${ZONE:-europe-west3-c}
-num_fv_batches=${NUM_FV_BATCHES:-8}
-batches=(ut xdp $(seq 1 ${num_fv_batches}))
 my_dir="$(dirname $0)"
 repo_dir="."
 artifacts_dir="$repo_dir/artifacts"

--- a/.semaphore/run-tests-on-vms
+++ b/.semaphore/run-tests-on-vms
@@ -41,7 +41,7 @@ for batch in "${batches[@]}"; do
     pid=$!
     pids+=( $pid )
   elif [ $batch = "xdp" ]; then
-    VM_NAME=$vm_name ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv GINKGO_FOCUS="XDP tests" >& "$log_file" &
+    VM_NAME=$vm_name ./.semaphore/on-test-vm make --directory=${REPO_NAME} fv GINKGO_FOCUS=XDP >& "$log_file" &
     pid=$!
     pids+=( $pid )
   else

--- a/bpf/bpf.go
+++ b/bpf/bpf.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -984,6 +984,8 @@ func (b *BPFLib) loadXDPRaw(objPath, ifName string, mode XDPMode, mapArgs []stri
 
 	printCommand(prog, args...)
 	output, err := exec.Command(prog, args...).CombinedOutput()
+	log.Debugf("out:\n%v", string(output))
+
 	if err != nil {
 		if removeErr := os.Remove(progPath); removeErr != nil {
 			return fmt.Errorf("failed to attach XDP program (%s) to %s: %s (also failed to remove the pinned program: %s)\n%s", progPath, ifName, err, removeErr, output)
@@ -1800,6 +1802,8 @@ func (b *BPFLib) loadBPF(objPath, progPath, progType string, mapArgs []string) e
 
 	printCommand(prog, args...)
 	output, err := exec.Command(prog, args...).CombinedOutput()
+	log.Debugf("out:\n%v", string(output))
+
 	if err != nil {
 		// FIXME: for some reason this function was called several times for a
 		// particular XDP program, just assume the map is loaded if the pinned

--- a/fv/xdp_test.go
+++ b/fv/xdp_test.go
@@ -39,7 +39,7 @@ const (
 	applyPeriod  = 5 * time.Second
 )
 
-var _ = infrastructure.DatastoreDescribe("with initialized Felix", []apiconfig.DatastoreType{apiconfig.EtcdV3 /*, apiconfig.Kubernetes*/}, func(getInfra infrastructure.InfraFactory) {
+var _ = infrastructure.DatastoreDescribe("XDP tests with initialized Felix", []apiconfig.DatastoreType{apiconfig.EtcdV3 /*, apiconfig.Kubernetes*/}, func(getInfra infrastructure.InfraFactory) {
 	var (
 		infra        infrastructure.DatastoreInfra
 		felixes      []*infrastructure.Felix


### PR DESCRIPTION
Our XDP FV tests had fallen through the cracks, as regards running in Semaphore CI.
- They don't run in the regular FV, because the default Semaphore kernel is <4.16 and doesn't support XDP acceleration.
- They don't run in the "new kernel" FV, because there we focus on "BPF-SAFE".

Also, if you run them manually, some of them fail.  Turns out this is because behaviour of `ip link set dev <ifname> <xdpmode> off` has changed, and now reports **success** if there **wasn't** any XDP program attached with mode `<xdpmode>`.