### PR TITLE
Fix wireguard bpf failure

### DIFF
--- a/bpf/tc/attach.go
+++ b/bpf/tc/attach.go
@@ -151,10 +151,12 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 		}
 		subDir := "globals"
 		if m.Type() == libbpf.MapTypeProgrArray && strings.Contains(m.Name(), "cali_jump") {
+			// Remove period in the interface name if any
+			ifName := strings.ReplaceAll(ap.Iface, ".", "")
 			if ap.Hook == HookIngress {
-				subDir = ap.Iface + "_igr/"
+				subDir = ifName + "_igr/"
 			} else {
-				subDir = ap.Iface + "_egr/"
+				subDir = ifName + "_egr/"
 			}
 		}
 		pinPath := path.Join(baseDir, subDir, m.Name())


### PR DESCRIPTION
## Description
Remove period from the interface name, as we create a dir with ifname to pin jump map.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
