### PR TITLE
bpf: reattach programs when their configuration changes

### DIFF
--- a/bpf/tc/attach.go
+++ b/bpf/tc/attach.go
@@ -86,7 +86,7 @@ func (ap AttachPoint) AlreadyAttached(object string) (string, bool) {
 		return "", false
 	}
 
-	isAttached, err := bpf.AlreadyAttachedProg(ap.IfaceName(), string(ap.Hook), object, progID)
+	isAttached, err := bpf.AlreadyAttachedProg(ap, object, progID)
 	if err != nil {
 		logCxt.WithError(err).Debugf("Failed to check if BPF program was already attached.")
 		return "", false
@@ -163,7 +163,8 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 		}
 	}
 
-	// Check if the bpf object is already attached, and we should skip re-attaching it
+	// Check if the bpf object is already attached, and we should skip
+	// re-attaching it if the binary and its configuration are the same.
 	progID, isAttached := ap.AlreadyAttached(preCompiledBinary)
 	if isAttached {
 		logCxt.Infof("Program already attached to TC, skip reattaching %s", ap.FileName())
@@ -221,11 +222,13 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 	// If the process fails, the json file with the correct name and program details
 	// is not stored on disk, and during Felix restarts the same program will be reattached
 	// which leads to an unnecessary load time
-	if err = bpf.RememberAttachedProg(ap.IfaceName(), string(ap.Hook), preCompiledBinary, strconv.Itoa(progId)); err != nil {
+	if err = bpf.RememberAttachedProg(ap, preCompiledBinary, strconv.Itoa(progId)); err != nil {
 		logCxt.WithError(err).Error("Failed to record hash of BPF program on disk; ignoring.")
 	}
+
 	return strconv.Itoa(progId), nil
 }
+
 func (ap AttachPoint) patchLogPrefix(logCtx *log.Entry, ifile, ofile string) error {
 	b, err := bpf.BinaryFromFile(ifile)
 	if err != nil {
@@ -579,8 +582,16 @@ func (ap *AttachPoint) JumpMapFDMapKey() string {
 	return "tc-" + string(ap.Hook)
 }
 
-func (ap *AttachPoint) IfaceName() string {
+func (ap AttachPoint) IfaceName() string {
 	return ap.Iface
+}
+
+func (ap AttachPoint) HookName() string {
+	return string(ap.Hook)
+}
+
+func (ap AttachPoint) Config() string {
+	return fmt.Sprintf("%+v", ap)
 }
 
 func (ap *AttachPoint) ConfigureProgram(m *libbpf.Map) error {

--- a/bpf/tc/attach.go
+++ b/bpf/tc/attach.go
@@ -166,7 +166,7 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 	// Check if the bpf object is already attached, and we should skip re-attaching it
 	progID, isAttached := ap.AlreadyAttached(preCompiledBinary)
 	if isAttached {
-		logCxt.Debugf("Program already attached, skip reattaching %s", ap.FileName())
+		logCxt.Infof("Program already attached to TC, skip reattaching %s", ap.FileName())
 		return progID, nil
 	}
 	logCxt.Debugf("Continue with attaching BPF program %s", ap.FileName())
@@ -189,6 +189,7 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	logCxt.Info("Program attached to TC.")
 
 	var progErrs []error
 	for _, p := range progsToClean {

--- a/bpf/xdp/attach.go
+++ b/bpf/xdp/attach.go
@@ -40,6 +40,14 @@ func (ap *AttachPoint) IfaceName() string {
 	return ap.Iface
 }
 
+func (ap *AttachPoint) HookName() string {
+	return "xdp"
+}
+
+func (ap *AttachPoint) Config() string {
+	return fmt.Sprintf("%+v", ap)
+}
+
 func (ap *AttachPoint) JumpMapFDMapKey() string {
 	return "xdp"
 }
@@ -77,7 +85,7 @@ func (ap *AttachPoint) AlreadyAttached(object string) (string, bool) {
 		return "", false
 	}
 
-	isAttached, err := bpf.AlreadyAttachedProg(ap.IfaceName(), "xdp", object, progID)
+	isAttached, err := bpf.AlreadyAttachedProg(ap, object, progID)
 	if err != nil {
 		ap.Log().Debugf("Failed to check if BPF program was already attached. err=%v", err)
 		return "", false
@@ -180,7 +188,7 @@ func (ap *AttachPoint) AttachProgram() (string, error) {
 	}
 
 	// program is now attached. Now we should store its information to prevent unnecessary reloads in future
-	if err = bpf.RememberAttachedProg(ap.IfaceName(), "xdp", preCompiledBinary, progID); err != nil {
+	if err = bpf.RememberAttachedProg(ap, preCompiledBinary, progID); err != nil {
 		ap.Log().Errorf("Failed to record hash of BPF program on disk; Ignoring. err=%v", err)
 	}
 

--- a/fv/bpf_attach_test.go
+++ b/fv/bpf_attach_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/felix/fv/infrastructure"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
@@ -69,7 +68,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf reattach object",
 		// These should happen at first execution of felix, since there is no program attached
 		firstRunProg1 := felix.WatchStdoutFor(regexp.MustCompile("Continue with attaching BPF program to_hep_debug.o"))
 		firstRunProg2 := felix.WatchStdoutFor(regexp.MustCompile("Continue with attaching BPF program from_hep_fib_debug.o"))
-		log.Info("Starting Felix")
+		By("Starting Felix")
 		felix.TriggerDelayedStart()
 		Eventually(firstRunProg1, "10s", "100ms").Should(BeClosed())
 		Eventually(firstRunProg2, "10s", "100ms").Should(BeClosed())
@@ -78,9 +77,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf reattach object",
 		// This should not happen at initial execution of felix, since there is no program attached
 		secondRunBase := felix.WatchStdoutFor(regexp.MustCompile("Continue with attaching BPF program"))
 		// These should happen after restart of felix, since BPF programs are already attached
-		secondRunProg1 := felix.WatchStdoutFor(regexp.MustCompile("Program already attached, skip reattaching to_hep_debug.o"))
-		secondRunProg2 := felix.WatchStdoutFor(regexp.MustCompile("Program already attached, skip reattaching from_hep_fib_debug.o"))
-		log.Info("Restartin Felix")
+		secondRunProg1 := felix.WatchStdoutFor(regexp.MustCompile("Program already attached to TC, skip reattaching to_hep_debug.o"))
+		secondRunProg2 := felix.WatchStdoutFor(regexp.MustCompile("Program already attached to TC, skip reattaching from_hep_fib_debug.o"))
+		By("Restarting Felix")
 		felix.Restart()
 		Eventually(secondRunProg1, "10s", "100ms").Should(BeClosed())
 		Eventually(secondRunProg2, "10s", "100ms").Should(BeClosed())


### PR DESCRIPTION
## Description

    Configuration is saved along the sha256 of the precompiled program. The
    UUID is not part of the sha256 and neither is log prefix as it is always
    the same for a given attach point.


## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
