### PR TITLE
remove unions in cali_tc_ctx/state structure

### DIFF
--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -23,7 +23,6 @@
 #include "bpf.h"
 #include "icmp.h"
 #include "types.h"
-#include "parsing.h"
 
 // Connection tracking.
 

--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -23,6 +23,7 @@
 #include "bpf.h"
 #include "icmp.h"
 #include "types.h"
+#include "parsing.h"
 
 // Connection tracking.
 
@@ -266,7 +267,7 @@ static CALI_BPF_INLINE bool skb_icmp_err_unpack(struct cali_tc_ctx *ctx, struct 
 	}
 
 	struct iphdr *ip_inner;
-	ip_inner = (struct iphdr *)(ctx->icmp_header + 1); /* skip to inner ip */
+	ip_inner = (struct iphdr *)(ICMPHDR(ctx) + 1); /* skip to inner ip */
 	CALI_DEBUG("CT-ICMP: proto %d\n", ip_inner->protocol);
 
 	ct_ctx->proto = ip_inner->protocol;
@@ -389,7 +390,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 			CALI_DEBUG("Too short\n");
 			bpf_exit(TC_ACT_SHOT);
 		}
-		ct_lookup_ctx.tcp = tc_ctx->tcp_header;
+		ct_lookup_ctx.tcp = TCPHDR(tc_ctx);
 	}
 
 	__u8 proto_orig = ct_ctx->proto;
@@ -455,9 +456,9 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 			goto out_lookup_fail;
 		}
 
-		if (!icmp_type_is_err(tc_ctx->icmp_header->type)) {
+		if (!icmp_type_is_err(ICMPHDR(tc_ctx)->type)) {
 			// ICMP but not an error response packet.
-			CALI_DEBUG("CT-ICMP: type %d not an error\n", tc_ctx->icmp_header->type);
+			CALI_DEBUG("CT-ICMP: type %d not an error\n", ICMPHDR(tc_ctx)->type);
 			goto out_lookup_fail;
 		}
 

--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -267,7 +267,7 @@ static CALI_BPF_INLINE bool skb_icmp_err_unpack(struct cali_tc_ctx *ctx, struct 
 	}
 
 	struct iphdr *ip_inner;
-	ip_inner = (struct iphdr *)(parsing_icmphdr(ctx) + 1); /* skip to inner ip */
+	ip_inner = (struct iphdr *)(tc_icmphdr(ctx) + 1); /* skip to inner ip */
 	CALI_DEBUG("CT-ICMP: proto %d\n", ip_inner->protocol);
 
 	ct_ctx->proto = ip_inner->protocol;
@@ -390,7 +390,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 			CALI_DEBUG("Too short\n");
 			bpf_exit(TC_ACT_SHOT);
 		}
-		ct_lookup_ctx.tcp = parsing_tcphdr(tc_ctx);
+		ct_lookup_ctx.tcp = tc_tcphdr(tc_ctx);
 	}
 
 	__u8 proto_orig = ct_ctx->proto;
@@ -456,10 +456,10 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 			goto out_lookup_fail;
 		}
 
-		if (!icmp_type_is_err(parsing_icmphdr(tc_ctx)->type)) {
+		if (!icmp_type_is_err(tc_icmphdr(tc_ctx)->type)) {
 			// ICMP but not an error response packet.
 			CALI_DEBUG("CT-ICMP: type %d not an error\n",
-					parsing_icmphdr(tc_ctx)->type);
+					tc_icmphdr(tc_ctx)->type);
 			goto out_lookup_fail;
 		}
 

--- a/bpf-gpl/conntrack.h
+++ b/bpf-gpl/conntrack.h
@@ -267,7 +267,7 @@ static CALI_BPF_INLINE bool skb_icmp_err_unpack(struct cali_tc_ctx *ctx, struct 
 	}
 
 	struct iphdr *ip_inner;
-	ip_inner = (struct iphdr *)(ICMPHDR(ctx) + 1); /* skip to inner ip */
+	ip_inner = (struct iphdr *)(parsing_icmphdr(ctx) + 1); /* skip to inner ip */
 	CALI_DEBUG("CT-ICMP: proto %d\n", ip_inner->protocol);
 
 	ct_ctx->proto = ip_inner->protocol;
@@ -390,7 +390,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 			CALI_DEBUG("Too short\n");
 			bpf_exit(TC_ACT_SHOT);
 		}
-		ct_lookup_ctx.tcp = TCPHDR(tc_ctx);
+		ct_lookup_ctx.tcp = parsing_tcphdr(tc_ctx);
 	}
 
 	__u8 proto_orig = ct_ctx->proto;
@@ -456,9 +456,10 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 			goto out_lookup_fail;
 		}
 
