### PR TITLE
Fix vxlan logspam

### DIFF
--- a/dataplane/linux/vxlan_mgr.go
+++ b/dataplane/linux/vxlan_mgr.go
@@ -116,7 +116,7 @@ func newVXLANManager(
 		0,
 		opRecorder,
 		routetable.WithAdditionalLogFields(log.Fields{"route_table": "vxlan_blackhole"}),
-		routetable.WithAdditionalRouteFilter(&netlink.Route{Type: syscall.RTN_BLACKHOLE}),
+		routetable.WithAdditionalRouteFilter(netlink.Route{Type: syscall.RTN_BLACKHOLE}),
 	)
 
 	return newVXLANManagerWithShims(
@@ -131,7 +131,7 @@ func newVXLANManager(
 				deviceRouteSourceAddress, deviceRouteProtocol, removeExternalRoutes, 0,
 				opRecorder,
 				routetable.WithAdditionalLogFields(log.Fields{"route_table": "vxlan_noencap"}),
-				routetable.WithAdditionalRouteFilter(&netlink.Route{Type: syscall.RTN_UNICAST}),
+				routetable.WithAdditionalRouteFilter(netlink.Route{Type: syscall.RTN_UNICAST}),
 			)
 		},
 	)

--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -1140,7 +1140,7 @@ func (r *RouteTable) filterErrorByIfaceState(ifaceName string, currentErr, defau
 	if ifaceName == InterfaceNone {
 		// Short circuit the no-OIF interface name.
 		logCxt.Info("No interface on route.")
-		return defaultErr
+		return nil
 	}
 
 	if strings.Contains(currentErr.Error(), "not found") {

--- a/routetable/route_table.go
+++ b/routetable/route_table.go
@@ -188,7 +188,7 @@ type RouteTable struct {
 	conntrack         conntrackIface
 	time              timeshim.Interface
 
-	additionalRouteFilter *netlink.Route
+	additionalRouteFilter netlink.Route
 
 	opReporter logutils.OpRecorder
 }
@@ -206,7 +206,7 @@ func WithAdditionalLogFields(fields log.Fields) RouteTableOption {
 // WithAdditionalRouteFilter - add additional route filters used in fullResyncRoutesForLink.
 //  this causes the aforementioned function to only touch specified programmed routes that match the filter.
 //  netlink.Route fields Table and LinkIndex will be ignored!
-func WithAdditionalRouteFilter(filter *netlink.Route) RouteTableOption {
+func WithAdditionalRouteFilter(filter netlink.Route) RouteTableOption {
 	return func(rt *RouteTable) {
 		rt.additionalRouteFilter = filter
 	}
@@ -798,13 +798,7 @@ func (r *RouteTable) createL3Route(linkAttrs *netlink.LinkAttrs, target Target) 
 }
 
 func (r *RouteTable) routeListFilterParams(linkAttrs *netlink.LinkAttrs) (*netlink.Route, uint64) {
-	var routeFilter *netlink.Route
-
-	if r.additionalRouteFilter == nil {
-		routeFilter = &netlink.Route{}
-	} else {
-		routeFilter = r.additionalRouteFilter
-	}
+	routeFilter := r.additionalRouteFilter
 
 	routeFilter.Table = r.tableIndex
 
@@ -823,7 +817,7 @@ func (r *RouteTable) routeListFilterParams(linkAttrs *netlink.LinkAttrs) (*netli
 		routeFilter.LinkIndex = linkAttrs.Index
 	}
 
-	return routeFilter, routeFilterFlags
+	return &routeFilter, routeFilterFlags
 }
 
 // fullResyncRoutesForLink performs a full resync of the routes by first listing current routes and correlating against


### PR DESCRIPTION
## Description

- `filterErrorByIfaceState` error could be just `nil` to prevent full resyncs at all times for a `NoOIF` interface
- `routeFilters` / `nl.RouteListFiltered` parameter construction shouldn't be using pointers

## Todos
- [ ] Backport v3.20

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```

## Related Issues
- https://github.com/projectcalico/calico/issues/4944
