### PR TITLE
Backport from PR #2944 - Fix dest match in XDP

### DIFF
--- a/bpf-gpl/parsing.h
+++ b/bpf-gpl/parsing.h
@@ -111,6 +111,7 @@ static CALI_BPF_INLINE void tc_state_fill_from_iphdr(struct cali_tc_ctx *ctx)
 {
 	ctx->state->ip_src = ctx->ip_header->saddr;
 	ctx->state->ip_dst = ctx->ip_header->daddr;
+	ctx->state->pre_nat_ip_dst = ctx->ip_header->daddr;
 	ctx->state->ip_proto = ctx->ip_header->protocol;
 	ctx->state->ip_size = ctx->ip_header->tot_len;
 }
@@ -129,11 +130,13 @@ static CALI_BPF_INLINE int tc_state_fill_from_nexthdr(struct cali_tc_ctx *ctx)
 		}
 		ctx->state->sport = bpf_ntohs(ctx->tcp_header->source);
 		ctx->state->dport = bpf_ntohs(ctx->tcp_header->dest);
+		ctx->state->pre_nat_dport = ctx->state->dport;
 		CALI_DEBUG("TCP; ports: s=%d d=%d\n", ctx->state->sport, ctx->state->dport);
 		break;
 	case IPPROTO_UDP:
 		ctx->state->sport = bpf_ntohs(ctx->udp_header->source);
 		ctx->state->dport = bpf_ntohs(ctx->udp_header->dest);
+		ctx->state->pre_nat_dport = ctx->state->dport;
 		CALI_DEBUG("UDP; ports: s=%d d=%d\n", ctx->state->sport, ctx->state->dport);
 		if (ctx->state->dport == VXLAN_PORT) {
 			/* CALI_F_FROM_HEP case is handled in vxlan_attempt_decap above since it already decoded

--- a/bpf/polprog/pol_prog_builder.go
+++ b/bpf/polprog/pol_prog_builder.go
@@ -221,10 +221,11 @@ normalPolicy:
 	if !rules.SuppressNormalHostPolicy {
 		// "Normal" host policy, i.e. for non-forwarded traffic.
 		p.b.LabelNextInsn("to_or_from_host")
-		p.writeTiers(rules.HostNormalTiers, legDest, "allowed_by_host_policy")
 		if rules.ForXDP {
+			p.writeTiers(rules.HostNormalTiers, legDestPreNAT, "allowed_by_host_policy")
 			p.b.Jump("xdp_pass")
 		} else {
+			p.writeTiers(rules.HostNormalTiers, legDest, "allowed_by_host_policy")
 			p.writeProfiles(rules.HostProfiles, "allowed_by_host_policy")
 		}
 	}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
This is the backport from a part of PR #2944 that fixes a bug related to matching against destination IP/Port in the policy program in XDP. The fix is to fill in `pre_dnat_dst_ip` and `pre_dnat_dport` with actual destination IP/Port from packets in the parser and use `legDestPreNAT` in the policy program to match against it. 

## Todos
- [x] Backport

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