-		if (!icmp_type_is_err(ICMPHDR(tc_ctx)->type)) {
+		if (!icmp_type_is_err(parsing_icmphdr(tc_ctx)->type)) {
 			// ICMP but not an error response packet.
-			CALI_DEBUG("CT-ICMP: type %d not an error\n", ICMPHDR(tc_ctx)->type);
+			CALI_DEBUG("CT-ICMP: type %d not an error\n",
+					parsing_icmphdr(tc_ctx)->type);
 			goto out_lookup_fail;
 		}
 

--- a/bpf-gpl/icmp.h
+++ b/bpf-gpl/icmp.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/bpf-gpl/icmp.h
+++ b/bpf-gpl/icmp.h
@@ -114,10 +114,10 @@ static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 	ctx->ip_header->saddr = INTF_IP;
 	ctx->ip_header->daddr = ip_orig.saddr;
 
-	ICMPHDR(ctx)->type = type;
-	ICMPHDR(ctx)->code = code;
-	*((__be32 *)&ICMPHDR(ctx)->un) = un;
-	ICMPHDR(ctx)->checksum = 0;
+	parsing_icmphdr(ctx)->type = type;
+	parsing_icmphdr(ctx)->code = code;
+	*((__be32 *)&parsing_icmphdr(ctx)->un) = un;
+	parsing_icmphdr(ctx)->checksum = 0;
 
 	__wsum ip_csum = bpf_csum_diff(0, 0, (void *)ctx->ip_header, sizeof(*ctx->ip_header), 0);
 	__wsum icmp_csum = bpf_csum_diff(0, 0, ctx->nh,

--- a/bpf-gpl/icmp.h
+++ b/bpf-gpl/icmp.h
@@ -25,6 +25,7 @@
 #include "bpf.h"
 #include "log.h"
 #include "skb.h"
+#include "parsing.h"
 
 static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 					__u8 type, __u8 code, __be32 un)
@@ -113,14 +114,14 @@ static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 	ctx->ip_header->saddr = INTF_IP;
 	ctx->ip_header->daddr = ip_orig.saddr;
 
-	ctx->icmp_header->type = type;
-	ctx->icmp_header->code = code;
-	*((__be32 *)&ctx->icmp_header->un) = un;
-	ctx->icmp_header->checksum = 0;
+	ICMPHDR(ctx)->type = type;
+	ICMPHDR(ctx)->code = code;
+	*((__be32 *)&ICMPHDR(ctx)->un) = un;
+	ICMPHDR(ctx)->checksum = 0;
 
 	__wsum ip_csum = bpf_csum_diff(0, 0, (void *)ctx->ip_header, sizeof(*ctx->ip_header), 0);
-	__wsum icmp_csum = bpf_csum_diff(0, 0, (void *)ctx->icmp_header,
-		len -  sizeof(*ctx->ip_header) - skb_iphdr_offset(), 0);
+	__wsum icmp_csum = bpf_csum_diff(0, 0, ctx->nh,
+		len - sizeof(struct iphdr) - skb_iphdr_offset(), 0);
 
 	ret = bpf_l3_csum_replace(ctx->skb,
 			skb_iphdr_offset() + offsetof(struct iphdr, check), 0, ip_csum, 0);

--- a/bpf-gpl/icmp.h
+++ b/bpf-gpl/icmp.h
@@ -25,7 +25,6 @@
 #include "bpf.h"
 #include "log.h"
 #include "skb.h"
-#include "parsing.h"
 
 static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 					__u8 type, __u8 code, __be32 un)

--- a/bpf-gpl/icmp.h
+++ b/bpf-gpl/icmp.h
@@ -114,10 +114,10 @@ static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 	ctx->ip_header->saddr = INTF_IP;
 	ctx->ip_header->daddr = ip_orig.saddr;
 
