### PR TITLE
Cleanup of map struct and compilation flags

### DIFF
--- a/bpf-gpl/arp.h
+++ b/bpf-gpl/arp.h
@@ -28,6 +28,6 @@ struct arp_value {
 	char mac_dst[6];
 };
 
-CALI_MAP(cali_v4_arp, 2, BPF_MAP_TYPE_LRU_HASH, struct arp_key, struct arp_value, 10000, 0, MAP_PIN_GLOBAL)
+CALI_MAP(cali_v4_arp, 2, BPF_MAP_TYPE_LRU_HASH, struct arp_key, struct arp_value, 10000, 0)
 
 #endif /* __CALI_ARP_H__ */

--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -30,30 +30,13 @@
 #define BPF_REDIR_EGRESS 0
 #define BPF_REDIR_INGRESS 1
 
-#ifndef __LIBBPF_LOADER__
-/* Extended map definition for compatibility with iproute2 loader. */
 struct bpf_map_def_extended {
-	__u32 type;
-	__u32 key_size;
-	__u32 value_size;
-	__u32 max_entries;
-	__u32 map_flags;
-	__u32 map_id;
-#ifndef __BPFTOOL_LOADER__
-	__u32 pinning_strategy;
-	__u32 unused1;
-	__u32 unused2;
-#endif
+        __u32 type;
+        __u32 key_size;
+        __u32 value_size;
+        __u32 max_entries;
+        __u32 map_flags;
 };
-#else
-struct bpf_map_def_extended {
-	__u32 type;
-	__u32 key_size;
-	__u32 value_size;
-	__u32 max_entries;
-	__u32 map_flags;
-};
-#endif
 
 /* These constants must be kept in sync with the calculate-flags script. */
 
@@ -272,14 +255,6 @@ CALI_CONFIGURABLE_DEFINE(psnat_len, 0x4c545250) /* be 0x4c545250 = ACSII(PRTL) *
 #define PSNAT_START	CALI_CONFIGURABLE(psnat_start)
 #define PSNAT_LEN	CALI_CONFIGURABLE(psnat_len)
 
-#define MAP_PIN_GLOBAL	2
-
-#ifndef __BPFTOOL_LOADER__
-#define CALI_MAP_TC_EXT_PIN(pin)	.pinning_strategy = pin,
-#else
-#define CALI_MAP_TC_EXT_PIN(pin)
-#endif
-
 #define map_symbol(name, ver) name##ver
 
 #define MAP_LOOKUP_FN(name, ver) \
@@ -300,36 +275,34 @@ static CALI_BPF_INLINE int name##_delete_elem(const void* key)	\
 	return bpf_map_delete_elem(&map_symbol(name, ver), key);	\
 }
 
-#ifndef __LIBBPF_LOADER__
-#define CALI_MAP(name, ver,  map_type, key_type, val_type, size, flags, pin) 		\
-struct bpf_map_def_extended __attribute__((section("maps"))) map_symbol(name, ver) = {	\
-	.type = map_type,								\
-	.key_size = sizeof(key_type),							\
-	.value_size = sizeof(val_type),							\
-	.map_flags = flags,								\
-	.max_entries = size,								\
-	CALI_MAP_TC_EXT_PIN(pin)							\
-};											\
-											\
-	MAP_LOOKUP_FN(name, ver)							\
-	MAP_UPDATE_FN(name, ver)							\
+#ifdef __BPFTOOL_LOADER__
+#define CALI_MAP(name, ver,  map_type, key_type, val_type, size, flags)                 \
+struct bpf_map_def_extended __attribute__((section("maps"))) map_symbol(name, ver) = {  \
+	.type = map_type,                                                               \
+	.key_size = sizeof(key_type),                                                   \
+	.value_size = sizeof(val_type),                                                 \
+	.map_flags = flags,                                                             \
+	.max_entries = size,                                                            \
+};                                                                                      \
+	MAP_LOOKUP_FN(name, ver)                                                        \
+	MAP_UPDATE_FN(name, ver)                                                        \
 	MAP_DELETE_FN(name, ver)
 #else
-#define CALI_MAP(name, ver,  map_type, key_type, val_type, size, flags, pin)            \
+#define CALI_MAP(name, ver,  map_type, key_type, val_type, size, flags)                 \
 struct {                                                                                \
-        __uint(type, map_type);                                                         \
-        __type(key, key_type);                                                          \
-        __type(value, val_type);                                                        \
-        __uint(max_entries, size);                                                      \
-        __uint(map_flags, flags);							\
+	__uint(type, map_type);                                                         \
+	__type(key, key_type);                                                          \
+	__type(value, val_type);                                                        \
+	__uint(max_entries, size);                                                      \
+	__uint(map_flags, flags);                                                       \
 }map_symbol(name, ver) SEC(".maps");                                                    \
-        MAP_LOOKUP_FN(name, ver)                                                        \
-        MAP_UPDATE_FN(name, ver)                                                        \
-        MAP_DELETE_FN(name, ver)
-#endif
+	MAP_LOOKUP_FN(name, ver)                                                        \
+	MAP_UPDATE_FN(name, ver)                                                        \
+	MAP_DELETE_FN(name, ver)
 
-#define CALI_MAP_V1(name, map_type, key_type, val_type, size, flags, pin) 	\
-		CALI_MAP(name,, map_type, key_type, val_type, size, flags, pin)
+#endif
+#define CALI_MAP_V1(name, map_type, key_type, val_type, size, flags) 	                \
+		CALI_MAP(name,, map_type, key_type, val_type, size, flags)
 
 
 #endif /* __CALI_BPF_H__ */

