### PR TITLE
Convert XDP callback usage to mainline Felix architecture

### DIFF
--- a/dataplane/linux/callbacks.go
+++ b/dataplane/linux/callbacks.go
@@ -21,8 +21,6 @@ import (
 )
 
 type callbacks struct {
-	UpdatePolicyV4           *UpdatePolicyDataFuncs
-	RemovePolicyV4           *RemovePolicyDataFuncs
 	AddInterfaceV4           *AddInterfaceFuncs
 	RemoveInterfaceV4        *RemoveInterfaceFuncs
 	UpdateInterfaceV4        *UpdateInterfaceFuncs
@@ -34,8 +32,6 @@ type callbacks struct {
 
 func newCallbacks() *callbacks {
 	return &callbacks{
-		UpdatePolicyV4:           &UpdatePolicyDataFuncs{},
-		RemovePolicyV4:           &RemovePolicyDataFuncs{},
 		AddInterfaceV4:           &AddInterfaceFuncs{},
 		RemoveInterfaceV4:        &RemoveInterfaceFuncs{},
 		UpdateInterfaceV4:        &UpdateInterfaceFuncs{},
@@ -55,58 +51,6 @@ func (c *callbacks) Drop(id *CbID) {
 
 type CbID struct {
 	dropper func()
-}
-
-type UpdatePolicyDataFunc func(policyID proto.PolicyID, policy *proto.Policy)
-
-type UpdatePolicyDataFuncs struct {
-	fs UpdatePolicyDataFunc
-}
-
-func (fs *UpdatePolicyDataFuncs) Invoke(policyID proto.PolicyID, policy *proto.Policy) {
-	if fs.fs != nil {
-		fs.fs(policyID, policy)
-	}
-}
-
-func (fs *UpdatePolicyDataFuncs) Append(f UpdatePolicyDataFunc) *CbID {
-	if f == nil {
-		return &CbID{
-			dropper: func() {},
-		}
-	}
-	fs.fs = f
-	return &CbID{
-		dropper: func() {
-			fs.fs = nil
-		},
-	}
-}
-
-type RemovePolicyDataFunc func(policyID proto.PolicyID)
-
-type RemovePolicyDataFuncs struct {
-	fs RemovePolicyDataFunc
-}
-
-func (fs *RemovePolicyDataFuncs) Invoke(policyID proto.PolicyID) {
-	if fs.fs != nil {
-		fs.fs(policyID)
-	}
-}
-
-func (fs *RemovePolicyDataFuncs) Append(f RemovePolicyDataFunc) *CbID {
-	if f == nil {
-		return &CbID{
-			dropper: func() {},
-		}
-	}
-	fs.fs = f
-	return &CbID{
-		dropper: func() {
-			fs.fs = nil
-		},
-	}
 }
 
 type AddMembersIPSetFunc func(setID string, members set.Set)

--- a/dataplane/linux/callbacks.go
+++ b/dataplane/linux/callbacks.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,10 +23,6 @@ import (
 type callbacks struct {
 	UpdatePolicyV4           *UpdatePolicyDataFuncs
 	RemovePolicyV4           *RemovePolicyDataFuncs
-	AddMembersIPSetV4        *AddMembersIPSetFuncs
-	RemoveMembersIPSetV4     *RemoveMembersIPSetFuncs
-	ReplaceIPSetV4           *ReplaceIPSetFuncs
-	RemoveIPSetV4            *RemoveIPSetFuncs
 	AddInterfaceV4           *AddInterfaceFuncs
 	RemoveInterfaceV4        *RemoveInterfaceFuncs
 	UpdateInterfaceV4        *UpdateInterfaceFuncs
@@ -40,10 +36,6 @@ func newCallbacks() *callbacks {
 	return &callbacks{
 		UpdatePolicyV4:           &UpdatePolicyDataFuncs{},
 		RemovePolicyV4:           &RemovePolicyDataFuncs{},
-		AddMembersIPSetV4:        &AddMembersIPSetFuncs{},
-		RemoveMembersIPSetV4:     &RemoveMembersIPSetFuncs{},
-		ReplaceIPSetV4:           &ReplaceIPSetFuncs{},
-		RemoveIPSetV4:            &RemoveIPSetFuncs{},
 		AddInterfaceV4:           &AddInterfaceFuncs{},
 		RemoveInterfaceV4:        &RemoveInterfaceFuncs{},
 		UpdateInterfaceV4:        &UpdateInterfaceFuncs{},

--- a/dataplane/linux/callbacks.go
+++ b/dataplane/linux/callbacks.go
@@ -16,8 +16,6 @@ package intdataplane
 
 import (
 	"github.com/projectcalico/felix/proto"
-
-	"github.com/projectcalico/libcalico-go/lib/set"
 )
 
 type callbacks struct {
@@ -51,110 +49,6 @@ func (c *callbacks) Drop(id *CbID) {
 
 type CbID struct {
 	dropper func()
-}
-
-type AddMembersIPSetFunc func(setID string, members set.Set)
-
-type AddMembersIPSetFuncs struct {
-	fs AddMembersIPSetFunc
-}
-
-func (fs *AddMembersIPSetFuncs) Invoke(setID string, members set.Set) {
-	if fs.fs != nil {
-		fs.fs(setID, members)
-	}
-}
-
-func (fs *AddMembersIPSetFuncs) Append(f AddMembersIPSetFunc) *CbID {
-	if f == nil {
-		return &CbID{
-			dropper: func() {},
-		}
-	}
-	fs.fs = f
-	return &CbID{
-		dropper: func() {
-			fs.fs = nil
-		},
-	}
-}
-
-type RemoveMembersIPSetFunc func(setID string, members set.Set)
-
-type RemoveMembersIPSetFuncs struct {
-	fs RemoveMembersIPSetFunc
-}
-
-func (fs *RemoveMembersIPSetFuncs) Invoke(setID string, members set.Set) {
-	if fs.fs != nil {
-		fs.fs(setID, members)
-	}
-}
-
-func (fs *RemoveMembersIPSetFuncs) Append(f RemoveMembersIPSetFunc) *CbID {
-	if f == nil {
-		return &CbID{
-			dropper: func() {},
-		}
-	}
-	fs.fs = f
-	return &CbID{
-		dropper: func() {
-			fs.fs = nil
-		},
-	}
-}
-
-type ReplaceIPSetFunc func(setID string, members set.Set)
-
-type ReplaceIPSetFuncs struct {
-	fs ReplaceIPSetFunc
-}
-
-func (fs *ReplaceIPSetFuncs) Invoke(setID string, members set.Set) {
-	if fs.fs != nil {
-		fs.fs(setID, members)
-	}
-}
-
-func (fs *ReplaceIPSetFuncs) Append(f ReplaceIPSetFunc) *CbID {
-	if f == nil {
-		return &CbID{
-			dropper: func() {},
-		}
-	}
-	fs.fs = f
-	return &CbID{
-		dropper: func() {
-			fs.fs = nil
-		},
-	}
-}
-
-type RemoveIPSetFunc func(setID string)
-
-type RemoveIPSetFuncs struct {
-	fs RemoveIPSetFunc
-}
-
-func (fs *RemoveIPSetFuncs) Invoke(setID string) {
-	if fs.fs != nil {
-		fs.fs(setID)
-	}
-}
-
-func (fs *RemoveIPSetFuncs) Append(f RemoveIPSetFunc) *CbID {
-	if f == nil {
-		return &CbID{
-			dropper: func() {},
-		}
-	}
-	fs.fs = f
-	return &CbID{
-		dropper: func() {
-			fs.fs = nil
-		},
-	}
 }
 
 type AddInterfaceFunc func(ifaceName string, hostEPID proto.HostEndpointID)

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -459,6 +459,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			} else {
 				dp.xdpState = st
 				dp.xdpState.PopulateCallbacks(callbacks)
+				dp.RegisterManager(st)
 				log.Info("XDP acceleration enabled.")
 			}
 		}
@@ -510,7 +511,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 
 	if !config.BPFEnabled {
 		// BPF mode disabled, create the iptables-only managers.
-		ipsetsManager := newIPSetsManager(ipSetsV4, config.MaxIPSetSize, callbacks)
+		ipsetsManager := newIPSetsManager(ipSetsV4, config.MaxIPSetSize)
 		dp.RegisterManager(ipsetsManager)
 		dp.ipsetsSourceV4 = ipsetsManager
 		// TODO Connect host IP manager to BPF
@@ -559,7 +560,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			dp.loopSummarizer,
 		)
 		dp.ipSets = append(dp.ipSets, ipSetsV4)
-		dp.RegisterManager(newIPSetsManager(ipSetsV4, config.MaxIPSetSize, callbacks))
+		dp.RegisterManager(newIPSetsManager(ipSetsV4, config.MaxIPSetSize))
 		bpfRTMgr := newBPFRouteManager(config.Hostname, config.ExternalNodesCidrs, bpfMapContext, dp.loopSummarizer)
 		dp.RegisterManager(bpfRTMgr)
 
@@ -794,7 +795,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			dp.loopSummarizer)
 
 		if !config.BPFEnabled {
-			dp.RegisterManager(newIPSetsManager(ipSetsV6, config.MaxIPSetSize, callbacks))
+			dp.RegisterManager(newIPSetsManager(ipSetsV6, config.MaxIPSetSize))
 			dp.RegisterManager(newHostIPManager(
 				config.RulesConfig.WorkloadIfacePrefixes,
 				rules.IPSetIDThisHostIPs,

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -520,7 +520,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			rules.IPSetIDThisHostIPs,
 			ipSetsV4,
 			config.MaxIPSetSize))
-		dp.RegisterManager(newPolicyManager(rawTableV4, mangleTableV4, filterTableV4, ruleRenderer, 4, callbacks))
+		dp.RegisterManager(newPolicyManager(rawTableV4, mangleTableV4, filterTableV4, ruleRenderer, 4))
 
 		// Clean up any leftover BPF state.
 		err := nat.RemoveConnectTimeLoadBalancer("")
@@ -801,7 +801,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				rules.IPSetIDThisHostIPs,
 				ipSetsV6,
 				config.MaxIPSetSize))
-			dp.RegisterManager(newPolicyManager(rawTableV6, mangleTableV6, filterTableV6, ruleRenderer, 6, callbacks))
+			dp.RegisterManager(newPolicyManager(rawTableV6, mangleTableV6, filterTableV6, ruleRenderer, 6))
 		}
 		dp.RegisterManager(newEndpointManager(
 			rawTableV6,

--- a/dataplane/linux/ipsets_mgr_test.go
+++ b/dataplane/linux/ipsets_mgr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ var _ = Describe("IP Sets manager", func() {
 
 	BeforeEach(func() {
 		ipSets = newMockIPSets()
-		ipsetsMgr = newIPSetsManager(ipSets, 1024, newCallbacks())
+		ipsetsMgr = newIPSetsManager(ipSets, 1024)
 	})
 
 	Describe("after sending a replace", func() {

--- a/dataplane/linux/policy_mgr_test.go
+++ b/dataplane/linux/policy_mgr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017,2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ var _ = Describe("Policy manager", func() {
 		mangleTable  *mockTable
 		filterTable  *mockTable
 		ruleRenderer *mockPolRenderer
-		callbacks    *callbacks
 	)
 
 	BeforeEach(func() {
@@ -38,8 +37,7 @@ var _ = Describe("Policy manager", func() {
 		mangleTable = newMockTable("mangle")
 		filterTable = newMockTable("filter")
 		ruleRenderer = newMockPolRenderer()
-		callbacks = newCallbacks()
-		policyMgr = newPolicyManager(rawTable, mangleTable, filterTable, ruleRenderer, 4, callbacks)
+		policyMgr = newPolicyManager(rawTable, mangleTable, filterTable, ruleRenderer, 4)
 	})
 
 	It("shouldn't touch iptables", func() {

--- a/dataplane/linux/xdp_state.go
+++ b/dataplane/linux/xdp_state.go
@@ -133,6 +133,12 @@ func (x *xdpState) OnUpdate(protoBufMsg interface{}) {
 	case *proto.IPSetRemove:
 		log.WithField("ipSetId", msg.Id).Debug("IP set remove")
 		x.ipV4State.removeIPSet(msg.Id)
+	case *proto.ActivePolicyUpdate:
+		log.WithField("id", msg.Id).Debug("Updating policy chains")
+		x.ipV4State.updatePolicy(*msg.Id, msg.Policy)
+	case *proto.ActivePolicyRemove:
+		log.WithField("id", msg.Id).Debug("Removing policy chains")
+		x.ipV4State.removePolicy(*msg.Id)
 	}
 }
 
@@ -143,8 +149,6 @@ func (x *xdpState) CompleteDeferredWork() error {
 func (x *xdpState) PopulateCallbacks(cbs *callbacks) {
 	if x.ipV4State != nil {
 		cbIDs := []*CbID{
-			cbs.UpdatePolicyV4.Append(x.ipV4State.updatePolicy),
-			cbs.RemovePolicyV4.Append(x.ipV4State.removePolicy),
 			cbs.AddInterfaceV4.Append(x.ipV4State.addInterface),
 			cbs.RemoveInterfaceV4.Append(x.ipV4State.removeInterface),
 			cbs.UpdateInterfaceV4.Append(x.ipV4State.updateInterface),

--- a/fv/xdp_test.go
+++ b/fv/xdp_test.go
@@ -291,6 +291,7 @@ var _ = infrastructure.DatastoreDescribe("XDP tests with initialized Felix", []a
 				expectAllAllowed(ccTCP)
 				expectAllAllowed(ccUDP)
 			})
+			// NJ: this is odd; no blacklist testing here.
 		})
 
 		Context("blocking full IP", func() {


### PR DESCRIPTION
This is part 1 of work to remove the XDP callbacks architecture and use mainline Felix patterns to achieve equivalent function.  Callbacks for policy and IP sets are replaced by xdp_state.go OnUpdate handling for the relevant proto messages.