-	parsing_icmphdr(ctx)->type = type;
-	parsing_icmphdr(ctx)->code = code;
-	*((__be32 *)&parsing_icmphdr(ctx)->un) = un;
-	parsing_icmphdr(ctx)->checksum = 0;
+	tc_icmphdr(ctx)->type = type;
+	tc_icmphdr(ctx)->code = code;
+	*((__be32 *)&tc_icmphdr(ctx)->un) = un;
+	tc_icmphdr(ctx)->checksum = 0;
 
 	__wsum ip_csum = bpf_csum_diff(0, 0, (void *)ctx->ip_header, sizeof(*ctx->ip_header), 0);
 	__wsum icmp_csum = bpf_csum_diff(0, 0, ctx->nh,

--- a/bpf-gpl/nat.h
+++ b/bpf-gpl/nat.h
@@ -27,6 +27,7 @@
 #include "skb.h"
 #include "routes.h"
 #include "nat_types.h"
+#include "parsing.h"
 
 #ifndef CALI_VXLAN_VNI
 #define CALI_VXLAN_VNI 0xca11c0
@@ -250,7 +251,7 @@ static CALI_BPF_INLINE int vxlan_v4_encap(struct cali_tc_ctx *ctx,  __be32 ip_sr
 	}
 
 	// Note: assuming L2 packet here so this code can't be used on an L3 device.
-	struct vxlanhdr *vxlan = (void *)(ctx->udp_header +1);
+	struct vxlanhdr *vxlan = (void *)(UDPHDR(ctx) + 1);
 	struct ethhdr *eth_inner = (void *)(vxlan+1);
 	struct iphdr *ip_inner = (void*)(eth_inner+1);
 
@@ -269,14 +270,14 @@ static CALI_BPF_INLINE int vxlan_v4_encap(struct cali_tc_ctx *ctx,  __be32 ip_sr
 	ctx->ip_header->check = 0;
 	ctx->ip_header->protocol = IPPROTO_UDP;
 
-	ctx->udp_header->source = ctx->udp_header->dest = bpf_htons(VXLAN_PORT);
-	ctx->udp_header->len = bpf_htons(bpf_ntohs(ctx->ip_header->tot_len) - sizeof(struct iphdr));
+	UDPHDR(ctx)->source = UDPHDR(ctx)->dest = bpf_htons(VXLAN_PORT);
+	UDPHDR(ctx)->len = bpf_htons(bpf_ntohs(ctx->ip_header->tot_len) - sizeof(struct iphdr));
 
 	*((__u8*)&vxlan->flags) = 1 << 3; /* set the I flag to make the VNI valid */
 	vxlan->vni = bpf_htonl(CALI_VXLAN_VNI) >> 8; /* it is actually 24-bit, last 8 reserved */
 
 	/* keep eth_inner MACs zeroed, it is useless after decap */
-	eth_inner->h_proto = ctx->eth->h_proto;
+	eth_inner->h_proto = ETHHDR(ctx)->h_proto;
 
 	CALI_DEBUG("vxlan encap %x : %x\n", bpf_ntohl(ctx->ip_header->saddr), bpf_ntohl(ctx->ip_header->daddr));
 
@@ -320,7 +321,7 @@ static CALI_BPF_INLINE __u32 vxlan_vni(struct cali_tc_ctx *ctx)
 {
 	struct vxlanhdr *vxlan;
 
-	vxlan = skb_ptr_after(skb, ctx->udp_header);
+	vxlan = skb_ptr_after(skb, UDPHDR(ctx));
 
 	return bpf_ntohl(vxlan->vni << 8); /* 24-bit field, last 8 reserved */
 }
@@ -329,7 +330,7 @@ static CALI_BPF_INLINE bool vxlan_vni_is_valid(struct cali_tc_ctx *ctx)
 {
 	struct vxlanhdr *vxlan;
 
-	vxlan = skb_ptr_after(ctx->skb, ctx->udp_header);
+	vxlan = skb_ptr_after(ctx->skb, UDPHDR(ctx));
 
 	return *((__u8*)&vxlan->flags) & (1 << 3);
 }
@@ -388,7 +389,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx) {
 		ctx->fwd.reason = CALI_REASON_UNAUTH_SOURCE;
 		goto deny;
 	}
-	if (!vxlan_udp_csum_ok(ctx->udp_header)) {
+	if (!vxlan_udp_csum_ok(UDPHDR(ctx))) {
 		/* Our VNI but checksum is incorrect (we always use check=0). */
 		CALI_DEBUG("VXLAN with our VNI but incorrect checksum.\n");
 		ctx->fwd.reason = CALI_REASON_UNAUTH_SOURCE;
@@ -402,7 +403,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx) {
 	 * dst:src but the value is src:dst so it flips it automatically
 	 * when we use it on xmit.
 	 */
-	cali_v4_arp_update_elem(&ctx->arpk, ctx->eth, 0);
+	cali_v4_arp_update_elem(&ctx->arpk, ETHHDR(ctx), 0);
 	CALI_DEBUG("ARP update for ifindex %d ip %x\n", ctx->arpk.ifindex, bpf_ntohl(ctx->arpk.ip));
 
 	ctx->state->tun_ip = ctx->ip_header->saddr;

--- a/bpf-gpl/nat.h
+++ b/bpf-gpl/nat.h
@@ -251,7 +251,7 @@ static CALI_BPF_INLINE int vxlan_v4_encap(struct cali_tc_ctx *ctx,  __be32 ip_sr
 	}
 
 	// Note: assuming L2 packet here so this code can't be used on an L3 device.
-	struct vxlanhdr *vxlan = (void *)(parsing_udphdr(ctx) + 1);
+	struct vxlanhdr *vxlan = (void *)(tc_udphdr(ctx) + 1);
 	struct ethhdr *eth_inner = (void *)(vxlan+1);
 	struct iphdr *ip_inner = (void*)(eth_inner+1);
 
@@ -270,14 +270,14 @@ static CALI_BPF_INLINE int vxlan_v4_encap(struct cali_tc_ctx *ctx,  __be32 ip_sr
 	ctx->ip_header->check = 0;
 	ctx->ip_header->protocol = IPPROTO_UDP;
 
-	parsing_udphdr(ctx)->source = parsing_udphdr(ctx)->dest = bpf_htons(VXLAN_PORT);
-	parsing_udphdr(ctx)->len = bpf_htons(bpf_ntohs(ctx->ip_header->tot_len) - sizeof(struct iphdr));
+	tc_udphdr(ctx)->source = tc_udphdr(ctx)->dest = bpf_htons(VXLAN_PORT);
+	tc_udphdr(ctx)->len = bpf_htons(bpf_ntohs(ctx->ip_header->tot_len) - sizeof(struct iphdr));
 
 	*((__u8*)&vxlan->flags) = 1 << 3; /* set the I flag to make the VNI valid */
 	vxlan->vni = bpf_htonl(CALI_VXLAN_VNI) >> 8; /* it is actually 24-bit, last 8 reserved */
 
 	/* keep eth_inner MACs zeroed, it is useless after decap */
-	eth_inner->h_proto = parsing_ethhdr(ctx)->h_proto;
+	eth_inner->h_proto = tc_ethhdr(ctx)->h_proto;
 
 	CALI_DEBUG("vxlan encap %x : %x\n", bpf_ntohl(ctx->ip_header->saddr), bpf_ntohl(ctx->ip_header->daddr));
 
@@ -321,7 +321,7 @@ static CALI_BPF_INLINE __u32 vxlan_vni(struct cali_tc_ctx *ctx)
 {
 	struct vxlanhdr *vxlan;
 
-	vxlan = skb_ptr_after(skb, parsing_udphdr(ctx));
+	vxlan = skb_ptr_after(skb, tc_udphdr(ctx));
 
 	return bpf_ntohl(vxlan->vni << 8); /* 24-bit field, last 8 reserved */
 }
@@ -330,7 +330,7 @@ static CALI_BPF_INLINE bool vxlan_vni_is_valid(struct cali_tc_ctx *ctx)
 {
 	struct vxlanhdr *vxlan;
 
-	vxlan = skb_ptr_after(ctx->skb, parsing_udphdr(ctx));
+	vxlan = skb_ptr_after(ctx->skb, tc_udphdr(ctx));
 
 	return *((__u8*)&vxlan->flags) & (1 << 3);
 }
@@ -389,7 +389,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx) {
 		ctx->fwd.reason = CALI_REASON_UNAUTH_SOURCE;
 		goto deny;
 	}
-	if (!vxlan_udp_csum_ok(parsing_udphdr(ctx))) {
+	if (!vxlan_udp_csum_ok(tc_udphdr(ctx))) {
 		/* Our VNI but checksum is incorrect (we always use check=0). */
 		CALI_DEBUG("VXLAN with our VNI but incorrect checksum.\n");
 		ctx->fwd.reason = CALI_REASON_UNAUTH_SOURCE;
@@ -403,7 +403,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx) {
 	 * dst:src but the value is src:dst so it flips it automatically
 	 * when we use it on xmit.
 	 */
-	cali_v4_arp_update_elem(&ctx->arpk, parsing_ethhdr(ctx), 0);
+	cali_v4_arp_update_elem(&ctx->arpk, tc_ethhdr(ctx), 0);
 	CALI_DEBUG("ARP update for ifindex %d ip %x\n", ctx->arpk.ifindex, bpf_ntohl(ctx->arpk.ip));
 
 	ctx->state->tun_ip = ctx->ip_header->saddr;

--- a/bpf-gpl/nat.h
+++ b/bpf-gpl/nat.h
@@ -27,7 +27,6 @@
 #include "skb.h"
 #include "routes.h"
 #include "nat_types.h"
-#include "parsing.h"
 
 #ifndef CALI_VXLAN_VNI
 #define CALI_VXLAN_VNI 0xca11c0

--- a/bpf-gpl/nat.h
+++ b/bpf-gpl/nat.h
@@ -251,7 +251,7 @@ static CALI_BPF_INLINE int vxlan_v4_encap(struct cali_tc_ctx *ctx,  __be32 ip_sr
 	}
 
 	// Note: assuming L2 packet here so this code can't be used on an L3 device.
-	struct vxlanhdr *vxlan = (void *)(UDPHDR(ctx) + 1);
+	struct vxlanhdr *vxlan = (void *)(parsing_udphdr(ctx) + 1);
 	struct ethhdr *eth_inner = (void *)(vxlan+1);
 	struct iphdr *ip_inner = (void*)(eth_inner+1);
 
@@ -270,14 +270,14 @@ static CALI_BPF_INLINE int vxlan_v4_encap(struct cali_tc_ctx *ctx,  __be32 ip_sr
 	ctx->ip_header->check = 0;
 	ctx->ip_header->protocol = IPPROTO_UDP;
 
-	UDPHDR(ctx)->source = UDPHDR(ctx)->dest = bpf_htons(VXLAN_PORT);
-	UDPHDR(ctx)->len = bpf_htons(bpf_ntohs(ctx->ip_header->tot_len) - sizeof(struct iphdr));
+	parsing_udphdr(ctx)->source = parsing_udphdr(ctx)->dest = bpf_htons(VXLAN_PORT);
+	parsing_udphdr(ctx)->len = bpf_htons(bpf_ntohs(ctx->ip_header->tot_len) - sizeof(struct iphdr));
 
 	*((__u8*)&vxlan->flags) = 1 << 3; /* set the I flag to make the VNI valid */
 	vxlan->vni = bpf_htonl(CALI_VXLAN_VNI) >> 8; /* it is actually 24-bit, last 8 reserved */
 
 	/* keep eth_inner MACs zeroed, it is useless after decap */
-	eth_inner->h_proto = ETHHDR(ctx)->h_proto;
+	eth_inner->h_proto = parsing_ethhdr(ctx)->h_proto;
 
 	CALI_DEBUG("vxlan encap %x : %x\n", bpf_ntohl(ctx->ip_header->saddr), bpf_ntohl(ctx->ip_header->daddr));
 
@@ -321,7 +321,7 @@ static CALI_BPF_INLINE __u32 vxlan_vni(struct cali_tc_ctx *ctx)
 {
 	struct vxlanhdr *vxlan;
 
-	vxlan = skb_ptr_after(skb, UDPHDR(ctx));
+	vxlan = skb_ptr_after(skb, parsing_udphdr(ctx));
 
 	return bpf_ntohl(vxlan->vni << 8); /* 24-bit field, last 8 reserved */
 }
@@ -330,7 +330,7 @@ static CALI_BPF_INLINE bool vxlan_vni_is_valid(struct cali_tc_ctx *ctx)
 {
 	struct vxlanhdr *vxlan;
 
-	vxlan = skb_ptr_after(ctx->skb, UDPHDR(ctx));
+	vxlan = skb_ptr_after(ctx->skb, parsing_udphdr(ctx));
 
 	return *((__u8*)&vxlan->flags) & (1 << 3);
 }
@@ -389,7 +389,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx) {
 		ctx->fwd.reason = CALI_REASON_UNAUTH_SOURCE;
 		goto deny;
 	}
-	if (!vxlan_udp_csum_ok(UDPHDR(ctx))) {
+	if (!vxlan_udp_csum_ok(parsing_udphdr(ctx))) {
 		/* Our VNI but checksum is incorrect (we always use check=0). */
 		CALI_DEBUG("VXLAN with our VNI but incorrect checksum.\n");
 		ctx->fwd.reason = CALI_REASON_UNAUTH_SOURCE;
@@ -403,7 +403,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx) {
 	 * dst:src but the value is src:dst so it flips it automatically
 	 * when we use it on xmit.
 	 */
-	cali_v4_arp_update_elem(&ctx->arpk, ETHHDR(ctx), 0);
+	cali_v4_arp_update_elem(&ctx->arpk, parsing_ethhdr(ctx), 0);
 	CALI_DEBUG("ARP update for ifindex %d ip %x\n", ctx->arpk.ifindex, bpf_ntohl(ctx->arpk.ip));
 
 	ctx->state->tun_ip = ctx->ip_header->saddr;

--- a/bpf-gpl/parsing.h
+++ b/bpf-gpl/parsing.h
@@ -39,7 +39,7 @@ static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
 			CALI_DEBUG("Too short\n");
 			goto deny;
 		}
-		protocol = bpf_ntohs(parsing_ethhdr(ctx)->h_proto);
+		protocol = bpf_ntohs(tc_ethhdr(ctx)->h_proto);
 	} else {
 		protocol = bpf_ntohs(ctx->skb->protocol);
 	}
@@ -128,14 +128,14 @@ static CALI_BPF_INLINE int tc_state_fill_from_nexthdr(struct cali_tc_ctx *ctx)
 			CALI_DEBUG("Too short\n");
 			goto deny;
 		}
-		ctx->state->sport = bpf_ntohs(parsing_tcphdr(ctx)->source);
-		ctx->state->dport = bpf_ntohs(parsing_tcphdr(ctx)->dest);
+		ctx->state->sport = bpf_ntohs(tc_tcphdr(ctx)->source);
+		ctx->state->dport = bpf_ntohs(tc_tcphdr(ctx)->dest);
 		ctx->state->pre_nat_dport = ctx->state->dport;
 		CALI_DEBUG("TCP; ports: s=%d d=%d\n", ctx->state->sport, ctx->state->dport);
 		break;
 	case IPPROTO_UDP:
-		ctx->state->sport = bpf_ntohs(parsing_udphdr(ctx)->source);
-		ctx->state->dport = bpf_ntohs(parsing_udphdr(ctx)->dest);
+		ctx->state->sport = bpf_ntohs(tc_udphdr(ctx)->source);
+		ctx->state->dport = bpf_ntohs(tc_udphdr(ctx)->dest);
 		ctx->state->pre_nat_dport = ctx->state->dport;
 		CALI_DEBUG("UDP; ports: s=%d d=%d\n", ctx->state->sport, ctx->state->dport);
 		if (ctx->state->dport == VXLAN_PORT) {
@@ -155,10 +155,10 @@ static CALI_BPF_INLINE int tc_state_fill_from_nexthdr(struct cali_tc_ctx *ctx)
 		}
 		break;
 	case IPPROTO_ICMP:
-		ctx->state->icmp_type = parsing_icmphdr(ctx)->type;
-		ctx->state->icmp_code = parsing_icmphdr(ctx)->code;
+		tc_state_set_icmp(ctx, tc_icmphdr(ctx)->type, tc_icmphdr(ctx)->code);
+
 		CALI_DEBUG("ICMP; type=%d code=%d\n",
-				parsing_icmphdr(ctx)->type, parsing_icmphdr(ctx)->code);
+				tc_icmphdr(ctx)->type, tc_icmphdr(ctx)->code);
 		break;
 	case IPPROTO_IPIP:
 		if (CALI_F_TUNNEL | CALI_F_WIREGUARD) {

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -93,26 +93,6 @@ static CALI_BPF_INLINE long skb_iphdr_offset(void)
 	}
 }
 
-static CALI_BPF_INLINE struct ethhdr* parsing_ethhdr(struct cali_tc_ctx *ctx)
-{
-	return (struct ethhdr *)ctx->data_start;
-}
-
-static CALI_BPF_INLINE struct tcphdr* parsing_tcphdr(struct cali_tc_ctx *ctx)
-{
-	return (struct tcphdr *)ctx->nh;
-}
-
-static CALI_BPF_INLINE struct udphdr* parsing_udphdr(struct cali_tc_ctx *ctx)
-{
-	return (struct udphdr *)ctx->nh;
-}
-
-static CALI_BPF_INLINE struct icmphdr* parsing_icmphdr(struct cali_tc_ctx *ctx)
-{
-	return (struct icmphdr *)ctx->nh;
-}
-
 /* skb_refresh_hdr_ptrs refreshes the ip_header/nh fields in the context.
  */
 static CALI_BPF_INLINE void skb_refresh_hdr_ptrs(struct cali_tc_ctx *ctx)

--- a/bpf-gpl/skb.h
+++ b/bpf-gpl/skb.h
@@ -18,7 +18,6 @@
 #ifndef __SKB_H__
 #define __SKB_H__
 
-
 #include <linux/if_ether.h>
 #include <linux/ip.h>
 #include <linux/udp.h>
@@ -92,6 +91,26 @@ static CALI_BPF_INLINE long skb_iphdr_offset(void)
 		// Normal L2 interface: skb is [ether|IP|payload]
 		return sizeof(struct ethhdr);
 	}
+}
+
+static CALI_BPF_INLINE struct ethhdr* parsing_ethhdr(struct cali_tc_ctx *ctx)
+{
+	return (struct ethhdr *)ctx->data_start;
+}
+
+static CALI_BPF_INLINE struct tcphdr* parsing_tcphdr(struct cali_tc_ctx *ctx)
+{
+	return (struct tcphdr *)ctx->nh;
+}
+
+static CALI_BPF_INLINE struct udphdr* parsing_udphdr(struct cali_tc_ctx *ctx)
+{
+	return (struct udphdr *)ctx->nh;
+}
+
+static CALI_BPF_INLINE struct icmphdr* parsing_icmphdr(struct cali_tc_ctx *ctx)
+{
+	return (struct icmphdr *)ctx->nh;
 }
 
 /* skb_refresh_hdr_ptrs refreshes the ip_header/nh fields in the context.

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -44,9 +44,9 @@
 #include "arp.h"
 #include "sendrecv.h"
 #include "fib.h"
+#include "parsing.h"
 #include "tc.h"
 #include "policy_program.h"
-#include "parsing.h"
 #include "failsafe.h"
 #include "metadata.h"
 
@@ -567,7 +567,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 			 * WARNING: this modifies the ip_header pointer in the main context; need to
 			 * be careful in later code to avoid overwriting that. */
 			l3_csum_off += sizeof(*ctx->ip_header) + sizeof(struct icmphdr);
