### PR TITLE
Ubuntu packaging: add Build-Depend on libelf-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: felix
 Section: net
 Priority: optional
 Maintainer: Project Calico Maintainers <maintainers@projectcalico.org>
-Build-Depends: debhelper (>= 8.0.0), dh-systemd
+Build-Depends: debhelper (>= 8.0.0), dh-systemd, libelf-dev
 Standards-Version: 3.9.4
 
 Package: calico-common


### PR DESCRIPTION
This is a cherry-pick of #3049 to the release-v3.21 branch.

Since the recent libbpf transition, launchpad builds have been failing
for trusty, xenial and bionic like this:

    dpkg-shlibdeps: error: cannot find library libelf.so.1 needed by debian/calico-felix/usr/bin/calico-felix (ELF format: 'elf64-x86-64' abi: '0201003e00000000'; RPATH: '')
    dpkg-shlibdeps: error: cannot continue due to the error above

E.g. https://launchpadlibrarian.net/565743800/buildlog_ubuntu-bionic-amd64.felix_3.22.0~0.dev.post1+20211026221416+0000+d6ffbd7-bionic_BUILDING.txt.gz

https://answers.launchpad.net/launchpad/+question/691996 indicates the
solution as in this commit.

I don't know for sure, but my interpretation of that is that
Launchpad's default build environment for Focal (and probably onwards)
includes libelf-dev, but its default build environment for Bionic and
earlier does not.
