### PR TITLE
bugfix: vxlan noencap blackhole contention

### DIFF
--- a/dataplane/linux/vxlan_mgr.go
+++ b/dataplane/linux/vxlan_mgr.go
@@ -118,8 +118,8 @@ func newVXLANManager(
 		false,
 		0,
 		opRecorder,
-		routetable.WithAddiionalLogFields(log.Fields{"route_table": "vxlan_blackhole"}),
-		routetable.WithAdditionalRouteFilters(&netlink.Route{Type: bhTarget.RouteType()}),
+		routetable.WithAdditionalLogFields(log.Fields{"route_table": "vxlan_blackhole"}),
+		routetable.WithAdditionalRouteFilter(&netlink.Route{Type: bhTarget.RouteType()}),
 	)
 
 	return newVXLANManagerWithShims(
@@ -133,8 +133,8 @@ func newVXLANManager(
 			return routetable.New(interfaceRegexes, ipVersion, vxlan, netlinkTimeout,
 				deviceRouteSourceAddress, deviceRouteProtocol, removeExternalRoutes, 0,
 				opRecorder,
-				routetable.WithAddiionalLogFields(log.Fields{"route_table": "vxlan_noencap"}),
-				routetable.WithAdditionalRouteFilters(&netlink.Route{Type: noencTarget.RouteType()}),
+				routetable.WithAdditionalLogFields(log.Fields{"route_table": "vxlan_noencap"}),
+				routetable.WithAdditionalRouteFilter(&netlink.Route{Type: noencTarget.RouteType()}),
 			)
 		},
 	)

--- a/dataplane/linux/vxlan_mgr.go
+++ b/dataplane/linux/vxlan_mgr.go
@@ -105,9 +105,6 @@ func newVXLANManager(
 		blackHoleProto = dpConfig.DeviceRouteProtocol
 	}
 
-	noencTarget := routetable.Target{Type: routetable.TargetTypeNoEncap}
-	bhTarget := routetable.Target{Type: routetable.TargetTypeBlackhole}
-
 	brt := routetable.New(
 		[]string{routetable.InterfaceNone},
 		4,
@@ -119,7 +116,7 @@ func newVXLANManager(
 		0,
 		opRecorder,
 		routetable.WithAdditionalLogFields(log.Fields{"route_table": "vxlan_blackhole"}),
-		routetable.WithAdditionalRouteFilter(&netlink.Route{Type: bhTarget.RouteType()}),
+		routetable.WithAdditionalRouteFilter(&netlink.Route{Type: syscall.RTN_BLACKHOLE}),
 	)
 
 	return newVXLANManagerWithShims(
@@ -134,7 +131,7 @@ func newVXLANManager(
 				deviceRouteSourceAddress, deviceRouteProtocol, removeExternalRoutes, 0,
 				opRecorder,
 				routetable.WithAdditionalLogFields(log.Fields{"route_table": "vxlan_noencap"}),
-				routetable.WithAdditionalRouteFilter(&netlink.Route{Type: noencTarget.RouteType()}),
+				routetable.WithAdditionalRouteFilter(&netlink.Route{Type: syscall.RTN_UNICAST}),
 			)
 		},
 	)

--- a/dataplane/linux/vxlan_mgr.go
+++ b/dataplane/linux/vxlan_mgr.go
@@ -105,6 +105,9 @@ func newVXLANManager(
 		blackHoleProto = dpConfig.DeviceRouteProtocol
 	}
 