-			ctx->ip_header = (struct iphdr *)(ctx->icmp_header + 1); /* skip to inner ip */
+			ctx->ip_header = (struct iphdr *)(ICMPHDR(ctx) + 1); /* skip to inner ip */
 			if (ctx->ip_header->ihl != 5) {
 				CALI_INFO("ICMP inner IP header has options; unsupported\n");
 				ctx->fwd.reason = CALI_REASON_IP_OPTIONS;
@@ -663,7 +663,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 				CALI_DEBUG("Too short for TCP: DROP\n");
 				goto deny;
 			}
-			ct_ctx_nat.tcp = ctx->tcp_header;
+			ct_ctx_nat.tcp = TCPHDR(ctx);
 		}
 
 		// If we get here, we've passed policy.
@@ -788,10 +788,10 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 
 		switch (ctx->ip_header->protocol) {
 		case IPPROTO_TCP:
-			ctx->tcp_header->dest = bpf_htons(state->post_nat_dport);
+			TCPHDR(ctx)->dest = bpf_htons(state->post_nat_dport);
 			break;
 		case IPPROTO_UDP:
-			ctx->udp_header->dest = bpf_htons(state->post_nat_dport);
+			UDPHDR(ctx)->dest = bpf_htons(state->post_nat_dport);
 			break;
 		}
 