--- a/bpf-gpl/calculate-flags
+++ b/bpf-gpl/calculate-flags
@@ -70,17 +70,17 @@ flags=0
 if [[ "${filename}" =~ .*hep.* ]]; then
   # Host endpoint.
   ((flags |= CALI_TC_HOST_EP))
-  args+=("-DCALI_NO_DEFAULT_POLICY_PROG" "-DCALI_LOG_PFX=CALICOLO" "-D__LIBBPF_LOADER__")
+  args+=("-DCALI_NO_DEFAULT_POLICY_PROG" "-DCALI_LOG_PFX=CALICOLO")
   ep_type="host"
 elif [[ "${filename}" =~ .*tnl.* ]]; then
   # Tunnel.
   ((flags |= CALI_TC_TUNNEL | CALI_TC_HOST_EP))
-  args+=("-DCALI_DEBUG_ALLOW_ALL" "-DCALI_LOG_PFX=CALICOLO" "-D__LIBBPF_LOADER__")
+  args+=("-DCALI_DEBUG_ALLOW_ALL" "-DCALI_LOG_PFX=CALICOLO")
   ep_type="tunnel"
 elif [[ "${filename}" =~ .*wg.* ]]; then
   # Wireguard.
   ((flags |= CALI_TC_WIREGUARD | CALI_TC_HOST_EP))
-  args+=("-DCALI_DEBUG_ALLOW_ALL" "-DCALI_LOG_PFX=CALICOLO" "-D__LIBBPF_LOADER__")
+  args+=("-DCALI_DEBUG_ALLOW_ALL" "-DCALI_LOG_PFX=CALICOLO")
   ep_type="wireguard"
 elif [[ "${filename}" =~ .*connect.* ]]; then
   # Connect-time load balancer (CGROUP attached).
@@ -89,7 +89,7 @@ elif [[ "${filename}" =~ .*connect.* ]]; then
 elif [[ "${filename}" =~ .*wep.* ]]; then
   # Workload endpoint; recognised by CALI_TC_HOST_EP bit being 0.
   ep_type="workload"
-  args+=("-DCALI_LOG_PFX=CALICOLO" "-D__LIBBPF_LOADER__")
+  args+=("-DCALI_LOG_PFX=CALICOLO")
 elif [[ "${filename}" =~ .*xdp.* ]]; then
   # XDP, so host endpoint.
   ((flags |= CALI_TC_HOST_EP))