+	noencTarget := routetable.Target{Type: routetable.TargetTypeNoEncap}
+	bhTarget := routetable.Target{Type: routetable.TargetTypeBlackhole}
+
 	brt := routetable.New(
 		[]string{routetable.InterfaceNone},
 		4,
@@ -115,6 +118,8 @@ func newVXLANManager(
 		false,
 		0,
 		opRecorder,
+		routetable.WithAddiionalLogFields(log.Fields{"route_table": "vxlan_blackhole"}),
+		routetable.WithAdditionalRouteFilters(&netlink.Route{Type: bhTarget.RouteType()}),
 	)
 
 	return newVXLANManagerWithShims(
@@ -127,7 +132,10 @@ func newVXLANManager(
 			deviceRouteSourceAddress net.IP, deviceRouteProtocol netlink.RouteProtocol, removeExternalRoutes bool) routeTable {
 			return routetable.New(interfaceRegexes, ipVersion, vxlan, netlinkTimeout,
 				deviceRouteSourceAddress, deviceRouteProtocol, removeExternalRoutes, 0,
-				opRecorder)
+				opRecorder,
+				routetable.WithAddiionalLogFields(log.Fields{"route_table": "vxlan_noencap"}),
+				routetable.WithAdditionalRouteFilters(&netlink.Route{Type: noencTarget.RouteType()}),
+			)
 		},
 	)
 }