@@ -871,10 +871,10 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 
 		switch (ctx->ip_header->protocol) {
 		case IPPROTO_TCP:
-			ctx->tcp_header->source = bpf_htons(state->ct_result.nat_port);
+			TCPHDR(ctx)->source = bpf_htons(state->ct_result.nat_port);
 			break;
 		case IPPROTO_UDP:
-			ctx->udp_header->source = bpf_htons(state->ct_result.nat_port);
+			UDPHDR(ctx)->source = bpf_htons(state->ct_result.nat_port);
 			break;
 		}
 
@@ -993,7 +993,7 @@ nat_encap:
 				reason = CALI_REASON_SHORT;
 				goto deny;
 			}
-			__builtin_memcpy(&ctx->eth->h_dest, arpv->mac_dst, ETH_ALEN);
+			__builtin_memcpy(&ETHHDR(ctx)->h_dest, arpv->mac_dst, ETH_ALEN);
 			if (state->ct_result.ifindex_fwd == skb->ifindex) {
 				/* No need to change src MAC, if we are at the right device */
 			} else {

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -268,8 +268,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 		ctx.state->post_nat_dport = ctx.nat_dest->port;
 	} else if (nat_res == NAT_NO_BACKEND) {
 		/* send icmp port unreachable if there is no backend for a service */
-		ctx.state->icmp_type = ICMP_DEST_UNREACH;
-		ctx.state->icmp_code = ICMP_PORT_UNREACH;
+		tc_state_set_icmp(&ctx, ICMP_DEST_UNREACH, ICMP_PORT_UNREACH);
 		ctx.state->tun_ip = 0;
 		goto icmp_send_reply;
 	} else {
@@ -567,7 +566,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 			 * WARNING: this modifies the ip_header pointer in the main context; need to
 			 * be careful in later code to avoid overwriting that. */
 			l3_csum_off += sizeof(*ctx->ip_header) + sizeof(struct icmphdr);
-			ctx->ip_header = (struct iphdr *)(parsing_icmphdr(ctx) + 1); /* skip to inner ip */
+			ctx->ip_header = (struct iphdr *)(tc_icmphdr(ctx) + 1); /* skip to inner ip */
 			if (ctx->ip_header->ihl != 5) {
 				CALI_INFO("ICMP inner IP header has options; unsupported\n");
 				ctx->fwd.reason = CALI_REASON_IP_OPTIONS;
@@ -663,7 +662,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 				CALI_DEBUG("Too short for TCP: DROP\n");
 				goto deny;
 			}
-			ct_ctx_nat.tcp = parsing_tcphdr(ctx);
+			ct_ctx_nat.tcp = tc_tcphdr(ctx);
 		}
 
 		// If we get here, we've passed policy.
