### PR TITLE
bpf: optionally disable CTLB for connected udp

### DIFF
--- a/bpf-gpl/bpf.h
+++ b/bpf-gpl/bpf.h
@@ -238,7 +238,7 @@ static CALI_BPF_INLINE void ip_dec_ttl(struct iphdr *ip)
 
 #define ip_ttl_exceeded(ip) (CALI_F_TO_HOST && !CALI_F_TUNNEL && (ip)->ttl <= 1)
 #if !defined(__BPFTOOL_LOADER__) && !defined (__IPTOOL_LOADER__)
-extern const volatile struct cali_global_data global_data;
+extern const volatile struct cali_tc_globals global_data;
 #define CALI_CONFIGURABLE_DEFINE(name, pattern)
 #define CALI_CONFIGURABLE(name)  global_data.name
 #else

--- a/bpf-gpl/calculate-flags
+++ b/bpf-gpl/calculate-flags
@@ -85,7 +85,7 @@ elif [[ "${filename}" =~ .*wg.* ]]; then
 elif [[ "${filename}" =~ .*connect.* ]]; then
   # Connect-time load balancer (CGROUP attached).
   ((flags |= CALI_CGROUP))
-  args+=("-DCALI_DEBUG_ALLOW_ALL" "-D__BPFTOOL_LOADER__" "-DCALI_LOG_PFX=CALI")
+  args+=("-DCALI_DEBUG_ALLOW_ALL" "-DCALI_LOG_PFX=CALI")
 elif [[ "${filename}" =~ .*wep.* ]]; then
   # Workload endpoint; recognised by CALI_TC_HOST_EP bit being 0.
   ep_type="workload"

--- a/bpf-gpl/connect_balancer.c
+++ b/bpf-gpl/connect_balancer.c
@@ -31,13 +31,6 @@
 
 #include "sendrecv.h"
 
