### PR TITLE
Fix XDP Cleanup issue

### DIFF
--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -467,7 +467,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	}
 
 	// TODO Integrate XDP and BPF infra.
-	if !config.BPFEnabled && dp.xdpState == nil {
+	if !config.BPFEnabled && config.XDPEnabled && dp.xdpState == nil {
 		xdpState, err := NewXDPState(config.XDPAllowGeneric)
 		if err == nil {
 			if err := xdpState.WipeXDP(); err != nil {


### PR DESCRIPTION
## Description
This patch fix issue #2619 'Felix clears XDP programs it doesn't own'.
I Added conditional statement to check XDPEnabled option is true, before initializing XDPState.
It works on my system, but I think more tests will be needed.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