@@ -788,10 +787,10 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 
 		switch (ctx->ip_header->protocol) {
 		case IPPROTO_TCP:
-			parsing_tcphdr(ctx)->dest = bpf_htons(state->post_nat_dport);
+			tc_tcphdr(ctx)->dest = bpf_htons(state->post_nat_dport);
 			break;
 		case IPPROTO_UDP:
-			parsing_udphdr(ctx)->dest = bpf_htons(state->post_nat_dport);
+			tc_udphdr(ctx)->dest = bpf_htons(state->post_nat_dport);
 			break;
 		}
 
@@ -871,10 +870,10 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 
 		switch (ctx->ip_header->protocol) {
 		case IPPROTO_TCP:
-			parsing_tcphdr(ctx)->source = bpf_htons(state->ct_result.nat_port);
+			tc_tcphdr(ctx)->source = bpf_htons(state->ct_result.nat_port);
 			break;
 		case IPPROTO_UDP:
-			parsing_tcphdr(ctx)->source = bpf_htons(state->ct_result.nat_port);
+			tc_tcphdr(ctx)->source = bpf_htons(state->ct_result.nat_port);
 			break;
 		}
 
@@ -947,14 +946,12 @@ icmp_ttl_exceeded:
 	if (ip_frag_no(ctx->ip_header)) {
 		goto deny;
 	}
