### PR TITLE
Avoid race + panic when unnecessarily cleaning up the Kubernetes API service

### DIFF
--- a/fv/infrastructure/infra_k8s.go
+++ b/fv/infrastructure/infra_k8s.go
@@ -977,6 +977,10 @@ func cleanupAllServices(clientset *kubernetes.Clientset, calicoClient client.Int
 			panic(err)
 		}
 		for _, s := range services.Items {
+			if s.Name == "kubernetes" {
+				// Skip cleaning up the Kubernetes API service.
+				continue
+			}
 			err := serviceInterface.Delete(context.Background(), s.Name, metav1.DeleteOptions{})
 			if err != nil {
 				panic(err)
@@ -988,6 +992,10 @@ func cleanupAllServices(clientset *kubernetes.Clientset, calicoClient client.Int
 			panic(err)
 		}
 		for _, ep := range endpoints.Items {
+			if ep.Name == "kubernetes" {
+				// Skip cleaning up the Kubernetes API service.
+				continue
+			}
 			err := endpointsInterface.Delete(context.Background(), ep.Name, metav1.DeleteOptions{})
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
We've been seeing panics from the Kubernetes infrastructure cleanup
code, e.g. at
https://tigera.semaphoreci.com/jobs/58885471-c537-438c-864d-d90bf6ec90f0/plain_logs.txt
and
https://tigera.semaphoreci.com/jobs/7b8478d6-d88b-4e42-90a9-e3a28260a1e8/plain_logs.txt,
like this:

    Test Panicked
    endpoints "kubernetes" not found
    /go/src/github.com/projectcalico/felix/fv/infrastructure/infra_k8s.go:1077

    Full Stack Trace
    github.com/projectcalico/felix/fv/infrastructure.cleanupAllServices(0xc0006a6840, 0x2576f80, 0xc000401400)
    	/go/src/github.com/projectcalico/felix/fv/infrastructure/infra_k8s.go:1077 +0x686
    github.com/projectcalico/felix/fv/infrastructure.(*K8sDatastoreInfra).CleanUp(0xc0004c0a20)
    	/go/src/github.com/projectcalico/felix/fv/infrastructure/infra_k8s.go:496 +0x1d4
    github.com/projectcalico/felix/fv/infrastructure.(*K8sDatastoreInfra).EnsureReady(0xc0004c0a20)
    	/go/src/github.com/projectcalico/felix/fv/infrastructure/infra_k8s.go:439 +0x1c5
    github.com/projectcalico/felix/fv/infrastructure.GetK8sDatastoreInfra(0x3a, 0x13a, 0x0)
    	/go/src/github.com/projectcalico/felix/fv/infrastructure/infra_k8s.go:150 +0x4b
    github.com/projectcalico/felix/fv/infrastructure.createK8sDatastoreInfra(0xc0015f3230, 0xc0000ae840)
    	/go/src/github.com/projectcalico/felix/fv/infrastructure/infra_k8s.go:140 +0x26
    github.com/projectcalico/felix/fv_test.glob..func31.1()
    	/go/src/github.com/projectcalico/felix/fv/ipsec_test.go:602 +0x90
    github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc000ce87e0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    	/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/internal/leafnodes/runner.go:113 +0xa3
    github.com/onsi/ginkgo/internal/leafnodes.(*runner).run(0xc000ce87e0, 0xc, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    	/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/internal/leafnodes/runner.go:64 +0xd7
    github.com/onsi/ginkgo/internal/leafnodes.(*SetupNode).Run(0xc000436db0, 0x24f4ea0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    	/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/internal/leafnodes/setup_nodes.go:15 +0x67
    github.com/onsi/ginkgo/internal/spec.(*Spec).runSample(0xc000fb3860, 0x0, 0x24f4ea0, 0xc0001388c0)
    	/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/internal/spec/spec.go:193 +0x25f
    github.com/onsi/ginkgo/internal/spec.(*Spec).Run(0xc000fb3860, 0x24f4ea0, 0xc0001388c0)
    	/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/internal/spec/spec.go:138 +0xf2
    github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpec(0xc000f6ef00, 0xc000fb3860, 0x0)
    	/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/internal/specrunner/spec_runner.go:200 +0x111
    github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpecs(0xc000f6ef00, 0x1)
    	/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/internal/specrunner/spec_runner.go:170 +0x127
    github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run(0xc000f6ef00, 0xc000243560)
    	/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/internal/specrunner/spec_runner.go:66 +0x117
    github.com/onsi/ginkgo/internal/suite.(*Suite).Run(0xc000162070, 0x7f1ba02a8360, 0xc00076cc00, 0x22338c7, 0x8, 0xc0003d9e00, 0x2, 0x2, 0x2550ee0, 0xc0001388c0, ...)
    	/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/internal/suite/suite.go:79 +0x586
    github.com/onsi/ginkgo.RunSpecsWithCustomReporters(0x24f69a0, 0xc00076cc00, 0x22338c7, 0x8, 0xc0003d9dc0, 0x2, 0x2, 0x2)
    	/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/ginkgo_dsl.go:229 +0x238
    github.com/onsi/ginkgo.RunSpecsWithDefaultAndCustomReporters(0x24f69a0, 0xc00076cc00, 0x22338c7, 0x8, 0xc000072760, 0x1, 0x1, 0x61000f89)
    	/go/pkg/mod/github.com/onsi/ginkgo@v1.14.2/ginkgo_dsl.go:217 +0xad
    github.com/projectcalico/felix/fv_test.TestFv(0xc00076cc00)
    	/go/src/github.com/projectcalico/felix/fv/fv_suite_test.go:44 +0xfa
    testing.tRunner(0xc00076cc00, 0x233b578)
    	/usr/local/go-cgo/src/testing/testing.go:1127 +0xef
    created by testing.(*T).Run
    	/usr/local/go-cgo/src/testing/testing.go:1178 +0x386

The tracing from the same time says:

    2021-07-27 14:09:32.963 [INFO][16354] infra_k8s.go 1040: FelixConfigurations present count=0
    2021-07-27 14:09:32.963 [INFO][16354] infra_k8s.go 1047: Cleaned up felix configurations
    2021-07-27 14:09:32.963 [INFO][16354] infra_k8s.go 1051: Cleaning up services
    apiserver-16354-6-felixfv[stderr] W0727 14:09:32.972928       1 lease.go:224] Resetting endpoints for master service "kubernetes" to [172.17.0.3]
    2021-07-27 14:09:32.987 [INFO][16354] workload.go 70: Stop no-op because nil workload
    2021-07-27 14:09:32.987 [INFO][16354] workload.go 70: Stop no-op because nil workload
    2021-07-27 14:09:32.987 [INFO][16354] workload.go 70: Stop no-op because nil workload
    2021-07-27 14:09:32.987 [INFO][16354] workload.go 70: Stop no-op because nil workload
    2021-07-27 14:09:32.987 [INFO][16354] workload.go 70: Stop no-op because nil workload

It looks like a straightforward race where we delete all the Service
objects, including “kubernetes”, and then:

- the API server responds to that by recreating the “kubernetes” Service and default Endpoint

- at the same time, we try to delete all the Endpoints.

We shouldn't actually need to delete the “kubernetes” Service or
Endpoints, so let's skip that.
