### PR TITLE
Fix service loop prevention flake

### DIFF
--- a/fv/service_loop_prevention_test.go
+++ b/fv/service_loop_prevention_test.go
@@ -306,6 +306,13 @@ var _ = infrastructure.DatastoreDescribe("service loop prevention; with 2 nodes"
 			cfg.Spec.ServiceLoopPrevention = "Disabled"
 		})
 
+		// Expect to see empty cali-cidr-block chains.  (Allowing time for a Felix
+		// restart.)  This ensures that the cali-cidr-block chain has been cleared
+		// before we try a test ping.
+		for _, felix := range felixes {
+			Eventually(getCIDRBlockRules(felix, "iptables-save"), "8s", "0.5s").Should(BeEmpty())
+		}
+
 		By("test that we DO get a routing loop")
 		// (In order to test that the tryRoutingLoop setup is genuine.)
 		tryRoutingLoop(true)
@@ -333,6 +340,13 @@ var _ = infrastructure.DatastoreDescribe("service loop prevention; with 2 nodes"
 		updateFelixConfig(func(cfg *api.FelixConfiguration) {
 			cfg.Spec.ServiceLoopPrevention = "Disabled"
 		})
+
+		// Expect to see empty cali-cidr-block chains.  (Allowing time for a Felix
+		// restart.)  This ensures that the cali-cidr-block chain has been cleared
+		// before we try a test ping.
+		for _, felix := range felixes {
+			Eventually(getCIDRBlockRules(felix, "iptables-save"), "8s", "0.5s").Should(BeEmpty())
+		}
 
 		By("test that we DO get a routing loop")
 		// (In order to test that the tryRoutingLoop setup is genuine.)


### PR DESCRIPTION
These loop prevention FVs were occasionally failing with

    • Failure [13.147 seconds]
    service loop prevention; with 2 nodes (kubernetes backend)
    /go/src/github.com/projectcalico/felix/fv/infrastructure/datastore_describe.go:42
      ServiceExternalIPs also blocks service routing loop [It]
      /go/src/github.com/projectcalico/felix/fv/service_loop_prevention_test.go:291
      Timed out after 1.000s.
      Expected
          <int>: 1
      to be >
          <int>: 2
      /go/src/github.com/projectcalico/felix/fv/service_loop_prevention_test.go:178

In other words, they expected tcpdump to show the ping request
multiple times (because of looping), but it only showed up once.

I think this was happening when we did the ping too early, at a time
when Felix had not yet updated its iptables to reflect the disabling
of service loop prevention.  For example, the relevant Felix had
completed its first update by 00:34:29.265:

    felix-0-19564-103-felixfv[stdout] 2021-09-01 00:34:29.265 [INFO][198] felix/int_dataplane.go 1650: Completed first update to dataplane. secsSinceStart=0.750337644

But the ping was kicked off a little before that at 00:34:29.186:

    2021-09-01 00:34:29.186 [DEBUG][19564] utils.go 148: Creating Command [docker exec external-client-19564-107-felixfv ping -c 1 -W 1 10.96.0.19].

This PR adds code to check the iptables before doing the ping.

