### PR TITLE
Remove unused BUILD_IMAGES env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ $(LOCAL_BUILD_DEP):
 endif
 
 FELIX_IMAGE    ?=calico/felix
-BUILD_IMAGES   ?=$(FELIX_IMAGE)
 DEV_REGISTRIES ?=$(DOCKERHUB_REGISTRY) quay.io
 LIBBPF_PATH=/go/src/github.com/projectcalico/felix/bpf-gpl/include/libbpf/src
 BPFGPL_PATH=/go/src/github.com/projectcalico/felix/bpf-gpl


### PR DESCRIPTION
This variable is used to build images, but felix doesn't build any
images. This messes with the cut release process as the presence of this
variable signals that it should try to "cut" a felix image that doesn't
exist.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
