### PR TITLE
bpf: Do not write services with no endpoints

### DIFF
--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -544,6 +544,11 @@ func (s *Syncer) apply(state DPSyncerState) error {
 		skey := getSvcKey(sname, "")
 		eps := state.EpsMap[sname]
 
+		if len(eps) == 0 {
+			log.Debugf("Service %s not written due to no Endpoints", sname)
+			continue
+		}
+
 		err := s.applySvc(skey, sinfo, eps)
 		if err != nil {
 			return err

--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -487,8 +487,11 @@ func (s *Syncer) applyDerived(
 	skey = getSvcKey(sname, getSvcKeyExtra(t, sinfo.ClusterIP().String()))
 	switch t {
 	case svcTypeLoadBalancer:
-		// Handle LB services the same as NodePort type.
-		fallthrough
+		// Handle LB services the same as NodePort if it has 1 or more local endpoints
+		// otherwise fall back to cluster behavior to avoid traffic blackholeing
+		if sinfo.NodeLocalExternal() && local > 0 {
+			count = local // use only local eps
+		}
 	case svcTypeNodePort:
 		if sinfo.NodeLocalExternal() {
 			count = local // use only local eps


### PR DESCRIPTION
## Description

https://github.com/projectcalico/felix/pull/2686 introduces a behavior where only node local endpoints are written to the BPF NAT table. The service entry itself is however still written, which leads to undesirable behavior if someone is trying to access the `LoadBalancer` endpoint from a Pod running on a node which does not have an endpoint for that service. The traffic is black-holed.

The simple workaround is to use the `ClusterIP` of the service when working inside the cluster. However, for many use cases it is not always possible to make special considerations for traffic originating from inside the cluster. It does make sense to allow traffic from inside the cluster to be treated the same as if it came from the internet for these.

This PR avoids programming service entries for services with:
1) No endpoints at all
2) No local endpoints in the case of an `externalTrafficPolicy: Local` service

This mitigates the black-holing behavior, letting the network route traffic to the local policy pods like if it came from outside the cluster. It also doesn't write service entries for services that have no endpoints at all, which should save some space in the map.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [X] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Services with `externalTrafficPolicy: Local` are not written to the forwarding table in case they have no local endpoints. This avoids black-holing of traffic coming from inside the cluster to a LoadBalancer IP.
```