--- a/bpf-gpl/conntrack_types.h
+++ b/bpf-gpl/conntrack_types.h
@@ -129,7 +129,7 @@ struct ct_create_ctx {
 CALI_MAP(cali_v4_ct, 2,
 		BPF_MAP_TYPE_HASH,
 		struct calico_ct_key, struct calico_ct_value,
-		512000, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
+		512000, BPF_F_NO_PREALLOC)
 
 enum calico_ct_result_type {
 	/* CALI_CT_NEW means that the packet is not part of a known conntrack flow.

--- a/bpf-gpl/failsafe.h
+++ b/bpf-gpl/failsafe.h
@@ -37,8 +37,7 @@ CALI_MAP(cali_v4_fsafes, 2,
 		BPF_MAP_TYPE_LPM_TRIE,
 		struct failsafe_key, struct failsafe_val,
 		65536,
-		BPF_F_NO_PREALLOC,
-		MAP_PIN_GLOBAL)
+		BPF_F_NO_PREALLOC)
 
 #define CALI_FSAFE_OUT 1
 

--- a/bpf-gpl/jump.h
+++ b/bpf-gpl/jump.h
@@ -24,7 +24,7 @@
 CALI_MAP(cali_v4_state, 3,
 		BPF_MAP_TYPE_PERCPU_ARRAY,
 		__u32, struct cali_tc_state,
-		1, 0, MAP_PIN_GLOBAL)
+		1, 0)
 
 static CALI_BPF_INLINE struct cali_tc_state *state_get(void)
 {
@@ -32,25 +32,12 @@ static CALI_BPF_INLINE struct cali_tc_state *state_get(void)
 	return cali_v4_state_lookup_elem(&key);
 }
 
-#ifdef __LIBBPF_LOADER__
 struct bpf_map_def_extended __attribute__((section("maps"))) cali_jump = {
 	.type = BPF_MAP_TYPE_PROG_ARRAY,
 	.key_size = 4,
 	.value_size = 4,
 	.max_entries = 8,
 };
-#else
-struct bpf_map_def_extended __attribute__((section("maps"))) cali_jump = {
-	.type = BPF_MAP_TYPE_PROG_ARRAY,
-	.key_size = 4,
-	.value_size = 4,
-	.max_entries = 8,
-#ifndef __BPFTOOL_LOADER__
-	.map_id = 1,
-	.pinning_strategy = 1 /* object namespace */,
-#endif
-};
-#endif
 
 /* Add new values to the end as these are program indices */
 enum cali_jump_index {

--- a/bpf-gpl/nat_types.h
+++ b/bpf-gpl/nat_types.h
@@ -71,7 +71,7 @@ struct calico_nat_v4_value {
 CALI_MAP(cali_v4_nat_fe, 2,
 		BPF_MAP_TYPE_LPM_TRIE,
 		union calico_nat_v4_lpm_key, struct calico_nat_v4_value,
-		511000, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
+		511000, BPF_F_NO_PREALLOC)
 
 
 // Map: NAT level two.  ID and ordinal -> new dest and port.
@@ -90,7 +90,7 @@ struct calico_nat_dest {
 CALI_MAP_V1(cali_v4_nat_be,
 		BPF_MAP_TYPE_HASH,
 		struct calico_nat_secondary_v4_key, struct calico_nat_dest,
-		510000, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
+		510000, BPF_F_NO_PREALLOC)
 
 struct calico_nat_v4_affinity_key {
 	struct calico_nat_v4 nat_key;
@@ -107,7 +107,7 @@ struct calico_nat_v4_affinity_val {
 CALI_MAP_V1(cali_v4_nat_aff,
 		BPF_MAP_TYPE_LRU_HASH,
 		struct calico_nat_v4_affinity_key, struct calico_nat_v4_affinity_val,
-		510000, 0, MAP_PIN_GLOBAL)
+		510000, 0)
 
 struct vxlanhdr {
 	__be32 flags;

--- a/bpf-gpl/policy.h
+++ b/bpf-gpl/policy.h
@@ -51,7 +51,6 @@ union ip4_set_lpm_key {
 	struct ip4_set_key ip;
 };
 
-#ifdef __LIBBPF_LOADER__
 struct bpf_map_def_extended __attribute__((section("maps"))) cali_v4_ip_sets = {
 	.type           = BPF_MAP_TYPE_LPM_TRIE,
 	.key_size       = sizeof(union ip4_set_lpm_key),
@@ -59,18 +58,6 @@ struct bpf_map_def_extended __attribute__((section("maps"))) cali_v4_ip_sets = {
 	.max_entries    = 1024*1024,
 	.map_flags      = BPF_F_NO_PREALLOC,
 };
-#else
-struct bpf_map_def_extended __attribute__((section("maps"))) cali_v4_ip_sets = {
-	.type           = BPF_MAP_TYPE_LPM_TRIE,
-	.key_size       = sizeof(union ip4_set_lpm_key),
-	.value_size     = sizeof(__u32),
-	.max_entries    = 1024*1024,
-	.map_flags      = BPF_F_NO_PREALLOC,
-#ifndef __BPFTOOL_LOADER__
-	.pinning_strategy        = MAP_PIN_GLOBAL,
-#endif
-};
-#endif
 
 #define RULE_START(id) \
 	CALI_DEBUG("Rule " #id " \n");

--- a/bpf-gpl/routes.h
+++ b/bpf-gpl/routes.h
@@ -56,7 +56,7 @@ struct cali_rt {
 CALI_MAP_V1(cali_v4_routes,
 		BPF_MAP_TYPE_LPM_TRIE,
 		union cali_rt_lpm_key, struct cali_rt,
-		1024*1024, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
+		1024*1024, BPF_F_NO_PREALLOC)
 
 static CALI_BPF_INLINE struct cali_rt *cali_rt_lookup(__be32 addr)
 {

--- a/bpf-gpl/sendrecv.h
+++ b/bpf-gpl/sendrecv.h
@@ -32,7 +32,7 @@ struct sendrecv4_val {
 CALI_MAP_V1(cali_v4_srmsg,
 		BPF_MAP_TYPE_LRU_HASH,
 		struct sendrecv4_key, struct sendrecv4_val,
-		510000, 0, MAP_PIN_GLOBAL)
+		510000, 0)
 
 struct ct_nats_key {
 	__u64 cookie;
@@ -45,7 +45,7 @@ struct ct_nats_key {
 CALI_MAP_V1(cali_v4_ct_nats,
 		BPF_MAP_TYPE_LRU_HASH,
 		struct ct_nats_key, struct sendrecv4_val,
-		10000, 0, MAP_PIN_GLOBAL)
+		10000, 0)
 
 static CALI_BPF_INLINE __u16 ctx_port_to_host(__u32 port)
 {


### PR DESCRIPTION
## Description
compilation flags are not right for test files as a result, both __LIBBPF_LOADER__ and __BPFTOOL_LOADER__ gets enabled, which is contradictory. This results in ut failures in ubuntu 20.04.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