-__attribute__((section("calico_connect_v4_noop")))
-int cali_noop_v4(struct bpf_sock_addr *ctx)
-{
-	CALI_INFO("Noop program executing\n");
-	return 1;
-}
-
 static CALI_BPF_INLINE void do_nat_common(struct bpf_sock_addr *ctx, __u8 proto)
 {
 	/* We do not know what the source address is yet, we only know that it
@@ -107,8 +100,8 @@ out:
 	return;
 }
 
-__attribute__((section("calico_connect_v4")))
-int cali_ctlb_v4(struct bpf_sock_addr *ctx)
+SEC("cgroup/connect4")
+int calico_connect_v4(struct bpf_sock_addr *ctx)
 {
 	CALI_DEBUG("calico_connect_v4\n");
 
@@ -141,8 +134,8 @@ out:
 	return 1;
 }
 
-__attribute__((section("calico_sendmsg_v4")))
-int cali_ctlb_sendmsg_v4(struct bpf_sock_addr *ctx)
+SEC("cgroup/sendmsg4")
+int calico_sendmsg_v4(struct bpf_sock_addr *ctx)
 {
 	CALI_DEBUG("sendmsg_v4 %x:%d\n",
 			bpf_ntohl(ctx->user_ip4), bpf_ntohl(ctx->user_port)>>16);
@@ -158,8 +151,8 @@ out:
 	return 1;
 }
 
-__attribute__((section("calico_recvmsg_v4")))
-int cali_ctlb_recvmsg_v4(struct bpf_sock_addr *ctx)
+SEC("cgroup/recvmsg4")
+int calico_recvmsg_v4(struct bpf_sock_addr *ctx)
 {
 	CALI_DEBUG("recvmsg_v4 %x:%d\n", bpf_ntohl(ctx->user_ip4), ctx_port_to_host(ctx->user_port));
 

--- a/bpf-gpl/connect_balancer.c
+++ b/bpf-gpl/connect_balancer.c
@@ -120,9 +120,8 @@ int calico_connect_v4(struct bpf_sock_addr *ctx)
 		ip_proto = IPPROTO_TCP;
 		break;
 	case SOCK_DGRAM:
-		CALI_DEBUG("SOCK_DGRAM -> assuming UDP\n");
-		ip_proto = IPPROTO_UDP;
-		break;
+		CALI_DEBUG("SOCK_DGRAM -> assuming UDP - not supported\n");
+		goto out;
 	default:
 		CALI_DEBUG("Unknown socket type: %d\n", (int)ctx->type);
 		goto out;

--- a/bpf-gpl/connect_balancer_v6.c
+++ b/bpf-gpl/connect_balancer_v6.c
@@ -30,16 +30,16 @@
 
 #include "sendrecv.h"
 
-__attribute__((section("calico_sendmsg_v6")))
-int cali_ctlb_sendmsg_v6(struct bpf_sock_addr *ctx)
+SEC("cgroup/sendmsg6")
+int calico_sendmsg_v6(struct bpf_sock_addr *ctx)
 {
 	CALI_DEBUG("sendmsg_v6\n");
 
 	return 1;
 }
 
-__attribute__((section("calico_recvmsg_v6")))
-int cali_ctlb_recvmsg_v6(struct bpf_sock_addr *ctx)
+SEC("cgroup/recvmsg6")
+int calico_recvmsg_v6(struct bpf_sock_addr *ctx)
 {
 	__be32 ipv4;
 

--- a/bpf-gpl/globals.h
+++ b/bpf-gpl/globals.h
@@ -18,7 +18,7 @@
 #ifndef __CALI_GLOBALS_H__
 #define __CALI_GLOBALS_H__
 
-struct cali_global_data {
+struct cali_tc_globals {
 	__be32 host_ip;
 	__be16 tunnel_mtu;
 	__be16 vxlan_port;

--- a/bpf-gpl/globals.h
+++ b/bpf-gpl/globals.h
@@ -27,4 +27,9 @@ struct cali_tc_globals {
 	__be16 psnat_start;
 	__be16 psnat_len;
 };
+
+struct cali_ctl_globals {
+	__be32 udp_connect_disabled;
+};
+
 #endif /* __CALI_GLOBALS_H__ */

--- a/bpf-gpl/tc.c
+++ b/bpf-gpl/tc.c
@@ -53,7 +53,7 @@
 #include "bpf_helpers.h"
 
 #if !defined(__BPFTOOL_LOADER__) && !defined (__IPTOOL_LOADER__)
-const volatile struct cali_global_data global_data;
+const volatile struct cali_tc_globals global_data;
 #endif
 /* calico_tc is the main function used in all of the tc programs.  It is specialised
  * for particular hook at build time based on the CALI_F build flags.

--- a/bpf/libbpf/libbpf.go
+++ b/bpf/libbpf/libbpf.go
@@ -187,8 +187,24 @@ func (o *Obj) Close() error {
 	return fmt.Errorf("error: libbpf obj nil")
 }
 
-func SetGlobalVars(m *Map, hostIP, intfIP, extToSvcMark uint32, tmtu, vxlanPort, psNatStart, psNatLen uint16) error {
-	_, err := C.bpf_set_global_vars(m.bpfMap, C.uint(hostIP), C.uint(intfIP), C.uint(extToSvcMark),
-		C.ushort(tmtu), C.ushort(vxlanPort), C.ushort(psNatStart), C.ushort(psNatLen))
+func TcSetGlobals(
+	m *Map,
+	hostIP uint32,
+	intfIP uint32,
+	extToSvcMark uint32,
+	tmtu uint16,
+	vxlanPort uint16,
+	psNatStart uint16,
+	psNatLen uint16,
+) error {
+	_, err := C.bpf_tc_set_globals(m.bpfMap,
+		C.uint(hostIP),
+		C.uint(intfIP),
+		C.uint(extToSvcMark),
+		C.ushort(tmtu),
+		C.ushort(vxlanPort),
+		C.ushort(psNatStart),
+		C.ushort(psNatLen))
+
 	return err
 }

--- a/bpf/libbpf/libbpf.go
+++ b/bpf/libbpf/libbpf.go
@@ -138,6 +138,22 @@ func (o *Obj) AttachClassifier(secName, ifName, hook string) (int, error) {
 	return int(progId), nil
 }
 
+type Link struct {
+	link *C.struct_bpf_link
+}
+
+func (l *Link) Close() error {
+	if l.link != nil {
+		err := C.bpf_link_destroy(l.link)
+		if err != 0 {
+			return fmt.Errorf("error destroying link: %v", err)
+		}
+		l.link = nil
+		return nil
+	}
+	return fmt.Errorf("link nil")
+}
+
 func CreateQDisc(ifName string) error {
 	cIfName := C.CString(ifName)
 	defer C.free(unsafe.Pointer(cIfName))

--- a/bpf/libbpf/libbpf.go
+++ b/bpf/libbpf/libbpf.go
@@ -244,3 +244,9 @@ func TcSetGlobals(
 
 	return err
 }
+
+func CTLBSetGlobals(m *Map, udpConnectDisabled bool) error {
+	_, err := C.bpf_ctlb_set_globals(m.bpfMap, C.bool(udpConnectDisabled))
+
+	return err
+}

--- a/bpf/libbpf/libbpf_api.h
+++ b/bpf/libbpf/libbpf_api.h
@@ -140,7 +140,7 @@ struct bpf_link *bpf_program_attach_cgroup(struct bpf_object *obj, int cgroup_fd
 	}
 
 	if (!(link = bpf_program__attach_cgroup(prog, cgroup_fd))) {
-		err = errno;
+		err = libbpf_get_error(link);
 		goto out;
 	}
 

--- a/bpf/libbpf/libbpf_api.h
+++ b/bpf/libbpf/libbpf_api.h
@@ -102,7 +102,15 @@ int bpf_tc_update_jump_map(struct bpf_object *obj, char* mapName, char *progName
 	return bpf_map_update_elem(map_fd, &progIndex, &prog_fd, 0);
 }
 
-void bpf_set_global_vars(struct bpf_map *map, uint hostIP, uint intfIP, uint ext_to_svc_mark, ushort tmtu, ushort vxlanPort, ushort psnat_start, ushort psnat_len) {
+void bpf_tc_set_globals(struct bpf_map *map,
+			uint hostIP,
+			uint intfIP,
+			uint ext_to_svc_mark,
+			ushort tmtu,
+			ushort vxlanPort,
+			ushort psnat_start,
+			ushort psnat_len)
+{
 	struct cali_global_data data = {
 	    .host_ip = hostIP,
 	    .tunnel_mtu = tmtu,
@@ -115,5 +123,3 @@ void bpf_set_global_vars(struct bpf_map *map, uint hostIP, uint intfIP, uint ext
 	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(struct cali_global_data)));
 	return;
 }
-
-	

--- a/bpf/libbpf/libbpf_api.h
+++ b/bpf/libbpf/libbpf_api.h
@@ -26,10 +26,10 @@ static void set_errno(int ret) {
 
 struct bpf_object* bpf_obj_open(char *filename) {
 	struct bpf_object *obj;
-	int err = 0;
 	obj = bpf_object__open(filename);
-	if (!obj) {
-		err = libbpf_get_error(obj);
+	int err = libbpf_get_error(obj);
+	if (err) {
+		obj = NULL;
 	}
 	set_errno(err);
 	return obj;

--- a/bpf/libbpf/libbpf_api.h
+++ b/bpf/libbpf/libbpf_api.h
@@ -102,6 +102,10 @@ int bpf_tc_update_jump_map(struct bpf_object *obj, char* mapName, char *progName
 	return bpf_map_update_elem(map_fd, &progIndex, &prog_fd, 0);
 }
 
+int bpf_link_destroy(struct bpf_link *link) {
+	return bpf_link__destroy(link);
+}
+
 void bpf_tc_set_globals(struct bpf_map *map,
 			uint hostIP,
 			uint intfIP,

--- a/bpf/libbpf/libbpf_api.h
+++ b/bpf/libbpf/libbpf_api.h
@@ -115,7 +115,7 @@ void bpf_tc_set_globals(struct bpf_map *map,
 			ushort psnat_start,
 			ushort psnat_len)
 {
-	struct cali_global_data data = {
+	struct cali_tc_globals data = {
 	    .host_ip = hostIP,
 	    .tunnel_mtu = tmtu,
 	    .vxlan_port = vxlanPort,
@@ -124,7 +124,7 @@ void bpf_tc_set_globals(struct bpf_map *map,
 	    .psnat_start = psnat_start,
 	    .psnat_len = psnat_len,
 	};
-	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(struct cali_global_data)));
+	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
 	return;
 }
 

--- a/bpf/libbpf/libbpf_api.h
+++ b/bpf/libbpf/libbpf_api.h
@@ -107,8 +107,8 @@ int bpf_link_destroy(struct bpf_link *link) {
 }
 
 void bpf_tc_set_globals(struct bpf_map *map,
-			uint hostIP,
-			uint intfIP,
+			uint host_ip,
+			uint intf_ip,
 			uint ext_to_svc_mark,
 			ushort tmtu,
 			ushort vxlanPort,
@@ -116,16 +116,16 @@ void bpf_tc_set_globals(struct bpf_map *map,
 			ushort psnat_len)
 {
 	struct cali_tc_globals data = {
-	    .host_ip = hostIP,
+	    .host_ip = host_ip,
 	    .tunnel_mtu = tmtu,
 	    .vxlan_port = vxlanPort,
-	    .intf_ip = intfIP,
+	    .intf_ip = intf_ip,
 	    .ext_to_svc_mark = ext_to_svc_mark,
 	    .psnat_start = psnat_start,
 	    .psnat_len = psnat_len,
 	};
+
 	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
-	return;
 }
 
 struct bpf_link *bpf_program_attach_cgroup(struct bpf_object *obj, int cgroup_fd, char *name)
@@ -147,4 +147,13 @@ struct bpf_link *bpf_program_attach_cgroup(struct bpf_object *obj, int cgroup_fd
 out:
 	set_errno(err);
 	return link;
+}
+
+void bpf_ctlb_set_globals(struct bpf_map *map, bool udp_connect_disabled)
+{
+	struct cali_ctl_globals data = {
+	    .udp_connect_disabled = udp_connect_disabled,
+	};
+
+	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
 }

--- a/bpf/libbpf/libbpf_stub.go
+++ b/bpf/libbpf/libbpf_stub.go
@@ -24,6 +24,9 @@ type Obj struct {
 type Map struct {
 }
 
+type Link struct {
+}
+
 func (m *Map) Name() string {
 	panic("LIBBPF syscall stub")
 }
@@ -53,6 +56,10 @@ func (m *Map) NextMap() (*Map, error) {
 }
 
 func (o *Obj) AttachClassifier(secName, ifName, hook string) (int, error) {
+	panic("LIBBPF syscall stub")
+}
+
+func (o *Obj) AttachCGroup(_, _ string) (*Link, error) {
 	panic("LIBBPF syscall stub")
 }
 

--- a/bpf/libbpf/libbpf_stub.go
+++ b/bpf/libbpf/libbpf_stub.go
@@ -76,6 +76,6 @@ func (m *Map) IsMapInternal() bool {
 	panic("LIBBPF syscall stub")
 }
 
-func SetGlobalVars(m *Map, hostIP, intfIP, extToSvcMark uint32, tmtu, vxlanPort, psNatStart, psNatLen uint16) error {
+func TcSetGlobals(m *Map, hostIP, intfIP, extToSvcMark uint32, tmtu, vxlanPort, psNatStart, psNatLen uint16) error {
 	panic("LIBBPF syscall stub")
 }

--- a/bpf/libbpf/libbpf_stub.go
+++ b/bpf/libbpf/libbpf_stub.go
@@ -83,6 +83,10 @@ func (m *Map) IsMapInternal() bool {
 	panic("LIBBPF syscall stub")
 }
 
-func TcSetGlobals(m *Map, hostIP, intfIP, extToSvcMark uint32, tmtu, vxlanPort, psNatStart, psNatLen uint16) error {
+func TcSetGlobals(_ *Map, _, _, _ uint32, _, _, _, _ uint16) error {
+	panic("LIBBPF syscall stub")
+}
+
+func CTLBSetGlobals(_ *Map, _ bool) error {
 	panic("LIBBPF syscall stub")
 }

--- a/bpf/nat/connecttime.go
+++ b/bpf/nat/connecttime.go
@@ -113,7 +113,9 @@ func installProgram(name, ipver, bpfMount, cgroupPath, logLevel string) error {
 		// The values are read only for the BPF programs, but can be set to a value from
 		// userspace before the program is loaded.
 		if m.IsMapInternal() {
-			log.WithField("prog", progName).Warn("Load-time configuration not supported, using defaults.")
+			if err := libbpf.CTLBSetGlobals(m, false); err != nil {
+				return fmt.Errorf("error setting globals: %w", err)
+			}
 			continue
 		}
 

--- a/bpf/tc/attach.go
+++ b/bpf/tc/attach.go
@@ -118,9 +118,8 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 		// The values are read only for the BPF programs, but can be set to a value from
 		// userspace before the program is loaded.
 		if m.IsMapInternal() {
-			perr := ap.ConfigureProgram(m)
-			if perr != nil {
-				return "", perr
+			if err := ap.ConfigureProgram(m); err != nil {
+				return "", fmt.Errorf("failed to configure %s: %w", filename, err)
 			}
 			continue
 		}
@@ -133,15 +132,13 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 			}
 		}
 		pinPath := path.Join(baseDir, subDir, m.Name())
-		perr := m.SetPinPath(pinPath)
-		if perr != nil {
-			return "", fmt.Errorf("error pinning map %v errno %v", m.Name(), perr)
+		if err := m.SetPinPath(pinPath); err != nil {
+			return "", fmt.Errorf("error pinning map %s: %w", m.Name(), err)
 		}
 	}
 
-	err = obj.Load()
-	if err != nil {
-		return "", fmt.Errorf("error loading program %v", err)
+	if err := obj.Load(); err != nil {
+		return "", fmt.Errorf("error loading program: %w", err)
 	}
 
 	isHost := false

--- a/bpf/tc/attach.go
+++ b/bpf/tc/attach.go
@@ -521,7 +521,9 @@ func (ap *AttachPoint) ConfigureProgram(m *libbpf.Map) error {
 	if err != nil {
 		return err
 	}
-	return libbpf.SetGlobalVars(m, hostIP, intfIP, ap.ExtToServiceConnmark, ap.TunnelMTU, vxlanPort, ap.PSNATStart, ap.PSNATEnd)
+
+	return libbpf.TcSetGlobals(m, hostIP, intfIP,
+		ap.ExtToServiceConnmark, ap.TunnelMTU, vxlanPort, ap.PSNATStart, ap.PSNATEnd)
 }
 
 // nolint

--- a/dataplane/linux/int_dataplane.go
+++ b/dataplane/linux/int_dataplane.go
@@ -694,7 +694,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 
 		if config.BPFConnTimeLBEnabled {
 			// Activate the connect-time load balancer.
-			err = nat.InstallConnectTimeLoadBalancer(frontendMap, backendMap, routeMap, config.BPFCgroupV2, config.BPFLogLevel)
+			err = nat.InstallConnectTimeLoadBalancer(config.BPFCgroupV2, config.BPFLogLevel)
 			if err != nil {
 				log.WithError(err).Panic("BPFConnTimeLBEnabled but failed to attach connect-time load balancer, bailing out.")
 			}


### PR DESCRIPTION
If the selected backend disappears, client is stuck with the selection
for ever. Kube-proxy resolves the issue by cleaning up old UDP entries.
If we avoid CTLD and resort to the regular NAT, and we clean up
conntrack entry because the backend is gone (which we do), a new backend
is selected by the next packed due to conntrack miss.

This may break connectivity from host to local pods using connected udp.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