-	state->icmp_type = ICMP_TIME_EXCEEDED;
-	state->icmp_code = ICMP_EXC_TTL;
+	tc_state_set_icmp(ctx, ICMP_TIME_EXCEEDED, ICMP_EXC_TTL);
 	state->tun_ip = 0;
 	goto icmp_send_reply;
 
 icmp_too_big:
-	state->icmp_type = ICMP_DEST_UNREACH;
-	state->icmp_code = ICMP_FRAG_NEEDED;
+	tc_state_set_icmp(ctx, ICMP_DEST_UNREACH, ICMP_FRAG_NEEDED);
 
 	struct {
 		__be16  unused;
@@ -993,7 +990,7 @@ nat_encap:
 				reason = CALI_REASON_SHORT;
 				goto deny;
 			}
-			__builtin_memcpy(&parsing_ethhdr(ctx)->h_dest, arpv->mac_dst, ETH_ALEN);
+			__builtin_memcpy(&tc_ethhdr(ctx)->h_dest, arpv->mac_dst, ETH_ALEN);
 			if (state->ct_result.ifindex_fwd == skb->ifindex) {
 				/* No need to change src MAC, if we are at the right device */
 			} else {
@@ -1059,9 +1056,10 @@ int calico_tc_skb_send_icmp_replies(struct __sk_buff *skb)
 		return TC_ACT_SHOT;
 	}
 
-	CALI_DEBUG("ICMP type %d and code %d\n",ctx.state->icmp_type, ctx.state->icmp_code);
+	CALI_DEBUG("ICMP type %d and code %d\n",tc_state_get_icmp_type(&ctx),
+			tc_state_get_icmp_code(&ctx));
 
