### PR TITLE
Cherry picks for v3.20: BPF mode implementation of untracked ingress Deny policy

### DIFF
--- a/bpf-gpl/Makefile
+++ b/bpf-gpl/Makefile
@@ -92,6 +92,8 @@ from%.ll: tc.c tc.d calculate-flags
 	$(COMPILE)
 test%.ll: tc.c tc.d calculate-flags
 	$(COMPILE)
+xdp%.ll: xdp.c xdp.d calculate-flags
+	$(COMPILE)
 
 LINK=$(LD) -march=bpf -filetype=obj -o $@ $<
 bin/to%.o: to%.ll | bin
@@ -99,6 +101,8 @@ bin/to%.o: to%.ll | bin
 bin/from%.o: from%.ll | bin
 	$(LINK)
 bin/test%.o: test%.ll | bin
+	$(LINK)
+bin/xdp%.o: xdp%.ll | bin
 	$(LINK)
 bin/connect_time_%v4.o: connect_time_%v4.ll | bin
 	$(LINK)

--- a/bpf-gpl/calculate-flags
+++ b/bpf-gpl/calculate-flags
@@ -61,6 +61,7 @@ flags=0
 ((CALI_CGROUP = 1 << 3))
 ((CALI_TC_DSR = 1 << 4))
 ((CALI_TC_WIREGUARD = 1 << 5))
+((CALI_XDP_PROG = 1 << 6))
 
 if [[ "${filename}" =~ .*hep.* ]]; then
   # Host endpoint.
@@ -85,6 +86,12 @@ elif [[ "${filename}" =~ .*wep.* ]]; then
   # Workload endpoint; recognised by CALI_TC_HOST_EP bit being 0.
   ep_type="workload"
   args+=("-DCALI_LOG_PFX=CALICOLO")
+elif [[ "${filename}" =~ .*xdp.* ]]; then
+  # XDP, so host endpoint.
+  ((flags |= CALI_TC_HOST_EP))
+  ((flags |= CALI_XDP_PROG))
+  args+=("-DCALI_NO_DEFAULT_POLICY_PROG" "-DCALI_LOG_PFX=CALICOLO")
+  ep_type="host"
 else
   echo "Can't recognise endpoint type"
   exit 2
@@ -96,7 +103,7 @@ if [[ "${filename}" =~ to.* ]]; then
     ((flags |= CALI_TC_INGRESS))
   fi
   from_or_to="to"
-elif [[ "${filename}" =~ from.* ]]; then
+elif [[ "${filename}" =~ (from|xdp).* ]]; then
   if ((flags & CALI_TC_HOST_EP)); then
     # Host endpoint.
     ((flags |= CALI_TC_INGRESS))

--- a/bpf-gpl/jump.h
+++ b/bpf-gpl/jump.h
@@ -43,14 +43,6 @@ struct bpf_map_def_extended __attribute__((section("maps"))) cali_jump = {
 #endif
 };
 
