### PR TITLE
Fix XDP flake: a check that we cannot reasonably rely on

### DIFF
--- a/.semaphore/create-test-vm
+++ b/.semaphore/create-test-vm
@@ -28,7 +28,7 @@ function create-vm() {
   gcloud --quiet compute instances create "${vm_name}" \
            --zone=${zone} \
            --machine-type=n1-standard-4 \
-           --image=ubuntu-2004-focal-v20200609 \
+           --image=ubuntu-2004-focal-v20210623 \
            --image-project=ubuntu-os-cloud \
            --boot-disk-size=20GB \
            --boot-disk-type=pd-standard && \

--- a/fv/xdp_test.go
+++ b/fv/xdp_test.go
@@ -424,8 +424,11 @@ var _ = infrastructure.DatastoreDescribe("XDP tests with initialized Felix", []a
 					err := utils.RunMayFail("docker", "exec", felixes[1].Name, "ip", "link", "set", "dev", "eth0", "xdp", "off")
 					Expect(err).NotTo(HaveOccurred())
 
-					utils.Run("docker", "exec", felixes[1].Name, "ip", "addr", "show", "eth0")
-					Expect(utils.LastRunOutput).NotTo(ContainSubstring("xdp"))
+					// Note: we can't reliably check the following here, because
+					// resync may have happened _immediately_ following the
+					// previous "xdp off" command.
+					// utils.Run("docker", "exec", felixes[1].Name, "ip", "addr", "show", "eth0")
+					// Expect(utils.LastRunOutput).NotTo(ContainSubstring("xdp"))
 
 					// wait for resync
 					time.Sleep(resyncPeriod)


### PR DESCRIPTION
Saw this flake once locally; let's squash it before it troubles CI.