### PR TITLE
Fix duplicate type static check

### DIFF
--- a/bpf/ut/bpf_prog_test.go
+++ b/bpf/ut/bpf_prog_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/google/gopacket/layers"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	. "github.com/onsi/gomega/types"
+	"github.com/onsi/gomega/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -654,7 +654,7 @@ var _ = withExtraMap
 
 // layersMatchFields matches all Exported fields and ignore the ones explicitly
 // listed. It always ignores BaseLayer as that is not set by the tests.
-func layersMatchFields(l gopacket.Layer, ignore ...string) GomegaMatcher {
+func layersMatchFields(l gopacket.Layer, ignore ...string) types.GomegaMatcher {
 	toIgnore := make(map[string]bool)
 	for _, x := range ignore {
 		toIgnore[x] = true


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

We'll need this when upgrading ginkgo / gomega. Was seeing the following without this change:

```
../../../../pkg/mod/github.com/onsi/gomega@v1.15.0/gomega_dsl.go:402:1:         other declaration of Assertion (typecheck)                   
type Assertion = types.Assertion                                                                                                             
^                                                                                                                                            
../../../../pkg/mod/github.com/onsi/gomega@v1.15.0/gomega_dsl.go:380:1:         other declaration of AsyncAssertion (typecheck)              
type AsyncAssertion = types.AsyncAssertion                                                                                                                                                                                                                                                
^                                                                                                                                                                                                                                                                                         
../../../../pkg/mod/github.com/onsi/gomega@v1.15.0/gomega_dsl.go:44:1:  other declaration of Gomega (typecheck)                                                                                                                                                                           
type Gomega = types.Gomega                                                                                                                   
^                      
```


## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```