### PR TITLE
Don't leak tcpdump containers

### DIFF
--- a/fv/containers/containers.go
+++ b/fv/containers/containers.go
@@ -695,7 +695,7 @@ func (c *Container) CanConnectTo(ip, port, protocol string, opts ...connectivity
 
 // AttachTCPDump returns tcpdump attached to the container
 func (c *Container) AttachTCPDump(iface string) *tcpdump.TCPDump {
-	return tcpdump.AttachUnavailable(c.Name, c.GetID(), iface)
+	return tcpdump.AttachUnavailable(c.GetID(), iface)
 }
 
 // NumTCBPFProgs Returns the number of TC BPF programs attached to the given interface.  Only direct-action


### PR DESCRIPTION
In recent testing I've noticed around 10 leaked corfr/tcpdump
containers.  They come from the cases where AttachTCPDump starts a new
container, as opposed to exec'ing tcpdump within an existing
container.  When that happens, it doesn't work to kill the original
"docker run ..." process, because for some reason that parent process
no longer exists (although the corfr/tcpdump container does, and the
desired underlying tcpdump process still exists).

Instead, use "docker stop" to clean up the container in that case.

In passing, I also found that we don't need to run the container with
--privileged.
