### PR TITLE
ease up wireguard metrics log levels

### DIFF
--- a/wireguard/metrics.go
+++ b/wireguard/metrics.go
@@ -124,7 +124,6 @@ func MustNewWireguardMetrics() *Metrics {
 func NewWireguardMetrics() (*Metrics, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		logrus.WithError(err).Warn("cannot register wireguard metrics stats")
 		return nil, err
 	}
 	return NewWireguardMetricsWithShims(hostname, netlinkshim.NewRealWireguard, defaultCollectionRatelimit), nil
@@ -149,13 +148,13 @@ func NewWireguardMetricsWithShims(hostname string, newWireguardClient func() (ne
 func (collector *Metrics) getDevices() []*wgtypes.Device {
 	wgClient, err := collector.newWireguardClient()
 	if err != nil {
-		collector.logCtx.WithError(err).Warn("something went wrong initializing wireguard rpc client")
+		collector.logCtx.WithError(err).Debug("something went wrong initializing wireguard rpc client")
 		return nil
 	}
 
 	devices, err := wgClient.Devices()
 	if err != nil {
-		collector.logCtx.WithError(err).Warn("something went wrong enumerating wireguard devices")
+		collector.logCtx.WithError(err).Debug("something went wrong enumerating wireguard devices")
 		return nil
 	}
 	return devices

--- a/wireguard/metrics.go
+++ b/wireguard/metrics.go
@@ -78,7 +78,7 @@ func (collector *Metrics) Describe(d chan<- *prometheus.Desc) {
 
 func (collector *Metrics) descsByDevice(d chan<- *prometheus.Desc, device *wgtypes.Device) {
 	if device == nil {
-		collector.logCtx.Error("BUG: called descsByDevice with nil device")
+		collector.logCtx.Debug("BUG: called descsByDevice with nil device")
 		return
 	}
 
@@ -95,7 +95,7 @@ func (collector *Metrics) descsByDevice(d chan<- *prometheus.Desc, device *wgtyp
 
 func (collector *Metrics) descByPeer(d chan<- *prometheus.Desc, peer *wgtypes.Peer) {
 	if peer == nil {
-		collector.logCtx.Error("BUG: called descByPeer with nil peer")
+		collector.logCtx.Debug("BUG: called descByPeer with nil peer")
 		return
 	}
 
@@ -124,7 +124,7 @@ func MustNewWireguardMetrics() *Metrics {
 func NewWireguardMetrics() (*Metrics, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		logrus.WithError(err).Error("cannot register wireguard metrics stats")
+		logrus.WithError(err).Warn("cannot register wireguard metrics stats")
 		return nil, err
 	}
 	return NewWireguardMetricsWithShims(hostname, netlinkshim.NewRealWireguard, defaultCollectionRatelimit), nil
@@ -149,13 +149,13 @@ func NewWireguardMetricsWithShims(hostname string, newWireguardClient func() (ne
 func (collector *Metrics) getDevices() []*wgtypes.Device {
 	wgClient, err := collector.newWireguardClient()
 	if err != nil {
-		collector.logCtx.WithError(err).Error("error initializing wireguard client devices")
+		collector.logCtx.WithError(err).Warn("error initializing wireguard client devices")
 		return nil
 	}
 
 	devices, err := wgClient.Devices()
 	if err != nil {
-		collector.logCtx.WithError(err).Error("error listing wireguard devices")
+		collector.logCtx.WithError(err).Warn("error enumerating wireguard devices")
 		return nil
 	}
 	return devices
@@ -166,7 +166,7 @@ func (collector *Metrics) refreshStats(m chan<- prometheus.Metric) {
 		collector.logCtx.WithFields(logrus.Fields{
 			"since":              ct.String(),
 			"ratelimit_interval": collector.rateLimitInterval.String(),
-		}).Error("refreshStats disallowed due to rate limit")
+		}).Debug("refreshStats disallowed due to rate limit")
 		return
 	}
 	devices := collector.getDevices()

--- a/wireguard/metrics.go
+++ b/wireguard/metrics.go
@@ -78,7 +78,7 @@ func (collector *Metrics) Describe(d chan<- *prometheus.Desc) {
 
 func (collector *Metrics) descsByDevice(d chan<- *prometheus.Desc, device *wgtypes.Device) {
 	if device == nil {
-		collector.logCtx.Debug("BUG: called descsByDevice with nil device")
+		collector.logCtx.Error("BUG: called descsByDevice with nil device")
 		return
 	}
 
@@ -95,7 +95,7 @@ func (collector *Metrics) descsByDevice(d chan<- *prometheus.Desc, device *wgtyp
 
 func (collector *Metrics) descByPeer(d chan<- *prometheus.Desc, peer *wgtypes.Peer) {
 	if peer == nil {
-		collector.logCtx.Debug("BUG: called descByPeer with nil peer")
+		collector.logCtx.Error("BUG: called descByPeer with nil peer")
 		return
 	}
 
@@ -149,13 +149,13 @@ func NewWireguardMetricsWithShims(hostname string, newWireguardClient func() (ne
 func (collector *Metrics) getDevices() []*wgtypes.Device {
 	wgClient, err := collector.newWireguardClient()
 	if err != nil {
-		collector.logCtx.WithError(err).Warn("error initializing wireguard client devices")
+		collector.logCtx.WithError(err).Warn("something went wrong initializing wireguard rpc client")
 		return nil
 	}
 
 	devices, err := wgClient.Devices()
 	if err != nil {
-		collector.logCtx.WithError(err).Warn("error enumerating wireguard devices")
+		collector.logCtx.WithError(err).Warn("something went wrong enumerating wireguard devices")
 		return nil
 	}
 	return devices


### PR DESCRIPTION
## Description

`logrus.Error` seems too harsh overall for the metrics collection functionality for WireGuard. At best, should be more or less informational even if it encounters program errors


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
None required

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