-	if (ctx.state->icmp_code == ICMP_FRAG_NEEDED) {
+	if (tc_state_get_icmp_code(&ctx) == ICMP_FRAG_NEEDED) {
 		fib_flags |= BPF_FIB_LOOKUP_OUTPUT;
 		if (CALI_F_FROM_WEP) {
 			/* we know it came from workload, just send it back the same way */
@@ -1069,7 +1067,7 @@ int calico_tc_skb_send_icmp_replies(struct __sk_buff *skb)
 		}
 	}
 
-	if (icmp_v4_reply(&ctx, ctx.state->icmp_type, ctx.state->icmp_code, ctx.state->tun_ip)) {
+	if (icmp_v4_reply(&ctx, tc_state_get_icmp_type(&ctx), tc_state_get_icmp_code(&ctx), ctx.state->tun_ip)) {
 		ctx.fwd.res = TC_ACT_SHOT;
 	} else {
 		ctx.fwd.mark = CALI_SKB_MARK_BYPASS_FWD;

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -44,9 +44,9 @@
 #include "arp.h"
 #include "sendrecv.h"
 #include "fib.h"
-#include "parsing.h"
 #include "tc.h"
 #include "policy_program.h"
+#include "parsing.h"
 #include "failsafe.h"
 #include "metadata.h"
 

--- a/bpf-gpl/types.h
+++ b/bpf-gpl/types.h
@@ -120,12 +120,10 @@ struct cali_tc_ctx {
   /* Our single copies of the data start/end pointers loaded from the skb. */
   void *data_start;
   void *data_end;
-
-  struct cali_tc_state *state;
-
   struct iphdr *ip_header;
   void *nh;
 
+  struct cali_tc_state *state;
   struct calico_nat_dest *nat_dest;
   struct arp_key arpk;
   struct fwd fwd;

--- a/bpf-gpl/types.h
+++ b/bpf-gpl/types.h
@@ -59,16 +59,10 @@ struct cali_tc_state {
 	/* Source port of the packet; updated on the CALI_CT_ESTABLISHED_SNAT path or when doing encap.
 	 * zeroed out on the ICMP response path. */
 	__u16 sport;
-	union
-	{
-		/* dport is the destination port of the packet; it may be pre or post NAT */
-		__u16 dport;
-		struct
-		{
-			__u8 icmp_type;
-			__u8 icmp_code;
-		};
-	};
+	/* dport is the destination port of the packet; it may be pre or post NAT.
+	 * This field is also used to keep ICMP Type and Code. The lower byte keeps
+	 * ICMP Type and the higher byte keeps ICMP Code */
+	__u16 dport;
 	/* Pre-NAT dest port; set similarly to pre_nat_ip_dst. */
 	__u16 pre_nat_dport;
 	/* Post-NAT dest port; set similarly to post_nat_ip_dst. */
@@ -128,5 +122,42 @@ struct cali_tc_ctx {
   struct arp_key arpk;
   struct fwd fwd;
 };
+
+static CALI_BPF_INLINE struct ethhdr* tc_ethhdr(struct cali_tc_ctx *ctx)
+{
+	return (struct ethhdr *)ctx->data_start;
+}
+
+static CALI_BPF_INLINE struct tcphdr* tc_tcphdr(struct cali_tc_ctx *ctx)
+{
+	return (struct tcphdr *)ctx->nh;
+}
+
+static CALI_BPF_INLINE struct udphdr* tc_udphdr(struct cali_tc_ctx *ctx)
+{
+	return (struct udphdr *)ctx->nh;
+}
+
+static CALI_BPF_INLINE struct icmphdr* tc_icmphdr(struct cali_tc_ctx *ctx)
+{
+	return (struct icmphdr *)ctx->nh;
+}
+
+static CALI_BPF_INLINE __u8 tc_state_get_icmp_type(struct cali_tc_ctx *ctx)
+{
+	// The lower byte of dport (type __u16) in cali_tc_state is used to store ICMP type
+	return (ctx->state->dport & 0xff);
+}
+
+static CALI_BPF_INLINE __u8 tc_state_get_icmp_code(struct cali_tc_ctx *ctx)
+{
+	// The higher byte of dport (type __u16) in cali_tc_state is used to store ICMP code
+	return (ctx->state->dport >> 8) & 0xff;
+}
+
+static CALI_BPF_INLINE void tc_state_set_icmp(struct cali_tc_ctx *ctx, __u8 type, __u8 code)
+{
+	ctx->state->dport = type + (code << 8);
+}
 
 #endif /* __CALI_BPF_TYPES_H__ */

--- a/bpf-gpl/types.h
+++ b/bpf-gpl/types.h
@@ -118,21 +118,13 @@ struct cali_tc_ctx {
   struct xdp_md *xdp;
 
   /* Our single copies of the data start/end pointers loaded from the skb. */
-  union {
-  	void *data_start;
-  	struct ethhdr *eth; /* If there is an ethhdr it's at the start. */
-  };
+  void *data_start;
   void *data_end;
 
   struct cali_tc_state *state;
 
   struct iphdr *ip_header;
-  union {
-    void *nh;
-    struct tcphdr *tcp_header;
-    struct udphdr *udp_header;
-    struct icmphdr *icmp_header;
-  };
+  void *nh;
 
   struct calico_nat_dest *nat_dest;
   struct arp_key arpk;

--- a/bpf-gpl/xdp.c
+++ b/bpf-gpl/xdp.c
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License along
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
-
-// NOTE: THIS FILE IS NOT YET IN ACTIVE USE.
 
 #include <linux/if_ether.h>
 #include <linux/ip.h>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
This PR corrects the type punning in bpf code by removing the unions in the `cai_tc_ctx` structure.

## Todos
- [x] Unit tests (full coverage)

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
