### PR TITLE
[WIP] Backout previous routetable fix and change how we handle empty interface regex

### DIFF
--- a/dataplane/linux/vxlan_mgr.go
+++ b/dataplane/linux/vxlan_mgr.go
@@ -115,8 +115,6 @@ func newVXLANManager(
 		false,
 		0,
 		opRecorder,
-		routetable.WithAdditionalLogFields(log.Fields{"route_table": "vxlan_blackhole"}),
-		routetable.WithAdditionalRouteFilter(&netlink.Route{Type: syscall.RTN_BLACKHOLE}),
 	)
 
 	return newVXLANManagerWithShims(
@@ -130,8 +128,6 @@ func newVXLANManager(
 			return routetable.New(interfaceRegexes, ipVersion, vxlan, netlinkTimeout,
 				deviceRouteSourceAddress, deviceRouteProtocol, removeExternalRoutes, 0,
 				opRecorder,
-				routetable.WithAdditionalLogFields(log.Fields{"route_table": "vxlan_noencap"}),
-				routetable.WithAdditionalRouteFilter(&netlink.Route{Type: syscall.RTN_UNICAST}),
 			)
 		},
 	)


### PR DESCRIPTION
## Description
This is I believe the more correct fix for this:  https://github.com/projectcalico/felix/pull/2986

Interface indexes start from 1 AFAIK so I don't believe the netlink library with a link index of 0 will show eth0. What I believe is going on in a conflict between the main V4 route table and the VXLAN blackhole route table due to the interface regex used to match listed interfaces to the route table manager instance.

Problem is:  blackhole route table passes in a set of interface matches only consisting of the InterfaceNone (see https://github.com/projectcalico/felix/blob/master/dataplane/linux/vxlan_mgr.go#L109).  This is removed from the regex (see https://github.com/projectcalico/felix/blob/master/routetable/route_table.go#L266), so the regex string is blank which becomes a match all interface match and so this table is inadvertently impacting all interfaces on the main routing table (https://github.com/projectcalico/felix/blob/master/routetable/route_table.go#L509).

There were a couple of logs that indicated (at least in the EKS cluster I was looking at) that there were two routing tables both acting on eth0.

```
2021-09-23 04:57:30.945 [INFO][29326] felix/route_table.go 975: Deleting from expected targets cidr=172.16.106.64/26 ifaceName="eth0" ifaceRegex="^eth0$" ipVersion=0x4
2021-09-23 04:57:30.958 [INFO][29326] felix/route_table.go 956: Syncing routes: found unexpected route; ignoring due to grace period. dest=172.16.106.64/26 ifaceName="eth0" ifaceRegex="" ipVersion=0x4
```

Both are acting on the same CIDR, but you can see they are different tables because they have different interface regexes.  The key is one of them (the blackhole table) has an ifaceRegex == "".  

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
