### PR TITLE
bpf/proxy: exclude local workloads from NodePortRemotes

### DIFF
--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -368,8 +368,6 @@ func (s *Syncer) applySvc(skey svcKey, sinfo k8sp.ServicePort, eps []k8sp.Endpoi
 		svc:        sinfo,
 	}
 
-	s.newEpsMap[skey.sname] = eps
-
 	if log.GetLevel() >= log.DebugLevel {
 		log.Debugf("applied a service %s update: sinfo=%+v", skey, s.newSvcMap[skey])
 	}

--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -456,12 +456,16 @@ func (s *Syncer) expandNodePorts(
 			continue
 		}
 
-		nodeIP := rt.NextHop().(ip.V4Addr)
-		if log.GetLevel() >= log.DebugLevel {
-			log.Debugf("found rt %s for dest %s", nodeIP, ipv4)
-		}
+		flags := rt.Flags()
 
-		ipToEp[nodeIP] = append(ipToEp[nodeIP], ep)
+		if flags&routes.FlagWorkload != 0 && flags&routes.FlagLocal == 0 {
+			nodeIP := rt.NextHop().(ip.V4Addr)
+
+			ipToEp[nodeIP] = append(ipToEp[nodeIP], ep)
+			if log.GetLevel() >= log.DebugLevel {
+				log.Debugf("found rt %s for remote dest %s", nodeIP, ipv4)
+			}
+		}
 	}
 	return ipToEp, miss
 }

--- a/bpf/proxy/syncer.go
+++ b/bpf/proxy/syncer.go
@@ -457,7 +457,7 @@ func (s *Syncer) expandNodePorts(
 		}
 
 		flags := rt.Flags()
-
+		// Include only remote workloads.
 		if flags&routes.FlagWorkload != 0 && flags&routes.FlagLocal == 0 {
 			nodeIP := rt.NextHop().(ip.V4Addr)
 


### PR DESCRIPTION
## Description

Fixes the problem, where bogus entries were written to NAT table due to the fact that local workloads do not have NextHop as an IP, but as the index of the cali interface. That lead to programming bogus entries like 3.0.0.0, 4.0.0.0 etc in the NAT table.

As a side effect, those entries each had just one backend (the pod with the cali iface) and due to another bug overwrote the backends for the cleaner that thought that there is just a single backend which leads to stalls if there is more then a single local backend https://github.com/projectcalico/calico/issues/4431. This PR fixes only programming the NAT table and does not address the cleaner.

    To work around the fact that CTLB does not resolve nodeports at the
    node, but immediately at connect time, we need to know if there are any
    local pods at the destination node if ExternalTrafficPolicy is set to
    Local. Otherwise we would not be compliant with legacy kube-proxy if we
    make connetion to a non-local pod of the destination node.
    
    Note that CTLB would make such a connection with source preservation and
    no extra hop anyway.

refs https://github.com/projectcalico/calico/issues/4431
refs https://github.com/projectcalico/calico/issues/4712
refs https://github.com/projectcalico/calico/issues/4817

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