--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -188,7 +188,32 @@ type RouteTable struct {
 	conntrack         conntrackIface
 	time              timeshim.Interface
 
+	additionalRouteFilters *netlink.Route
+
 	opReporter logutils.OpRecorder
+}
+
+type RouteTableOptions func(rt *RouteTable)
+
+// WithAdditionalLogFields - add additional log fields to merge into logCxt.
+//  useful if we want to discern between multiple route tables in operation e.g. in vxlan_mgr.go
+func WithAddiionalLogFields(fields log.Fields) RouteTableOptions {
+	return func(rt *RouteTable) {
+		if rt.logCxt != nil {
+			rt.logCxt = rt.logCxt.WithFields(fields)
+			return
+		}
+
+	}
+}
+
+// WithAdditionalRouteFilters - add additional route filters used in fullResyncRoutesForLink.
+//  this causes the aforementioned function to only touch specified programmed routes that match the filter.
+//  netlink.Route fields Table and LinkIndex will be ignored!
+func WithAdditionalRouteFilters(filter *netlink.Route) RouteTableOptions {
+	return func(rt *RouteTable) {
+		rt.additionalRouteFilters = filter
+	}
 }
 
 func New(
@@ -201,6 +226,7 @@ func New(
 	removeExternalRoutes bool,
 	tableIndex int,
 	opReporter logutils.OpRecorder,
+	opts ...RouteTableOptions,
 ) *RouteTable {
 	return NewWithShims(
 		interfaceRegexes,
@@ -216,6 +242,7 @@ func New(
 		removeExternalRoutes,
 		tableIndex,
 		opReporter,
+		opts...,
 	)
 }
 
@@ -234,6 +261,7 @@ func NewWithShims(
 	removeExternalRoutes bool,
 	tableIndex int,
 	opReporter logutils.OpRecorder,
+	opts ...RouteTableOptions,
 ) *RouteTable {
 	var regexpParts []string
 	includeNoOIF := false
@@ -255,7 +283,7 @@ func NewWithShims(
 		log.WithField("ipVersion", ipVersion).Panic("Unknown IP version")
 	}
 
-	return &RouteTable{
+	rt := &RouteTable{
 		logCxt: log.WithFields(log.Fields{
 			"ipVersion":  ipVersion,
 			"ifaceRegex": ifaceNamePattern,
@@ -284,6 +312,13 @@ func NewWithShims(
 		tableIndex:                     tableIndex,
 		opReporter:                     opReporter,
 	}
+
+	// apply any RouteTableOptions found
+	for _, opt := range opts {
+		opt(rt)
+	}
+
+	return rt
 }
 
 func (r *RouteTable) OnIfaceStateChanged(ifaceName string, state ifacemonitor.State) {
@@ -766,6 +801,33 @@ func (r *RouteTable) createL3Route(linkAttrs *netlink.LinkAttrs, target Target) 
 	return route
 }
 
+func (r *RouteTable) routeListFilterParams(linkAttrs *netlink.LinkAttrs) (*netlink.Route, uint64) {
+	var routeFilter *netlink.Route
+
+	if r.additionalRouteFilters == nil {
+		routeFilter = &netlink.Route{}
+	}
+
+	routeFilter.Table = r.tableIndex
+
+	routeFilterFlags := netlink.RT_FILTER_OIF
+
+	if routeFilter.Table != 0 {
+		routeFilterFlags |= netlink.RT_FILTER_TABLE
+	}
+
+	if routeFilter.Type != syscall.RTN_UNSPEC {
+		routeFilterFlags |= netlink.RT_FILTER_TYPE
+	}
+
+	if linkAttrs != nil {
+		// Link attributes might be nil for the special "no-OIF" interface name.
+		routeFilter.LinkIndex = linkAttrs.Index
+	}
+
+	return routeFilter, routeFilterFlags
+}
+
 // fullResyncRoutesForLink performs a full resync of the routes by first listing current routes and correlating against
 // the expected set. After correlation, it will create a set of routes to delete and update the delta routes to add
 // back any missing routes.
@@ -793,18 +855,12 @@ func (r *RouteTable) fullResyncRoutesForLink(logCxt *log.Entry, ifaceName string
 	// was oper down before we tried to do the sync but that prevented us from removing
 	// routes from an interface in some corner cases (such as being admin up but oper
 	// down).
-	routeFilter := &netlink.Route{
-		Table: r.tableIndex,
-	}
-	routeFilterFlags := netlink.RT_FILTER_OIF
-	if r.tableIndex != 0 {
-		routeFilterFlags |= netlink.RT_FILTER_TABLE
-	}
-	if linkAttrs != nil {
-		// Link attributes might be nil for the special "no-OIF" interface name.
-		routeFilter.LinkIndex = linkAttrs.Index
-	}
+	routeFilter, routeFilterFlags := r.routeListFilterParams(linkAttrs)
+	logCxt.WithFields(log.Fields{"filter": routeFilter, "flags": routeFilterFlags}).Debug("route filter and flags")
+
 	programmedRoutes, err := nl.RouteListFiltered(r.netlinkFamily, routeFilter, routeFilterFlags)
+	logCxt.WithField("routes", programmedRoutes).Debug("programmed routes list")
+
 	if err != nil {
 		// Filter the error so that we don't spam errors if the interface is being torn
 		// down.

--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -806,6 +806,8 @@ func (r *RouteTable) routeListFilterParams(linkAttrs *netlink.LinkAttrs) (*netli
 
 	if r.additionalRouteFilters == nil {
 		routeFilter = &netlink.Route{}
+	} else {
+		routeFilter = r.additionalRouteFilters
 	}
 
 	routeFilter.Table = r.tableIndex


### PR DESCRIPTION
## Description
bugfix for `fullResyncRoutesForLink` criteria on `programmedRoutes`. If your `RouteTable` has 1.) `InterfaceNone`/No-OIF 2.)  Has to operate with another `RouteTable` on the same route table number (e.g. blackhole routing and noencap routing in this example), `netlink.RouteListFiltered` will only have a single, valid filter (route table number) left to operate with and will select more routes than needed for the resync operation (clear and re-add routes, if needed / not correct)


vxlan_mgr.go:
- blackhole routing table and noencap routing table were cleaning each other's routes because they share a protocol number, table index. link index for blackhole routes are 0 so it is unusable by the programmed routes filter in `fullResyncRoutesForLink`. prevented that by adding an additional, and optional route filter: route type

route_table.go
- can now provide additional options for logging context 
- can now provide additional options for route filters in `fullResyncRoutesForLink` / `netlink.RouteListFiltered`

## Todos
- [ ] Unit tests (full coverage)
- [ ] Backport (v.3.20)
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
bugfix: blackhole routing table with No-OIF / InterfaceNone-only is clobbering all other routes in the same routing table because if netlink.RT_FILTER_OIF is specified with a netlink.Route{LinkIndex: 0}, it will return all routes using the remaining applicable filter (netlink.RT_FILTER_TABLE / Table 254) link routes.
```

## Related Issues

Fixes https://github.com/projectcalico/calico/issues/4866