-static CALI_BPF_INLINE void tc_state_fill_from_iphdr(struct cali_tc_state *state, struct iphdr *ip)
-{
-	state->ip_src = ip->saddr;
-	state->ip_dst = ip->daddr;
-	state->ip_proto = ip->protocol;
-	state->ip_size = ip->tot_len;
-}
-
 /* Add new values to the end as these are program indices */
 enum cali_jump_index {
 	PROG_INDEX_POLICY,

--- a/bpf-gpl/list-objs
+++ b/bpf-gpl/list-objs
@@ -29,6 +29,7 @@ emit_filename() {
 for log_level in debug info no_log; do
   echo "bin/connect_time_${log_level}_v4.o"
   echo "bin/connect_time_${log_level}_v6.o"
+  echo "bin/xdp_${log_level}.o"
   for host_drop in "" "host_drop_"; do
     if [ "${host_drop}" = "host_drop_" ]; then
       # The workload-to-host drop setting only applies to the from-workload hook.

--- a/bpf-gpl/log.h
+++ b/bpf-gpl/log.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -61,6 +61,8 @@
 #define CALI_LOG_FLAG(flags, fmt, ...) do { \
 	if ((flags) & CALI_CGROUP) { \
 		CALI_LOG(XSTR(CALI_LOG_PFX) "-C: " fmt, ## __VA_ARGS__); \
+	} else if ((flags) & CALI_XDP_PROG) { \
+		CALI_LOG(XSTR(CALI_LOG_PFX) "-X: " fmt, ## __VA_ARGS__); \
 	} else if (((flags) & CALI_TC_HOST_EP) && ((flags) & CALI_TC_INGRESS)) { \
 		CALI_LOG(XSTR(CALI_LOG_PFX) "-I: " fmt, ## __VA_ARGS__); \
 	} else if ((flags) & CALI_TC_HOST_EP) { \

--- a/bpf-gpl/metadata.h
+++ b/bpf-gpl/metadata.h
@@ -1,0 +1,80 @@
+// Project Calico BPF dataplane programs.
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#ifndef __CALI_METADATA_H__
+#define __CALI_METADATA_H__
+
+/* A struct to share information between TC and XDP programs.
+ * The struct must be 4 byte aligned, based on
+ * samples/bpf/xdp2skb_meta_kern.c code in the Kernel source. */
+struct cali_metadata {
+	// Flags from parsing_metadata_flags
+	__u32  flags;
+}__attribute__((aligned(4)));
+
+enum cali_metadata_flags {
+	// METADATA_ACCEPTED_BY_XDP is set if the packet is already accepted by XDP
+	CALI_META_ACCEPTED_BY_XDP = 0x01,
+};
+
+// Set metadata to be received by TC programs
+static CALI_BPF_INLINE int xdp2tc_set_metadata(struct xdp_md *xdp, __u32 flags) {
+	if (CALI_F_XDP) {
+		struct cali_metadata *metadata;
+		// Reserve space in-front of xdp_md.meta for metadata.
+		// Drivers not supporting data_meta will fail here.
+		int ret = bpf_xdp_adjust_meta(xdp, -(int)sizeof(*metadata));
+		if (ret < 0) {
+			CALI_DEBUG("Failed to add space for metadata: %d\n", ret);
+			return PARSING_ERROR;
+		}
+
+		if (xdp->data_meta + sizeof(struct cali_metadata) > xdp->data) {
+			CALI_DEBUG("No enough space for metadata\n");
+			return PARSING_ERROR;
+		}
+
+		metadata = (void *)(unsigned long)xdp->data_meta;
+
+		CALI_DEBUG("Set metadata for TC: %d\n", flags);
+		metadata->flags = flags;
+		return PARSING_OK;
+	} else {
+		CALI_DEBUG("Setting metadata in TC no supported\n");
+		return PARSING_ERROR;
+	}
+}
+
+// Fetch metadata set by XDP program. If not set or on error return 0.
+static CALI_BPF_INLINE __u32 xdp2tc_get_metadata(struct __sk_buff *skb) {
+	if (CALI_F_FROM_HEP && !CALI_F_XDP) {
+		struct cali_metadata *metadata = (void *)(unsigned long)skb->data_meta;
+
+		if (skb->data_meta + sizeof(struct cali_metadata) > skb->data) {
+			CALI_DEBUG("No metadata is shared by XDP\n");
+			return 0;
+		}
+
+		CALI_DEBUG("Received metadata from XDP: %d\n", metadata->flags);
+		return metadata->flags;
+	} else {
+		CALI_DEBUG("Fetching metadata from XDP not supported in this hook\n");
+		return 0;
+	}
+}
+
+#endif

--- a/bpf-gpl/parsing.h
+++ b/bpf-gpl/parsing.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,6 +17,10 @@
 
 #ifndef __CALI_PARSING_H__
 #define __CALI_PARSING_H__
+
+#define PARSING_OK 0
+#define PARSING_ERROR -1
+#define PARSING_ALLOW_WITHOUT_ENFORCING_POLICY -2
 
 static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
 	__u16 protocol = 0;
@@ -94,12 +98,108 @@ static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
 		goto allow_no_fib;
 	}
 
-	return 0;
+	return PARSING_OK;
 
 allow_no_fib:
-	return -1;
+	return PARSING_ALLOW_WITHOUT_ENFORCING_POLICY;
+
 deny:
-	return -2;
+	return PARSING_ERROR;
+}
+
+static CALI_BPF_INLINE void tc_state_fill_from_iphdr(struct cali_tc_ctx *ctx)
+{
+	ctx->state->ip_src = ctx->ip_header->saddr;
+	ctx->state->ip_dst = ctx->ip_header->daddr;
+	ctx->state->ip_proto = ctx->ip_header->protocol;
+	ctx->state->ip_size = ctx->ip_header->tot_len;
+}
+
+/* Continue parsing packet based on the IP protocol and fill in relevant fields
+ * in the state (struct cali_tc_state). */
+static CALI_BPF_INLINE int tc_state_fill_from_nexthdr(struct cali_tc_ctx *ctx)
+{
+	switch (ctx->state->ip_proto) {
+	case IPPROTO_TCP:
+		// Re-check buffer space for TCP (has larger headers than UDP).
+		if (skb_refresh_validate_ptrs(ctx, TCP_SIZE)) {
+			ctx->fwd.reason = CALI_REASON_SHORT;
+			CALI_DEBUG("Too short\n");
+			goto deny;
+		}
+		ctx->state->sport = bpf_ntohs(ctx->tcp_header->source);
+		ctx->state->dport = bpf_ntohs(ctx->tcp_header->dest);
+		CALI_DEBUG("TCP; ports: s=%d d=%d\n", ctx->state->sport, ctx->state->dport);
+		break;
+	case IPPROTO_UDP:
+		ctx->state->sport = bpf_ntohs(ctx->udp_header->source);
+		ctx->state->dport = bpf_ntohs(ctx->udp_header->dest);
+		CALI_DEBUG("UDP; ports: s=%d d=%d\n", ctx->state->sport, ctx->state->dport);
+		if (ctx->state->dport == VXLAN_PORT) {
+			/* CALI_F_FROM_HEP case is handled in vxlan_attempt_decap above since it already decoded
+			 * the header. */
+			if (CALI_F_TO_HEP) {
+				if (rt_addr_is_remote_host(ctx->state->ip_dst) &&
+						rt_addr_is_local_host(ctx->state->ip_src)) {
+					CALI_DEBUG("VXLAN packet to known Calico host, allow.\n");
+					goto allow;
+				} else {
+					/* Unlike IPIP, the user can be using VXLAN on a different VNI
+					 * so we don't simply drop it. */
+					CALI_DEBUG("VXLAN packet to unknown dest, fall through to policy.\n");
+				}
+			}
+		}
+		break;
+	case IPPROTO_ICMP:
+		ctx->state->icmp_type = ctx->icmp_header->type;
+		ctx->state->icmp_code = ctx->icmp_header->code;
+		CALI_DEBUG("ICMP; type=%d code=%d\n",
+				ctx->icmp_header->type, ctx->icmp_header->code);
+		break;
+	case IPPROTO_IPIP:
+		if (CALI_F_TUNNEL | CALI_F_WIREGUARD) {
+			// IPIP should never be sent down the tunnel.
+			CALI_DEBUG("IPIP traffic to/from tunnel: drop\n");
+			ctx->fwd.reason = CALI_REASON_UNAUTH_SOURCE;
+			goto deny;
+		}
+		if (CALI_F_FROM_HEP) {
+			if (rt_addr_is_remote_host(ctx->state->ip_src)) {
+				CALI_DEBUG("IPIP packet from known Calico host, allow.\n");
+				goto allow;
+			} else {
+				CALI_DEBUG("IPIP packet from unknown source, drop.\n");
+				ctx->fwd.reason = CALI_REASON_UNAUTH_SOURCE;
+				goto deny;
+			}
+		} else if (CALI_F_TO_HEP && !CALI_F_TUNNEL && !CALI_F_WIREGUARD) {
+			if (rt_addr_is_remote_host(ctx->state->ip_dst)) {
+				CALI_DEBUG("IPIP packet to known Calico host, allow.\n");
+				goto allow;
+			} else {
+				CALI_DEBUG("IPIP packet to unknown dest, drop.\n");
+				ctx->fwd.reason = CALI_REASON_UNAUTH_SOURCE;
+				goto deny;
+			}
+		}
+		if (CALI_F_FROM_WEP) {
+			CALI_DEBUG("IPIP traffic from workload: drop\n");
+			ctx->fwd.reason = CALI_REASON_UNAUTH_SOURCE;
+			goto deny;
+		}
+	default:
+		CALI_DEBUG("Unknown protocol (%d), unable to extract ports\n",
+					(int)ctx->state->ip_proto);
+	}
+
+	return PARSING_OK;
+
+allow:
+	return PARSING_ALLOW_WITHOUT_ENFORCING_POLICY;
+
+deny:
+	return PARSING_ERROR;
 }
 
 #endif /* __CALI_PARSING_H__ */

--- a/bpf-gpl/reasons.h
+++ b/bpf-gpl/reasons.h
@@ -38,6 +38,7 @@ enum calico_reason {
 	CALI_REASON_IP_MALFORMED = 0xec,
 	CALI_REASON_UNAUTH_SOURCE = 0xed,
 	CALI_REASON_RT_UNKNOWN = 0xdead,
+	CALI_REASON_ACCEPTED_BY_XDP = 0xd9,
 };
 
 #endif /* __CALI_REASONS_H__ */

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -48,6 +48,7 @@
 #include "policy_program.h"
 #include "parsing.h"
 #include "failsafe.h"
+#include "metadata.h"
 
 /* calico_tc is the main function used in all of the tc programs.  It is specialised
  * for particular hook at build time based on the CALI_F build flags.
@@ -67,6 +68,15 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	if (!CALI_F_TO_HOST && skb->mark == CALI_SKB_MARK_BYPASS) {
 		CALI_INFO("Final result=ALLOW (%d). Bypass mark bit set.\n", CALI_REASON_BYPASS);
 		return TC_ACT_UNSPEC;
+	}
+
+	/* Optimisation: if XDP program has already accepted the packet,
+	 * skip all processing. */
+	if (CALI_F_FROM_HEP) {
+		if (xdp2tc_get_metadata(skb) & CALI_META_ACCEPTED_BY_XDP) {
+			CALI_INFO("Final result=ALLOW (%d). Accepted by XDP.\n", CALI_REASON_ACCEPTED_BY_XDP);
+			return TC_ACT_UNSPEC;
+		}
 	}
 
 	/* Initialise the context, which is stored on the stack, and the state, which
@@ -138,15 +148,15 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	/* Parse the packet as far as the IP header; as a side-effect this validates the packet size
 	 * is large enough for UDP. */
 	switch (parse_packet_ip(&ctx)) {
-	case -1:
-		// A packet that we automatically let through
-		fwd_fib_set(&ctx.fwd, false);
-		ctx.fwd.res = TC_ACT_UNSPEC;
-		goto finalize;
-	case -2:
+	case PARSING_ERROR:
 		// A malformed packet or a packet we don't support
 		CALI_DEBUG("Drop malformed or unsupported packet\n");
 		ctx.fwd.res = TC_ACT_SHOT;
+		goto finalize;
+	case PARSING_ALLOW_WITHOUT_ENFORCING_POLICY:
+		// A packet that we automatically let through
+		fwd_fib_set(&ctx.fwd, false);
+		ctx.fwd.res = TC_ACT_UNSPEC;
 		goto finalize;
 	}
 
@@ -168,79 +178,14 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 	}
 
 	/* Copy fields that are needed by downstream programs from the packet to the state. */
-	tc_state_fill_from_iphdr(ctx.state, ctx.ip_header);
+	tc_state_fill_from_iphdr(&ctx);
 
 	/* Parse out the source/dest ports (or type/code for ICMP). */
-	switch (ctx.state->ip_proto) {
-	case IPPROTO_TCP:
-		// Re-check buffer space for TCP (has larger headers than UDP).
-		if (skb_refresh_validate_ptrs(&ctx, TCP_SIZE)) {
-			ctx.fwd.reason = CALI_REASON_SHORT;
-			CALI_DEBUG("Too short\n");
-			goto deny;
-		}
-		ctx.state->sport = bpf_ntohs(ctx.tcp_header->source);
-		ctx.state->dport = bpf_ntohs(ctx.tcp_header->dest);
-		CALI_DEBUG("TCP; ports: s=%d d=%d\n", ctx.state->sport, ctx.state->dport);
-		break;
-	case IPPROTO_UDP:
-		ctx.state->sport = bpf_ntohs(ctx.udp_header->source);
-		ctx.state->dport = bpf_ntohs(ctx.udp_header->dest);
-		CALI_DEBUG("UDP; ports: s=%d d=%d\n", ctx.state->sport, ctx.state->dport);
-		if (ctx.state->dport == VXLAN_PORT) {
-			/* CALI_F_FROM_HEP case is handled in vxlan_attempt_decap above since it already decoded
-			 * the header. */
-			if (CALI_F_TO_HEP) {
-				if (rt_addr_is_remote_host(ctx.state->ip_dst) &&
-						rt_addr_is_local_host(ctx.state->ip_src)) {
-					CALI_DEBUG("VXLAN packet to known Calico host, allow.\n");
-					goto allow;
-				} else {
-					/* Unlike IPIP, the user can be using VXLAN on a different VNI so we don't
-					 * simply drop it. */
-					CALI_DEBUG("VXLAN packet to unknown dest, fall through to policy.\n");
-				}
-			}
-		}
-		break;
-	case IPPROTO_ICMP:
-		CALI_DEBUG("ICMP; type=%d code=%d\n",
-				ctx.icmp_header->type, ctx.icmp_header->code);
-		break;
-	case 4:
-		// IPIP
-		if (CALI_F_TUNNEL | CALI_F_WIREGUARD) {
-			// IPIP should never be sent down the tunnel.
-			CALI_DEBUG("IPIP traffic to/from tunnel: drop\n");
-			ctx.fwd.reason = CALI_REASON_UNAUTH_SOURCE;
-			goto deny;
-		}
-		if (CALI_F_FROM_HEP) {
-			if (rt_addr_is_remote_host(ctx.state->ip_src)) {
-				CALI_DEBUG("IPIP packet from known Calico host, allow.\n");
-				goto allow;
-			} else {
-				CALI_DEBUG("IPIP packet from unknown source, drop.\n");
-				ctx.fwd.reason = CALI_REASON_UNAUTH_SOURCE;
-				goto deny;
-			}
-		} else if (CALI_F_TO_HEP && !CALI_F_TUNNEL && !CALI_F_WIREGUARD) {
-			if (rt_addr_is_remote_host(ctx.state->ip_dst)) {
-				CALI_DEBUG("IPIP packet to known Calico host, allow.\n");
-				goto allow;
-			} else {
-				CALI_DEBUG("IPIP packet to unknown dest, drop.\n");
-				ctx.fwd.reason = CALI_REASON_UNAUTH_SOURCE;
-				goto deny;
-			}
-		}
-		if (CALI_F_FROM_WEP) {
-			CALI_DEBUG("IPIP traffic from workload: drop\n");
-			ctx.fwd.reason = CALI_REASON_UNAUTH_SOURCE;
-			goto deny;
-		}
-	default:
-		CALI_DEBUG("Unknown protocol (%d), unable to extract ports\n", (int)ctx.state->ip_proto);
+	switch (tc_state_fill_from_nexthdr(&ctx)) {
+	case PARSING_ERROR:
+		goto deny;
+	case PARSING_ALLOW_WITHOUT_ENFORCING_POLICY:
+		goto allow;
 	}
 
 	ctx.state->pol_rc = CALI_POL_NO_MATCH;
@@ -387,16 +332,6 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 		CALI_DEBUG("Too short\n");
 		goto deny;
 	}
-
-	/* icmp_type and icmp_code share storage with the ports; now we've used
-	 * the ports set to 0 to do the conntrack lookup, we can set the ICMP fields
-	 * for policy.
-	 */
-	if (ctx.state->ip_proto == IPPROTO_ICMP) {
-		ctx.state->icmp_type = ctx.icmp_header->type;
-		ctx.state->icmp_code = ctx.icmp_header->code;
-	}
-
 
 	ctx.state->pol_rc = CALI_POL_NO_MATCH;
 	if (ctx.nat_dest) {
@@ -1152,7 +1087,7 @@ int calico_tc_skb_send_icmp_replies(struct __sk_buff *skb)
 		goto deny;
 	}
 
-	tc_state_fill_from_iphdr(ctx.state, ctx.ip_header);
+	tc_state_fill_from_iphdr(&ctx);
 	ctx.state->sport = ctx.state->dport = 0;
 	return forward_or_drop(&ctx);
 deny:

--- a/bpf/bpf_syscall_stub.go
+++ b/bpf/bpf_syscall_stub.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ func GetMapFDByID(mapID int) (MapFD, error) {
 	panic("BPF syscall stub")
 }
 
-func LoadBPFProgramFromInsns(insns asm.Insns, license string) (ProgFD, error) {
+func LoadBPFProgramFromInsns(insns asm.Insns, license string, forXDP bool) (ProgFD, error) {
 	panic("BPF syscall stub")
 }
 

--- a/bpf/polprog/pol_prog_builder.go
+++ b/bpf/polprog/pol_prog_builder.go
@@ -158,6 +158,11 @@ type Rules struct {
 	HostForwardTiers []Tier
 	HostNormalTiers  []Tier
 	HostProfiles     []Profile
+
+	// True when building a policy program for XDP, as opposed to for TC.  This also means that
+	// we are implementing untracked policy (provided in the HostNormalTiers field) and that
+	// traffic is allowed to continue if not explicitly allowed or denied.
+	ForXDP bool
 }
 
 type Profile = Policy
@@ -173,6 +178,12 @@ const (
 func (p *Builder) Instructions(rules Rules) (Insns, error) {
 	p.b = NewBlock()
 	p.writeProgramHeader()
+
+	if rules.ForXDP {
+		// For an XDP program HostNormalTiers continues the untracked policy to enforce;
+		// other fields are unused.
+		goto normalPolicy
+	}
 
 	// Pre-DNAT policy: on a host interface, or host-* policy on a workload interface.  Traffic
 	// is allowed to continue if there is no applicable pre-DNAT policy.
@@ -206,11 +217,16 @@ func (p *Builder) Instructions(rules Rules) (Insns, error) {
 	// Now skip over normal host policy and jump to where we apply possible workload policy.
 	p.b.Jump("allowed_by_host_policy")
 
+normalPolicy:
 	if !rules.SuppressNormalHostPolicy {
 		// "Normal" host policy, i.e. for non-forwarded traffic.
 		p.b.LabelNextInsn("to_or_from_host")
 		p.writeTiers(rules.HostNormalTiers, legDest, "allowed_by_host_policy")
-		p.writeProfiles(rules.HostProfiles, "allowed_by_host_policy")
+		if rules.ForXDP {
+			p.b.Jump("xdp_pass")
+		} else {
+			p.writeProfiles(rules.HostProfiles, "allowed_by_host_policy")
+		}
 	}
 
 	// End of host policy.
@@ -225,7 +241,7 @@ func (p *Builder) Instructions(rules Rules) (Insns, error) {
 		p.writeProfiles(rules.Profiles, "allow")
 	}
 
-	p.writeProgramFooter()
+	p.writeProgramFooter(rules.ForXDP)
 	return p.b.Assemble()
 }
 
@@ -233,7 +249,7 @@ func (p *Builder) Instructions(rules Rules) (Insns, error) {
 // R6 = program context
 // R9 = pointer to state map
 func (p *Builder) writeProgramHeader() {
-	// Pre-amble to the policy program.
+	// Preamble to the policy program.
 	p.b.LabelNextInsn("start")
 	p.b.Mov64(R6, R1) // Save R1 (context) in R6.
 	// Zero-out the map key
@@ -274,11 +290,21 @@ func (p *Builder) writeJumpIfToOrFromHost(label string) {
 }
 
 // writeProgramFooter emits the program exit jump targets.
-func (p *Builder) writeProgramFooter() {
+func (p *Builder) writeProgramFooter(forXDP bool) {
 	// Fall through here if there's no match.  Also used when we hit an error or if policy rejects packet.
 	p.b.LabelNextInsn("deny")
-	p.b.MovImm64(R0, 2 /* TC_ACT_SHOT */)
+	if forXDP {
+		p.b.MovImm64(R0, 1 /* XDP_DROP */)
+	} else {
+		p.b.MovImm64(R0, 2 /* TC_ACT_SHOT */)
+	}
 	p.b.Exit()
+
+	if forXDP {
+		p.b.LabelNextInsn("xdp_pass")
+		p.b.MovImm64(R0, 2 /* XDP_PASS */)
+		p.b.Exit()
+	}
 
 	if p.b.TargetIsUsed("allow") {
 		p.b.LabelNextInsn("allow")

--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ func TestCompileTemplateRun(t *testing.T) {
 
 func TestLoadZeroProgram(t *testing.T) {
 	RegisterTestingT(t)
-	fd, err := bpf.LoadBPFProgramFromInsns(nil, "Apache-2.0")
+	fd, err := bpf.LoadBPFProgramFromInsns(nil, "Apache-2.0", false)
 	if err == nil {
 		_ = fd.Close()
 	}
@@ -238,7 +238,7 @@ outter:
 		pg := polprog.NewBuilder(alloc, ipsMap.MapFD(), stateMap.MapFD(), jumpMap.MapFD())
 		insns, err := pg.Instructions(*rules)
 		Expect(err).NotTo(HaveOccurred())
-		polProgFD, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0")
+		polProgFD, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", false)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = polProgFD.Close() }()
 		progFDBytes := make([]byte, 4)
@@ -948,7 +948,7 @@ func TestJumpMap(t *testing.T) {
 	rules := polprog.Rules{}
 	insns, err := pg.Instructions(rules)
 	Expect(err).NotTo(HaveOccurred())
-	progFD, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0")
+	progFD, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", false)
 	Expect(err).NotTo(HaveOccurred())
 
 	k := make([]byte, 4)

--- a/bpf/ut/pol_prog_test.go
+++ b/bpf/ut/pol_prog_test.go
@@ -43,7 +43,7 @@ func TestLoadAllowAllProgram(t *testing.T) {
 	insns, err := b.Assemble()
 	Expect(err).NotTo(HaveOccurred())
 
-	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0")
+	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", false)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(fd).NotTo(BeZero())
 	defer func() {
@@ -77,7 +77,7 @@ func TestLoadProgramWithMapAccess(t *testing.T) {
 	insns, err := b.Assemble()
 	Expect(err).NotTo(HaveOccurred())
 
-	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0")
+	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", false)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(fd).NotTo(BeZero())
 	defer func() {
@@ -152,7 +152,7 @@ func TestLoadKitchenSinkPolicy(t *testing.T) {
 		}}})
 
 	Expect(err).NotTo(HaveOccurred())
-	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0")
+	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", false)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(fd).NotTo(BeZero())
 	Expect(fd.Close()).NotTo(HaveOccurred())
@@ -167,7 +167,7 @@ func TestLoadGarbageProgram(t *testing.T) {
 		insns = append(insns, asm.Insn{i, i, i, i, i, i, i, i})
 	}
 
-	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0")
+	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", false)
 	Expect(err).To(HaveOccurred())
 	Expect(fd).To(BeZero())
 }
@@ -1583,7 +1583,7 @@ func runTest(t *testing.T, tp testPolicy) {
 
 	// Load the program into the kernel.  We don't pin it so it'll be removed when the
 	// test process exits (or by the defer).
-	polProgFD, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0")
+	polProgFD, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", false)
 	Expect(err).NotTo(HaveOccurred(), "failed to load program into the kernel")
 	Expect(polProgFD).NotTo(BeZero())
 	defer func() {
@@ -1624,7 +1624,7 @@ func installEpilogueProgram(jumpMap bpf.Map) bpf.ProgFD {
 
 	epiInsns, err := b.Assemble()
 	Expect(err).NotTo(HaveOccurred())
-	epiFD, err := bpf.LoadBPFProgramFromInsns(epiInsns, "Apache-2.0")
+	epiFD, err := bpf.LoadBPFProgramFromInsns(epiInsns, "Apache-2.0", false)
 	Expect(err).NotTo(HaveOccurred(), "failed to load program into the kernel")
 	Expect(epiFD).NotTo(BeZero())
 

--- a/bpf/xdp/attach.go
+++ b/bpf/xdp/attach.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/projectcalico/felix/bpf"
+	log "github.com/sirupsen/logrus"
+)
+
+type AttachPoint struct {
+	Iface    string
+	LogLevel string
+	Modes    []bpf.XDPMode
+}
+
+func (ap *AttachPoint) IfaceName() string {
+	return ap.Iface
+}
+
+func (ap *AttachPoint) JumpMapFDMapKey() string {
+	return "xdp"
+}
+
+func (ap *AttachPoint) FileName() string {
+	logLevel := strings.ToLower(ap.LogLevel)
+	if logLevel == "off" {
+		logLevel = "no_log"
+	}
+	return "xdp_" + logLevel + ".o"
+}
+
+func (ap *AttachPoint) SectionName() string {
+	return "calico_entrypoint_xdp"
+}
+
+func (ap *AttachPoint) Log() *log.Entry {
+	return log.WithFields(log.Fields{
+		"iface":    ap.Iface,
+		"modes":    ap.Modes,
+		"logLevel": ap.LogLevel,
+	})
+}
+
+func (ap *AttachPoint) AttachProgram() error {
+	preCompiledBinary := path.Join(bpf.ObjectDir, ap.FileName())
+	sectionName := ap.SectionName()
+
+	// Patch the binary so that its log prefix is like "eth0------X".
+	tempDir, err := ioutil.TempDir("", "calico-xdp")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+	tempBinary := path.Join(tempDir, ap.FileName())
+	err = ap.patchBinary(preCompiledBinary, tempBinary)
+	if err != nil {
+		ap.Log().WithError(err).Error("Failed to patch binary")
+		return err
+	}
+
+	// Note that there are a few considerations here.
+	//
+	// Firstly, we use -force when attaching, so as to minimise any flap in the XDP program when
+	// restarting or upgrading Felix.
+	//
+	// Secondly, we need to consider any other XDP programs that might be there at start of day.
+	// (Either 3rd party, or maybe some earlier version of Felix.)  We fundamentally have to
+	// clean those up, as our XDP usage cannot coexist with anyone else's.
+	//
+	// Thirdly, for a given host interface, is it possible for our best attachment mode to
+	// change, other than at start of day?  In principle it's possible if we do a patch that
+	// alters some conditionally included code.  We don't have that for XDP right now, but we
+	// conceivably could in future.  So safest to assume it's possible for the attachment mode
+	// to improve, which means needing to do `off` for subsequent modes.
+	//
+	// Hence this logic:
+	// - Loop through the modes.
+	//   - If we haven't yet successfully attached (for this loop), do the attachment (with
+	//     -force).
+	//   - If that failed, or we attached with an earlier mode, do `off` to remove any existing
+	//     program with this mode.
+	//   - Continue through remaining modes even if attachment already successful.
+	var errs []error
+	attachmentSucceeded := false
+	for _, mode := range ap.Modes {
+		ap.Log().Debugf("XDP remove/attach with mode %v", mode)
+
+		// We will need to do "ip link set dev <dev> xdp off" if we've successfully attached
+		// with an earlier mode, or if we fail to attach with this mode.  So we only _don't_
+		// need "off" if we successfully attach in this iteration.
+		offNeeded := true
+
+		if !attachmentSucceeded {
+			// Try to attach our XDP program in this mode.
+			cmd := exec.Command("ip", "-force", "link", "set", "dev", ap.Iface, mode.String(), "object", tempBinary, "section", sectionName)
+			ap.Log().Debugf("Running: %v %v", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			ap.Log().WithField("mode", mode).Debugf("Result: err=%v out=\n%v", err, string(out))
+			if err == nil {
+				ap.Log().Infof("Successful XDP attachment with mode %v", mode)
+				attachmentSucceeded = true
+				offNeeded = false
+			} else {
+				errs = append(errs, err)
+			}
+		}
+
+		if offNeeded {
+			// Remove any existing program for this mode.
+			cmd := exec.Command("ip", "link", "set", "dev", ap.Iface, mode.String(), "off")
+			ap.Log().Debugf("Running: %v %v", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			ap.Log().WithField("mode", mode).Debugf("Result: err=%v out=\n%v", err, string(out))
+		}
+	}
+	if !attachmentSucceeded {
+		return fmt.Errorf("Couldn't attach XDP program %v section %v to iface %v; modes=%v errs=%v", tempBinary, sectionName, ap.Iface, ap.Modes, errs)
+	}
+	return nil
+}
+
+func (ap AttachPoint) DetachProgram() error {
+	// Get the current XDP program ID, if any.
+	progID, err := ap.ProgramID()
+	if err != nil {
+		if errors.Is(err, ErrNoXDP) {
+			// Interface has no XDP attached - that's what we want.
+			return nil
+		}
+		// Some other error: return it to trigger a retry.
+		return fmt.Errorf("Couldn't get XDP program ID for %v: %w", ap.Iface, err)
+	}
+
+	// Get the map IDs that the program is using.
+	out, err := exec.Command("bpftool", "prog", "show", "id", progID, "-j").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Couldn't query XDP prog id=%v iface=%v out=\n%v err=%w", progID, ap.Iface, string(out), err)
+	}
+	var progJSON struct {
+		Maps []int `json:"map_ids"`
+	}
+	err = json.Unmarshal(out, &progJSON)
+	if err != nil {
+		ap.Log().WithError(err).Debugf("Failed to parse bpftool output out=\n%v.  Assume not our XDP program.", string(out))
+		return nil
+	}
+
+	ourProgram := false
+	for _, mapID := range progJSON.Maps {
+		// Check if this map is one of ours.
+		ap.Log().Debugf("Check if map id %v is one of ours", mapID)
+		out, err = exec.Command("bpftool", "map", "show", "id", fmt.Sprintf("%v", mapID), "-j").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Couldn't query map id=%v iface=%v out=\n%v err=%w", progID, ap.Iface, string(out), err)
+		}
+		var mapJSON struct {
+			Name string `json:"name"`
+		}
+		err = json.Unmarshal(out, &mapJSON)
+		if err != nil {
+			ap.Log().WithError(err).Debugf("Failed to parse bpftool output out=\n%v.  Assume not our map.", string(out))
+		} else if strings.HasPrefix(mapJSON.Name, "cali_") {
+			ourProgram = true
+			break
+		}
+	}
+
+	if ourProgram {
+		// It's our XDP program; remove it.
+		ap.Log().Debug("Removing our XDP program")
+		removalSucceeded := false
+		for _, mode := range ap.Modes {
+			cmd := exec.Command("ip", "link", "set", "dev", ap.Iface, mode.String(), "off")
+			ap.Log().Debugf("Running: %v %v", cmd.Path, cmd.Args)
+			out, err := cmd.CombinedOutput()
+			ap.Log().WithField("mode", mode).Debugf("Result: err=%v out=\n%v", err, string(out))
+			if err == nil {
+				removalSucceeded = true
+			}
+		}
+		if !removalSucceeded {
+			return fmt.Errorf("Couldn't remove our XDP program from iface %v", ap.Iface)
+		}
+	}
+
+	return nil
+}
+
+func (ap *AttachPoint) patchBinary(ifile, ofile string) error {
+	b, err := bpf.BinaryFromFile(ifile)
+	if err != nil {
+		return fmt.Errorf("failed to read pre-compiled BPF binary: %w", err)
+	}
+
+	b.PatchLogPrefix(ap.Iface)
+
+	err = b.WriteToFile(ofile)
+	if err != nil {
+		return fmt.Errorf("failed to write pre-compiled BPF binary: %w", err)
+	}
+
+	return nil
+}
+
+func (ap *AttachPoint) IsAttached() (bool, error) {
+	_, err := ap.ProgramID()
+	return err == nil, err
+}
+
+var ErrNoXDP = errors.New("no XDP program attached")
+
+func (ap *AttachPoint) ProgramID() (string, error) {
+	cmd := exec.Command("ip", "link", "show", "dev", ap.Iface)
+	ap.Log().Debugf("Running: %v %v", cmd.Path, cmd.Args)
+	out, err := cmd.CombinedOutput()
+	ap.Log().Debugf("Result: err=%v out=\n%v", err, string(out))
+	if err != nil {
+		return "", fmt.Errorf("Couldn't check for XDP program on iface %v: %w", ap.Iface, err)
+	}
+	s := strings.Fields(string(out))
+	for i := range s {
+		// Example of output:
+		//
+		// 196: test_A@test_B: <BROADCAST,MULTICAST> mtu 1500 xdpgeneric qdisc noop state DOWN mode DEFAULT group default qlen 1000
+		//    link/ether 1a:d0:df:a5:12:59 brd ff:ff:ff:ff:ff:ff
+		//    prog/xdp id 175 tag 5199fa060702bbff jited
+		if s[i] == "prog/xdp" && len(s) > i+2 && s[i+1] == "id" {
+			_, err := strconv.Atoi(s[i+2])
+			if err != nil {
+				return "", fmt.Errorf("Couldn't parse ID following 'prog/xdp' err=%w out=\n%v", err, string(out))
+			}
+			return s[i+2], nil
+		}
+	}
+	return "", fmt.Errorf("Couldn't find 'prog/xdp id <ID>' out=\n%v err=%w", string(out), ErrNoXDP)
+}

--- a/dataplane/linux/bpf_ep_mgr_test.go
+++ b/dataplane/linux/bpf_ep_mgr_test.go
@@ -30,7 +30,6 @@ import (
 	bpfipsets "github.com/projectcalico/felix/bpf/ipsets"
 	"github.com/projectcalico/felix/bpf/polprog"
 	"github.com/projectcalico/felix/bpf/state"
-	"github.com/projectcalico/felix/bpf/tc"
 	"github.com/projectcalico/felix/idalloc"
 	"github.com/projectcalico/felix/ifacemonitor"
 	"github.com/projectcalico/felix/ipsets"
@@ -56,17 +55,20 @@ func newMockDataplane() *mockDataplane {
 func (m *mockDataplane) ensureStarted() {
 }
 
-func (m *mockDataplane) ensureProgramAttached(ap *tc.AttachPoint, polDirection PolDirection) (bpf.MapFD, error) {
+func (m *mockDataplane) ensureProgramAttached(ap attachPoint) (bpf.MapFD, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	suffixes := []string{"-I", "-E"}
-	key := ap.Iface + suffixes[int(polDirection)]
+	key := ap.IfaceName() + ":" + ap.JumpMapFDMapKey()
 	if fd, exists := m.fds[key]; exists {
 		return bpf.MapFD(fd), nil
 	}
 	m.lastFD += 1
 	m.fds[key] = m.lastFD
 	return bpf.MapFD(m.lastFD), nil
+}
+
+func (m *mockDataplane) ensureNoProgram(ap attachPoint) error {
+	return nil
 }
 
 func (m *mockDataplane) ensureQdisc(iface string) error {
@@ -167,17 +169,21 @@ var _ = Describe("BPF Endpoint Manager", func() {
 	JustBeforeEach(func() {
 		dp = newMockDataplane()
 		bpfEpMgr = newBPFEndpointManager(
-			"info", // config.BPFLogLevel,
-			"uthost",
+			&Config{
+				Hostname:              "uthost",
+				BPFLogLevel:           "info",
+				BPFDataIfacePattern:   regexp.MustCompile(dataIfacePattern),
+				VXLANMTU:              vxlanMTU,
+				VXLANPort:             rrConfigNormal.VXLANPort,
+				BPFNodePortDSREnabled: nodePortDSR,
+				RulesConfig: rules.Config{
+					EndpointToHostAction: endpointToHostAction,
+				},
+				BPFExtToServiceConnmark: 0,
+			},
 			fibLookupEnabled,
-			endpointToHostAction,
-			regexp.MustCompile(dataIfacePattern),
 			regexp.MustCompile(workloadIfaceRegex),
 			ipSetIDAllocator,
-			vxlanMTU,
-			uint16(rrConfigNormal.VXLANPort),
-			nodePortDSR,
-			0,
 			ipSetsMap,
 			stateMap,
 			ruleRenderer,
@@ -278,26 +284,26 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			var eth0I, eth0E, caliI, caliE *polprog.Rules
 
 			// Check eth0 ingress.
-			Eventually(dp.setAndReturn(&eth0I, "eth0-I")).ShouldNot(BeNil())
+			Eventually(dp.setAndReturn(&eth0I, "eth0:tc-ingress")).ShouldNot(BeNil())
 			Expect(eth0I.ForHostInterface).To(BeTrue())
 			Expect(eth0I.HostNormalTiers).To(HaveLen(1))
 			Expect(eth0I.HostNormalTiers[0].Policies).To(HaveLen(1))
 			Expect(eth0I.SuppressNormalHostPolicy).To(BeFalse())
 
 			// Check eth0 egress.
-			Eventually(dp.setAndReturn(&eth0E, "eth0-E")).ShouldNot(BeNil())
+			Eventually(dp.setAndReturn(&eth0E, "eth0:tc-egress")).ShouldNot(BeNil())
 			Expect(eth0E.ForHostInterface).To(BeTrue())
 			Expect(eth0E.HostNormalTiers).To(HaveLen(1))
 			Expect(eth0E.HostNormalTiers[0].Policies).To(HaveLen(1))
 			Expect(eth0E.SuppressNormalHostPolicy).To(BeFalse())
 
 			// Check workload ingress.
-			Eventually(dp.setAndReturn(&caliI, "cali12345-I")).ShouldNot(BeNil())
+			Eventually(dp.setAndReturn(&caliI, "cali12345:tc-egress")).ShouldNot(BeNil())
 			Expect(caliI.ForHostInterface).To(BeFalse())
 			Expect(caliI.SuppressNormalHostPolicy).To(BeTrue())
 
 			// Check workload egress.
-			Eventually(dp.setAndReturn(&caliE, "cali12345-E")).ShouldNot(BeNil())
+			Eventually(dp.setAndReturn(&caliE, "cali12345:tc-ingress")).ShouldNot(BeNil())
 			Expect(caliE.ForHostInterface).To(BeFalse())
 			Expect(caliE.SuppressNormalHostPolicy).To(BeTrue())
 		})
@@ -311,12 +317,12 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				var caliI, caliE *polprog.Rules
 
 				// Check workload ingress.
-				Eventually(dp.setAndReturn(&caliI, "cali12345-I")).ShouldNot(BeNil())
+				Eventually(dp.setAndReturn(&caliI, "cali12345:tc-egress")).ShouldNot(BeNil())
 				Expect(caliI.ForHostInterface).To(BeFalse())
 				Expect(caliI.SuppressNormalHostPolicy).To(BeTrue())
 
 				// Check workload egress.
-				Eventually(dp.setAndReturn(&caliE, "cali12345-E")).ShouldNot(BeNil())
+				Eventually(dp.setAndReturn(&caliE, "cali12345:tc-ingress")).ShouldNot(BeNil())
 				Expect(caliE.ForHostInterface).To(BeFalse())
 				Expect(caliE.HostNormalTiers).To(HaveLen(1))
 				Expect(caliE.HostNormalTiers[0].Policies).To(HaveLen(1))
@@ -344,13 +350,13 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				var eth0I, eth0E *polprog.Rules
 
 				// Check ingress rules.
-				Eventually(dp.setAndReturn(&eth0I, "eth0-I")).ShouldNot(BeNil())
+				Eventually(dp.setAndReturn(&eth0I, "eth0:tc-ingress")).ShouldNot(BeNil())
 				Expect(eth0I.ForHostInterface).To(BeTrue())
 				Expect(eth0I.HostPreDnatTiers).To(HaveLen(1))
 				Expect(eth0I.HostPreDnatTiers[0].Policies).To(HaveLen(1))
 
 				// Check egress rules.
-				Eventually(dp.setAndReturn(&eth0E, "eth0-E")).ShouldNot(BeNil())
+				Eventually(dp.setAndReturn(&eth0E, "eth0:tc-egress")).ShouldNot(BeNil())
 				Expect(eth0E.ForHostInterface).To(BeTrue())
 				Expect(eth0E.HostPreDnatTiers).To(BeNil())
 			})

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -449,10 +449,11 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 
 	callbacks := newCallbacks()
 	dp.callbacks = callbacks
-	if !config.BPFEnabled && config.XDPEnabled {
+	if config.XDPEnabled {
 		if err := bpf.SupportsXDP(); err != nil {
 			log.WithError(err).Warn("Can't enable XDP acceleration.")
-		} else {
+			config.XDPEnabled = false
+		} else if !config.BPFEnabled {
 			st, err := NewXDPState(config.XDPAllowGeneric)
 			if err != nil {
 				log.WithError(err).Warn("Can't enable XDP acceleration.")
@@ -467,7 +468,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		log.Info("XDP acceleration disabled.")
 	}
 
-	// TODO Integrate XDP and BPF infra.
+	// TODO Support cleaning up non-BPF XDP state from a previous Felix run, when BPF mode has just been enabled.
 	if !config.BPFEnabled && dp.xdpState == nil {
 		xdpState, err := NewXDPState(config.XDPAllowGeneric)
 		if err == nil {
@@ -596,17 +597,10 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 
 		workloadIfaceRegex := regexp.MustCompile(strings.Join(interfaceRegexes, "|"))
 		bpfEndpointManager = newBPFEndpointManager(
-			config.BPFLogLevel,
-			config.Hostname,
+			&config,
 			fibLookupEnabled,
-			config.RulesConfig.EndpointToHostAction,
-			config.BPFDataIfacePattern,
 			workloadIfaceRegex,
 			ipSetIDAllocator,
-			config.VXLANMTU,
-			uint16(config.VXLANPort),
-			config.BPFNodePortDSREnabled,
-			config.BPFExtToServiceConnmark,
 			ipSetsMap,
 			stateMap,
 			ruleRenderer,


### PR DESCRIPTION
This PR adds BPF mode support for untracked ingress Deny policies (using XDP as the implementation of that), by picking #2888 and #2905 from master.

(We're also continuing with the work to support untracked policy more generally, but I don't think there's any chance now of squeezing that into OSS v3.20.)